### PR TITLE
Add tiered expand options for collapsed diff lines

### DIFF
--- a/app/Actions/ExpandDiffGapAction.php
+++ b/app/Actions/ExpandDiffGapAction.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+final readonly class ExpandDiffGapAction
+{
+    /**
+     * Expand a gap between diff hunks by inserting lines from the full-context diff.
+     *
+     * @param  list<array{header: string, oldStart: int, oldCount: int, newStart: int, newCount: int, lines: list<array>}>  $hunks
+     * @param  int  $hunkIndex  0 = leading gap, count($hunks) = trailing gap (sentinel, not an actual index), else middle gap before hunks[$hunkIndex]
+     * @param  list<array{type: string, newLineNum: ?int, oldLineNum: ?int, content: string, highlightedContent: string}>  $fullDiffLines  All lines from the full-context diff's single hunk
+     * @param  ?int  $lineCount  Lines to expand (null = full gap)
+     * @param  ?int  $newFileLineCount  Total lines in new file (needed for trailing gap boundary)
+     * @return list<array> Modified hunks
+     */
+    public function handle(
+        array $hunks,
+        int $hunkIndex,
+        array $fullDiffLines,
+        ?int $lineCount = null,
+        ?int $newFileLineCount = null,
+    ): array {
+        if (empty($hunks)) {
+            return $hunks;
+        }
+
+        // hunkIndex past the last hunk is a sentinel for the trailing gap
+        $isTrailing = $hunkIndex === count($hunks);
+
+        if ($isTrailing) {
+            $last = $hunks[count($hunks) - 1];
+            $gapNewStart = $last['newStart'] + $last['newCount'];
+            $gapNewEnd = $newFileLineCount ?? $gapNewStart;
+        } elseif ($hunkIndex === 0) {
+            $gapNewStart = 1;
+            $gapNewEnd = $hunks[0]['newStart'] - 1;
+        } else {
+            $prev = $hunks[$hunkIndex - 1];
+            $gapNewStart = $prev['newStart'] + $prev['newCount'];
+            $gapNewEnd = $hunks[$hunkIndex]['newStart'] - 1;
+        }
+
+        if ($gapNewStart > $gapNewEnd) {
+            return $hunks;
+        }
+
+        // Narrow range for partial expansion
+        $totalGapSize = $gapNewEnd - $gapNewStart + 1;
+        $isPartial = $lineCount !== null && $lineCount < $totalGapSize;
+
+        if ($isPartial) {
+            if ($hunkIndex === 0) {
+                // Leading: expand bottom of gap (closest to first hunk)
+                $gapNewStart = $gapNewEnd - $lineCount + 1;
+            } else {
+                // Middle or trailing: expand top of gap (closest to prev/last hunk)
+                $gapNewEnd = $gapNewStart + $lineCount - 1;
+            }
+        }
+
+        // Extract gap lines from the full diff by newLineNum
+        $gapLines = collect($fullDiffLines)
+            ->filter(fn (array $line): bool => ($line['newLineNum'] ?? null) !== null
+                && $line['newLineNum'] >= $gapNewStart
+                && $line['newLineNum'] <= $gapNewEnd
+                && $line['type'] === 'context')
+            ->values()
+            ->all();
+
+        if (empty($gapLines)) {
+            return $hunks;
+        }
+
+        $gapSize = count($gapLines);
+
+        if ($isTrailing) {
+            $lastIdx = count($hunks) - 1;
+            $hunks[$lastIdx]['lines'] = array_merge($hunks[$lastIdx]['lines'], $gapLines);
+            $hunks[$lastIdx]['oldCount'] += $gapSize;
+            $hunks[$lastIdx]['newCount'] += $gapSize;
+        } elseif ($hunkIndex === 0) {
+            $hunks[0]['lines'] = array_merge($gapLines, $hunks[0]['lines']);
+            $hunks[0]['oldStart'] -= $gapSize;
+            $hunks[0]['oldCount'] += $gapSize;
+            $hunks[0]['newStart'] -= $gapSize;
+            $hunks[0]['newCount'] += $gapSize;
+        } elseif ($isPartial) {
+            // Partial middle: append to prev hunk, leave current for remaining gap
+            $hunks[$hunkIndex - 1]['lines'] = array_merge($hunks[$hunkIndex - 1]['lines'], $gapLines);
+            $hunks[$hunkIndex - 1]['oldCount'] += $gapSize;
+            $hunks[$hunkIndex - 1]['newCount'] += $gapSize;
+        } else {
+            // Full middle: merge prev + gap + current into one hunk
+            $prev = $hunks[$hunkIndex - 1];
+            $curr = $hunks[$hunkIndex];
+
+            $merged = [
+                'header' => $prev['header'],
+                'oldStart' => $prev['oldStart'],
+                'oldCount' => $prev['oldCount'] + $gapSize + $curr['oldCount'],
+                'newStart' => $prev['newStart'],
+                'newCount' => $prev['newCount'] + $gapSize + $curr['newCount'],
+                'lines' => array_merge($prev['lines'], $gapLines, $curr['lines']),
+            ];
+
+            array_splice($hunks, $hunkIndex - 1, 2, [$merged]);
+        }
+
+        return $hunks;
+    }
+}

--- a/resources/views/components/tiered-expand-gap.blade.php
+++ b/resources/views/components/tiered-expand-gap.blade.php
@@ -7,23 +7,35 @@
         wire:click="expandGap({{ $hunkIndex }})"
         wire:loading.attr="disabled"
         wire:target="expandGap"
-        class="text-gh-link hover:underline inline-flex items-center gap-1 disabled:opacity-50"
+        class="text-gh-link hover:text-gh-text transition-colors inline-flex items-center gap-1.5 disabled:opacity-50"
     >
-        <flux:icon wire:loading wire:target="expandGap" icon="arrow-path" variant="outline" class="animate-spin" />
+        <flux:icon wire:loading wire:target="expandGap" icon="arrow-path" variant="outline" class="size-3.5 animate-spin" />
         <span wire:loading.remove wire:target="expandGap">Expand {{ $hiddenCount }} hidden lines</span>
         <span wire:loading wire:target="expandGap">Expanding...</span>
     </button>
 @else
-    <span wire:loading.remove wire:target="expandGap" class="inline-flex items-center gap-0.5">
-        <span class="text-gh-muted">Expand</span>
-        @foreach($applicableTiers as $tier)
-            <button wire:click="expandGap({{ $hunkIndex }}, {{ $tier }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $tier }}</button>
-            <span class="text-gh-muted/50">&middot;</span>
-        @endforeach
-        <button wire:click="expandGap({{ $hunkIndex }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $hiddenCount }} <span class="text-gh-muted">hidden lines</span></button>
+    <span wire:loading.remove wire:target="expandGap" class="inline-flex items-center gap-1.5">
+        <span class="text-gh-muted/60 select-none">Expand</span>
+        <span class="inline-flex items-center">
+            @foreach($applicableTiers as $tier)
+                <button
+                    wire:click="expandGap({{ $hunkIndex }}, {{ $tier }})"
+                    wire:loading.attr="disabled"
+                    wire:target="expandGap"
+                    class="text-gh-link hover:bg-gh-link/10 hover:text-gh-text rounded px-1.5 py-0.5 transition-colors disabled:opacity-50 tabular-nums"
+                >{{ $tier }}</button>
+                <span class="text-gh-muted/20 select-none">&middot;</span>
+            @endforeach
+            <button
+                wire:click="expandGap({{ $hunkIndex }})"
+                wire:loading.attr="disabled"
+                wire:target="expandGap"
+                class="text-gh-link hover:bg-gh-link/10 hover:text-gh-text rounded px-1.5 py-0.5 transition-colors disabled:opacity-50 tabular-nums"
+            >{{ $hiddenCount }} <span class="text-gh-muted/60">hidden lines</span></button>
+        </span>
     </span>
-    <span wire:loading wire:target="expandGap" class="inline-flex items-center gap-1">
-        <flux:icon icon="arrow-path" variant="outline" class="animate-spin" />
+    <span wire:loading wire:target="expandGap" class="inline-flex items-center gap-1.5 text-gh-muted">
+        <flux:icon icon="arrow-path" variant="outline" class="size-3.5 animate-spin" />
         Expanding...
     </span>
 @endif

--- a/resources/views/components/tiered-expand-gap.blade.php
+++ b/resources/views/components/tiered-expand-gap.blade.php
@@ -1,0 +1,29 @@
+@props(['hunkIndex', 'hiddenCount', 'expandTiers' => [15, 50, 100]])
+
+@php $applicableTiers = collect($expandTiers)->filter(fn ($t) => $t < $hiddenCount)->values(); @endphp
+
+@if($applicableTiers->isEmpty())
+    <button
+        wire:click="expandGap({{ $hunkIndex }})"
+        wire:loading.attr="disabled"
+        wire:target="expandGap"
+        class="text-gh-link hover:underline inline-flex items-center gap-1 disabled:opacity-50"
+    >
+        <flux:icon wire:loading wire:target="expandGap" icon="arrow-path" variant="outline" class="animate-spin" />
+        <span wire:loading.remove wire:target="expandGap">Expand {{ $hiddenCount }} hidden lines</span>
+        <span wire:loading wire:target="expandGap">Expanding...</span>
+    </button>
+@else
+    <span wire:loading.remove wire:target="expandGap" class="inline-flex items-center gap-0.5">
+        <span class="text-gh-muted">Expand</span>
+        @foreach($applicableTiers as $tier)
+            <button wire:click="expandGap({{ $hunkIndex }}, {{ $tier }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $tier }}</button>
+            <span class="text-gh-muted/50">&middot;</span>
+        @endforeach
+        <button wire:click="expandGap({{ $hunkIndex }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $hiddenCount }} <span class="text-gh-muted">hidden lines</span></button>
+    </span>
+    <span wire:loading wire:target="expandGap" class="inline-flex items-center gap-1">
+        <flux:icon icon="arrow-path" variant="outline" class="animate-spin" />
+        Expanding...
+    </span>
+@endif

