### PR TITLE
Add edit button for finalized comments

### DIFF
--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -61,7 +61,7 @@
                 const comments = this.$wire.fileComments || [];
                 const existingDraft = comments.find(c => c.isDraft && c.side === side && c.startLine !== null && lineNum >= c.startLine && lineNum <= (c.endLine ?? c.startLine));
                 if (existingDraft) {
-                    this.editDraft(existingDraft);
+                    this.editComment(existingDraft);
                     return;
                 }
                 this.isDragging = true;
@@ -155,7 +155,7 @@
                 this.submitComment(true);
             },
 
-            editDraft(comment) {
+            editComment(comment) {
                 this.formBody = comment.body;
                 this.formLine = comment.startLine;
                 this.formEndLine = comment.endLine;

--- a/resources/views/components/comment-display.blade.php
+++ b/resources/views/components/comment-display.blade.php
@@ -1,4 +1,4 @@
-{{-- Parent Alpine scope contract: editDraft() (for draft comments), $wire (for delete-comment dispatch) --}}
+{{-- Parent Alpine scope contract: editComment(), $wire (for delete-comment dispatch) --}}
 @props(['comment', 'borderClass' => 'border-y'])
 
 @php $isDraft = $comment['isDraft'] ?? false; @endphp
@@ -6,7 +6,7 @@
 <div
     class="{{ $isDraft ? 'draft-indicator' : 'comment-indicator' }} bg-gh-surface/80 {{ $borderClass }} border-gh-border px-4 py-2 {{ $isDraft ? 'cursor-pointer' : '' }}"
     @if($isDraft)
-        x-on:click="editDraft(@js($comment))"
+        x-on:click="editComment(@js($comment))"
         data-testid="draft-comment"
     @endif
 >
@@ -17,17 +17,33 @@
             @endif
             <flux:text size="sm" class="whitespace-pre-wrap">{{ $comment['body'] }}</flux:text>
         </div>
-        <flux:tooltip content="Delete comment">
-            <flux:button
-                icon="x-mark"
-                icon:variant="outline"
-                variant="ghost"
-                size="xs"
-                aria-label="Delete comment"
-                x-on:click.stop="$wire.dispatch('delete-comment', { commentId: '{{ $comment['id'] }}' })"
-                class="shrink-0 hover:!text-red-400"
-            />
-        </flux:tooltip>
+        <div class="flex items-center gap-0.5 shrink-0">
+            @unless($isDraft)
+                <flux:tooltip content="Edit comment">
+                    <flux:button
+                        icon="pencil-square"
+                        icon:variant="outline"
+                        variant="ghost"
+                        size="xs"
+                        aria-label="Edit comment"
+                        x-on:click.stop="editComment(@js($comment))"
+                        class="hover:!text-gh-accent"
+                        data-testid="edit-comment"
+                    />
+                </flux:tooltip>
+            @endunless
+            <flux:tooltip content="Delete comment">
+                <flux:button
+                    icon="x-mark"
+                    icon:variant="outline"
+                    variant="ghost"
+                    size="xs"
+                    aria-label="Delete comment"
+                    x-on:click.stop="$wire.dispatch('delete-comment', { commentId: '{{ $comment['id'] }}' })"
+                    class="hover:!text-red-400"
+                />
+            </flux:tooltip>
+        </div>
     </div>
     @if(($comment['startLine'] ?? null) !== ($comment['endLine'] ?? null) && ($comment['endLine'] ?? null) !== null)
         <flux:text variant="subtle" size="sm" class="!text-[10px] mt-1">Lines {{ $comment['startLine'] }}-{{ $comment['endLine'] }}</flux:text>

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -406,7 +406,7 @@ new class extends Component {
             </template>
             @foreach($fileComments as $comment)
                 @if($comment['side'] === 'file')
-                    <div x-data @if($comment['isDraft'] ?? false) x-show="editingCommentId !== '{{ $comment['id'] }}'" @endif>
+                    <div x-data x-show="editingCommentId !== '{{ $comment['id'] }}'">
                         <x-comment-display :comment="$comment" border-class="border-b" />
                     </div>
                 @endif
@@ -422,7 +422,7 @@ new class extends Component {
         @endphp
         @if($unplacedComments->isNotEmpty())
             @foreach($unplacedComments as $comment)
-                <div x-data @if($comment['isDraft'] ?? false) x-show="editingCommentId !== '{{ $comment['id'] }}'" @endif>
+                <div x-data x-show="editingCommentId !== '{{ $comment['id'] }}'">
                     <x-comment-display :comment="$comment" border-class="border-b" />
                 </div>
             @endforeach
@@ -658,7 +658,7 @@ new class extends Component {
                                 }
                             @endphp
                             @foreach($lineComments as $comment)
-                                <tr x-data @if($comment['isDraft'] ?? false) x-show="editingCommentId !== '{{ $comment['id'] }}'" @endif>
+                                <tr x-data x-show="editingCommentId !== '{{ $comment['id'] }}'">
                                     <td colspan="4" class="p-0">
                                         <x-comment-display :comment="$comment" border-class="border-y" />
                                     </td>

--- a/tests/Browser/EditCommentTest.php
+++ b/tests/Browser/EditCommentTest.php
@@ -1,0 +1,67 @@
+<?php
+
+beforeEach(function () {
+    $this->setUpTestRepo();
+});
+
+test('finalized comment shows edit button', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $page->page()->getByTestId('diff-line-number')->first()->click();
+    $page->page()->getByPlaceholder('Write a comment', false)->fill('Editable comment');
+    $page->press('Save');
+
+    $page->assertSee('Editable comment');
+    expect($page->page()->getByTestId('edit-comment')->count())->toBeGreaterThanOrEqual(1);
+});
+
+test('clicking edit button opens form with pre-filled text', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $page->page()->getByTestId('diff-line-number')->first()->click();
+    $page->page()->getByPlaceholder('Write a comment', false)->fill('Original text');
+    $page->press('Save');
+
+    $page->assertSee('Original text');
+
+    $page->page()->getByTestId('edit-comment')->first()->click();
+
+    $page->assertSee('Cancel');
+    expect($page->page()->getByPlaceholder('Write a comment', false)->inputValue())->toBe('Original text');
+});
+
+test('editing finalized comment and saving updates the comment', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $page->page()->getByTestId('diff-line-number')->first()->click();
+    $page->page()->getByPlaceholder('Write a comment', false)->fill('Before edit');
+    $page->press('Save');
+
+    $page->assertSee('Before edit');
+
+    $page->page()->getByTestId('edit-comment')->first()->click();
+    $page->page()->getByPlaceholder('Write a comment', false)->fill('After edit');
+    $page->page()->getByPlaceholder('Write a comment', false)->press('Meta+Enter');
+
+    $page->assertSee('After edit');
+    $page->assertDontSee('Before edit');
+    // Should remain finalized (no Draft badge)
+    expect($page->page()->getByTestId('draft-comment')->count())->toBe(0);
+});
+
+test('canceling edit restores original comment', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $page->page()->getByTestId('diff-line-number')->first()->click();
+    $page->page()->getByPlaceholder('Write a comment', false)->fill('Do not change');
+    $page->press('Save');
+
+    $page->assertSee('Do not change');
+
+    $page->page()->getByTestId('edit-comment')->first()->click();
+    $page->page()->getByPlaceholder('Write a comment', false)->fill('Changed text');
+    $page->press('Cancel');
+
+    $page->assertSee('Do not change');
+    $page->assertDontSee('Changed text');
+});


### PR DESCRIPTION
Finalized comments previously only had a delete button. This adds a
pencil icon that opens the existing edit form, reusing the same
infrastructure that draft comments already used.

- Rename editDraft() to editComment() in Alpine component
- Add pencil-square edit button to comment-display for non-draft comments
- Remove isDraft guard from x-show so all comments hide during editing
- Add browser tests for edit comment flow

https://claude.ai/code/session_01CMy83K9BgsdbJWrNmiai1m