### PR TITLE
Add "Hide reviewed" filter and rename Viewed to Reviewed

### DIFF
--- a/app/Actions/RestoreSessionAction.php
+++ b/app/Actions/RestoreSessionAction.php
@@ -17,7 +17,7 @@ final readonly class RestoreSessionAction
 
     /**
      * @param  array<int, array<string, mixed>>  $currentFiles
-     * @return array{comments: array<int, array<string, mixed>>, viewedFiles: array<string, string>, globalComment: string, orphanedPaths: array<int, string>}
+     * @return array{comments: array<int, array<string, mixed>>, reviewedFiles: array<string, string>, globalComment: string, orphanedPaths: array<int, string>}
      */
     public function handle(string $repoPath, array $currentFiles, ?int $projectId = null, string $contextFingerprint = DiffTarget::WORKING_CONTEXT, ?DiffTarget $target = null): array
     {
@@ -33,29 +33,29 @@ final readonly class RestoreSessionAction
             $currentPathSet[$f['path']] = true;
         }
 
-        // Restore viewed files
+        // Restore reviewed files
         /** @var array<int|string, string> $rawViewed */
         $rawViewed = $session->viewed_files ?? [];
         $isImmutable = $target !== null && $target->isImmutable();
 
         // Legacy compat: convert indexed array to associative with fresh fingerprints
         if ($rawViewed !== [] && array_is_list($rawViewed)) {
-            $viewedFiles = [];
+            $reviewedFiles = [];
             foreach ($rawViewed as $path) {
                 if (isset($currentPathSet[$path])) {
-                    $viewedFiles[$path] = $isImmutable ? '' : $this->gitDiffService->fileDiffFingerprint($repoPath, $path, $target);
+                    $reviewedFiles[$path] = $isImmutable ? '' : $this->gitDiffService->fileDiffFingerprint($repoPath, $path, $target);
                 }
             }
         } else {
-            /** @var array<string, string> $viewedFiles */
-            $viewedFiles = array_intersect_key($rawViewed, $currentPathSet);
+            /** @var array<string, string> $reviewedFiles */
+            $reviewedFiles = array_intersect_key($rawViewed, $currentPathSet);
 
             // Fingerprint validation (skip for immutable targets)
             if (! $isImmutable) {
-                foreach ($viewedFiles as $path => $storedHash) {
+                foreach ($reviewedFiles as $path => $storedHash) {
                     $currentHash = $this->gitDiffService->fileDiffFingerprint($repoPath, $path, $target);
                     if ($storedHash !== '' && $currentHash !== '' && $storedHash !== $currentHash) {
-                        unset($viewedFiles[$path]);
+                        unset($reviewedFiles[$path]);
                     }
                 }
             }
@@ -87,7 +87,7 @@ final readonly class RestoreSessionAction
 
         return [
             'comments' => $comments,
-            'viewedFiles' => $viewedFiles,
+            'reviewedFiles' => $reviewedFiles,
             'globalComment' => $session->global_comment ?? '',
             'orphanedPaths' => $orphanedPaths,
         ];

--- a/app/Actions/RestoreSessionAction.php
+++ b/app/Actions/RestoreSessionAction.php
@@ -33,7 +33,6 @@ final readonly class RestoreSessionAction
             $currentPathSet[$f['path']] = true;
         }
 
-        // Restore reviewed files
         /** @var array<int|string, string> $rawViewed */
         $rawViewed = $session->viewed_files ?? [];
         $isImmutable = $target !== null && $target->isImmutable();

--- a/app/Actions/SaveSessionAction.php
+++ b/app/Actions/SaveSessionAction.php
@@ -11,15 +11,15 @@ final readonly class SaveSessionAction
 {
     /**
      * @param  array<int, array<string, mixed>>  $comments
-     * @param  array<string, string>  $viewedFiles
+     * @param  array<string, string>  $reviewedFiles
      */
-    public function handle(string $repoPath, array $comments, array $viewedFiles, string $globalComment, ?int $projectId = null, string $contextFingerprint = DiffTarget::WORKING_CONTEXT): void
+    public function handle(string $repoPath, array $comments, array $reviewedFiles, string $globalComment, ?int $projectId = null, string $contextFingerprint = DiffTarget::WORKING_CONTEXT): void
     {
         ReviewSession::updateOrCreate(
             ReviewSession::lookupKey($repoPath, $projectId, $contextFingerprint),
             [
                 'repo_path' => $repoPath,
-                'viewed_files' => $viewedFiles,
+                'viewed_files' => $reviewedFiles,
                 'comments' => $comments,
                 'global_comment' => $globalComment,
             ]

--- a/app/Actions/ToggleViewedAction.php
+++ b/app/Actions/ToggleViewedAction.php
@@ -14,11 +14,11 @@ final readonly class ToggleViewedAction
     ) {}
 
     /**
-     * @param  array<string, string>  $viewedFiles
+     * @param  array<string, string>  $reviewedFiles
      * @param  array<int, array<string, mixed>>  $knownFiles
      * @return array<string, string>|null
      */
-    public function handle(array $viewedFiles, string $filePath, array $knownFiles, string $repoPath = '', ?DiffTarget $target = null): ?array
+    public function handle(array $reviewedFiles, string $filePath, array $knownFiles, string $repoPath = '', ?DiffTarget $target = null): ?array
     {
         $file = collect($knownFiles)->firstWhere('path', $filePath);
 
@@ -26,18 +26,18 @@ final readonly class ToggleViewedAction
             return null;
         }
 
-        if (array_key_exists($filePath, $viewedFiles)) {
-            unset($viewedFiles[$filePath]);
+        if (array_key_exists($filePath, $reviewedFiles)) {
+            unset($reviewedFiles[$filePath]);
 
-            return $viewedFiles;
+            return $reviewedFiles;
         }
 
         $fingerprint = $repoPath !== ''
             ? $this->gitDiffService->fileDiffFingerprint($repoPath, $filePath, $target)
             : '';
 
-        $viewedFiles[$filePath] = $fingerprint;
+        $reviewedFiles[$filePath] = $fingerprint;
 
-        return $viewedFiles;
+        return $reviewedFiles;
     }
 }

--- a/app/Console/Benchmark/PerfScenarioRunner.php
+++ b/app/Console/Benchmark/PerfScenarioRunner.php
@@ -191,7 +191,7 @@ final class PerfScenarioRunner
         {
             /**
              * @param  array<int, array<string, mixed>>  $currentFiles
-             * @return array{comments: array<int, mixed>, reviewedFiles: array<string, string>, globalComment: string}
+             * @return array{comments: array<int, array<string, mixed>>, reviewedFiles: array<string, string>, globalComment: string, orphanedPaths: array<int, string>}
              */
             public function handle(
                 string $repoPath,
@@ -199,7 +199,7 @@ final class PerfScenarioRunner
                 ?int $projectId = null,
                 string $contextFingerprint = DiffTarget::WORKING_CONTEXT,
             ): array {
-                return ['comments' => [], 'reviewedFiles' => [], 'globalComment' => ''];
+                return ['comments' => [], 'reviewedFiles' => [], 'globalComment' => '', 'orphanedPaths' => []];
             }
         });
 

--- a/app/Console/Benchmark/PerfScenarioRunner.php
+++ b/app/Console/Benchmark/PerfScenarioRunner.php
@@ -191,7 +191,7 @@ final class PerfScenarioRunner
         {
             /**
              * @param  array<int, array<string, mixed>>  $currentFiles
-             * @return array{comments: array<int, mixed>, viewedFiles: array<int, mixed>, globalComment: string}
+             * @return array{comments: array<int, mixed>, reviewedFiles: array<int, mixed>, globalComment: string}
              */
             public function handle(
                 string $repoPath,
@@ -199,7 +199,7 @@ final class PerfScenarioRunner
                 ?int $projectId = null,
                 string $contextFingerprint = DiffTarget::WORKING_CONTEXT,
             ): array {
-                return ['comments' => [], 'viewedFiles' => [], 'globalComment' => ''];
+                return ['comments' => [], 'reviewedFiles' => [], 'globalComment' => ''];
             }
         });
 