--- a/resources/views/components/tiered-expand-gap.blade.php
+++ b/resources/views/components/tiered-expand-gap.blade.php
@@ -1,41 +1,50 @@
-@props(['hunkIndex', 'hiddenCount', 'expandTiers' => [15, 50, 100]])
+@props(['hunkIndex', 'hiddenCount'])
 
-@php $applicableTiers = collect($expandTiers)->filter(fn ($t) => $t < $hiddenCount)->values(); @endphp
+@php
+    $expandTiers = [15, 50, 100];
+    $applicableTiers = collect($expandTiers)->filter(fn ($t) => $t < $hiddenCount)->values();
+@endphp
 
-@if($applicableTiers->isEmpty())
-    <button
-        wire:click="expandGap({{ $hunkIndex }})"
-        wire:loading.attr="disabled"
-        wire:target="expandGap"
-        class="text-gh-link hover:text-gh-text transition-colors inline-flex items-center gap-1.5 disabled:opacity-50"
-    >
-        <flux:icon wire:loading wire:target="expandGap" icon="arrow-path" variant="outline" class="size-3.5 animate-spin" />
-        <span wire:loading.remove wire:target="expandGap">Expand {{ $hiddenCount }} hidden lines</span>
-        <span wire:loading wire:target="expandGap">Expanding...</span>
-    </button>
-@else
-    <span wire:loading.remove wire:target="expandGap" class="inline-flex items-center gap-1.5">
-        <span class="text-gh-muted/60 select-none">Expand</span>
-        <span class="inline-flex items-center">
-            @foreach($applicableTiers as $tier)
-                <button
-                    wire:click="expandGap({{ $hunkIndex }}, {{ $tier }})"
-                    wire:loading.attr="disabled"
-                    wire:target="expandGap"
-                    class="text-gh-link hover:bg-gh-link/10 hover:text-gh-text rounded px-1.5 py-0.5 transition-colors disabled:opacity-50 tabular-nums"
-                >{{ $tier }}</button>
-                <span class="text-gh-muted/20 select-none">&middot;</span>
-            @endforeach
+<span wire:key="expand-gap-{{ $hunkIndex }}-{{ $hiddenCount }}" x-data="{ loading: false }">
+    @if($applicableTiers->isEmpty())
+        <button
+            wire:click="expandGap({{ $hunkIndex }})"
+            wire:loading.attr="disabled"
+            wire:target="expandGap"
+            @click="loading = true"
+            x-show="!loading"
+            class="text-gh-link hover:text-gh-text transition-colors inline-flex items-center gap-1.5 disabled:opacity-50"
+        >
+            Expand {{ $hiddenCount }} hidden lines
+        </button>
+    @else
+        <span x-show="!loading" class="inline-flex items-center gap-1.5">
+            <span class="text-gh-muted/60 select-none">Expand</span>
+            <span class="inline-flex items-center">
+                @foreach($applicableTiers as $tier)
+                    @if(!$loop->first)
+                        <span class="text-gh-muted/20 select-none">&middot;</span>
+                    @endif
+                    <button
+                        wire:click="expandGap({{ $hunkIndex }}, {{ $tier }})"
+                        wire:loading.attr="disabled"
+                        wire:target="expandGap"
+                        @click="loading = true"
+                        class="text-gh-link hover:bg-gh-link/10 hover:text-gh-text rounded px-1.5 py-0.5 transition-colors disabled:opacity-50 tabular-nums"
+                    >{{ $tier }}</button>
+                @endforeach
+            </span>
             <button
                 wire:click="expandGap({{ $hunkIndex }})"
                 wire:loading.attr="disabled"
                 wire:target="expandGap"
+                @click="loading = true"
                 class="text-gh-link hover:bg-gh-link/10 hover:text-gh-text rounded px-1.5 py-0.5 transition-colors disabled:opacity-50 tabular-nums"
             >{{ $hiddenCount }} <span class="text-gh-muted/60">hidden lines</span></button>
         </span>
-    </span>
-    <span wire:loading wire:target="expandGap" class="inline-flex items-center gap-1.5 text-gh-muted">
+    @endif
+    <span x-show="loading" x-cloak class="inline-flex items-center gap-1.5 text-gh-muted">
         <flux:icon icon="arrow-path" variant="outline" class="size-3.5 animate-spin" />
         Expanding...
     </span>
-@endif
+</span>

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -569,25 +569,28 @@ new class extends Component {
                     @endif
 
                     @foreach($diffData['hunks'] as $hunkIndex => $hunk)
-                        {{-- Hunk separator with expand button --}}
-                        @if($hunkIndex > 0 || $hunk['header'] !== '')
+                        {{-- Gap row with expand controls --}}
+                        @if($hunkIndex > 0 || $hunk['newStart'] > 1)
                             <tr class="bg-gh-hunk-bg">
-                                <td colspan="4" class="px-4 py-1 text-gh-muted text-xs">
+                                <td colspan="4" class="py-1.5 text-center text-xs border-y border-dashed border-gh-border/20">
                                     @if($hunkIndex > 0)
                                         @php
                                             $prevHunk = $hunks[$hunkIndex - 1];
                                             $hiddenCount = $hunk['newStart'] - ($prevHunk['newStart'] + $prevHunk['newCount']);
                                         @endphp
                                         <x-tiered-expand-gap :hunk-index="$hunkIndex" :hidden-count="$hiddenCount" :expand-tiers="$expandTiers" />
-                                    @elseif($hunk['newStart'] > 1)
+                                    @else
                                         @php $hiddenCount = $hunk['newStart'] - 1; @endphp
                                         <x-tiered-expand-gap :hunk-index="0" :hidden-count="$hiddenCount" :expand-tiers="$expandTiers" />
-                                    @else
-                                        @@ -{{ $hunk['oldStart'] }} +{{ $hunk['newStart'] }} @@
                                     @endif
-                                    @if($hunk['header'])
-                                        <span class="text-gh-muted/60">{{ $hunk['header'] }}</span>
-                                    @endif
+                                </td>
+                            </tr>
+                        @elseif($hunk['header'] !== '')
+                            {{-- Hunk header only (no gap) --}}
+                            <tr class="bg-gh-hunk-bg">
+                                <td colspan="4" class="px-4 py-1 text-gh-muted text-xs">
+                                    @@ -{{ $hunk['oldStart'] }} +{{ $hunk['newStart'] }} @@
+                                    <span class="text-gh-muted/60">{{ $hunk['header'] }}</span>
                                 </td>
                             </tr>
                         @endif
@@ -674,7 +677,7 @@ new class extends Component {
 
                     @if($hasTrailingGap)
                         <tr class="bg-gh-hunk-bg">
-                            <td colspan="4" class="px-4 py-1 text-gh-muted text-xs">
+                            <td colspan="4" class="py-1.5 text-center text-xs border-y border-dashed border-gh-border/20">
                                 <x-tiered-expand-gap :hunk-index="count($hunks)" :hidden-count="$trailingHiddenCount" :expand-tiers="$expandTiers" />
                             </td>
                         </tr>

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -596,8 +596,7 @@ new class extends Component {
                                                     <button wire:click="expandGap({{ $hunkIndex }}, {{ $tier }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $tier }}</button>
                                                     <span class="text-gh-muted/50">&middot;</span>
                                                 @endforeach
-                                                <button wire:click="expandGap({{ $hunkIndex }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $hiddenCount }}</button>
-                                                <span class="text-gh-muted">hidden lines</span>
+                                                <button wire:click="expandGap({{ $hunkIndex }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $hiddenCount }} <span class="text-gh-muted">hidden lines</span></button>
                                             </span>
                                             <span wire:loading wire:target="expandGap" class="inline-flex items-center gap-1">
                                                 <flux:icon icon="arrow-path" variant="outline" class="animate-spin" />
@@ -627,8 +626,7 @@ new class extends Component {
                                                     <button wire:click="expandGap(0, {{ $tier }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $tier }}</button>
                                                     <span class="text-gh-muted/50">&middot;</span>
                                                 @endforeach
-                                                <button wire:click="expandGap(0)" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $hiddenCount }}</button>
-                                                <span class="text-gh-muted">hidden lines</span>
+                                                <button wire:click="expandGap(0)" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $hiddenCount }} <span class="text-gh-muted">hidden lines</span></button>
                                             </span>
                                             <span wire:loading wire:target="expandGap" class="inline-flex items-center gap-1">
                                                 <flux:icon icon="arrow-path" variant="outline" class="animate-spin" />
@@ -747,8 +745,7 @@ new class extends Component {
                                             <button wire:click="expandGap({{ count($hunks) }}, {{ $tier }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $tier }}</button>
                                             <span class="text-gh-muted/50">&middot;</span>
                                         @endforeach
-                                        <button wire:click="expandGap({{ count($hunks) }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $trailingHiddenCount }}</button>
-                                        <span class="text-gh-muted">hidden lines</span>
+                                        <button wire:click="expandGap({{ count($hunks) }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $trailingHiddenCount }} <span class="text-gh-muted">hidden lines</span></button>
                                     </span>
                                     <span wire:loading wire:target="expandGap" class="inline-flex items-center gap-1">
                                         <flux:icon icon="arrow-path" variant="outline" class="animate-spin" />

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -142,11 +142,12 @@ new class extends Component {
             }
         }
 
-        // Fetch full-context diff to get the hidden lines with syntax highlighting
+        // Fetch full-context diff (cached so sequential partial expansions reuse it)
         $fullDiff = app(LoadFileDiffAction::class)->handle(
             $this->repoPath,
             $this->file['path'],
             $this->file['isUntracked'] ?? false,
+            cacheKey: $this->diffCacheKey().':full-context',
             contextLines: 99999,
             target: $this->buildDiffTarget(),
         );
