### PR TITLE
Add file size display for binary files in diff view

### DIFF
--- a/src/app/DTOs/FileListEntry.php
+++ b/src/app/DTOs/FileListEntry.php
@@ -20,6 +20,7 @@ class FileListEntry
         public readonly ?string $lastModified = null,
         public readonly bool $isSymlink = false,
         public readonly ?string $symlinkTarget = null,
+        public readonly ?string $fileSize = null,
     ) {}
 
     public static function idForPath(string $path): string
@@ -55,6 +56,7 @@ class FileListEntry
             'lastModified' => $this->lastModified,
             'isSymlink' => $this->isSymlink,
             'symlinkTarget' => $this->symlinkTarget,
+            'fileSize' => $this->fileSize,
         ];
     }
 }

--- a/src/app/Services/GitDiffService.php
+++ b/src/app/Services/GitDiffService.php
@@ -8,6 +8,7 @@ use App\DTOs\DiffTarget;
 use App\DTOs\FileListEntry;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Number;
 
 class GitDiffService
 {
@@ -109,6 +110,7 @@ class GitDiffService
                     lastModified: $target->isWorkingDirectory() ? $this->getLastModified($repoPath, $path) : null,
                     isSymlink: $symlinkTarget !== null,
                     symlinkTarget: $symlinkTarget,
+                    fileSize: $target->isWorkingDirectory() ? $this->getHumanFileSize($repoPath, $path) : null,
                 );
             })
             ->values()
@@ -166,6 +168,7 @@ class GitDiffService
                             isBinary: true,
                             isUntracked: true,
                             lastModified: $this->getLastModified($repoPath, $file),
+                            fileSize: $this->getHumanFileSize($repoPath, $file),
                         );
 
                         continue;
@@ -324,6 +327,17 @@ class GitDiffService
         }
 
         return Carbon::createFromTimestamp(File::lastModified($fullPath))->diffForHumans(short: true);
+    }
+
+    private function getHumanFileSize(string $repoPath, string $path): ?string
+    {
+        $fullPath = $repoPath.'/'.$path;
+
+        if (! File::isFile($fullPath)) {
+            return null;
+        }
+
+        return Number::fileSize(File::size($fullPath), precision: 1);
     }
 
     private function symlinkTarget(string $fullPath): ?string

--- a/src/resources/views/livewire/⚡diff-file.blade.php
+++ b/src/resources/views/livewire/⚡diff-file.blade.php
@@ -385,6 +385,13 @@ new class extends Component {
         @elseif($file['isBinary'] && !($file['isImage'] ?? false))
             <div class="px-4 py-8 text-center">
                 <flux:text variant="subtle" size="sm">Binary file not shown</flux:text>
+                @if(($file['fileSize'] ?? null) || ($file['lastModified'] ?? null))
+                    <div class="mt-1">
+                        <flux:text variant="subtle" size="sm">
+                            {{ $file['fileSize'] ?? '' }}@if(($file['fileSize'] ?? null) && ($file['lastModified'] ?? null)) &middot; @endif@if($file['lastModified'] ?? null)modified {{ $file['lastModified'] }}@endif
+                        </flux:text>
+                    </div>
+                @endif
             </div>
         @elseif($file['isBinary'] && ($file['isImage'] ?? false))
             @php

--- a/src/tests/Unit/FileListEntryTest.php
+++ b/src/tests/Unit/FileListEntryTest.php
@@ -51,6 +51,7 @@ test('toArray includes all properties and computed id', function () {
         'lastModified' => null,
         'isSymlink' => false,
         'symlinkTarget' => null,
+        'fileSize' => null,
     ]);
 });
 


### PR DESCRIPTION
## Summary
This PR adds human-readable file size information to the file list and displays it in the diff view, particularly for binary files where the content cannot be shown.

## Key Changes
- Added `getHumanFileSize()` method to `GitDiffService` that retrieves and formats file sizes using Laravel's `Number::fileSize()` utility
- Extended `FileListEntry` DTO with a new `fileSize` property to carry file size information
- Populated `fileSize` for both tracked files in the working directory and untracked files
- Updated the binary file display in the diff view to show file size and last modified date in a subtle format

## Implementation Details
- File sizes are only calculated for working directory files (not for git objects)
- The `Number::fileSize()` helper is used with `precision: 1` for concise, human-readable output (e.g., "2.5 MB")
- In the UI, file size and modification date are displayed together with a middle dot separator when both are available
- The display gracefully handles cases where either or both metadata fields are missing

https://claude.ai/code/session_01URL1pMpn4Cb8UszTkL8JsP