@@ -207,12 +207,12 @@ final class PerfScenarioRunner
         {
             /**
              * @param  array<int, mixed>  $comments
-             * @param  array<int, mixed>  $viewedFiles
+             * @param  array<int, mixed>  $reviewedFiles
              */
             public function handle(
                 string $repoPath,
                 array $comments,
-                array $viewedFiles,
+                array $reviewedFiles,
                 string $globalComment,
                 ?int $projectId = null,
                 string $contextFingerprint = DiffTarget::WORKING_CONTEXT,

--- a/app/Console/Benchmark/PerfScenarioRunner.php
+++ b/app/Console/Benchmark/PerfScenarioRunner.php
@@ -191,7 +191,7 @@ final class PerfScenarioRunner
         {
             /**
              * @param  array<int, array<string, mixed>>  $currentFiles
-             * @return array{comments: array<int, mixed>, reviewedFiles: array<int, mixed>, globalComment: string}
+             * @return array{comments: array<int, mixed>, reviewedFiles: array<string, string>, globalComment: string}
              */
             public function handle(
                 string $repoPath,
@@ -206,8 +206,8 @@ final class PerfScenarioRunner
         $this->app->bind(SaveSessionAction::class, fn () => new class
         {
             /**
-             * @param  array<int, mixed>  $comments
-             * @param  array<int, mixed>  $reviewedFiles
+             * @param  array<int, array<string, mixed>>  $comments
+             * @param  array<string, string>  $reviewedFiles
              */
             public function handle(
                 string $repoPath,

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -1,11 +1,11 @@
 // Alpine component for livewire/⚡diff-file.blade.php
 (function () {
     function init() {
-        Alpine.data('diffFile', ({ fileId, filePath, isViewed, singleFile = false }) => ({
+        Alpine.data('diffFile', ({ fileId, filePath, isReviewed, singleFile = false }) => ({
             fileId,
             filePath,
-            collapsed: singleFile ? false : (Alpine.store('settings')?.collapseAll || isViewed),
-            viewed: isViewed,
+            collapsed: singleFile ? false : (Alpine.store('settings')?.collapseAll || isReviewed),
+            reviewed: isReviewed,
 
             // Comment form state
             formLine: null,
@@ -284,10 +284,10 @@
                 return lineNum >= this.formLine && lineNum <= (this.formEndLine ?? this.formLine);
             },
 
-            onViewedChange() {
-                this.collapsed = this.viewed;
-                this.$dispatch('file-viewed-changed', { id: this.fileId, viewed: this.viewed });
-                this.$wire.dispatch('toggle-viewed', { filePath: this.filePath });
+            onReviewedChange() {
+                this.collapsed = this.reviewed;
+                this.$dispatch('file-reviewed-changed', { id: this.fileId, reviewed: this.reviewed });
+                this.$wire.dispatch('toggle-reviewed', { filePath: this.filePath });
             },
         }));
     }

--- a/resources/CLAUDE.md
+++ b/resources/CLAUDE.md
@@ -73,7 +73,7 @@ ReviewPage (`resources/views/pages/⚡review-page.blade.php`) renders N DiffFile
 | `clearAllComments` | Yes | Dispatches comment-updated + undo-available events |
 | `restoreComments` | Yes | Dispatches comment-updated events to affected files |
 | `updatedGlobalComment` | Yes | No UI change needed server-side |
-| `toggleViewed` | Yes | Sidebar state managed client-side via Alpine |
+| `toggleReviewed` | Yes | Sidebar state managed client-side via Alpine |
 | `submitReview` | No | Replaces entire submit bar UI (submitted state) |
 | `discardFileChanges` | No | Structural change: file removed from list, trash updated |
 | `restoreDiscardedFile` | No | Structural change: file reappears in list |
@@ -85,10 +85,10 @@ ReviewPage (`resources/views/pages/⚡review-page.blade.php`) renders N DiffFile
 |---|---|---|---|
 | `add-comment` | DiffFile Alpine -> parent | ReviewPage `#[On]` | `{fileId, side, startLine, endLine, body}` |
 | `delete-comment` | DiffFile Alpine -> parent | ReviewPage `#[On]` | `{commentId}` |
-| `toggle-viewed` | DiffFile Alpine -> parent | ReviewPage `#[On]` | `{filePath}` |
+| `toggle-reviewed` | DiffFile Alpine -> parent | ReviewPage `#[On]` | `{filePath}` |
 | `comment-updated` | ReviewPage PHP dispatch | DiffFile Alpine `@window` | `{fileId, comments}` |
 | `copy-to-clipboard` | DiffFile Alpine/PHP, ReviewPage PHP | ReviewPage Alpine `@window` | `{text}` |
-| `file-viewed-changed` | DiffFile Alpine `$dispatch` | ReviewPage Alpine `@window` | `{id, viewed}` |
+| `file-reviewed-changed` | DiffFile Alpine `$dispatch` | ReviewPage Alpine `@window` | `{id, reviewed}` |
 | `collapse-all-files` | ReviewPage Alpine `$dispatch` | DiffFile Alpine `@window` | none |
 | `expand-all-files` | ReviewPage Alpine `$dispatch` | DiffFile Alpine `@window` | none |
 | `expand-file` | ReviewPage Alpine `$dispatch` | DiffFile Alpine `@window` | `{id}` |

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -132,6 +132,9 @@
         ::-webkit-scrollbar-thumb { background: var(--gh-scrollbar-thumb); border-radius: 3px; }
         ::-webkit-scrollbar-thumb:hover { background: var(--gh-scrollbar-hover); }
 
+        /* Prevent Flux menu scroll-lock from hiding scrollbar and causing layout shift */
+        html { overflow-y: scroll !important; }
+
         /* Fix checkbox visibility in dark mode */
         .dark [data-flux-checkbox-indicator] {
             border-color: rgb(var(--gh-border));

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -252,44 +252,45 @@ new class extends Component {
         </div>
 
         {{-- Actions toolbar --}}
-        <div class="flex items-center gap-2.5 text-xs shrink-0 font-mono">
-            <flux:tooltip content="Copy file name">
+        <div class="flex items-center gap-2 text-xs shrink-0 font-mono">
+            {{-- Secondary actions: ghost icons, brighten on hover --}}
+            <div class="flex items-center gap-0.5 opacity-30 group-hover:opacity-100 transition-opacity">
                 <flux:button
+                    tooltip="Copy file name"
                     icon="square-2-stack"
                     icon:variant="outline"
                     variant="ghost"
                     size="sm"
                     @click="$dispatch('copy-to-clipboard', { text: filePath })"
                 />
-            </flux:tooltip>
 
-            @php
-                $showContentCopy = !($file['isBinary'] ?? false)
-                    && !($file['isSymlink'] ?? false)
-                    && !($diffData['tooLarge'] ?? false);
-                $isAdded = ($file['status'] ?? '') === 'added' || ($file['isUntracked'] ?? false);
-                $isDeleted = ($file['status'] ?? '') === 'deleted';
-            @endphp
-            @if($showContentCopy)
-                <flux:dropdown position="bottom" align="end">
-                    <flux:button icon="ellipsis-vertical" icon:variant="outline" variant="ghost" size="sm" aria-label="Copy content" />
-                    <flux:menu>
-                        <flux:menu.item icon="code-bracket" @click="$wire.copyContent('diff')">
-                            Copy diff
-                        </flux:menu.item>
-                        <flux:menu.item icon="document-minus" @click="$wire.copyContent('original')" :disabled="$isAdded">
-                            Copy original
-                        </flux:menu.item>
-                        <flux:menu.item icon="document-plus" @click="$wire.copyContent('new')" :disabled="$isDeleted">
-                            Copy new
-                        </flux:menu.item>
-                    </flux:menu>
-                </flux:dropdown>
-            @endif
+                @php
+                    $showContentCopy = !($file['isBinary'] ?? false)
+                        && !($file['isSymlink'] ?? false)
+                        && !($diffData['tooLarge'] ?? false);
+                    $isAdded = ($file['status'] ?? '') === 'added' || ($file['isUntracked'] ?? false);
+                    $isDeleted = ($file['status'] ?? '') === 'deleted';
+                @endphp
+                @if($showContentCopy)
+                    <flux:dropdown position="bottom" align="end">
+                        <flux:button icon="ellipsis-vertical" icon:variant="outline" variant="ghost" size="sm" aria-label="Copy content" />
+                        <flux:menu>
+                            <flux:menu.item icon="code-bracket" @click="$wire.copyContent('diff')">
+                                Copy diff
+                            </flux:menu.item>
+                            <flux:menu.item icon="document-minus" @click="$wire.copyContent('original')" :disabled="$isAdded">
+                                Copy original
+                            </flux:menu.item>
+                            <flux:menu.item icon="document-plus" @click="$wire.copyContent('new')" :disabled="$isDeleted">
+                                Copy new
+                            </flux:menu.item>
+                        </flux:menu>
+                    </flux:dropdown>
+                @endif
 
-            @if($diffTo === null && ($file['status'] ?? '') !== 'commented')
-                <flux:tooltip content="Discard changes">
+                @if($diffTo === null && ($file['status'] ?? '') !== 'commented')
                     <flux:button
+                        tooltip="Discard changes"
                         icon="arrow-uturn-left"
                         icon:variant="outline"
                         variant="ghost"
@@ -303,8 +304,8 @@ new class extends Component {
                                 $dispatch('discard-file', { fileId: @js($file['id']) })
                         "
                     />
-                </flux:tooltip>
-            @endif
+                @endif
+            </div>
 
             @if($file['additions'] > 0)
                 <span class="text-gh-green">+{{ $file['additions'] }}</span>
@@ -312,24 +313,29 @@ new class extends Component {
             @if($file['deletions'] > 0)
                 <span class="text-gh-red">-{{ $file['deletions'] }}</span>
             @endif
-            <flux:checkbox x-model="reviewed" @change="onReviewedChange()" label="Reviewed" class="text-xs" />
-            <flux:tooltip content="Add file comment">
+
+            {{-- Comment indicator: ghost when no comments, full when comments exist --}}
+            <div class="flex items-center gap-0.5"
+                 :class="$wire.fileComments.length === 0 && 'opacity-30 group-hover:opacity-100 transition-opacity'"
                 <flux:button
                     x-ref="fileCommentBtn"
+                    tooltip="Add file comment"
                     icon="chat-bubble-left"
                     icon:variant="outline"
                     variant="ghost"
                     size="sm"
-                    aria-label="Add file comment"
                     @click="openFileComment()"
-                    class="ml-2"
                 />
+                <span
+                    x-show="$wire.fileComments.length"
+                    x-text="$wire.fileComments.length"
+                    class="text-[10px] font-mono text-gh-muted tabular-nums"
+                ></span>
+            </div>
+
+            <flux:tooltip content="Mark as reviewed">
+                <flux:checkbox x-model="reviewed" @change="onReviewedChange()" aria-label="Reviewed" class="cursor-pointer" />
             </flux:tooltip>
-            <span
-                x-show="$wire.fileComments.length"
-                x-text="$wire.fileComments.length"
-                class="text-[10px] font-mono text-gh-muted tabular-nums"
-            ></span>
         </div>
 
     </div>

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -29,7 +29,7 @@ new class extends Component {
     #[Locked]
     public ?string $diffTo = null;
 
-    public bool $isViewed = false;
+    public bool $isReviewed = false;
 
     public bool $singleFile = false;
 
@@ -215,7 +215,7 @@ new class extends Component {
     x-data="diffFile({
         fileId: @js($file['id']),
         filePath: @js($file['path']),
-        isViewed: @js($isViewed ?? false),
+        isReviewed: @js($isReviewed ?? false),
         singleFile: @js($singleFile ?? false),
     })"
     @mouseup.window="endDrag()"
@@ -312,7 +312,7 @@ new class extends Component {
             @if($file['deletions'] > 0)
                 <span class="text-gh-red">-{{ $file['deletions'] }}</span>
             @endif
-            <flux:checkbox x-model="viewed" @change="onViewedChange()" label="Viewed" class="text-xs" />
+            <flux:checkbox x-model="reviewed" @change="onReviewedChange()" label="Reviewed" class="text-xs" />
             <flux:tooltip content="Add file comment">
                 <flux:button
                     x-ref="fileCommentBtn"

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -320,6 +320,7 @@ new class extends Component {
                 <flux:button
                     x-ref="fileCommentBtn"
                     tooltip="Add file comment"
+                    aria-label="Add file comment"
                     icon="chat-bubble-left"
                     icon:variant="outline"
                     variant="ghost"

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -667,39 +667,62 @@ new #[Layout('layouts.app')] class extends Component
                 <livewire:branch-explorer :repo-path="$repoPath" :current-branch="$projectBranch" :project-slug="$projectSlug" :active-commit-hash="$diffTo" />
             @endif
         </div>
-        <div class="flex items-center gap-3 text-xs">
+        <div class="flex items-center gap-2.5 text-xs">
+            {{-- Stats --}}
             <span class="font-mono text-gh-muted"
                 x-text="fileFilter === '' && !hideReviewed
                     ? '{{ count($sourceFiles) }} {{ Str::plural('file', count($sourceFiles)) }}'
                     : sourceFileEntries.filter(f => fileMatchesFilter(f.path, f.id)).length + '/{{ count($sourceFiles) }} files'"
             >{{ count($sourceFiles) }} {{ Str::plural('file', count($sourceFiles)) }}</span>
-            <span class="font-mono text-gh-muted"
-                x-show="reviewedCount > 0"
-                x-text="reviewedCount + '/{{ count($sourceFiles) }} reviewed'"
-                x-cloak></span>
-            <flux:checkbox x-model="hideReviewed" label="Hide reviewed" class="text-xs"
-                x-show="reviewedCount > 0" x-cloak />
+            <span class="font-mono text-gh-green">+{{ collect($sourceFiles)->sum('additions') }}</span>
+            <span class="font-mono text-gh-red">-{{ collect($sourceFiles)->sum('deletions') }}</span>
+
+            {{-- Reviewed progress --}}
+            <div x-show="reviewedCount > 0" x-cloak class="flex items-center gap-1.5">
+                <span class="w-px h-3.5 bg-gh-border"></span>
+                <div class="flex flex-col items-center min-w-[2.5rem]">
+                    <span class="font-mono text-gh-muted" x-text="reviewedCount + '/{{ count($sourceFiles) }} reviewed'"></span>
+                    <div class="w-full h-0.5 bg-gh-border/50 rounded-full overflow-hidden mt-0.5">
+                        <div class="h-full bg-gh-green/70 rounded-full transition-all duration-300" :style="'width:' + Math.round(reviewedCount / {{ count($sourceFiles) }} * 100) + '%'"></div>
+                    </div>
+                </div>
+            </div>
+
             @if(count($reviewPairs) > 0)
                 <span class="font-mono text-xs text-gh-muted px-1.5 py-0.5 rounded border border-gh-border">{{ count($reviewPairs) }} {{ Str::plural('review', count($reviewPairs)) }}</span>
             @endif
-            <span class="font-mono text-gh-green">+{{ collect($sourceFiles)->sum('additions') }}</span>
-            <span class="font-mono text-gh-red">-{{ collect($sourceFiles)->sum('deletions') }}</span>
-            @if(! $this->isCommitMode())
-                <span class="w-px h-4 bg-gh-border"></span>
-                <flux:checkbox wire:model.live="respectGlobalGitignore"
-                    label="Global .gitignore" class="text-xs" />
-            @endif
+
             <span class="w-px h-4 bg-gh-border"></span>
-            <flux:tooltip content="Expand all (Shift+E)">
+
+            {{-- Hide reviewed toggle --}}
+            <div x-show="reviewedCount > 0" x-cloak class="grid place-items-center">
+                <flux:button variant="ghost" size="sm" icon="eye-slash" icon:variant="outline"
+                    tooltip="Hide reviewed"
+                    class="col-start-1 row-start-1"
+                    @click="hideReviewed = true"
+                    x-show="!hideReviewed" />
+                <flux:button variant="ghost" size="sm" icon="eye" icon:variant="outline"
+                    tooltip="Show all files"
+                    class="col-start-1 row-start-1"
+                    @click="hideReviewed = false"
+                    x-show="hideReviewed" x-cloak />
+            </div>
+
+            {{-- Expand/Collapse toggle --}}
+            <div class="grid place-items-center">
                 <flux:button variant="ghost" size="sm" icon="expand-all" icon:variant="outline"
-                    @click="$store.settings.collapseAll = false; $dispatch('expand-all-files')" />
-            </flux:tooltip>
-            <flux:tooltip content="Collapse all (Shift+C)">
+                    tooltip="Expand all (Shift+E)"
+                    class="col-start-1 row-start-1"
+                    @click="$store.settings.collapseAll = false; $dispatch('expand-all-files')"
+                    x-show="$store.settings.collapseAll" x-cloak />
                 <flux:button variant="ghost" size="sm" icon="collapse-all" icon:variant="outline"
-                    @click="$store.settings.collapseAll = true; $dispatch('collapse-all-files')" />
-            </flux:tooltip>
+                    tooltip="Collapse all (Shift+C)"
+                    class="col-start-1 row-start-1"
+                    @click="$store.settings.collapseAll = true; $dispatch('collapse-all-files')"
+                    x-show="!$store.settings.collapseAll" />
+            </div>
+
             @if(! $this->isCommitMode())
-                <span class="w-px h-4 bg-gh-border"></span>
                 <div data-testid="change-polling" x-data="{
                     hasChanges: false,
                     fingerprint: null,
@@ -725,10 +748,8 @@ new #[Layout('layouts.app')] class extends Component
                         window.location.reload();
                     }
                 }" x-init="startPolling()" @fingerprint-reset.window="fingerprint = null; hasChanges = false" class="relative flex items-center">
-                    <flux:tooltip content="Refresh page">
-                        <flux:button variant="ghost" size="sm" icon="arrow-path" icon:variant="outline"
-                            @click="refresh()" />
-                    </flux:tooltip>
+                    <flux:button variant="ghost" size="sm" icon="arrow-path" icon:variant="outline"
+                        tooltip="Refresh page" @click="refresh()" />
                     <span x-show="hasChanges" x-cloak
                         class="absolute -top-0.5 -right-0.5 flex h-2.5 w-2.5">
                         <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-400 opacity-75"></span>
@@ -736,7 +757,22 @@ new #[Layout('layouts.app')] class extends Component
                     </span>
                 </div>
             @endif
+
             <span class="w-px h-4 bg-gh-border"></span>
+
+            {{-- Settings --}}
+            @if(! $this->isCommitMode())
+                <flux:dropdown position="bottom" align="end">
+                    <flux:button variant="ghost" size="sm" icon="cog-6-tooth" icon:variant="outline"
+                        aria-label="Settings" />
+                    <flux:menu>
+                        <flux:menu.item keep-open>
+                            <flux:checkbox wire:model.live="respectGlobalGitignore" label="Global .gitignore" class="text-xs whitespace-nowrap" />
+                        </flux:menu.item>
+                    </flux:menu>
+                </flux:dropdown>
+            @endif
+
             <livewire:theme-switcher />
         </div>
     </header>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -356,7 +356,6 @@ new #[Layout('layouts.app')] class extends Component
         $projectKey = $this->projectId > 0 ? $this->projectId : $this->repoPath;
         Cache::forget(DiffCacheKey::for($projectKey, $fileId, $this->buildDiffTarget()->contextKey()));
 
-        // Prune reviewed state for the discarded file
         unset($this->reviewedFiles[$file['path']]);
 
         $this->refreshFileList();
@@ -575,13 +574,15 @@ new #[Layout('layouts.app')] class extends Component
         reviewedFiles: @js((object) collect($sourceFiles)->filter(fn($f) => array_key_exists($f['path'], $reviewedFiles))->pluck('id')->flip()->map(fn() => true)->all()),
         hideReviewed: false,
         fileFilter: '',
-        filePaths: @js(collect($sourceFiles)->pluck('path')->all()),
-        fileIds: @js(collect($sourceFiles)->pluck('id')->all()),
+        sourceFileEntries: @js(collect($sourceFiles)->map(fn($f) => ['id' => $f['id'], 'path' => $f['path']])->values()->all()),
         sidebarWidth: $store.settings.sidebarWidth,
         resizing: false,
+        get reviewedCount() {
+            return Object.values(this.reviewedFiles).filter(Boolean).length;
+        },
         fileMatchesFilter(path, fileId) {
             if (this.fileFilter !== '' && !path.toLowerCase().includes(this.fileFilter.toLowerCase())) return false;
-            if (fileId && this.hideReviewed && this.reviewedFiles[fileId]) return false;
+            if (this.hideReviewed && this.reviewedFiles[fileId]) return false;
             return true;
         },
         scrollToFile(id) {
@@ -670,14 +671,14 @@ new #[Layout('layouts.app')] class extends Component
             <span class="font-mono text-gh-muted"
                 x-text="fileFilter === '' && !hideReviewed
                     ? '{{ count($sourceFiles) }} {{ Str::plural('file', count($sourceFiles)) }}'
-                    : filePaths.filter((p, i) => fileMatchesFilter(p, fileIds[i])).length + '/{{ count($sourceFiles) }} files'"
+                    : sourceFileEntries.filter(f => fileMatchesFilter(f.path, f.id)).length + '/{{ count($sourceFiles) }} files'"
             >{{ count($sourceFiles) }} {{ Str::plural('file', count($sourceFiles)) }}</span>
             <span class="font-mono text-gh-muted"
-                x-show="Object.values(reviewedFiles).filter(Boolean).length > 0"
-                x-text="Object.values(reviewedFiles).filter(Boolean).length + '/{{ count($sourceFiles) }} reviewed'"
+                x-show="reviewedCount > 0"
+                x-text="reviewedCount + '/{{ count($sourceFiles) }} reviewed'"
                 x-cloak></span>
             <flux:checkbox x-model="hideReviewed" label="Hide reviewed" class="text-xs"
-                x-show="Object.values(reviewedFiles).filter(Boolean).length > 0" x-cloak />
+                x-show="reviewedCount > 0" x-cloak />
             @if(count($reviewPairs) > 0)
                 <span class="font-mono text-xs text-gh-muted px-1.5 py-0.5 rounded border border-gh-border">{{ count($reviewPairs) }} {{ Str::plural('review', count($reviewPairs)) }}</span>
             @endif

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -63,7 +63,7 @@ new #[Layout('layouts.app')] class extends Component
     public ?string $gitError = null;
 
     /** @var array<string, string> */
-    public array $viewedFiles = [];
+    public array $reviewedFiles = [];
 
     public ?string $activeFileId = null;
 
@@ -129,7 +129,7 @@ new #[Layout('layouts.app')] class extends Component
         $target = $this->buildDiffTarget();
         $session = app(RestoreSessionAction::class)->handle($this->repoPath, $this->files, $this->projectId, $target->contextKey(), $target);
         $this->comments = $session['comments'];
-        $this->viewedFiles = $session['viewedFiles'];
+        $this->reviewedFiles = $session['reviewedFiles'];
         $this->globalComment = $session['globalComment'];
 
         if (! empty($session['orphanedPaths'])) {
@@ -192,7 +192,7 @@ new #[Layout('layouts.app')] class extends Component
         $target = $this->buildDiffTarget();
         $session = app(RestoreSessionAction::class)->handle($this->repoPath, $this->files, $this->projectId, $target->contextKey(), $target);
         $this->comments = $session['comments'];
-        $this->viewedFiles = $session['viewedFiles'];
+        $this->reviewedFiles = $session['reviewedFiles'];
 
         if (! empty($session['orphanedPaths'])) {
             $this->injectOrphanedFiles($session['orphanedPaths']);
@@ -356,8 +356,8 @@ new #[Layout('layouts.app')] class extends Component
         $projectKey = $this->projectId > 0 ? $this->projectId : $this->repoPath;
         Cache::forget(DiffCacheKey::for($projectKey, $fileId, $this->buildDiffTarget()->contextKey()));
 
-        // Prune viewed state for the discarded file
-        unset($this->viewedFiles[$file['path']]);
+        // Prune reviewed state for the discarded file
+        unset($this->reviewedFiles[$file['path']]);
 
         $this->refreshFileList();
         $this->saveSession();
@@ -401,16 +401,16 @@ new #[Layout('layouts.app')] class extends Component
         };
     }
 
-    #[On('toggle-viewed')]
-    public function toggleViewed(string $filePath): void
+    #[On('toggle-reviewed')]
+    public function toggleReviewed(string $filePath): void
     {
-        $result = app(ToggleViewedAction::class)->handle($this->viewedFiles, $filePath, $this->files, $this->repoPath, $this->buildDiffTarget());
+        $result = app(ToggleViewedAction::class)->handle($this->reviewedFiles, $filePath, $this->files, $this->repoPath, $this->buildDiffTarget());
 
         if ($result === null) {
             return;
         }
 
-        $this->viewedFiles = $result;
+        $this->reviewedFiles = $result;
         $this->saveSession();
         $this->skipRender();
     }
@@ -441,11 +441,11 @@ new #[Layout('layouts.app')] class extends Component
         $affectedFileIds = collect($this->comments)->pluck('fileId')->unique();
         $this->comments = array_values(array_filter($this->comments, fn ($c) => $c['isDraft'] ?? false));
         $this->globalComment = '';
-        $this->viewedFiles = [];
+        $this->reviewedFiles = [];
         $this->saveSession();
 
         $affectedFileIds->each(fn (string $fileId) => $this->dispatchFileComments($fileId));
-        $this->dispatch('reset-viewed-files');
+        $this->dispatch('reset-reviewed-files');
     }
 
     /** @return array<string, array<int, array<string, mixed>>> */
@@ -538,7 +538,7 @@ new #[Layout('layouts.app')] class extends Component
 
     private function saveSession(): void
     {
-        app(SaveSessionAction::class)->handle($this->repoPath, $this->comments, $this->viewedFiles, $this->globalComment, $this->projectId, $this->buildDiffTarget()->contextKey());
+        app(SaveSessionAction::class)->handle($this->repoPath, $this->comments, $this->reviewedFiles, $this->globalComment, $this->projectId, $this->buildDiffTarget()->contextKey());
     }
 
     private function loadTrashedFiles(): void
@@ -572,13 +572,17 @@ new #[Layout('layouts.app')] class extends Component
             });
         },
         activeFile: null,
-        viewedFiles: @js((object) collect($sourceFiles)->filter(fn($f) => array_key_exists($f['path'], $viewedFiles))->pluck('id')->flip()->map(fn() => true)->all()),
+        reviewedFiles: @js((object) collect($sourceFiles)->filter(fn($f) => array_key_exists($f['path'], $reviewedFiles))->pluck('id')->flip()->map(fn() => true)->all()),
+        hideReviewed: false,
         fileFilter: '',
         filePaths: @js(collect($sourceFiles)->pluck('path')->all()),
+        fileIds: @js(collect($sourceFiles)->pluck('id')->all()),
         sidebarWidth: $store.settings.sidebarWidth,
         resizing: false,
-        fileMatchesFilter(path) {
-            return this.fileFilter === '' || path.toLowerCase().includes(this.fileFilter.toLowerCase());
+        fileMatchesFilter(path, fileId) {
+            if (this.fileFilter !== '' && !path.toLowerCase().includes(this.fileFilter.toLowerCase())) return false;
+            if (fileId && this.hideReviewed && this.reviewedFiles[fileId]) return false;
+            return true;
         },
         scrollToFile(id) {
             this.activeFile = id;
@@ -629,8 +633,8 @@ new #[Layout('layouts.app')] class extends Component
             document.addEventListener('mouseup', onUp);
         }
     }"
-    @file-viewed-changed.window="viewedFiles[$event.detail.id] = $event.detail.viewed"
-    @reset-viewed-files.window="viewedFiles = {}"
+    @file-reviewed-changed.window="reviewedFiles[$event.detail.id] = $event.detail.reviewed"
+    @reset-reviewed-files.window="reviewedFiles = {}"
     @copy-to-clipboard.window="
         navigator.clipboard.writeText($event.detail.text).catch(() => {});
     "
@@ -664,14 +668,16 @@ new #[Layout('layouts.app')] class extends Component
         </div>
         <div class="flex items-center gap-3 text-xs">
             <span class="font-mono text-gh-muted"
-                x-text="fileFilter === ''
+                x-text="fileFilter === '' && !hideReviewed
                     ? '{{ count($sourceFiles) }} {{ Str::plural('file', count($sourceFiles)) }}'
-                    : filePaths.filter(p => fileMatchesFilter(p)).length + '/{{ count($sourceFiles) }} files'"
+                    : filePaths.filter((p, i) => fileMatchesFilter(p, fileIds[i])).length + '/{{ count($sourceFiles) }} files'"
             >{{ count($sourceFiles) }} {{ Str::plural('file', count($sourceFiles)) }}</span>
             <span class="font-mono text-gh-muted"
-                x-show="Object.values(viewedFiles).filter(Boolean).length > 0"
-                x-text="Object.values(viewedFiles).filter(Boolean).length + '/{{ count($sourceFiles) }} viewed'"
+                x-show="Object.values(reviewedFiles).filter(Boolean).length > 0"
+                x-text="Object.values(reviewedFiles).filter(Boolean).length + '/{{ count($sourceFiles) }} reviewed'"
                 x-cloak></span>
+            <flux:checkbox x-model="hideReviewed" label="Hide reviewed" class="text-xs"
+                x-show="Object.values(reviewedFiles).filter(Boolean).length > 0" x-cloak />
             @if(count($reviewPairs) > 0)
                 <span class="font-mono text-xs text-gh-muted px-1.5 py-0.5 rounded border border-gh-border">{{ count($reviewPairs) }} {{ Str::plural('review', count($reviewPairs)) }}</span>
             @endif
@@ -816,7 +822,7 @@ new #[Layout('layouts.app')] class extends Component
                         };
                     @endphp
                     <div
-                        x-show="fileMatchesFilter(@js($file['path']))"
+                        x-show="fileMatchesFilter(@js($file['path']), '{{ $file['id'] }}')"
                         class="w-full text-left px-2.5 py-2 rounded text-xs hover:bg-gh-border/30 flex items-center gap-2.5 group transition-colors"
                         :class="activeFile === '{{ $file['id'] }}' ? 'bg-gh-link/10 text-gh-link' : 'text-gh-muted'"
                     >
@@ -827,7 +833,7 @@ new #[Layout('layouts.app')] class extends Component
                             @endif
                             <span class="truncate font-mono" title="{{ $file['path'] }}{{ ($file['isSymlink'] ?? false) ? ' -> ' . $file['symlinkTarget'] : '' }}{{ ($file['lastModified'] ?? null) ? "\nModified " . $file['lastModified'] : '' }}">{{ $file['path'] }}</span>
                         </button>
-                        <flux:icon icon="check" variant="outline" x-show="viewedFiles['{{ $file['id'] }}']"
+                        <flux:icon icon="check" variant="outline" x-show="reviewedFiles['{{ $file['id'] }}']"
                             class="text-gh-green shrink-0" x-cloak />
                         @if(! $this->isCommitMode() && $file['status'] !== 'commented')
                             <button
@@ -955,7 +961,7 @@ new #[Layout('layouts.app')] class extends Component
                                         :file="$pair['jsonFile']"
                                         :load-delay="0"
                                         :file-comments="$this->groupedComments[$pair['jsonFile']['id']] ?? []"
-                                        :is-viewed="array_key_exists($pair['jsonFile']['path'], $viewedFiles)"
+                                        :is-reviewed="array_key_exists($pair['jsonFile']['path'], $reviewedFiles)"
                                         :repo-path="$repoPath"
                                         :project-id="$projectId"
                                         :diff-from="$diffFrom"
@@ -968,7 +974,7 @@ new #[Layout('layouts.app')] class extends Component
                                         :file="$pair['mdFile']"
                                         :load-delay="0"
                                         :file-comments="$this->groupedComments[$pair['mdFile']['id']] ?? []"
-                                        :is-viewed="array_key_exists($pair['mdFile']['path'], $viewedFiles)"
+                                        :is-reviewed="array_key_exists($pair['mdFile']['path'], $reviewedFiles)"
                                         :repo-path="$repoPath"
                                         :project-id="$projectId"
                                         :diff-from="$diffFrom"
@@ -983,13 +989,13 @@ new #[Layout('layouts.app')] class extends Component
                 {{-- Source Files --}}
                 @php $singleFile = count($sourceFiles) === 1 && count($reviewPairs) === 0; @endphp
                 @foreach($sourceFiles as $file)
-                    <div id="{{ $file['id'] }}" class="border-b border-gh-border" x-show="fileMatchesFilter(@js($file['path']))">
+                    <div id="{{ $file['id'] }}" class="border-b border-gh-border" x-show="fileMatchesFilter(@js($file['path']), '{{ $file['id'] }}')">
                         <livewire:diff-file
                             :key="$file['id']"
                             :file="$file"
                             :load-delay="(int) (floor($loop->index / 15) * 100)"
                             :file-comments="$this->groupedComments[$file['id']] ?? []"
-                            :is-viewed="array_key_exists($file['path'], $viewedFiles)"
+                            :is-reviewed="array_key_exists($file['path'], $reviewedFiles)"
                             :single-file="$singleFile"
                             :repo-path="$repoPath"
                             :project-id="$projectId"

--- a/tests/Browser/FileInteractionTest.php
+++ b/tests/Browser/FileInteractionTest.php
@@ -187,9 +187,9 @@ test('shift+e expands all files', function () {
 });
 
 test('checking reviewed updates sidebar indicator', function () {
-    $page = $this->visit($this->projectUrl());
+    $page = $this->visitAndLoad($this->projectUrl());
 
-    $page->page()->getByLabel('Reviewed')->first()->click();
+    $page->page()->getByRole('checkbox', ['name' => 'Reviewed'])->first()->click();
 
     $page->assertSee('1/3 reviewed');
 });

--- a/tests/Browser/FileInteractionTest.php
+++ b/tests/Browser/FileInteractionTest.php
@@ -186,12 +186,12 @@ test('shift+e expands all files', function () {
     $page->assertSee('function greet');
 });
 
-test('checking viewed updates sidebar indicator', function () {
+test('checking reviewed updates sidebar indicator', function () {
     $page = $this->visit($this->projectUrl());
 
-    $page->page()->getByLabel('Viewed')->first()->click();
+    $page->page()->getByLabel('Reviewed')->first()->click();
 
-    $page->assertSee('1/3 viewed');
+    $page->assertSee('1/3 reviewed');
 });
 
 test('clicking sidebar file scrolls to it', function () {

--- a/tests/Browser/SessionPersistenceTest.php
+++ b/tests/Browser/SessionPersistenceTest.php
@@ -33,13 +33,13 @@ test('global comment persists after page reload', function () {
     expect($value)->toBe('Global persisted note');
 });
 
-test('viewed files persist after page reload', function () {
+test('reviewed files persist after page reload', function () {
     $page = $this->visit($this->projectUrl());
 
-    $page->page()->getByLabel('Viewed')->first()->click();
+    $page->page()->getByLabel('Reviewed')->first()->click();
     // Wait for Livewire round-trip to complete before refreshing
-    $page->assertSee('1/3 viewed');
+    $page->assertSee('1/3 reviewed');
 
     $page->refresh();
-    $page->assertSee('1/3 viewed');
+    $page->assertSee('1/3 reviewed');
 });

--- a/tests/Browser/SessionPersistenceTest.php
+++ b/tests/Browser/SessionPersistenceTest.php
@@ -34,9 +34,9 @@ test('global comment persists after page reload', function () {
 });
 
 test('reviewed files persist after page reload', function () {
-    $page = $this->visit($this->projectUrl());
+    $page = $this->visitAndLoad($this->projectUrl());
 
-    $page->page()->getByLabel('Reviewed')->first()->click();
+    $page->page()->getByRole('checkbox', ['name' => 'Reviewed'])->first()->click();
     // Wait for Livewire round-trip to complete before refreshing
     $page->assertSee('1/3 reviewed');
 

--- a/tests/Unit/Actions/RestoreSessionActionTest.php
+++ b/tests/Unit/Actions/RestoreSessionActionTest.php
@@ -23,7 +23,7 @@ test('creates session when none exists and returns defaults', function () {
     $result = app(RestoreSessionAction::class)->handle($repoPath, $files);
 
     expect($result['comments'])->toBeEmpty();
-    expect($result['viewedFiles'])->toBeEmpty();
+    expect($result['reviewedFiles'])->toBeEmpty();
     expect($result['globalComment'])->toBe('');
     expect($result['orphanedPaths'])->toBeEmpty();
     expect(ReviewSession::where('repo_path', $repoPath)->exists())->toBeTrue();
@@ -56,7 +56,7 @@ test('restores comments and tracks orphaned paths', function () {
     expect($result['comments'][1]['file'])->toBe('gone.php');
     expect($result['comments'][1]['fileId'])->toBe('file-'.hash('xxh128', 'gone.php'));
     expect($result['orphanedPaths'])->toBe(['gone.php']);
-    expect($result['viewedFiles'])->toBe(['exists.php' => 'somehash']);
+    expect($result['reviewedFiles'])->toBe(['exists.php' => 'somehash']);
     expect($result['globalComment'])->toBe('hello');
 });
 
@@ -131,12 +131,12 @@ test('migrates legacy indexed array to associative with fresh fingerprints', fun
 
     $result = app(RestoreSessionAction::class)->handle($repoPath, $files);
 
-    expect($result['viewedFiles'])->toBe(['a.php' => 'hash-a', 'b.php' => 'hash-b']);
+    expect($result['reviewedFiles'])->toBe(['a.php' => 'hash-a', 'b.php' => 'hash-b']);
 });
 
 // -- Fingerprint validation --
 
-test('unmarks viewed file when fingerprint mismatches', function () {
+test('unmarks reviewed file when fingerprint mismatches', function () {
     $repoPath = '/tmp/'.$this->faker->word();
     ReviewSession::create([
         'repo_path' => $repoPath,
@@ -161,7 +161,7 @@ test('unmarks viewed file when fingerprint mismatches', function () {
 
     $result = app(RestoreSessionAction::class)->handle($repoPath, $files);
 
-    expect($result['viewedFiles'])->toBe(['b.php' => 'still-good']);
+    expect($result['reviewedFiles'])->toBe(['b.php' => 'still-good']);
 });
 
 test('skips fingerprint validation for immutable targets', function () {
@@ -187,5 +187,5 @@ test('skips fingerprint validation for immutable targets', function () {
 
     $result = app(RestoreSessionAction::class)->handle($repoPath, $files, null, $target->contextKey(), $target);
 
-    expect($result['viewedFiles'])->toBe(['a.php' => '']);
+    expect($result['reviewedFiles'])->toBe(['a.php' => '']);
 });

--- a/tests/Unit/Actions/SaveSessionActionTest.php
+++ b/tests/Unit/Actions/SaveSessionActionTest.php
@@ -35,11 +35,14 @@ test('updates existing session', function () {
     ReviewSession::create(['repo_path' => $repoPath, 'comments' => [], 'viewed_files' => [], 'global_comment' => '']);
 
     $newComments = [['id' => 'c-2', 'file' => 'a.php', 'body' => 'updated']];
+    $reviewedFiles = ['a.php' => 'hash-a'];
 
-    app(SaveSessionAction::class)->handle($repoPath, $newComments, ['a.php'], 'global');
+    app(SaveSessionAction::class)->handle($repoPath, $newComments, $reviewedFiles, 'global');
 
+    $session = ReviewSession::where('repo_path', $repoPath)->first();
     expect(ReviewSession::where('repo_path', $repoPath)->count())->toBe(1);
-    expect(ReviewSession::where('repo_path', $repoPath)->first()->comments)->toBe($newComments);
+    expect($session->comments)->toBe($newComments);
+    expect($session->viewed_files)->toBe($reviewedFiles);
 });
 
 test('keys by project_id when provided', function () {

--- a/tests/Unit/Actions/SaveSessionActionTest.php
+++ b/tests/Unit/Actions/SaveSessionActionTest.php
@@ -17,7 +17,7 @@ beforeEach(function () {
 test('creates session when none exists', function () {
     $repoPath = '/tmp/'.$this->faker->word();
     $comments = [['id' => 'c-1', 'file' => 'f.php', 'body' => $this->faker->sentence()]];
-    $reviewedFiles = ['f.php'];
+    $reviewedFiles = ['f.php' => 'hash-f'];
     $globalComment = $this->faker->sentence();
 
     app(SaveSessionAction::class)->handle($repoPath, $comments, $reviewedFiles, $globalComment);

--- a/tests/Unit/Actions/SaveSessionActionTest.php
+++ b/tests/Unit/Actions/SaveSessionActionTest.php
@@ -17,16 +17,16 @@ beforeEach(function () {
 test('creates session when none exists', function () {
     $repoPath = '/tmp/'.$this->faker->word();
     $comments = [['id' => 'c-1', 'file' => 'f.php', 'body' => $this->faker->sentence()]];
-    $viewedFiles = ['f.php'];
+    $reviewedFiles = ['f.php'];
     $globalComment = $this->faker->sentence();
 
-    app(SaveSessionAction::class)->handle($repoPath, $comments, $viewedFiles, $globalComment);
+    app(SaveSessionAction::class)->handle($repoPath, $comments, $reviewedFiles, $globalComment);
 
     $session = ReviewSession::where('repo_path', $repoPath)->first();
 
     expect($session)->not->toBeNull();
     expect($session->comments)->toBe($comments);
-    expect($session->viewed_files)->toBe($viewedFiles);
+    expect($session->viewed_files)->toBe($reviewedFiles);
     expect($session->global_comment)->toBe($globalComment);
 });
 

--- a/tests/Unit/Actions/ToggleViewedActionTest.php
+++ b/tests/Unit/Actions/ToggleViewedActionTest.php
@@ -24,13 +24,13 @@ beforeEach(function () {
     $this->action = app(ToggleViewedAction::class);
 });
 
-test('adds file to viewed list with fingerprint', function () {
+test('adds file to reviewed list with fingerprint', function () {
     $result = $this->action->handle([], 'a.php', $this->knownFiles, '/tmp/repo');
 
     expect($result)->toBe(['a.php' => 'mock-hash']);
 });
 
-test('removes file from viewed list', function () {
+test('removes file from reviewed list', function () {
     $result = $this->action->handle(['a.php' => 'hash1', 'b.php' => 'hash2'], 'a.php', $this->knownFiles, '/tmp/repo');
 
     expect($result)->toBe(['b.php' => 'hash2']);

--- a/tests/Unit/Livewire/ReviewPageTest.php
+++ b/tests/Unit/Livewire/ReviewPageTest.php
@@ -63,13 +63,13 @@ beforeEach(function () {
     {
         public function handle(string $repoPath, array $currentFiles, ?int $projectId = null, string $contextFingerprint = DiffTarget::WORKING_CONTEXT, ?DiffTarget $target = null): array
         {
-            return ['comments' => [], 'viewedFiles' => [], 'globalComment' => '', 'orphanedPaths' => []];
+            return ['comments' => [], 'reviewedFiles' => [], 'globalComment' => '', 'orphanedPaths' => []];
         }
     });
 
     app()->bind(SaveSessionAction::class, fn () => new class
     {
-        public function handle(string $repoPath, array $comments, array $viewedFiles, string $globalComment, ?int $projectId = null, string $contextFingerprint = DiffTarget::WORKING_CONTEXT): void {}
+        public function handle(string $repoPath, array $comments, array $reviewedFiles, string $globalComment, ?int $projectId = null, string $contextFingerprint = DiffTarget::WORKING_CONTEXT): void {}
     });
 
     // Mock GitDiffService to avoid real git calls
@@ -87,16 +87,16 @@ beforeEach(function () {
     });
 });
 
-test('toggleViewed updates viewedFiles state', function () {
+test('toggleReviewed updates reviewedFiles state', function () {
     $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
-        ->dispatch('toggle-viewed', filePath: 'src/Foo.php');
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php');
 
-    expect($component->get('viewedFiles'))->toBe(['src/Foo.php' => 'mock-hash']);
+    expect($component->get('reviewedFiles'))->toBe(['src/Foo.php' => 'mock-hash']);
 });
 
-test('toggleViewed skips parent re-render', function () {
+test('toggleReviewed skips parent re-render', function () {
     $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
-        ->dispatch('toggle-viewed', filePath: 'src/Foo.php');
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php');
 
     expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue();
 });


### PR DESCRIPTION
Rename all UI labels from "Viewed" to "Reviewed" and add a toolbar
checkbox that hides reviewed files from both the sidebar and content
area, making it easy to focus on files that still need attention.

https://claude.ai/code/session_01E6A46fHS9dhHJCgvFroWBz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Updates**
  * Renamed "Viewed" to "Reviewed" across the review page (labels, counters, and toggle behavior).
  * Added "Hide reviewed" filter and reviewed-aware collapsing for files.
  * Adjusted per-file toolbar (tooltip/layout and comment button dimming).

* **Documentation**
  * Sidebar docs updated to reflect reviewed terminology and events.

* **Tests**
  * Browser and unit tests updated to use reviewed terminology.

* **Chores**
  * Global scrollbar rule added to prevent layout shift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->