@@ -576,63 +577,11 @@ new class extends Component {
                                         @php
                                             $prevHunk = $hunks[$hunkIndex - 1];
                                             $hiddenCount = $hunk['newStart'] - ($prevHunk['newStart'] + $prevHunk['newCount']);
-                                            $applicableTiers = collect($expandTiers)->filter(fn ($t) => $t < $hiddenCount)->values();
                                         @endphp
-                                        @if($applicableTiers->isEmpty())
-                                            <button
-                                                wire:click="expandGap({{ $hunkIndex }})"
-                                                wire:loading.attr="disabled"
-                                                wire:target="expandGap"
-                                                class="text-gh-link hover:underline inline-flex items-center gap-1 disabled:opacity-50"
-                                            >
-                                                <flux:icon wire:loading wire:target="expandGap" icon="arrow-path" variant="outline" class="animate-spin" />
-                                                <span wire:loading.remove wire:target="expandGap">Expand {{ $hiddenCount }} hidden lines</span>
-                                                <span wire:loading wire:target="expandGap">Expanding...</span>
-                                            </button>
-                                        @else
-                                            <span wire:loading.remove wire:target="expandGap" class="inline-flex items-center gap-0.5">
-                                                <span class="text-gh-muted">Expand</span>
-                                                @foreach($applicableTiers as $tier)
-                                                    <button wire:click="expandGap({{ $hunkIndex }}, {{ $tier }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $tier }}</button>
-                                                    <span class="text-gh-muted/50">&middot;</span>
-                                                @endforeach
-                                                <button wire:click="expandGap({{ $hunkIndex }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $hiddenCount }} <span class="text-gh-muted">hidden lines</span></button>
-                                            </span>
-                                            <span wire:loading wire:target="expandGap" class="inline-flex items-center gap-1">
-                                                <flux:icon icon="arrow-path" variant="outline" class="animate-spin" />
-                                                Expanding...
-                                            </span>
-                                        @endif
+                                        <x-tiered-expand-gap :hunk-index="$hunkIndex" :hidden-count="$hiddenCount" :expand-tiers="$expandTiers" />
                                     @elseif($hunk['newStart'] > 1)
-                                        @php
-                                            $hiddenCount = $hunk['newStart'] - 1;
-                                            $applicableTiers = collect($expandTiers)->filter(fn ($t) => $t < $hiddenCount)->values();
-                                        @endphp
-                                        @if($applicableTiers->isEmpty())
-                                            <button
-                                                wire:click="expandGap(0)"
-                                                wire:loading.attr="disabled"
-                                                wire:target="expandGap"
-                                                class="text-gh-link hover:underline inline-flex items-center gap-1 disabled:opacity-50"
-                                            >
-                                                <flux:icon wire:loading wire:target="expandGap" icon="arrow-path" variant="outline" class="animate-spin" />
-                                                <span wire:loading.remove wire:target="expandGap">Expand {{ $hiddenCount }} hidden lines</span>
-                                                <span wire:loading wire:target="expandGap">Expanding...</span>
-                                            </button>
-                                        @else
-                                            <span wire:loading.remove wire:target="expandGap" class="inline-flex items-center gap-0.5">
-                                                <span class="text-gh-muted">Expand</span>
-                                                @foreach($applicableTiers as $tier)
-                                                    <button wire:click="expandGap(0, {{ $tier }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $tier }}</button>
-                                                    <span class="text-gh-muted/50">&middot;</span>
-                                                @endforeach
-                                                <button wire:click="expandGap(0)" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $hiddenCount }} <span class="text-gh-muted">hidden lines</span></button>
-                                            </span>
-                                            <span wire:loading wire:target="expandGap" class="inline-flex items-center gap-1">
-                                                <flux:icon icon="arrow-path" variant="outline" class="animate-spin" />
-                                                Expanding...
-                                            </span>
-                                        @endif
+                                        @php $hiddenCount = $hunk['newStart'] - 1; @endphp
+                                        <x-tiered-expand-gap :hunk-index="0" :hidden-count="$hiddenCount" :expand-tiers="$expandTiers" />
                                     @else
                                         @@ -{{ $hunk['oldStart'] }} +{{ $hunk['newStart'] }} @@
                                     @endif
@@ -724,34 +673,9 @@ new class extends Component {
                     @endforeach
 
                     @if($hasTrailingGap)
-                        @php $trailingApplicableTiers = collect($expandTiers)->filter(fn ($t) => $t < $trailingHiddenCount)->values(); @endphp
                         <tr class="bg-gh-hunk-bg">
                             <td colspan="4" class="px-4 py-1 text-gh-muted text-xs">
-                                @if($trailingApplicableTiers->isEmpty())
-                                    <button
-                                        wire:click="expandGap({{ count($hunks) }})"
-                                        wire:loading.attr="disabled"
-                                        wire:target="expandGap"
-                                        class="text-gh-link hover:underline inline-flex items-center gap-1 disabled:opacity-50"
-                                    >
-                                        <flux:icon wire:loading wire:target="expandGap" icon="arrow-path" variant="outline" class="animate-spin" />
-                                        <span wire:loading.remove wire:target="expandGap">Expand {{ $trailingHiddenCount }} hidden lines</span>
-                                        <span wire:loading wire:target="expandGap">Expanding...</span>
-                                    </button>
-                                @else
-                                    <span wire:loading.remove wire:target="expandGap" class="inline-flex items-center gap-0.5">
-                                        <span class="text-gh-muted">Expand</span>
-                                        @foreach($trailingApplicableTiers as $tier)
-                                            <button wire:click="expandGap({{ count($hunks) }}, {{ $tier }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $tier }}</button>
-                                            <span class="text-gh-muted/50">&middot;</span>
-                                        @endforeach
-                                        <button wire:click="expandGap({{ count($hunks) }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $trailingHiddenCount }} <span class="text-gh-muted">hidden lines</span></button>
-                                    </span>
-                                    <span wire:loading wire:target="expandGap" class="inline-flex items-center gap-1">
-                                        <flux:icon icon="arrow-path" variant="outline" class="animate-spin" />
-                                        Expanding...
-                                    </span>
-                                @endif
+                                <x-tiered-expand-gap :hunk-index="count($hunks)" :hidden-count="$trailingHiddenCount" :expand-tiers="$expandTiers" />
                             </td>
                         </tr>
                     @endif

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -100,7 +100,7 @@ new class extends Component {
         );
     }
 
