### PR TITLE
Add GitHub Actions release pipeline with auto-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - run: composer install --no-interaction --prefer-dist
+      - run: composer test:lint
+
+  types:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - run: composer install --no-interaction --prefer-dist
+      - run: composer test:types
+
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - run: composer install --no-interaction --prefer-dist
+      - run: cp .env.example .env
+      - run: php artisan key:generate
+      - run: touch database/database.sqlite
+      - run: php artisan migrate --force
+      - run: composer test
+
+  build:
+    needs: [lint, types, test]
+    runs-on: macos-14
+    defaults:
+      run:
+        working-directory: src
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Extract version from tag
+        id: version
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-dev
+
+      - name: Prepare environment
+        run: |
+          cp .env.example .env
+          php artisan key:generate
+
+      - name: Build and publish to GitHub Releases
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: rfa
+          GITHUB_OWNER: fgilio
+          NATIVEPHP_APP_VERSION: ${{ steps.version.outputs.value }}
+        run: php artisan native:build mac arm64 --publish --no-interaction
+
+      - name: Upload build logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs
+          path: src/nativephp/
+          retention-days: 7

--- a/src/config/nativephp.php
+++ b/src/config/nativephp.php
@@ -108,13 +108,13 @@ return [
          * Supported: "github", "s3", "spaces"
          * Note: The "s3" provider is compatible with S3-compatible services like Cloudflare R2.
          */
-        'default' => env('NATIVEPHP_UPDATER_PROVIDER', 'spaces'),
+        'default' => env('NATIVEPHP_UPDATER_PROVIDER', 'github'),
 
         'providers' => [
             'github' => [
                 'driver' => 'github',
-                'repo' => env('GITHUB_REPO'),
-                'owner' => env('GITHUB_OWNER'),
+                'repo' => env('GITHUB_REPO', 'rfa'),
+                'owner' => env('GITHUB_OWNER', 'fgilio'),
                 'token' => env('GITHUB_TOKEN'),
                 'vPrefixedTagName' => env('GITHUB_V_PREFIXED_TAG_NAME', true),
                 'private' => env('GITHUB_PRIVATE', false),


### PR DESCRIPTION
## Summary

- Add release workflow (`.github/workflows/release.yml`) triggered on `v*` tags
- CI gate (lint, types, test) on Ubuntu before building on `macos-14` (arm64)
- Builds and publishes `.dmg`/`.zip`/`latest-mac.yml` to GitHub Releases as draft
- Switch NativePHP updater from DO Spaces to GitHub provider with hardcoded repo/owner defaults (needed because `cleanup_env_keys` strips `GITHUB_*` from bundled `.env`)

## Release flow

1. `git tag v1.0.0 && git push --tags`
2. CI checks pass on Ubuntu
3. Build runs on macOS arm64, publishes draft release
4. Review draft on GitHub, edit notes, click "Publish"
5. Running apps auto-update from `latest-mac.yml`

## Test plan

- [ ] CI passes on this PR (lint, types, test)
- [ ] Push a test tag after merge to verify the release workflow runs
- [ ] Confirm draft release appears with `.dmg` and `latest-mac.yml`
- [ ] Publish release and verify auto-update from an older version

🤖 Generated with [Claude Code](https://claude.com/claude-code)