-    public function expandGap(int $hunkIndex): void
+    public function expandGap(int $hunkIndex, ?int $lineCount = null): void
     {
         if ($this->diffData === null || empty($this->diffData['hunks'])) {
             return;
@@ -126,6 +126,20 @@ new class extends Component {
 
         if ($gapNewStart > $gapNewEnd) {
             return;
+        }
+
+        // Narrow range for partial expansion
+        $totalGapSize = $gapNewEnd - $gapNewStart + 1;
+        $isPartial = $lineCount !== null && $lineCount < $totalGapSize;
+
+        if ($isPartial) {
+            if ($hunkIndex === 0) {
+                // Leading: expand bottom of gap (closest to first hunk)
+                $gapNewStart = $gapNewEnd - $lineCount + 1;
+            } else {
+                // Middle or trailing: expand top of gap (closest to prev/last hunk)
+                $gapNewEnd = $gapNewStart + $lineCount - 1;
+            }
         }
 
         // Fetch full-context diff to get the hidden lines with syntax highlighting
@@ -171,23 +185,30 @@ new class extends Component {
             $hunks[0]['lines'] = array_merge($gapLines, $hunks[0]['lines']);
             $hunks[0]['oldStart'] -= $gapSize;
             $hunks[0]['oldCount'] += $gapSize;
-            $hunks[0]['newStart'] = 1;
+            $hunks[0]['newStart'] -= $gapSize;
             $hunks[0]['newCount'] += $gapSize;
         } else {
-            // Merge: prevHunk + gapLines + currentHunk -> single hunk
-            $prev = $hunks[$hunkIndex - 1];
-            $curr = $hunks[$hunkIndex];
+            if ($isPartial) {
+                // Partial: append to prev hunk only, leave curr hunk for remaining gap
+                $hunks[$hunkIndex - 1]['lines'] = array_merge($hunks[$hunkIndex - 1]['lines'], $gapLines);
+                $hunks[$hunkIndex - 1]['oldCount'] += $gapSize;
+                $hunks[$hunkIndex - 1]['newCount'] += $gapSize;
+            } else {
+                // Full: merge prevHunk + gapLines + currentHunk -> single hunk
+                $prev = $hunks[$hunkIndex - 1];
+                $curr = $hunks[$hunkIndex];
 
-            $merged = [
-                'header' => $prev['header'],
-                'oldStart' => $prev['oldStart'],
-                'oldCount' => $prev['oldCount'] + $gapSize + $curr['oldCount'],
-                'newStart' => $prev['newStart'],
-                'newCount' => $prev['newCount'] + $gapSize + $curr['newCount'],
-                'lines' => array_merge($prev['lines'], $gapLines, $curr['lines']),
-            ];
+                $merged = [
+                    'header' => $prev['header'],
+                    'oldStart' => $prev['oldStart'],
+                    'oldCount' => $prev['oldCount'] + $gapSize + $curr['oldCount'],
+                    'newStart' => $prev['newStart'],
+                    'newCount' => $prev['newCount'] + $gapSize + $curr['newCount'],
+                    'lines' => array_merge($prev['lines'], $gapLines, $curr['lines']),
+                ];
 
-            array_splice($hunks, $hunkIndex - 1, 2, [$merged]);
+                array_splice($hunks, $hunkIndex - 1, 2, [$merged]);
+            }
         }
 
         $this->diffData['hunks'] = $hunks;
@@ -523,6 +544,7 @@ new class extends Component {
                 $hasTrailingGap = $newFileLineCount !== null && $lastHunkEnd < $newFileLineCount;
                 $trailingHiddenCount = $hasTrailingGap ? $newFileLineCount - $lastHunkEnd : 0;
                 $hasGaps = count($hunks) > 1 || (count($hunks) === 1 && $hunks[0]['newStart'] > 1) || $hasTrailingGap;
+                $expandTiers = [15, 50, 100];
             @endphp
             @if($diffData['syntaxStyles'] ?? '')
                 {!! '<style>' . $diffData['syntaxStyles'] . '</style>' !!}
@@ -554,29 +576,65 @@ new class extends Component {
                                         @php
                                             $prevHunk = $hunks[$hunkIndex - 1];
                                             $hiddenCount = $hunk['newStart'] - ($prevHunk['newStart'] + $prevHunk['newCount']);
+                                            $applicableTiers = collect($expandTiers)->filter(fn ($t) => $t < $hiddenCount)->values();
                                         @endphp
-                                        <button
-                                            wire:click="expandGap({{ $hunkIndex }})"
-                                            wire:loading.attr="disabled"
-                                            wire:target="expandGap"
-                                            class="text-gh-link hover:underline inline-flex items-center gap-1 disabled:opacity-50"
-                                        >
-                                            <flux:icon wire:loading wire:target="expandGap" icon="arrow-path" variant="outline" class="animate-spin" />
-                                            <span wire:loading.remove wire:target="expandGap">Expand {{ $hiddenCount }} hidden lines</span>
-                                            <span wire:loading wire:target="expandGap">Expanding...</span>
-                                        </button>
+                                        @if($applicableTiers->isEmpty())
+                                            <button
+                                                wire:click="expandGap({{ $hunkIndex }})"
+                                                wire:loading.attr="disabled"
+                                                wire:target="expandGap"
+                                                class="text-gh-link hover:underline inline-flex items-center gap-1 disabled:opacity-50"
+                                            >
+                                                <flux:icon wire:loading wire:target="expandGap" icon="arrow-path" variant="outline" class="animate-spin" />
+                                                <span wire:loading.remove wire:target="expandGap">Expand {{ $hiddenCount }} hidden lines</span>
+                                                <span wire:loading wire:target="expandGap">Expanding...</span>
+                                            </button>
+                                        @else
+                                            <span wire:loading.remove wire:target="expandGap" class="inline-flex items-center gap-0.5">
+                                                <span class="text-gh-muted">Expand</span>
+                                                @foreach($applicableTiers as $tier)
+                                                    <button wire:click="expandGap({{ $hunkIndex }}, {{ $tier }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $tier }}</button>
+                                                    <span class="text-gh-muted/50">&middot;</span>
+                                                @endforeach
+                                                <button wire:click="expandGap({{ $hunkIndex }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $hiddenCount }}</button>
+                                                <span class="text-gh-muted">hidden lines</span>
+                                            </span>
+                                            <span wire:loading wire:target="expandGap" class="inline-flex items-center gap-1">
+                                                <flux:icon icon="arrow-path" variant="outline" class="animate-spin" />
+                                                Expanding...
+                                            </span>
+                                        @endif
                                     @elseif($hunk['newStart'] > 1)
-                                        @php $hiddenCount = $hunk['newStart'] - 1; @endphp
-                                        <button
-                                            wire:click="expandGap(0)"
-                                            wire:loading.attr="disabled"
-                                            wire:target="expandGap"
-                                            class="text-gh-link hover:underline inline-flex items-center gap-1 disabled:opacity-50"
-                                        >
-                                            <flux:icon wire:loading wire:target="expandGap" icon="arrow-path" variant="outline" class="animate-spin" />
-                                            <span wire:loading.remove wire:target="expandGap">Expand {{ $hiddenCount }} hidden lines</span>
-                                            <span wire:loading wire:target="expandGap">Expanding...</span>
-                                        </button>
+                                        @php
+                                            $hiddenCount = $hunk['newStart'] - 1;
+                                            $applicableTiers = collect($expandTiers)->filter(fn ($t) => $t < $hiddenCount)->values();
+                                        @endphp
+                                        @if($applicableTiers->isEmpty())
+                                            <button
+                                                wire:click="expandGap(0)"
+                                                wire:loading.attr="disabled"
+                                                wire:target="expandGap"
+                                                class="text-gh-link hover:underline inline-flex items-center gap-1 disabled:opacity-50"
+                                            >
+                                                <flux:icon wire:loading wire:target="expandGap" icon="arrow-path" variant="outline" class="animate-spin" />
+                                                <span wire:loading.remove wire:target="expandGap">Expand {{ $hiddenCount }} hidden lines</span>
+                                                <span wire:loading wire:target="expandGap">Expanding...</span>
+                                            </button>
+                                        @else
+                                            <span wire:loading.remove wire:target="expandGap" class="inline-flex items-center gap-0.5">
+                                                <span class="text-gh-muted">Expand</span>
+                                                @foreach($applicableTiers as $tier)
+                                                    <button wire:click="expandGap(0, {{ $tier }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $tier }}</button>
+                                                    <span class="text-gh-muted/50">&middot;</span>
+                                                @endforeach
+                                                <button wire:click="expandGap(0)" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $hiddenCount }}</button>
+                                                <span class="text-gh-muted">hidden lines</span>
+                                            </span>
+                                            <span wire:loading wire:target="expandGap" class="inline-flex items-center gap-1">
+                                                <flux:icon icon="arrow-path" variant="outline" class="animate-spin" />
+                                                Expanding...
+                                            </span>
+                                        @endif
                                     @else
                                         @@ -{{ $hunk['oldStart'] }} +{{ $hunk['newStart'] }} @@
                                     @endif
@@ -668,18 +726,35 @@ new class extends Component {
                     @endforeach
 
                     @if($hasTrailingGap)
+                        @php $trailingApplicableTiers = collect($expandTiers)->filter(fn ($t) => $t < $trailingHiddenCount)->values(); @endphp
                         <tr class="bg-gh-hunk-bg">
                             <td colspan="4" class="px-4 py-1 text-gh-muted text-xs">
-                                <button
-                                    wire:click="expandGap({{ count($hunks) }})"
-                                    wire:loading.attr="disabled"
-                                    wire:target="expandGap"
-                                    class="text-gh-link hover:underline inline-flex items-center gap-1 disabled:opacity-50"
-                                >
-                                    <flux:icon wire:loading wire:target="expandGap" icon="arrow-path" variant="outline" class="animate-spin" />
-                                    <span wire:loading.remove wire:target="expandGap">Expand {{ $trailingHiddenCount }} hidden lines</span>
-                                    <span wire:loading wire:target="expandGap">Expanding...</span>
-                                </button>
+                                @if($trailingApplicableTiers->isEmpty())
+                                    <button
+                                        wire:click="expandGap({{ count($hunks) }})"
+                                        wire:loading.attr="disabled"
+                                        wire:target="expandGap"
+                                        class="text-gh-link hover:underline inline-flex items-center gap-1 disabled:opacity-50"
+                                    >
+                                        <flux:icon wire:loading wire:target="expandGap" icon="arrow-path" variant="outline" class="animate-spin" />
+                                        <span wire:loading.remove wire:target="expandGap">Expand {{ $trailingHiddenCount }} hidden lines</span>
+                                        <span wire:loading wire:target="expandGap">Expanding...</span>
+                                    </button>
+                                @else
+                                    <span wire:loading.remove wire:target="expandGap" class="inline-flex items-center gap-0.5">
+                                        <span class="text-gh-muted">Expand</span>
+                                        @foreach($trailingApplicableTiers as $tier)
+                                            <button wire:click="expandGap({{ count($hunks) }}, {{ $tier }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $tier }}</button>
+                                            <span class="text-gh-muted/50">&middot;</span>
+                                        @endforeach
+                                        <button wire:click="expandGap({{ count($hunks) }})" wire:loading.attr="disabled" wire:target="expandGap" class="text-gh-link hover:underline disabled:opacity-50">{{ $trailingHiddenCount }}</button>
+                                        <span class="text-gh-muted">hidden lines</span>
+                                    </span>
+                                    <span wire:loading wire:target="expandGap" class="inline-flex items-center gap-1">
+                                        <flux:icon icon="arrow-path" variant="outline" class="animate-spin" />
+                                        Expanding...
+                                    </span>
+                                @endif
                             </td>
                         </tr>
                     @endif

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Actions\ExpandDiffGapAction;
 use App\Actions\GetFileCopyContentAction;
 use App\Actions\LoadFileDiffAction;
 use App\DTOs\DiffTarget;
@@ -106,48 +107,11 @@ new class extends Component {
             return;
         }
 
-        $hunks = $this->diffData['hunks'];
-
-        // Determine the new-line range for this gap
-        $isTrailing = $hunkIndex === count($hunks);
-
-        if ($isTrailing) {
-            $last = $hunks[count($hunks) - 1];
-            $gapNewStart = $last['newStart'] + $last['newCount'];
-            $gapNewEnd = $this->diffData['newFileLineCount'] ?? $gapNewStart;
-        } elseif ($hunkIndex === 0) {
-            $gapNewStart = 1;
-            $gapNewEnd = $hunks[0]['newStart'] - 1;
-        } else {
-            $prev = $hunks[$hunkIndex - 1];
-            $gapNewStart = $prev['newStart'] + $prev['newCount'];
-            $gapNewEnd = $hunks[$hunkIndex]['newStart'] - 1;
-        }
-
-        if ($gapNewStart > $gapNewEnd) {
-            return;
-        }
-
-        // Narrow range for partial expansion
-        $totalGapSize = $gapNewEnd - $gapNewStart + 1;
-        $isPartial = $lineCount !== null && $lineCount < $totalGapSize;
-
-        if ($isPartial) {
-            if ($hunkIndex === 0) {
-                // Leading: expand bottom of gap (closest to first hunk)
-                $gapNewStart = $gapNewEnd - $lineCount + 1;
-            } else {
-                // Middle or trailing: expand top of gap (closest to prev/last hunk)
-                $gapNewEnd = $gapNewStart + $lineCount - 1;
-            }
-        }
-
-        // Fetch full-context diff (cached so sequential partial expansions reuse it)
         $fullDiff = app(LoadFileDiffAction::class)->handle(
             $this->repoPath,
             $this->file['path'],
             $this->file['isUntracked'] ?? false,
-            cacheKey: $this->diffCacheKey().':full-context',
+            cacheKey: $this->diffCacheKey(':full-context'),
             contextLines: 99999,
             target: $this->buildDiffTarget(),
         );
@@ -156,70 +120,18 @@ new class extends Component {
             return;
         }
 
-        // Extract gap lines from the full diff's single hunk by newLineNum
-        $gapLines = collect($fullDiff['hunks'][0]['lines'])
-            ->filter(function (array $line) use ($gapNewStart, $gapNewEnd): bool {
-                $num = $line['newLineNum'] ?? null;
+        $this->diffData['hunks'] = app(ExpandDiffGapAction::class)->handle(
+            hunks: $this->diffData['hunks'],
+            hunkIndex: $hunkIndex,
+            fullDiffLines: $fullDiff['hunks'][0]['lines'],
+            lineCount: $lineCount,
+            newFileLineCount: $this->diffData['newFileLineCount'] ?? null,
+        );
 
-                return $num !== null
-                    && $num >= $gapNewStart
-                    && $num <= $gapNewEnd
-                    && $line['type'] === 'context';
-            })
-            ->values()
-            ->all();
-
-        if (empty($gapLines)) {
-            return;
-        }
-
-        $gapSize = count($gapLines);
-
-        if ($isTrailing) {
-            // Append gap lines to last hunk
-            $lastIdx = count($hunks) - 1;
-            $hunks[$lastIdx]['lines'] = array_merge($hunks[$lastIdx]['lines'], $gapLines);
-            $hunks[$lastIdx]['oldCount'] += $gapSize;
-            $hunks[$lastIdx]['newCount'] += $gapSize;
-        } elseif ($hunkIndex === 0) {
-            // Prepend gap lines to first hunk
-            $hunks[0]['lines'] = array_merge($gapLines, $hunks[0]['lines']);
-            $hunks[0]['oldStart'] -= $gapSize;
-            $hunks[0]['oldCount'] += $gapSize;
-            $hunks[0]['newStart'] -= $gapSize;
-            $hunks[0]['newCount'] += $gapSize;
-        } else {
-            if ($isPartial) {
-                // Partial: append to prev hunk only, leave curr hunk for remaining gap
-                $hunks[$hunkIndex - 1]['lines'] = array_merge($hunks[$hunkIndex - 1]['lines'], $gapLines);
-                $hunks[$hunkIndex - 1]['oldCount'] += $gapSize;
-                $hunks[$hunkIndex - 1]['newCount'] += $gapSize;
-            } else {
-                // Full: merge prevHunk + gapLines + currentHunk -> single hunk
-                $prev = $hunks[$hunkIndex - 1];
-                $curr = $hunks[$hunkIndex];
-
-                $merged = [
-                    'header' => $prev['header'],
-                    'oldStart' => $prev['oldStart'],
-                    'oldCount' => $prev['oldCount'] + $gapSize + $curr['oldCount'],
-                    'newStart' => $prev['newStart'],
-                    'newCount' => $prev['newCount'] + $gapSize + $curr['newCount'],
-                    'lines' => array_merge($prev['lines'], $gapLines, $curr['lines']),
-                ];
-
-                array_splice($hunks, $hunkIndex - 1, 2, [$merged]);
-            }
-        }
-
-        $this->diffData['hunks'] = $hunks;
-
-        // Merge syntax styles from the full diff
         if (! empty($fullDiff['syntaxStyles'])) {
             $this->diffData['syntaxStyles'] = ($this->diffData['syntaxStyles'] ?? '').$fullDiff['syntaxStyles'];
         }
 
-        // Update cache with expanded state
         Cache::put($this->diffCacheKey(), $this->diffData, now()->addHours($this->buildDiffTarget()->cacheTtlHours()));
     }
 
@@ -278,11 +190,11 @@ new class extends Component {
         return $this->cachedTarget ??= DiffTarget::fromRefs($this->diffFrom, $this->diffTo);
     }
 
-    private function diffCacheKey(): string
+    private function diffCacheKey(string $variant = ''): string
     {
         $projectKey = $this->projectId > 0 ? $this->projectId : $this->repoPath;
 
-        return DiffCacheKey::for($projectKey, $this->file['id'], $this->buildDiffTarget()->contextKey());
+        return DiffCacheKey::for($projectKey, $this->file['id'], $this->buildDiffTarget()->contextKey().$variant);
     }
 
     public function render(): \Illuminate\Contracts\View\View
@@ -545,7 +457,6 @@ new class extends Component {
                 $hasTrailingGap = $newFileLineCount !== null && $lastHunkEnd < $newFileLineCount;
                 $trailingHiddenCount = $hasTrailingGap ? $newFileLineCount - $lastHunkEnd : 0;
                 $hasGaps = count($hunks) > 1 || (count($hunks) === 1 && $hunks[0]['newStart'] > 1) || $hasTrailingGap;
-                $expandTiers = [15, 50, 100];
             @endphp
             @if($diffData['syntaxStyles'] ?? '')
                 {!! '<style>' . $diffData['syntaxStyles'] . '</style>' !!}
@@ -578,10 +489,10 @@ new class extends Component {
                                             $prevHunk = $hunks[$hunkIndex - 1];
                                             $hiddenCount = $hunk['newStart'] - ($prevHunk['newStart'] + $prevHunk['newCount']);
                                         @endphp
-                                        <x-tiered-expand-gap :hunk-index="$hunkIndex" :hidden-count="$hiddenCount" :expand-tiers="$expandTiers" />
+                                        <x-tiered-expand-gap :hunk-index="$hunkIndex" :hidden-count="$hiddenCount" />
                                     @else
                                         @php $hiddenCount = $hunk['newStart'] - 1; @endphp
-                                        <x-tiered-expand-gap :hunk-index="0" :hidden-count="$hiddenCount" :expand-tiers="$expandTiers" />
+                                        <x-tiered-expand-gap :hunk-index="0" :hidden-count="$hiddenCount" />
                                     @endif
                                 </td>
                             </tr>
@@ -678,7 +589,7 @@ new class extends Component {
                     @if($hasTrailingGap)
                         <tr class="bg-gh-hunk-bg">
                             <td colspan="4" class="py-1.5 text-center text-xs border-y border-dashed border-gh-border/20">
-                                <x-tiered-expand-gap :hunk-index="count($hunks)" :hidden-count="$trailingHiddenCount" :expand-tiers="$expandTiers" />
+                                <x-tiered-expand-gap :hunk-index="count($hunks)" :hidden-count="$trailingHiddenCount" />
                             </td>
                         </tr>
                     @endif

--- a/tests/Unit/Actions/ExpandDiffGapActionTest.php
+++ b/tests/Unit/Actions/ExpandDiffGapActionTest.php
@@ -1,0 +1,146 @@
+<?php
+
+use App\Actions\ExpandDiffGapAction;
+use App\Console\Benchmark\DiffFixtureFactory;
+
+function buildFullContextLines(int $totalLines): array
+{
+    $lines = [];
+    for ($i = 1; $i <= $totalLines; $i++) {
+        $lines[] = [
+            'type' => 'context',
+            'content' => "    // line {$i}",
+            'oldLineNum' => $i,
+            'newLineNum' => $i,
+            'highlightedContent' => "// line {$i}",
+        ];
+    }
+
+    return $lines;
+}
+
+// -- Partial middle gap --
+
+test('partial middle gap expansion preserves separate hunks', function () {
+    // 2-hunk fixture: hunk 0 (lines 1-8), hunk 1 (lines 29-36), gap = 20 lines (9-28)
+    $diffData = DiffFixtureFactory::diffData(hunks: 2, path: 'src/Test.php');
+    $fullDiffLines = buildFullContextLines(36);
+
+    $result = app(ExpandDiffGapAction::class)->handle(
+        hunks: $diffData['hunks'],
+        hunkIndex: 1,
+        fullDiffLines: $fullDiffLines,
+        lineCount: 15,
+    );
+
+    expect($result)->toHaveCount(2);
+    expect($result[0]['newCount'])->toBe($diffData['hunks'][0]['newCount'] + 15);
+
+    $remainingGap = $result[1]['newStart'] - ($result[0]['newStart'] + $result[0]['newCount']);
+    expect($remainingGap)->toBe(5);
+
+    // Lines 9-23 (top of gap) appended to hunk 0
+    $originalLineCount = count($diffData['hunks'][0]['lines']);
+    expect($result[0]['lines'][$originalLineCount]['newLineNum'])->toBe(9);
+    expect($result[0]['lines'][$originalLineCount + 14]['newLineNum'])->toBe(23);
+});
+
+// -- Full middle gap --
+
+test('full middle gap expansion merges hunks into one', function () {
+    $diffData = DiffFixtureFactory::diffData(hunks: 2, path: 'src/Test.php');
+    $fullDiffLines = buildFullContextLines(36);
+
+    $result = app(ExpandDiffGapAction::class)->handle(
+        hunks: $diffData['hunks'],
+        hunkIndex: 1,
+        fullDiffLines: $fullDiffLines,
+    );
+
+    expect($result)->toHaveCount(1);
+
+    $newLineNums = array_column($result[0]['lines'], 'newLineNum');
+    foreach (range(9, 28) as $expected) {
+        expect($newLineNums)->toContain($expected);
+    }
+});
+
+// -- Partial leading gap --
+
+test('partial leading gap expansion shrinks the gap', function () {
+    // Hunk starts at line 25, so 24-line leading gap
+    $diffData = DiffFixtureFactory::diffData(hunks: 1, path: 'src/Test.php');
+    $diffData['hunks'][0]['newStart'] = 25;
+    $diffData['hunks'][0]['oldStart'] = 25;
+
+    $fullDiffLines = buildFullContextLines(40);
+
+    $result = app(ExpandDiffGapAction::class)->handle(
+        hunks: $diffData['hunks'],
+        hunkIndex: 0,
+        fullDiffLines: $fullDiffLines,
+        lineCount: 15,
+    );
+
+    expect($result[0]['newStart'])->toBe(10)
+        ->and($result[0]['newCount'])->toBe($diffData['hunks'][0]['newCount'] + 15);
+
+    // Lines 10-24 (bottom of gap, closest to hunk) prepended
+    expect($result[0]['lines'][0]['newLineNum'])->toBe(10);
+    expect($result[0]['lines'][14]['newLineNum'])->toBe(24);
+});
+
+// -- Partial trailing gap --
+
+test('partial trailing gap expansion appends to last hunk', function () {
+    $diffData = DiffFixtureFactory::diffData(hunks: 1, path: 'src/Test.php');
+    $diffData['newFileLineCount'] = 50;
+
+    $fullDiffLines = buildFullContextLines(50);
+    $originalNewCount = $diffData['hunks'][0]['newCount'];
+
+    $result = app(ExpandDiffGapAction::class)->handle(
+        hunks: $diffData['hunks'],
+        hunkIndex: 1,
+        fullDiffLines: $fullDiffLines,
+        lineCount: 15,
+        newFileLineCount: 50,
+    );
+
+    expect($result[0]['newCount'])->toBe($originalNewCount + 15);
+
+    $remainingGap = 50 - ($result[0]['newStart'] + $result[0]['newCount'] - 1);
+    expect($remainingGap)->toBe(27);
+
+    // Lines 9-23 (top of gap) appended
+    $originalLineCount = count($diffData['hunks'][0]['lines']);
+    expect($result[0]['lines'][$originalLineCount]['newLineNum'])->toBe(9);
+    expect($result[0]['lines'][$originalLineCount + 14]['newLineNum'])->toBe(23);
+});
+
+// -- Edge cases --
+
+test('returns hunks unchanged when gap is empty', function () {
+    $diffData = DiffFixtureFactory::diffData(hunks: 1, path: 'src/Test.php');
+    $diffData['hunks'][0]['newStart'] = 1; // No leading gap
+
+    $result = app(ExpandDiffGapAction::class)->handle(
+        hunks: $diffData['hunks'],
+        hunkIndex: 0,
+        fullDiffLines: buildFullContextLines(10),
+    );
+
+    expect($result)->toBe($diffData['hunks']);
+});
+
+test('returns hunks unchanged when full diff has no matching lines', function () {
+    $diffData = DiffFixtureFactory::diffData(hunks: 2, path: 'src/Test.php');
+
+    $result = app(ExpandDiffGapAction::class)->handle(
+        hunks: $diffData['hunks'],
+        hunkIndex: 1,
+        fullDiffLines: [], // empty
+    );
+
+    expect($result)->toBe($diffData['hunks']);
+});

--- a/tests/Unit/Livewire/DiffFileTest.php
+++ b/tests/Unit/Livewire/DiffFileTest.php
@@ -305,6 +305,30 @@ function mountMultiHunkDiffFile(array $diffData, array $file, ?array $fullDiff =
     return $component;
 }
 
+function buildContextHunk(int $startLine, int $lineCount = 3): array
+{
+    $lines = [];
+    for ($i = 0; $i < $lineCount; $i++) {
+        $lineNum = $startLine + $i;
+        $lines[] = [
+            'type' => 'context',
+            'content' => "// line {$lineNum}",
+            'oldLineNum' => $lineNum,
+            'newLineNum' => $lineNum,
+            'highlightedContent' => "// line {$lineNum}",
+        ];
+    }
+
+    return [
+        'header' => '@@ hunk @@',
+        'oldStart' => $startLine,
+        'oldCount' => $lineCount,
+        'newStart' => $startLine,
+        'newCount' => $lineCount,
+        'lines' => $lines,
+    ];
+}
+
 test('tiered expand buttons render for middle gap larger than 15 lines', function () {
     // 2-hunk fixture has a 20-line gap between hunks (lines 9-28)
     $diffData = DiffFixtureFactory::diffData(hunks: 2, path: 'src/Test.php');
@@ -320,30 +344,12 @@ test('tiered expand buttons render for middle gap larger than 15 lines', functio
 });
 
 test('single expand button renders for gap of 15 or fewer lines', function () {
-    // Build a custom 2-hunk diff with a 10-line gap
     $diffData = DiffFixtureFactory::diffData(hunks: 1, path: 'src/Test.php');
     $hunk0 = $diffData['hunks'][0];
-
-    // Create second hunk starting 10 lines after the first
-    $hunk1Start = $hunk0['newStart'] + $hunk0['newCount'] + 10;
-    $hunk1 = [
-        'header' => '@@ hunk2 @@',
-        'oldStart' => $hunk1Start,
-        'oldCount' => 3,
-        'newStart' => $hunk1Start,
-        'newCount' => 3,
-        'lines' => [
-            ['type' => 'context', 'content' => '// a', 'oldLineNum' => $hunk1Start, 'newLineNum' => $hunk1Start, 'highlightedContent' => '// a'],
-            ['type' => 'context', 'content' => '// b', 'oldLineNum' => $hunk1Start + 1, 'newLineNum' => $hunk1Start + 1, 'highlightedContent' => '// b'],
-            ['type' => 'context', 'content' => '// c', 'oldLineNum' => $hunk1Start + 2, 'newLineNum' => $hunk1Start + 2, 'highlightedContent' => '// c'],
-        ],
-    ];
-
-    $diffData['hunks'][] = $hunk1;
+    $diffData['hunks'][] = buildContextHunk($hunk0['newStart'] + $hunk0['newCount'] + 10);
 
     $html = mountMultiHunkDiffFile($diffData, $this->file)->html();
 
-    // Should show single button, no tiered expand
     expect($html)->toContain('Expand 10 hidden lines')
         ->and($html)->not->toContain('expandGap(1, 15)');
 });
@@ -376,6 +382,41 @@ test('tiered expand buttons render for trailing gap larger than 15 lines', funct
         ->and($html)->toContain('hidden lines');
 });
 
+test('exactly 15-line gap shows single expand button with no tiers', function () {
+    $diffData = DiffFixtureFactory::diffData(hunks: 1, path: 'src/Test.php');
+    $hunk0 = $diffData['hunks'][0];
+    $diffData['hunks'][] = buildContextHunk($hunk0['newStart'] + $hunk0['newCount'] + 15);
+
+    $html = mountMultiHunkDiffFile($diffData, $this->file)->html();
+
+    expect($html)->toContain('Expand 15 hidden lines')
+        ->and($html)->not->toContain('expandGap(1, 15)');
+});
+
+test('16-line gap shows first tier', function () {
+    $diffData = DiffFixtureFactory::diffData(hunks: 1, path: 'src/Test.php');
+    $hunk0 = $diffData['hunks'][0];
+    $diffData['hunks'][] = buildContextHunk($hunk0['newStart'] + $hunk0['newCount'] + 16);
+
+    $html = mountMultiHunkDiffFile($diffData, $this->file)->html();
+
+    expect($html)->toContain('expandGap(1, 15)')
+        ->and($html)->toContain('expandGap(1)')
+        ->and($html)->toContain('16')
+        ->and($html)->toContain('hidden lines');
+});
+
+test('1-line gap shows single expand button', function () {
+    $diffData = DiffFixtureFactory::diffData(hunks: 1, path: 'src/Test.php');
+    $hunk0 = $diffData['hunks'][0];
+    $diffData['hunks'][] = buildContextHunk($hunk0['newStart'] + $hunk0['newCount'] + 1);
+
+    $html = mountMultiHunkDiffFile($diffData, $this->file)->html();
+
+    expect($html)->toContain('Expand 1 hidden lines')
+        ->and($html)->not->toContain('&middot;');
+});
+
 test('partial middle gap expansion preserves separate hunks', function () {
     $diffData = DiffFixtureFactory::diffData(hunks: 2, path: 'src/Test.php');
     $fullDiff = buildFullContextDiff(36, 'src/Test.php');
@@ -389,13 +430,14 @@ test('partial middle gap expansion preserves separate hunks', function () {
     $instance->expandGap(1, 15);
 
     $result = $ref->getValue($instance);
-    // Should still have 2 hunks (not merged)
     expect($result['hunks'])->toHaveCount(2);
-    // Previous hunk should have grown by 15
     expect($result['hunks'][0]['newCount'])->toBe($diffData['hunks'][0]['newCount'] + 15);
-    // Remaining gap should be 5 lines
     $remainingGap = $result['hunks'][1]['newStart'] - ($result['hunks'][0]['newStart'] + $result['hunks'][0]['newCount']);
     expect($remainingGap)->toBe(5);
+    // Lines 9-23 (top of gap) appended to hunk 0
+    $originalLineCount = count($diffData['hunks'][0]['lines']);
+    expect($result['hunks'][0]['lines'][$originalLineCount]['newLineNum'])->toBe(9);
+    expect($result['hunks'][0]['lines'][$originalLineCount + 14]['newLineNum'])->toBe(23);
 });
 
 test('full middle gap expansion merges hunks into one', function () {
@@ -407,11 +449,14 @@ test('full middle gap expansion merges hunks into one', function () {
     $ref = new ReflectionProperty($instance, 'diffData');
     $ref->setValue($instance, $diffData);
 
-    // Expand all (no lineCount) - should merge hunks
     $instance->expandGap(1);
 
     $result = $ref->getValue($instance);
     expect($result['hunks'])->toHaveCount(1);
+    $newLineNums = array_column($result['hunks'][0]['lines'], 'newLineNum');
+    foreach (range(9, 28) as $expected) {
+        expect($newLineNums)->toContain($expected);
+    }
 });
 
 test('partial leading gap expansion shrinks the gap', function () {
@@ -427,13 +472,14 @@ test('partial leading gap expansion shrinks the gap', function () {
     $ref = new ReflectionProperty($instance, 'diffData');
     $ref->setValue($instance, $diffData);
 
-    // Expand 15 of the 24-line leading gap
     $instance->expandGap(0, 15);
 
     $result = $ref->getValue($instance);
-    // newStart should decrease by 15: 25 - 15 = 10
     expect($result['hunks'][0]['newStart'])->toBe(10)
         ->and($result['hunks'][0]['newCount'])->toBe($diffData['hunks'][0]['newCount'] + 15);
+    // Lines 10-24 (bottom of gap, closest to hunk) prepended
+    expect($result['hunks'][0]['lines'][0]['newLineNum'])->toBe(10);
+    expect($result['hunks'][0]['lines'][14]['newLineNum'])->toBe(24);
 });
 
 test('partial trailing gap expansion appends to last hunk', function () {
@@ -449,14 +495,15 @@ test('partial trailing gap expansion appends to last hunk', function () {
 
     $originalNewCount = $diffData['hunks'][0]['newCount'];
 
-    // Hunk covers lines 1-8, trailing gap is 42 lines. Expand 15.
     $instance->expandGap(1, 15);
 
     $result = $ref->getValue($instance);
-    // Last hunk should have grown by 15 lines
     expect($result['hunks'][0]['newCount'])->toBe($originalNewCount + 15);
-    // Remaining trailing gap: 50 - (8 + 15) = 27 lines
     $lastHunk = $result['hunks'][0];
     $remainingGap = $result['newFileLineCount'] - ($lastHunk['newStart'] + $lastHunk['newCount'] - 1);
     expect($remainingGap)->toBe(27);
+    // Lines 9-23 (top of gap) appended
+    $originalLineCount = count($diffData['hunks'][0]['lines']);
+    expect($result['hunks'][0]['lines'][$originalLineCount]['newLineNum'])->toBe(9);
+    expect($result['hunks'][0]['lines'][$originalLineCount + 14]['newLineNum'])->toBe(23);
 });

--- a/tests/Unit/Livewire/DiffFileTest.php
+++ b/tests/Unit/Livewire/DiffFileTest.php
@@ -245,51 +245,15 @@ test('context lines have both data-line-new and data-line-old', function () {
 
 // -- Tiered expand buttons --
 
-function buildFullContextDiff(int $totalLines, string $path = 'src/Test.php'): array
+function mountMultiHunkDiffFile(array $diffData, array $file): Testable
 {
-    $lines = [];
-    for ($i = 1; $i <= $totalLines; $i++) {
-        $lines[] = [
-            'type' => 'context',
-            'content' => "    // line {$i}",
-            'oldLineNum' => $i,
-            'newLineNum' => $i,
-            'highlightedContent' => "// line {$i}",
-        ];
-    }
-
-    return [
-        'path' => $path,
-        'status' => 'modified',
-        'oldPath' => null,
-        'hunks' => [[
-            'header' => '',
-            'oldStart' => 1,
-            'oldCount' => $totalLines,
-            'newStart' => 1,
-            'newCount' => $totalLines,
-            'lines' => $lines,
-        ]],
-        'additions' => 0,
-        'deletions' => 0,
-        'isBinary' => false,
-        'tooLarge' => false,
-        'syntaxStyles' => '',
-    ];
-}
-
-function mountMultiHunkDiffFile(array $diffData, array $file, ?array $fullDiff = null): Testable
-{
-    // Rebind mock to return the specific diff data (and optionally a full diff for expandGap)
-    app()->bind(LoadFileDiffAction::class, fn () => new class($diffData, $fullDiff)
+    app()->bind(LoadFileDiffAction::class, fn () => new class($diffData)
     {
-        public function __construct(private array $diffData, private ?array $fullDiff) {}
+        public function __construct(private array $diffData) {}
 
         public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, int $contextLines = 3, ?DiffTarget $target = null): array
         {
-            return ($contextLines >= 99999 && $this->fullDiff !== null)
-                ? $this->fullDiff
-                : $this->diffData;
+            return $this->diffData;
         }
     });
 
@@ -335,10 +299,9 @@ test('tiered expand buttons render for middle gap larger than 15 lines', functio
 
     $html = mountMultiHunkDiffFile($diffData, $this->file)->html();
 
-    // Should show tiered buttons: "Expand 15 · 20 hidden lines"
+    // Should show tiered buttons: "Expand 15  20 hidden lines"
     expect($html)->toContain('expandGap(1, 15)')
         ->and($html)->toContain('expandGap(1)')
-        ->and($html)->toContain('&middot;')
         ->and($html)->toContain('20')
         ->and($html)->toContain('hidden lines');
 });
@@ -415,95 +378,4 @@ test('1-line gap shows single expand button', function () {
 
     expect($html)->toContain('Expand 1 hidden lines')
         ->and($html)->not->toContain('&middot;');
-});
-
-test('partial middle gap expansion preserves separate hunks', function () {
-    $diffData = DiffFixtureFactory::diffData(hunks: 2, path: 'src/Test.php');
-    $fullDiff = buildFullContextDiff(36, 'src/Test.php');
-
-    $component = mountMultiHunkDiffFile($diffData, $this->file, $fullDiff);
-    $instance = $component->instance();
-    $ref = new ReflectionProperty($instance, 'diffData');
-    $ref->setValue($instance, $diffData);
-
-    // Expand 15 of the 20-line gap between hunks
-    $instance->expandGap(1, 15);
-
-    $result = $ref->getValue($instance);
-    expect($result['hunks'])->toHaveCount(2);
-    expect($result['hunks'][0]['newCount'])->toBe($diffData['hunks'][0]['newCount'] + 15);
-    $remainingGap = $result['hunks'][1]['newStart'] - ($result['hunks'][0]['newStart'] + $result['hunks'][0]['newCount']);
-    expect($remainingGap)->toBe(5);
-    // Lines 9-23 (top of gap) appended to hunk 0
-    $originalLineCount = count($diffData['hunks'][0]['lines']);
-    expect($result['hunks'][0]['lines'][$originalLineCount]['newLineNum'])->toBe(9);
-    expect($result['hunks'][0]['lines'][$originalLineCount + 14]['newLineNum'])->toBe(23);
-});
-
-test('full middle gap expansion merges hunks into one', function () {
-    $diffData = DiffFixtureFactory::diffData(hunks: 2, path: 'src/Test.php');
-    $fullDiff = buildFullContextDiff(36, 'src/Test.php');
-
-    $component = mountMultiHunkDiffFile($diffData, $this->file, $fullDiff);
-    $instance = $component->instance();
-    $ref = new ReflectionProperty($instance, 'diffData');
-    $ref->setValue($instance, $diffData);
-
-    $instance->expandGap(1);
-
-    $result = $ref->getValue($instance);
-    expect($result['hunks'])->toHaveCount(1);
-    $newLineNums = array_column($result['hunks'][0]['lines'], 'newLineNum');
-    foreach (range(9, 28) as $expected) {
-        expect($newLineNums)->toContain($expected);
-    }
-});
-
-test('partial leading gap expansion shrinks the gap', function () {
-    // Hunk starts at line 25, so 24-line leading gap
-    $diffData = DiffFixtureFactory::diffData(hunks: 1, path: 'src/Test.php');
-    $diffData['hunks'][0]['newStart'] = 25;
-    $diffData['hunks'][0]['oldStart'] = 25;
-
-    $fullDiff = buildFullContextDiff(40, 'src/Test.php');
-
-    $component = mountMultiHunkDiffFile($diffData, $this->file, $fullDiff);
-    $instance = $component->instance();
-    $ref = new ReflectionProperty($instance, 'diffData');
-    $ref->setValue($instance, $diffData);
-
-    $instance->expandGap(0, 15);
-
-    $result = $ref->getValue($instance);
-    expect($result['hunks'][0]['newStart'])->toBe(10)
-        ->and($result['hunks'][0]['newCount'])->toBe($diffData['hunks'][0]['newCount'] + 15);
-    // Lines 10-24 (bottom of gap, closest to hunk) prepended
-    expect($result['hunks'][0]['lines'][0]['newLineNum'])->toBe(10);
-    expect($result['hunks'][0]['lines'][14]['newLineNum'])->toBe(24);
-});
-
-test('partial trailing gap expansion appends to last hunk', function () {
-    $diffData = DiffFixtureFactory::diffData(hunks: 1, path: 'src/Test.php');
-    $diffData['newFileLineCount'] = 50;
-
-    $fullDiff = buildFullContextDiff(50, 'src/Test.php');
-
-    $component = mountMultiHunkDiffFile($diffData, $this->file, $fullDiff);
-    $instance = $component->instance();
-    $ref = new ReflectionProperty($instance, 'diffData');
-    $ref->setValue($instance, $diffData);
-
-    $originalNewCount = $diffData['hunks'][0]['newCount'];
-
-    $instance->expandGap(1, 15);
-
-    $result = $ref->getValue($instance);
-    expect($result['hunks'][0]['newCount'])->toBe($originalNewCount + 15);
-    $lastHunk = $result['hunks'][0];
-    $remainingGap = $result['newFileLineCount'] - ($lastHunk['newStart'] + $lastHunk['newCount'] - 1);
-    expect($remainingGap)->toBe(27);
-    // Lines 9-23 (top of gap) appended
-    $originalLineCount = count($diffData['hunks'][0]['lines']);
-    expect($result['hunks'][0]['lines'][$originalLineCount]['newLineNum'])->toBe(9);
-    expect($result['hunks'][0]['lines'][$originalLineCount + 14]['newLineNum'])->toBe(23);
 });

--- a/tests/Unit/Livewire/DiffFileTest.php
+++ b/tests/Unit/Livewire/DiffFileTest.php
@@ -242,3 +242,221 @@ test('context lines have both data-line-new and data-line-old', function () {
             ->and($row)->toContain('data-line-old="');
     }
 });
+
+// -- Tiered expand buttons --
+
+function buildFullContextDiff(int $totalLines, string $path = 'src/Test.php'): array
+{
+    $lines = [];
+    for ($i = 1; $i <= $totalLines; $i++) {
+        $lines[] = [
+            'type' => 'context',
+            'content' => "    // line {$i}",
+            'oldLineNum' => $i,
+            'newLineNum' => $i,
+            'highlightedContent' => "// line {$i}",
+        ];
+    }
+
+    return [
+        'path' => $path,
+        'status' => 'modified',
+        'oldPath' => null,
+        'hunks' => [[
+            'header' => '',
+            'oldStart' => 1,
+            'oldCount' => $totalLines,
+            'newStart' => 1,
+            'newCount' => $totalLines,
+            'lines' => $lines,
+        ]],
+        'additions' => 0,
+        'deletions' => 0,
+        'isBinary' => false,
+        'tooLarge' => false,
+        'syntaxStyles' => '',
+    ];
+}
+
+function mountMultiHunkDiffFile(array $diffData, array $file, ?array $fullDiff = null): Testable
+{
+    // Rebind mock to return the specific diff data (and optionally a full diff for expandGap)
+    app()->bind(LoadFileDiffAction::class, fn () => new class($diffData, $fullDiff)
+    {
+        public function __construct(private array $diffData, private ?array $fullDiff) {}
+
+        public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, int $contextLines = 3, ?DiffTarget $target = null): array
+        {
+            return ($contextLines >= 99999 && $this->fullDiff !== null)
+                ? $this->fullDiff
+                : $this->diffData;
+        }
+    });
+
+    $component = Livewire::test('diff-file', [
+        'file' => $file,
+        'repoPath' => '/tmp/test',
+        'projectId' => 0,
+        'fileComments' => [],
+    ]);
+
+    $component->call('loadFileDiff');
+
+    return $component;
+}
+
+test('tiered expand buttons render for middle gap larger than 15 lines', function () {
+    // 2-hunk fixture has a 20-line gap between hunks (lines 9-28)
+    $diffData = DiffFixtureFactory::diffData(hunks: 2, path: 'src/Test.php');
+
+    $html = mountMultiHunkDiffFile($diffData, $this->file)->html();
+
+    // Should show tiered buttons: "Expand 15 · 20 hidden lines"
+    expect($html)->toContain('expandGap(1, 15)')
+        ->and($html)->toContain('expandGap(1)')
+        ->and($html)->toContain('&middot;')
+        ->and($html)->toContain('20')
+        ->and($html)->toContain('hidden lines');
+});
+
+test('single expand button renders for gap of 15 or fewer lines', function () {
+    // Build a custom 2-hunk diff with a 10-line gap
+    $diffData = DiffFixtureFactory::diffData(hunks: 1, path: 'src/Test.php');
+    $hunk0 = $diffData['hunks'][0];
+
+    // Create second hunk starting 10 lines after the first
+    $hunk1Start = $hunk0['newStart'] + $hunk0['newCount'] + 10;
+    $hunk1 = [
+        'header' => '@@ hunk2 @@',
+        'oldStart' => $hunk1Start,
+        'oldCount' => 3,
+        'newStart' => $hunk1Start,
+        'newCount' => 3,
+        'lines' => [
+            ['type' => 'context', 'content' => '// a', 'oldLineNum' => $hunk1Start, 'newLineNum' => $hunk1Start, 'highlightedContent' => '// a'],
+            ['type' => 'context', 'content' => '// b', 'oldLineNum' => $hunk1Start + 1, 'newLineNum' => $hunk1Start + 1, 'highlightedContent' => '// b'],
+            ['type' => 'context', 'content' => '// c', 'oldLineNum' => $hunk1Start + 2, 'newLineNum' => $hunk1Start + 2, 'highlightedContent' => '// c'],
+        ],
+    ];
+
+    $diffData['hunks'][] = $hunk1;
+
+    $html = mountMultiHunkDiffFile($diffData, $this->file)->html();
+
+    // Should show single button, no tiered expand
+    expect($html)->toContain('Expand 10 hidden lines')
+        ->and($html)->not->toContain('expandGap(1, 15)');
+});
+
+test('tiered expand buttons render for leading gap larger than 15 lines', function () {
+    // Create a single hunk that starts at line 25 (leading gap of 24 lines)
+    $diffData = DiffFixtureFactory::diffData(hunks: 1, path: 'src/Test.php');
+    $diffData['hunks'][0]['newStart'] = 25;
+    $diffData['hunks'][0]['oldStart'] = 25;
+
+    $html = mountMultiHunkDiffFile($diffData, $this->file)->html();
+
+    // Should show tiered buttons for leading gap: "Expand 15 · 24 hidden lines"
+    expect($html)->toContain('expandGap(0, 15)')
+        ->and($html)->toContain('expandGap(0)')
+        ->and($html)->toContain('24')
+        ->and($html)->toContain('hidden lines');
+});
+
+test('tiered expand buttons render for trailing gap larger than 15 lines', function () {
+    $diffData = DiffFixtureFactory::diffData(hunks: 1, path: 'src/Test.php');
+    // File has 50 lines total, hunk covers lines 1-8, trailing gap is 42 lines
+    $diffData['newFileLineCount'] = 50;
+
+    $html = mountMultiHunkDiffFile($diffData, $this->file)->html();
+
+    // Should show tiered buttons for trailing gap
+    expect($html)->toContain('expandGap(1, 15)')
+        ->and($html)->toContain('expandGap(1)')
+        ->and($html)->toContain('hidden lines');
+});
+
+test('partial middle gap expansion preserves separate hunks', function () {
+    $diffData = DiffFixtureFactory::diffData(hunks: 2, path: 'src/Test.php');
+    $fullDiff = buildFullContextDiff(36, 'src/Test.php');
+
+    $component = mountMultiHunkDiffFile($diffData, $this->file, $fullDiff);
+    $instance = $component->instance();
+    $ref = new ReflectionProperty($instance, 'diffData');
+    $ref->setValue($instance, $diffData);
+
+    // Expand 15 of the 20-line gap between hunks
+    $instance->expandGap(1, 15);
+
+    $result = $ref->getValue($instance);
+    // Should still have 2 hunks (not merged)
+    expect($result['hunks'])->toHaveCount(2);
+    // Previous hunk should have grown by 15
+    expect($result['hunks'][0]['newCount'])->toBe($diffData['hunks'][0]['newCount'] + 15);
+    // Remaining gap should be 5 lines
+    $remainingGap = $result['hunks'][1]['newStart'] - ($result['hunks'][0]['newStart'] + $result['hunks'][0]['newCount']);
+    expect($remainingGap)->toBe(5);
+});
+
+test('full middle gap expansion merges hunks into one', function () {
+    $diffData = DiffFixtureFactory::diffData(hunks: 2, path: 'src/Test.php');
+    $fullDiff = buildFullContextDiff(36, 'src/Test.php');
+
+    $component = mountMultiHunkDiffFile($diffData, $this->file, $fullDiff);
+    $instance = $component->instance();
+    $ref = new ReflectionProperty($instance, 'diffData');
+    $ref->setValue($instance, $diffData);
+
+    // Expand all (no lineCount) - should merge hunks
+    $instance->expandGap(1);
+
+    $result = $ref->getValue($instance);
+    expect($result['hunks'])->toHaveCount(1);
+});
+
+test('partial leading gap expansion shrinks the gap', function () {
+    // Hunk starts at line 25, so 24-line leading gap
+    $diffData = DiffFixtureFactory::diffData(hunks: 1, path: 'src/Test.php');
+    $diffData['hunks'][0]['newStart'] = 25;
+    $diffData['hunks'][0]['oldStart'] = 25;
+
+    $fullDiff = buildFullContextDiff(40, 'src/Test.php');
+
+    $component = mountMultiHunkDiffFile($diffData, $this->file, $fullDiff);
+    $instance = $component->instance();
+    $ref = new ReflectionProperty($instance, 'diffData');
+    $ref->setValue($instance, $diffData);
+
+    // Expand 15 of the 24-line leading gap
+    $instance->expandGap(0, 15);
+
+    $result = $ref->getValue($instance);
+    // newStart should decrease by 15: 25 - 15 = 10
+    expect($result['hunks'][0]['newStart'])->toBe(10)
+        ->and($result['hunks'][0]['newCount'])->toBe($diffData['hunks'][0]['newCount'] + 15);
+});
+
+test('partial trailing gap expansion appends to last hunk', function () {
+    $diffData = DiffFixtureFactory::diffData(hunks: 1, path: 'src/Test.php');
+    $diffData['newFileLineCount'] = 50;
+
+    $fullDiff = buildFullContextDiff(50, 'src/Test.php');
+
+    $component = mountMultiHunkDiffFile($diffData, $this->file, $fullDiff);
+    $instance = $component->instance();
+    $ref = new ReflectionProperty($instance, 'diffData');
+    $ref->setValue($instance, $diffData);
+
+    $originalNewCount = $diffData['hunks'][0]['newCount'];
+
+    // Hunk covers lines 1-8, trailing gap is 42 lines. Expand 15.
+    $instance->expandGap(1, 15);
+
+    $result = $ref->getValue($instance);
+    // Last hunk should have grown by 15 lines
+    expect($result['hunks'][0]['newCount'])->toBe($originalNewCount + 15);
+    // Remaining trailing gap: 50 - (8 + 15) = 27 lines
+    $lastHunk = $result['hunks'][0];
+    $remainingGap = $result['newFileLineCount'] - ($lastHunk['newStart'] + $lastHunk['newCount'] - 1);
+    expect($remainingGap)->toBe(27);
+});


### PR DESCRIPTION
Instead of a single "Expand N hidden lines" button, show increasingly
larger expand options (e.g., "Expand 15 · 50 · 100 · 482 hidden lines")
when a gap exceeds 15 lines. For small gaps (<=15), the single button
is preserved. Partial expansion works for leading, middle, and trailing
gaps by expanding lines closest to the already-visible code.

https://claude.ai/code/session_01QbYD73GsB7RkHXxshJqhiL