### PR TITLE
Improve search ranking to prioritize exact and word-start matches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # RFA Project Conventions
 
+## Local Desktop App
+
+RFA runs as a local NativePHP desktop app. Server-side operations have negligible latency, so prefer Livewire server-side logic over complex client-side (Alpine/JS) alternatives for filtering, sorting, and state management.
+
 ## PHP / Laravel
 
 - Use `Storage` facade for user-generated or external file operations

--- a/app/Actions/ListProjectsAction.php
+++ b/app/Actions/ListProjectsAction.php
@@ -11,9 +11,9 @@ use Carbon\Carbon;
 final readonly class ListProjectsAction
 {
     /**
-     * @return array<string, array<int, array<string, mixed>>>
+     * @return array{groups: array<string, array<int, array<string, mixed>>>, total: int}
      */
-    public function handle(string $sortBy = 'recent'): array
+    public function handle(string $sortBy = 'recent', string $search = ''): array
     {
         $projects = Project::query()
             ->select('projects.*')
@@ -43,18 +43,87 @@ final readonly class ListProjectsAction
                 return $data;
             });
 
+        $total = $projects->count();
+
+        $search = trim($search);
+        if ($search !== '') {
+            $projects = $projects
+                ->map(fn (array $p) => $p + ['_rank' => self::rankMatch($p['name'], $p['branch'] ?? '', $p['path'], $search)])
+                ->filter(fn (array $p) => $p['_rank'] < PHP_INT_MAX)
+                ->sortBy('_rank');
+
+            $groups = $projects
+                ->groupBy('git_common_dir')
+                ->map(fn ($group) => $group->map(function (array $p) {
+                    unset($p['_rank']);
+
+                    return $p;
+                })->values()->all())
+                ->all();
+
+            return ['groups' => $groups, 'total' => $total];
+        }
+
         if ($sortBy === 'alpha') {
             $projects = $projects->sortBy('name', SORT_NATURAL | SORT_FLAG_CASE);
         } else {
             $projects = $projects->sortByDesc('last_active_at');
         }
 
-        return $projects
+        $groups = $projects
             ->groupBy('git_common_dir')
             ->when($sortBy === 'recent', function ($groups) {
                 return $groups->sortByDesc(fn ($group) => $group->max('last_active_at'));
             })
             ->map(fn ($group) => $group->values()->all())
             ->all();
+
+        return ['groups' => $groups, 'total' => $total];
+    }
+
+    /**
+     * Rank a project against a search query. Lower = better match. PHP_INT_MAX = no match.
+     *
+     * Tiers: 0=name exact, 1=name prefix, 2=name word-start, 3=branch exact/prefix,
+     * 4=branch word-start, 5=path word-start, 6=name substring, 7=branch substring, 8=path substring.
+     */
+    public static function rankMatch(string $name, string $branch, string $path, string $query): int
+    {
+        $q = mb_strtolower($query);
+        $n = mb_strtolower($name);
+        $b = mb_strtolower($branch);
+        $p = mb_strtolower($path);
+        $esc = preg_quote($q, '/');
+        $ws = '/(?:^|[^a-z0-9])'.$esc.'/';
+
+        if ($n === $q) {
+            return 0;
+        }
+        if (str_starts_with($n, $q)) {
+            return 1;
+        }
+        if (preg_match($ws, $n)) {
+            return 2;
+        }
+        if ($b === $q || str_starts_with($b, $q)) {
+            return 3;
+        }
+        if (preg_match($ws, $b)) {
+            return 4;
+        }
+        if (preg_match($ws, $p)) {
+            return 5;
+        }
+        if (str_contains($n, $q)) {
+            return 6;
+        }
+        if (str_contains($b, $q)) {
+            return 7;
+        }
+        if (str_contains($p, $q)) {
+            return 8;
+        }
+
+        return PHP_INT_MAX;
     }
 }

--- a/app/Actions/ListProjectsAction.php
+++ b/app/Actions/ListProjectsAction.php
@@ -7,6 +7,7 @@ namespace App\Actions;
 use App\Models\Project;
 use App\Models\ReviewSession;
 use Carbon\Carbon;
+use Illuminate\Support\Str;
 
 final readonly class ListProjectsAction
 {
@@ -48,17 +49,17 @@ final readonly class ListProjectsAction
         $search = trim($search);
         if ($search !== '') {
             $projects = $projects
-                ->map(fn (array $p) => $p + ['_rank' => self::rankMatch($p['name'], $p['branch'] ?? '', $p['path'], $search)])
-                ->filter(fn (array $p) => $p['_rank'] < PHP_INT_MAX)
-                ->sortBy('_rank');
+                ->map(fn (array $p) => ['rank' => self::rankMatch($p['name'], $p['branch'] ?? '', $p['path'], $search), 'project' => $p])
+                ->filter(fn (array $pair) => $pair['rank'] !== null)
+                ->sortBy([
+                    fn (array $a, array $b) => $a['rank'] <=> $b['rank'],
+                    fn (array $a, array $b) => Str::lower($a['project']['name']) <=> Str::lower($b['project']['name']),
+                ])
+                ->map(fn (array $pair) => $pair['project']);
 
             $groups = $projects
                 ->groupBy('git_common_dir')
-                ->map(fn ($group) => $group->map(function (array $p) {
-                    unset($p['_rank']);
-
-                    return $p;
-                })->values()->all())
+                ->map(fn ($group) => $group->values()->all())
                 ->all();
 
             return ['groups' => $groups, 'total' => $total];
@@ -82,48 +83,46 @@ final readonly class ListProjectsAction
     }
 
     /**
-     * Rank a project against a search query. Lower = better match. PHP_INT_MAX = no match.
+     * Rank a project against a search query. Lower = better match. null = no match.
      *
-     * Tiers: 0=name exact, 1=name prefix, 2=name word-start, 3=branch exact/prefix,
-     * 4=branch word-start, 5=path word-start, 6=name substring, 7=branch substring, 8=path substring.
+     * Score = tier * 10 + field (field: 0=name, 1=branch, 2=path).
+     * Tier 0: exact name. Tier 1: starts-with / word-boundary. Tier 2: substring.
      */
-    public static function rankMatch(string $name, string $branch, string $path, string $query): int
+    private static function rankMatch(string $name, string $branch, string $path, string $query): ?int
     {
-        $q = mb_strtolower($query);
-        $n = mb_strtolower($name);
-        $b = mb_strtolower($branch);
-        $p = mb_strtolower($path);
-        $esc = preg_quote($q, '/');
-        $ws = '/(?:^|[^a-z0-9])'.$esc.'/';
+        $lowerQuery = Str::lower($query);
+        $lowerName = Str::lower($name);
+        $lowerBranch = Str::lower($branch);
+        $lowerPath = Str::lower($path);
+        $wordBoundaryPattern = '/(?:^|[^a-z0-9])'.preg_quote($lowerQuery, '/').'/';
 
-        if ($n === $q) {
+        // Tier 0: exact name
+        if ($lowerName === $lowerQuery) {
             return 0;
         }
-        if (str_starts_with($n, $q)) {
-            return 1;
+
+        // Tier 1: starts-with or word-boundary (score 10 + field)
+        if (str_starts_with($lowerName, $lowerQuery) || preg_match($wordBoundaryPattern, $lowerName)) {
+            return 10;
         }
-        if (preg_match($ws, $n)) {
-            return 2;
+        if (str_starts_with($lowerBranch, $lowerQuery) || preg_match($wordBoundaryPattern, $lowerBranch)) {
+            return 11;
         }
-        if ($b === $q || str_starts_with($b, $q)) {
-            return 3;
-        }
-        if (preg_match($ws, $b)) {
-            return 4;
-        }
-        if (preg_match($ws, $p)) {
-            return 5;
-        }
-        if (str_contains($n, $q)) {
-            return 6;
-        }
-        if (str_contains($b, $q)) {
-            return 7;
-        }
-        if (str_contains($p, $q)) {
-            return 8;
+        if (preg_match($wordBoundaryPattern, $lowerPath)) {
+            return 12;
         }
 
-        return PHP_INT_MAX;
+        // Tier 2: substring (score 20 + field)
+        if (str_contains($lowerName, $lowerQuery)) {
+            return 20;
+        }
+        if (str_contains($lowerBranch, $lowerQuery)) {
+            return 21;
+        }
+        if (str_contains($lowerPath, $lowerQuery)) {
+            return 22;
+        }
+
+        return null;
     }
 }

--- a/app/Actions/ResolveProjectAction.php
+++ b/app/Actions/ResolveProjectAction.php
@@ -11,8 +11,18 @@ final readonly class ResolveProjectAction
     /**
      * @return array<string, mixed>|null
      */
-    public function handle(string $slug): ?array
+    public function handle(string $slug, bool $touch = false): ?array
     {
-        return Project::where('slug', $slug)->first()?->toArray();
+        $project = Project::where('slug', $slug)->first();
+
+        if ($project === null) {
+            return null;
+        }
+
+        if ($touch) {
+            $project->touch();
+        }
+
+        return $project->toArray();
     }
 }

--- a/app/Actions/RestoreSessionAction.php
+++ b/app/Actions/RestoreSessionAction.php
@@ -33,21 +33,21 @@ final readonly class RestoreSessionAction
             $currentPathSet[$f['path']] = true;
         }
 
-        /** @var array<int|string, string> $rawViewed */
-        $rawViewed = $session->viewed_files ?? [];
+        /** @var array<int|string, string> $rawReviewed */
+        $rawReviewed = $session->reviewed_files ?? [];
         $isImmutable = $target !== null && $target->isImmutable();
 
         // Legacy compat: convert indexed array to associative with fresh fingerprints
-        if ($rawViewed !== [] && array_is_list($rawViewed)) {
+        if ($rawReviewed !== [] && array_is_list($rawReviewed)) {
             $reviewedFiles = [];
-            foreach ($rawViewed as $path) {
+            foreach ($rawReviewed as $path) {
                 if (isset($currentPathSet[$path])) {
                     $reviewedFiles[$path] = $isImmutable ? '' : $this->gitDiffService->fileDiffFingerprint($repoPath, $path, $target);
                 }
             }
         } else {
             /** @var array<string, string> $reviewedFiles */
-            $reviewedFiles = array_intersect_key($rawViewed, $currentPathSet);
+            $reviewedFiles = array_intersect_key($rawReviewed, $currentPathSet);
 
             // Fingerprint validation (skip for immutable targets)
             if (! $isImmutable) {

--- a/app/Actions/SaveSessionAction.php
+++ b/app/Actions/SaveSessionAction.php
@@ -19,7 +19,7 @@ final readonly class SaveSessionAction
             ReviewSession::lookupKey($repoPath, $projectId, $contextFingerprint),
             [
                 'repo_path' => $repoPath,
-                'viewed_files' => $reviewedFiles,
+                'reviewed_files' => $reviewedFiles,
                 'comments' => $comments,
                 'global_comment' => $globalComment,
             ]

--- a/app/Actions/ToggleReviewedAction.php
+++ b/app/Actions/ToggleReviewedAction.php
@@ -7,7 +7,7 @@ namespace App\Actions;
 use App\DTOs\DiffTarget;
 use App\Services\GitDiffService;
 
-final readonly class ToggleViewedAction
+final readonly class ToggleReviewedAction
 {
     public function __construct(
         private GitDiffService $gitDiffService,

--- a/app/Console/Benchmark/PerfScenarioRunner.php
+++ b/app/Console/Benchmark/PerfScenarioRunner.php
@@ -181,7 +181,7 @@ final class PerfScenarioRunner
             public function __construct(private readonly Project $project) {}
 
             /** @return array<string, mixed> */
-            public function handle(string $slug): array
+            public function handle(string $slug, bool $touch = false): array
             {
                 return $this->project->toArray();
             }

--- a/app/Models/ReviewSession.php
+++ b/app/Models/ReviewSession.php
@@ -14,7 +14,7 @@ class ReviewSession extends Model
     /** @use HasFactory<ReviewSessionFactory> */
     use HasFactory;
 
-    protected $fillable = ['repo_path', 'project_id', 'context_fingerprint', 'viewed_files', 'comments', 'global_comment'];
+    protected $fillable = ['repo_path', 'project_id', 'context_fingerprint', 'reviewed_files', 'comments', 'global_comment'];
 
     /** @return array<string, int|string> */
     public static function lookupKey(string $repoPath, ?int $projectId, string $contextFingerprint): array
@@ -33,7 +33,7 @@ class ReviewSession extends Model
     protected function casts(): array
     {
         return [
-            'viewed_files' => 'array',
+            'reviewed_files' => 'array',
             'comments' => 'array',
         ];
     }

--- a/database/factories/ReviewSessionFactory.php
+++ b/database/factories/ReviewSessionFactory.php
@@ -24,7 +24,7 @@ class ReviewSessionFactory extends Factory
             'project_id' => Project::factory(),
             'repo_path' => '/tmp/'.fake()->unique()->slug(2),
             'context_fingerprint' => 'working',
-            'viewed_files' => [],
+            'reviewed_files' => [],
             'comments' => [],
             'global_comment' => '',
         ];

--- a/database/migrations/2026_02_12_000000_create_review_sessions_table.php
+++ b/database/migrations/2026_02_12_000000_create_review_sessions_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
         Schema::create('review_sessions', function (Blueprint $table) {
             $table->id();
             $table->string('repo_path')->unique();
-            $table->json('viewed_files')->default('[]');
+            $table->json('reviewed_files')->default('[]');
             $table->json('comments')->default('[]');
             $table->text('global_comment')->default('');
             $table->timestamps();

--- a/database/migrations/2026_04_10_124401_rename_viewed_files_to_reviewed_files.php
+++ b/database/migrations/2026_04_10_124401_rename_viewed_files_to_reviewed_files.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('review_sessions', 'viewed_files') && ! Schema::hasColumn('review_sessions', 'reviewed_files')) {
+            Schema::table('review_sessions', function (Blueprint $table) {
+                $table->renameColumn('viewed_files', 'reviewed_files');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('review_sessions', 'reviewed_files') && ! Schema::hasColumn('review_sessions', 'viewed_files')) {
+            Schema::table('review_sessions', function (Blueprint $table) {
+                $table->renameColumn('reviewed_files', 'viewed_files');
+            });
+        }
+    }
+};

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -317,6 +317,7 @@ new class extends Component {
             {{-- Comment indicator: ghost when no comments, full when comments exist --}}
             <div class="flex items-center gap-0.5"
                  :class="$wire.fileComments.length === 0 && 'opacity-30 group-hover:opacity-100 transition-opacity'"
+            >
                 <flux:button
                     x-ref="fileCommentBtn"
                     tooltip="Add file comment"

--- a/resources/views/pages/⚡dashboard-page.blade.php
+++ b/resources/views/pages/⚡dashboard-page.blade.php
@@ -162,7 +162,7 @@ new #[Layout('layouts.app')] class extends Component
     @keydown.window="
         if ($event.key === 'ArrowDown') { navigate(1); $event.preventDefault(); return; }
         if ($event.key === 'ArrowUp') { navigate(-1); $event.preventDefault(); return; }
-        if ($event.key === 'Enter' && selectedIndex >= 0) { openSelected(); $event.preventDefault(); return; }
+        if ($event.key === 'Enter') { if (selectedIndex >= 0) { openSelected(); $event.preventDefault(); return; } if (search !== '') { openFirst(); $event.preventDefault(); return; } }
         if ($event.target.tagName === 'INPUT' || $event.target.tagName === 'TEXTAREA' || $event.target.isContentEditable) {
             if ($event.key === 'Escape' && $event.target.tagName === 'INPUT') { search = ''; selectedIndex = -1; selectedProjectId = null; $event.target.blur(); $event.preventDefault(); }
             return;

--- a/resources/views/pages/⚡dashboard-page.blade.php
+++ b/resources/views/pages/⚡dashboard-page.blade.php
@@ -288,7 +288,7 @@ new #[Layout('layouts.app')] class extends Component
                     wire:key="group-{{ md5($commonDir) }}"
                     data-group-wrapper
                     x-show="@js($groupSearchData).some(([n, b, p]) => matchesSearch(n, b, p))"
-                    :style="search ? 'order: ' + Math.min(...@js($groupSearchData).map(([n, b, p]) => rankMatch(n, b, p))) : ''"
+                    :style="search ? { order: Math.min(...@js($groupSearchData).map(([n, b, p]) => rankMatch(n, b, p))) } : {}"
                 >
                     @if(count($projects) > 1)
                         <p class="section-label text-gh-muted mb-3 font-mono truncate">{{ $commonDir }}</p>

--- a/resources/views/pages/⚡dashboard-page.blade.php
+++ b/resources/views/pages/⚡dashboard-page.blade.php
@@ -162,7 +162,7 @@ new #[Layout('layouts.app')] class extends Component
     @keydown.window="
         if ($event.key === 'ArrowDown') { navigate(1); $event.preventDefault(); return; }
         if ($event.key === 'ArrowUp') { navigate(-1); $event.preventDefault(); return; }
-        if ($event.key === 'Enter') { if (selectedIndex >= 0) { openSelected(); $event.preventDefault(); return; } if (search !== '') { openFirst(); $event.preventDefault(); return; } }
+        if ($event.key === 'Enter' && selectedIndex >= 0) { openSelected(); $event.preventDefault(); return; }
         if ($event.target.tagName === 'INPUT' || $event.target.tagName === 'TEXTAREA' || $event.target.isContentEditable) {
             if ($event.key === 'Escape' && $event.target.tagName === 'INPUT') { search = ''; selectedIndex = -1; selectedProjectId = null; $event.target.blur(); $event.preventDefault(); }
             return;

--- a/resources/views/pages/⚡dashboard-page.blade.php
+++ b/resources/views/pages/⚡dashboard-page.blade.php
@@ -14,7 +14,11 @@ new #[Layout('layouts.app')] class extends Component
     /** @var array<string, array<int, array<string, mixed>>> */
     public array $projectGroups = [];
 
+    public int $totalProjects = 0;
+
     public string $sortBy = 'recent';
+
+    public string $search = '';
 
     public function mount(): void
     {
@@ -22,7 +26,12 @@ new #[Layout('layouts.app')] class extends Component
             \Native\Desktop\Facades\Window::get('main')->title('rfa');
         }
 
-        $this->projectGroups = app(ListProjectsAction::class)->handle($this->sortBy);
+        $this->refreshProjects();
+    }
+
+    public function updatedSearch(): void
+    {
+        $this->refreshProjects();
     }
 
     #[On('projects-changed')]
@@ -31,14 +40,21 @@ new #[Layout('layouts.app')] class extends Component
         if ($sortBy !== '') {
             $this->sortBy = $sortBy;
         }
-        $this->projectGroups = app(ListProjectsAction::class)->handle($this->sortBy);
+        $this->refreshProjects();
     }
 
     public function removeProject(int $projectId): void
     {
         app(RemoveProjectAction::class)->handle($projectId);
 
-        $this->projectGroups = app(ListProjectsAction::class)->handle($this->sortBy);
+        $this->refreshProjects();
+    }
+
+    private function refreshProjects(): void
+    {
+        $result = app(ListProjectsAction::class)->handle($this->sortBy, $this->search);
+        $this->projectGroups = $result['groups'];
+        $this->totalProjects = $result['total'];
     }
 
     public function registerProject(string $path): void
@@ -72,64 +88,32 @@ new #[Layout('layouts.app')] class extends Component
     class="min-h-screen"
     wire:poll.30s="loadProjects('{{ $sortBy }}')"
     x-data="{
-        search: '',
         selectedIndex: -1,
         selectedProjectId: null,
         sortBy: $store.settings.dashboardSort,
         dragging: false,
         dragCounter: 0,
-        get flatProjects() {
+        get allProjects() {
             return Array.from(this.$root.querySelectorAll('[data-project-card]'));
         },
-        get visibleProjects() {
-            return this.flatProjects
-                .filter(el => el.style.display !== 'none')
-                .sort((a, b) => {
-                    const ag = parseInt(a.closest('[data-group-wrapper]')?.style.order) || 0;
-                    const bg = parseInt(b.closest('[data-group-wrapper]')?.style.order) || 0;
-                    return ag - bg;
-                });
-        },
-        rankMatch(name, branch, path) {
-            if (this.search === '') return 0;
-            const q = this.search.toLowerCase();
-            const n = name.toLowerCase();
-            const b = (branch || '').toLowerCase();
-            const p = path.toLowerCase();
-            const esc = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-            const ws = new RegExp('(?:^|[^a-z0-9])' + esc);
-            if (n === q) return 0;
-            if (n.startsWith(q)) return 1;
-            if (ws.test(n)) return 2;
-            if (b === q || b.startsWith(q)) return 3;
-            if (ws.test(b)) return 4;
-            if (ws.test(p)) return 5;
-            if (n.includes(q)) return 6;
-            if (b.includes(q)) return 7;
-            if (p.includes(q)) return 8;
-            return Infinity;
-        },
-        matchesSearch(name, branch, path) {
-            return this.rankMatch(name, branch, path) !== Infinity;
-        },
         navigate(dir) {
-            const visible = this.visibleProjects;
-            if (!visible.length) return;
-            this.selectedIndex = Math.max(0, Math.min(visible.length - 1, this.selectedIndex + dir));
-            this.selectedProjectId = visible[this.selectedIndex]?.dataset.projectId ?? null;
-            visible[this.selectedIndex]?.scrollIntoView({ block: 'nearest' });
+            const cards = this.allProjects;
+            if (!cards.length) return;
+            this.selectedIndex = Math.max(0, Math.min(cards.length - 1, this.selectedIndex + dir));
+            this.selectedProjectId = cards[this.selectedIndex]?.dataset.projectId ?? null;
+            cards[this.selectedIndex]?.scrollIntoView({ block: 'nearest' });
         },
         openSelected() {
-            const visible = this.visibleProjects;
-            if (this.selectedIndex >= 0 && this.selectedIndex < visible.length) {
-                const link = visible[this.selectedIndex]?.querySelector('a[data-project-link]');
+            const cards = this.allProjects;
+            if (this.selectedIndex >= 0 && this.selectedIndex < cards.length) {
+                const link = cards[this.selectedIndex]?.querySelector('a[data-project-link]');
                 if (link) window.location.href = link.href;
             }
         },
         openFirst() {
-            const visible = this.visibleProjects;
-            if (visible.length) {
-                const link = visible[0]?.querySelector('a[data-project-link]');
+            const cards = this.allProjects;
+            if (cards.length) {
+                const link = cards[0]?.querySelector('a[data-project-link]');
                 if (link) window.location.href = link.href;
             }
         },
@@ -164,7 +148,7 @@ new #[Layout('layouts.app')] class extends Component
         if ($event.key === 'ArrowUp') { navigate(-1); $event.preventDefault(); return; }
         if ($event.key === 'Enter' && selectedIndex >= 0) { openSelected(); $event.preventDefault(); return; }
         if ($event.target.tagName === 'INPUT' || $event.target.tagName === 'TEXTAREA' || $event.target.isContentEditable) {
-            if ($event.key === 'Escape' && $event.target.tagName === 'INPUT') { search = ''; selectedIndex = -1; selectedProjectId = null; $event.target.blur(); $event.preventDefault(); }
+            if ($event.key === 'Escape' && $event.target.tagName === 'INPUT') { $wire.set('search', ''); selectedIndex = -1; selectedProjectId = null; $event.target.blur(); $event.preventDefault(); }
             return;
         }
         if ($event.key === 'Escape') { selectedIndex = -1; selectedProjectId = null; $event.preventDefault(); return; }
@@ -207,7 +191,7 @@ new #[Layout('layouts.app')] class extends Component
     </header>
 
     <main class="max-w-2xl mx-auto py-16 px-6">
-        @if(empty($projectGroups))
+        @if($totalProjects === 0)
             <div class="flex items-center justify-center h-[60vh]">
                 <div class="text-center">
                     <p class="rfa-logo text-5xl text-gh-muted/30 mb-6">rfa</p>
@@ -249,7 +233,7 @@ new #[Layout('layouts.app')] class extends Component
 
             <div class="mb-6">
                 <flux:input
-                    x-model.debounce.150ms="search"
+                    wire:model.live.debounce.250ms="search"
                     placeholder="Filter projects..."
                     icon="magnifying-glass"
                     icon:variant="outline"
@@ -257,39 +241,35 @@ new #[Layout('layouts.app')] class extends Component
                     variant="filled"
                     x-ref="searchInput"
                     autofocus
-                    @keydown.escape="search = ''; selectedIndex = -1; selectedProjectId = null; $el.blur()"
-                    @keydown.enter.prevent.stop="selectedIndex >= 0 ? openSelected() : (search !== '' && openFirst())"
+                    @keydown.escape="$wire.set('search', ''); selectedIndex = -1; selectedProjectId = null; $el.blur()"
+                    @keydown.enter.prevent.stop="selectedIndex >= 0 ? openSelected() : ($wire.search !== '' && openFirst())"
                     @input="selectedIndex = -1; selectedProjectId = null"
                 />
-                @php
-                    $totalProjects = collect($projectGroups)->flatten(1)->count();
-                @endphp
+                @php $matchCount = collect($projectGroups)->flatten(1)->count(); @endphp
                 <div class="flex items-center justify-between mt-2">
-                    <span
-                        class="font-mono text-xs text-gh-muted"
-                        x-text="search === ''
-                            ? '{{ $totalProjects }} {{ Str::plural('project', $totalProjects) }}'
-                            : visibleProjects.length + '/{{ $totalProjects }} projects'"
-                    >{{ $totalProjects }} {{ Str::plural('project', $totalProjects) }}</span>
-                    <span class="font-mono text-xs text-gh-muted/50" x-show="search === ''">
-                        <kbd class="px-1 py-0.5 rounded border border-gh-border text-[10px]">/</kbd> search
-                        <kbd class="px-1 py-0.5 rounded border border-gh-border text-[10px] ml-2">&uarr;</kbd><kbd class="px-1 py-0.5 rounded border border-gh-border text-[10px]">&darr;</kbd> navigate
+                    <span class="font-mono text-xs text-gh-muted">
+                        @if($search !== '')
+                            {{ $matchCount }}/{{ $totalProjects }} {{ Str::plural('project', $totalProjects) }}
+                        @else
+                            {{ $totalProjects }} {{ Str::plural('project', $totalProjects) }}
+                        @endif
                     </span>
+                    @if($search === '')
+                        <span class="font-mono text-xs text-gh-muted/50">
+                            <kbd class="px-1 py-0.5 rounded border border-gh-border text-[10px]">/</kbd> search
+                            <kbd class="px-1 py-0.5 rounded border border-gh-border text-[10px] ml-2">&uarr;</kbd><kbd class="px-1 py-0.5 rounded border border-gh-border text-[10px]">&darr;</kbd> navigate
+                        </span>
+                    @endif
                 </div>
             </div>
 
             @php $projectIndex = 0; @endphp
+            @if($search !== '' && empty($projectGroups))
+                <p class="text-center font-mono text-sm text-gh-muted py-12">No matching projects</p>
+            @endif
             <div class="flex flex-col gap-8">
             @foreach($projectGroups as $commonDir => $projects)
-                @php
-                    $groupSearchData = collect($projects)->map(fn($p) => [$p['name'], $p['branch'] ?? '', $p['path']])->values()->all();
-                @endphp
-                <div
-                    wire:key="group-{{ md5($commonDir) }}"
-                    data-group-wrapper
-                    x-show="@js($groupSearchData).some(([n, b, p]) => matchesSearch(n, b, p))"
-                    :style="search ? { order: Math.min(...@js($groupSearchData).map(([n, b, p]) => rankMatch(n, b, p))) } : {}"
-                >
+                <div wire:key="group-{{ md5($commonDir) }}">
                     @if(count($projects) > 1)
                         <p class="section-label text-gh-muted mb-3 font-mono truncate">{{ $commonDir }}</p>
                     @endif
@@ -311,8 +291,7 @@ new #[Layout('layouts.app')] class extends Component
                                         .then(d => { status = d; loading = false; })
                                         .catch(() => { loading = false; });
                                 }, {{ $projectIndex * 100 }})"
-                                x-show="matchesSearch(@js($project['name']), @js($project['branch'] ?? ''), @js($project['path']))"
-                                :data-selected="selectedProjectId === $el.dataset.projectId"
+                                    :data-selected="selectedProjectId === $el.dataset.projectId"
                                 :class="selectedProjectId && selectedProjectId === $el.dataset.projectId ? 'ring-1 ring-gh-link/40' : ''"
                                 class="rounded-lg border border-gh-border hover:border-gh-text/30 bg-gh-surface transition-all"
                             >
@@ -389,7 +368,7 @@ new #[Layout('layouts.app')] class extends Component
         @endif
     </main>
 
-    @if(!empty($projectGroups))
+    @if($totalProjects > 0)
         <footer class="fixed bottom-0 inset-x-0 py-2 flex items-center justify-center gap-1.5 font-mono text-[11px] text-gh-muted/40">
             <x-external-link href="https://x.com/fgili0" class="hover:text-gh-muted transition-colors">Franco Gilio</x-external-link>
             <span>&middot;</span>

--- a/resources/views/pages/⚡dashboard-page.blade.php
+++ b/resources/views/pages/⚡dashboard-page.blade.php
@@ -82,12 +82,35 @@ new #[Layout('layouts.app')] class extends Component
             return Array.from(this.$root.querySelectorAll('[data-project-card]'));
         },
         get visibleProjects() {
-            return this.flatProjects.filter(el => el.style.display !== 'none');
+            return this.flatProjects
+                .filter(el => el.style.display !== 'none')
+                .sort((a, b) => {
+                    const ag = parseInt(a.closest('[data-group-wrapper]')?.style.order) || 0;
+                    const bg = parseInt(b.closest('[data-group-wrapper]')?.style.order) || 0;
+                    return ag - bg;
+                });
+        },
+        rankMatch(name, branch, path) {
+            if (this.search === '') return 0;
+            const q = this.search.toLowerCase();
+            const n = name.toLowerCase();
+            const b = (branch || '').toLowerCase();
+            const p = path.toLowerCase();
+            const esc = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const ws = new RegExp('(?:^|[^a-z0-9])' + esc);
+            if (n === q) return 0;
+            if (n.startsWith(q)) return 1;
+            if (ws.test(n)) return 2;
+            if (b === q || b.startsWith(q)) return 3;
+            if (ws.test(b)) return 4;
+            if (ws.test(p)) return 5;
+            if (n.includes(q)) return 6;
+            if (b.includes(q)) return 7;
+            if (p.includes(q)) return 8;
+            return Infinity;
         },
         matchesSearch(name, branch, path) {
-            if (this.search === '') return true;
-            const q = this.search.toLowerCase();
-            return name.toLowerCase().includes(q) || (branch && branch.toLowerCase().includes(q)) || path.toLowerCase().includes(q);
+            return this.rankMatch(name, branch, path) !== Infinity;
         },
         navigate(dir) {
             const visible = this.visibleProjects;
@@ -100,6 +123,13 @@ new #[Layout('layouts.app')] class extends Component
             const visible = this.visibleProjects;
             if (this.selectedIndex >= 0 && this.selectedIndex < visible.length) {
                 const link = visible[this.selectedIndex]?.querySelector('a[data-project-link]');
+                if (link) window.location.href = link.href;
+            }
+        },
+        openFirst() {
+            const visible = this.visibleProjects;
+            if (visible.length) {
+                const link = visible[0]?.querySelector('a[data-project-link]');
                 if (link) window.location.href = link.href;
             }
         },
@@ -211,7 +241,8 @@ new #[Layout('layouts.app')] class extends Component
                         x-on:click="setSort(sortBy === 'recent' ? 'alpha' : 'recent')"
                         class="text-gh-muted hover:text-gh-text font-mono text-xs"
                     >
-                        <span x-text="sortBy === 'recent' ? 'A-Z' : 'Recent'"></span>
+                        <flux:icon icon="arrows-up-down" variant="outline" class="size-3.5" />
+                        <span x-text="sortBy === 'recent' ? 'Recent' : 'A-Z'"></span>
                     </flux:button>
                 </div>
             </div>
@@ -227,6 +258,7 @@ new #[Layout('layouts.app')] class extends Component
                     x-ref="searchInput"
                     autofocus
                     @keydown.escape="search = ''; selectedIndex = -1; selectedProjectId = null; $el.blur()"
+                    @keydown.enter.prevent.stop="selectedIndex >= 0 ? openSelected() : (search !== '' && openFirst())"
                     @input="selectedIndex = -1; selectedProjectId = null"
                 />
                 @php
@@ -247,11 +279,17 @@ new #[Layout('layouts.app')] class extends Component
             </div>
 
             @php $projectIndex = 0; @endphp
+            <div class="flex flex-col gap-8">
             @foreach($projectGroups as $commonDir => $projects)
                 @php
                     $groupSearchData = collect($projects)->map(fn($p) => [$p['name'], $p['branch'] ?? '', $p['path']])->values()->all();
                 @endphp
-                <div wire:key="group-{{ md5($commonDir) }}" class="mb-8" x-show="@js($groupSearchData).some(([n, b, p]) => matchesSearch(n, b, p))">
+                <div
+                    wire:key="group-{{ md5($commonDir) }}"
+                    data-group-wrapper
+                    x-show="@js($groupSearchData).some(([n, b, p]) => matchesSearch(n, b, p))"
+                    :style="search ? 'order: ' + Math.min(...@js($groupSearchData).map(([n, b, p]) => rankMatch(n, b, p))) : ''"
+                >
                     @if(count($projects) > 1)
                         <p class="section-label text-gh-muted mb-3 font-mono truncate">{{ $commonDir }}</p>
                     @endif
@@ -347,7 +385,7 @@ new #[Layout('layouts.app')] class extends Component
                     </div>
                 </div>
             @endforeach
-
+            </div>
         @endif
     </main>
 

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -20,6 +20,7 @@ use App\Actions\SaveSessionAction;
 use App\Actions\ToggleViewedAction;
 use App\Actions\UpdateProjectSettingAction;
 use App\DTOs\DiffTarget;
+use App\Models\Project;
 use App\DTOs\FileListEntry;
 use App\Exceptions\GitCommandException;
 use App\Support\DiffCacheKey;
@@ -87,6 +88,7 @@ new #[Layout('layouts.app')] class extends Component
     public function mount(string $slug, ?string $hash = null, ?string $ref = null, ?string $baseRef = null): void
     {
         $project = app(ResolveProjectAction::class)->handle($slug) ?? abort(404);
+        Project::where('id', $project['id'])->update(['updated_at' => now()]);
         $this->repoPath = $project['path'];
         $this->projectId = $project['id'];
         $this->projectName = $project['name'];

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -84,6 +84,22 @@ new #[Layout('layouts.app')] class extends Component
     #[Locked]
     public ?array $commitInfo = null;
 
+    /*
+    |----------------------------------------------------------------------
+    | Responsibility clusters (5):
+    |   1. Initialization & Diff Context  (mount..refreshFileList)
+    |   2. Comment Management             (addComment..restoreComments)
+    |   3. Trash & Discard                (discardFileChanges..undo)
+    |   4. Review State & Export           (toggleReviewed..submitReview)
+    |   5. Computed, Helpers & Persistence (groupedComments..loadTrashedFiles)
+    |
+    | Shared deps: $files, $comments, $reviewedFiles, saveSession()
+    | Extraction blocker: 1+N hydration (see resources/CLAUDE.md)
+    |----------------------------------------------------------------------
+    */
+
+    // region: Initialization & Diff Context
+
     public function mount(string $slug, ?string $hash = null, ?string $ref = null, ?string $baseRef = null): void
     {
         $project = app(ResolveProjectAction::class)->handle($slug, touch: true) ?? abort(404);
@@ -198,6 +214,10 @@ new #[Layout('layouts.app')] class extends Component
             $this->injectOrphanedFiles($session['orphanedPaths']);
         }
     }
+
+    // endregion: Initialization & Diff Context
+
+    // region: Comment Management
 
     #[On('add-comment')]
     public function addComment(string $fileId, string $side, ?int $startLine, ?int $endLine, string $body): void
@@ -314,6 +334,10 @@ new #[Layout('layouts.app')] class extends Component
         $this->skipRender();
     }
 
+    // endregion: Comment Management
+
+    // region: Trash & Discard
+
     #[On('discard-file')]
     public function discardFileChanges(string $fileId): void
     {
@@ -400,6 +424,10 @@ new #[Layout('layouts.app')] class extends Component
         };
     }
 
+    // endregion: Trash & Discard
+
+    // region: Review State & Export
+
     #[On('toggle-reviewed')]
     public function toggleReviewed(string $filePath): void
     {
@@ -446,6 +474,10 @@ new #[Layout('layouts.app')] class extends Component
         $affectedFileIds->each(fn (string $fileId) => $this->dispatchFileComments($fileId));
         $this->dispatch('reset-reviewed-files');
     }
+
+    // endregion: Review State & Export
+
+    // region: Computed, Helpers & Persistence
 
     /** @return array<string, array<int, array<string, mixed>>> */
     #[Computed]
@@ -550,6 +582,8 @@ new #[Layout('layouts.app')] class extends Component
 
         $this->trashedFiles = app(CleanExpiredTrashAction::class)->handle($this->projectId);
     }
+
+    // endregion: Computed, Helpers & Persistence
 };
 ?>
 

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -17,14 +17,13 @@ use App\Actions\ResolveProjectAction;
 use App\Actions\RestoreDiscardedFileAction;
 use App\Actions\RestoreSessionAction;
 use App\Actions\SaveSessionAction;
-use App\Actions\ToggleViewedAction;
+use App\Actions\ToggleReviewedAction;
 use App\Actions\UpdateProjectSettingAction;
 use App\DTOs\DiffTarget;
 use App\DTOs\FileListEntry;
 use App\Exceptions\GitCommandException;
 use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Locked;
@@ -87,8 +86,7 @@ new #[Layout('layouts.app')] class extends Component
 
     public function mount(string $slug, ?string $hash = null, ?string $ref = null, ?string $baseRef = null): void
     {
-        $project = app(ResolveProjectAction::class)->handle($slug) ?? abort(404);
-        DB::table('projects')->where('id', $project['id'])->update(['updated_at' => now()]);
+        $project = app(ResolveProjectAction::class)->handle($slug, touch: true) ?? abort(404);
         $this->repoPath = $project['path'];
         $this->projectId = $project['id'];
         $this->projectName = $project['name'];
@@ -405,7 +403,7 @@ new #[Layout('layouts.app')] class extends Component
     #[On('toggle-reviewed')]
     public function toggleReviewed(string $filePath): void
     {
-        $result = app(ToggleViewedAction::class)->handle($this->reviewedFiles, $filePath, $this->files, $this->repoPath, $this->buildDiffTarget());
+        $result = app(ToggleReviewedAction::class)->handle($this->reviewedFiles, $filePath, $this->files, $this->repoPath, $this->buildDiffTarget());
 
         if ($result === null) {
             return;

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -20,11 +20,11 @@ use App\Actions\SaveSessionAction;
 use App\Actions\ToggleViewedAction;
 use App\Actions\UpdateProjectSettingAction;
 use App\DTOs\DiffTarget;
-use App\Models\Project;
 use App\DTOs\FileListEntry;
 use App\Exceptions\GitCommandException;
 use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Locked;
@@ -88,7 +88,7 @@ new #[Layout('layouts.app')] class extends Component
     public function mount(string $slug, ?string $hash = null, ?string $ref = null, ?string $baseRef = null): void
     {
         $project = app(ResolveProjectAction::class)->handle($slug) ?? abort(404);
-        Project::where('id', $project['id'])->update(['updated_at' => now()]);
+        DB::table('projects')->where('id', $project['id'])->update(['updated_at' => now()]);
         $this->repoPath = $project['path'];
         $this->projectId = $project['id'];
         $this->projectName = $project['name'];

--- a/tests/Browser/DashboardKeyboardNavTest.php
+++ b/tests/Browser/DashboardKeyboardNavTest.php
@@ -71,17 +71,17 @@ test('escape clears selection', function () {
 test('search and arrow nav on filtered results', function () {
     $page = $this->visit('/');
 
-    // Type a filter that matches only one project
+    // Type a filter that matches only one project (server-side filtering)
     $page->page()->getByPlaceholder('Filter projects...')->fill('beta');
 
-    // Wait for 150ms debounce + Alpine reactivity to hide non-matching cards
-    $page->page()->waitForFunction("document.querySelectorAll('[data-project-card]:not([style*=\"display: none\"])').length === 1");
+    // Wait for Livewire to re-render with only the matching project
+    $page->page()->waitForFunction("document.querySelectorAll('[data-project-card]').length === 1");
 
     $this->pressGlobalKey($page, 'ArrowDown');
 
-    // Wait for selection to land on the visible card (atomic check avoids race between reads)
+    // Wait for selection to land on the visible card
     $page->page()->waitForFunction("
-        document.querySelector('[data-project-card]:not([style*=\"display: none\"])[data-selected]') !== null
+        document.querySelector('[data-project-card][data-selected]') !== null
     ");
 
     $selectedId = $page->script("document.querySelector('[data-testid=\"project-card\"][data-selected]')?.dataset.projectId");

--- a/tests/Browser/DashboardSearchRankingTest.php
+++ b/tests/Browser/DashboardSearchRankingTest.php
@@ -56,22 +56,3 @@ test('search ranks start-of-word above mid-word match', function () {
     $selectedText = $page->script("document.querySelector('[data-project-card][data-selected]')?.textContent");
     expect($selectedText)->toContain('my-api-tool');
 });
-
-// -- Enter to open first result --
-
-test('enter in search opens first matching result', function () {
-    $page = $this->visit('/');
-
-    $searchInput = $page->page()->getByPlaceholder('Filter projects...');
-    $searchInput->fill('rfa');
-
-    // Wait for debounce + Alpine reactivity
-    $page->page()->waitForFunction("document.querySelectorAll('[data-project-card]:not([style*=\"display: none\"])').length === 2");
-
-    // Press Enter on the search input — should open first ranked result
-    $searchInput->press('Enter');
-
-    $page->page()->waitForURL('**/p/**');
-    $url = $page->script('window.location.pathname');
-    expect($url)->toContain('/p/');
-});

--- a/tests/Browser/DashboardSearchRankingTest.php
+++ b/tests/Browser/DashboardSearchRankingTest.php
@@ -11,20 +11,20 @@ beforeEach(function () {
     $projects[1]->update(['name' => 'farfalla']);
 });
 
-// -- Search ranking --
+// -- Search ranking (server-side) --
 
 test('search ranks exact name match above substring match', function () {
     $page = $this->visit('/');
 
     $page->page()->getByPlaceholder('Filter projects...')->fill('rfa');
 
-    // Wait for debounce + Alpine reactivity — both should match ("rfa" exact, "farfalla" contains "rfa")
-    $page->page()->waitForFunction("document.querySelectorAll('[data-project-card]:not([style*=\"display: none\"])').length === 2");
+    // Server-side search: wait for Livewire to re-render with only matching projects
+    $page->page()->waitForFunction("document.querySelectorAll('[data-project-card]').length === 2");
 
     $this->pressGlobalKey($page, 'ArrowDown');
 
     $page->page()->waitForFunction("
-        document.querySelector('[data-project-card]:not([style*=\"display: none\"])[data-selected]') !== null
+        document.querySelector('[data-project-card][data-selected]') !== null
     ");
 
     // First selected card should be the exact match "rfa", not "farfalla"
@@ -44,12 +44,12 @@ test('search ranks start-of-word above mid-word match', function () {
     $page->page()->getByPlaceholder('Filter projects...')->fill('api');
 
     // Both match: "my-api-tool" has word-start match, "rapid" has mid-word substring
-    $page->page()->waitForFunction("document.querySelectorAll('[data-project-card]:not([style*=\"display: none\"])').length === 2");
+    $page->page()->waitForFunction("document.querySelectorAll('[data-project-card]').length === 2");
 
     $this->pressGlobalKey($page, 'ArrowDown');
 
     $page->page()->waitForFunction("
-        document.querySelector('[data-project-card]:not([style*=\"display: none\"])[data-selected]') !== null
+        document.querySelector('[data-project-card][data-selected]') !== null
     ");
 
     // Word-start match "my-api-tool" should rank above mid-word "rapid"

--- a/tests/Browser/DashboardSearchRankingTest.php
+++ b/tests/Browser/DashboardSearchRankingTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Models\Project;
+
+beforeEach(function () {
+    $this->setUpRegisteredProjects(['proj-a', 'proj-b']);
+
+    // Rename to clean names so search ranking is testable independent of temp dir paths
+    $projects = Project::orderBy('id')->get();
+    $projects[0]->update(['name' => 'rfa']);
+    $projects[1]->update(['name' => 'farfalla']);
+});
+
+// -- Search ranking --
+
+test('search ranks exact name match above substring match', function () {
+    $page = $this->visit('/');
+
+    $page->page()->getByPlaceholder('Filter projects...')->fill('rfa');
+
+    // Wait for debounce + Alpine reactivity — both should match ("rfa" exact, "farfalla" contains "rfa")
+    $page->page()->waitForFunction("document.querySelectorAll('[data-project-card]:not([style*=\"display: none\"])').length === 2");
+
+    $this->pressGlobalKey($page, 'ArrowDown');
+
+    $page->page()->waitForFunction("
+        document.querySelector('[data-project-card]:not([style*=\"display: none\"])[data-selected]') !== null
+    ");
+
+    // First selected card should be the exact match "rfa", not "farfalla"
+    $selectedText = $page->script("document.querySelector('[data-project-card][data-selected]')?.textContent");
+    expect($selectedText)->toContain('rfa')
+        ->and($selectedText)->not->toContain('farfalla');
+});
+
+test('search ranks start-of-word above mid-word match', function () {
+    // Rename to test word-boundary ranking
+    $projects = Project::orderBy('id')->get();
+    $projects[0]->update(['name' => 'my-api-tool']);
+    $projects[1]->update(['name' => 'rapid']);
+
+    $page = $this->visit('/');
+
+    $page->page()->getByPlaceholder('Filter projects...')->fill('api');
+
+    // Both match: "my-api-tool" has word-start match, "rapid" has mid-word substring
+    $page->page()->waitForFunction("document.querySelectorAll('[data-project-card]:not([style*=\"display: none\"])').length === 2");
+
+    $this->pressGlobalKey($page, 'ArrowDown');
+
+    $page->page()->waitForFunction("
+        document.querySelector('[data-project-card]:not([style*=\"display: none\"])[data-selected]') !== null
+    ");
+
+    // Word-start match "my-api-tool" should rank above mid-word "rapid"
+    $selectedText = $page->script("document.querySelector('[data-project-card][data-selected]')?.textContent");
+    expect($selectedText)->toContain('my-api-tool');
+});

--- a/tests/Browser/DashboardSearchRankingTest.php
+++ b/tests/Browser/DashboardSearchRankingTest.php
@@ -56,3 +56,21 @@ test('search ranks start-of-word above mid-word match', function () {
     $selectedText = $page->script("document.querySelector('[data-project-card][data-selected]')?.textContent");
     expect($selectedText)->toContain('my-api-tool');
 });
+
+// -- Enter to open first result --
+
+test('enter in search opens first matching result', function () {
+    $page = $this->visit('/');
+
+    $page->page()->getByPlaceholder('Filter projects...')->fill('rfa');
+
+    // Wait for debounce + Alpine reactivity
+    $page->page()->waitForFunction("document.querySelectorAll('[data-project-card]:not([style*=\"display: none\"])').length === 2");
+
+    // Press Enter without selecting via arrows — should open first ranked result
+    $this->pressGlobalKey($page, 'Enter');
+
+    $page->page()->waitForURL('**/p/**');
+    $url = $page->script('window.location.pathname');
+    expect($url)->toContain('/p/');
+});

--- a/tests/Browser/DashboardSearchRankingTest.php
+++ b/tests/Browser/DashboardSearchRankingTest.php
@@ -62,13 +62,14 @@ test('search ranks start-of-word above mid-word match', function () {
 test('enter in search opens first matching result', function () {
     $page = $this->visit('/');
 
-    $page->page()->getByPlaceholder('Filter projects...')->fill('rfa');
+    $searchInput = $page->page()->getByPlaceholder('Filter projects...');
+    $searchInput->fill('rfa');
 
     // Wait for debounce + Alpine reactivity
     $page->page()->waitForFunction("document.querySelectorAll('[data-project-card]:not([style*=\"display: none\"])').length === 2");
 
-    // Press Enter without selecting via arrows — should open first ranked result
-    $this->pressGlobalKey($page, 'Enter');
+    // Press Enter on the search input — should open first ranked result
+    $searchInput->press('Enter');
 
     $page->page()->waitForURL('**/p/**');
     $url = $page->script('window.location.pathname');

--- a/tests/Unit/Actions/ListProjectsActionTest.php
+++ b/tests/Unit/Actions/ListProjectsActionTest.php
@@ -7,80 +7,69 @@ use Tests\TestCase;
 
 uses(TestCase::class, LazilyRefreshDatabase::class);
 
-// -- rankMatch --
+function searchNames(string $query): array
+{
+    return collect(app(ListProjectsAction::class)->handle('recent', $query)['groups'])->flatten(1)->pluck('name')->all();
+}
 
-test('rankMatch returns 0 for exact name match', function () {
-    expect(ListProjectsAction::rankMatch('rfa', 'main', '/tmp/rfa', 'rfa'))->toBe(0);
+// -- search ranking --
+
+test('ranks name-prefix above branch match', function () {
+    Project::factory()->create(['name' => 'rfa-app', 'git_common_dir' => '/tmp/shared/.git']);
+    Project::factory()->create(['name' => 'other', 'branch' => 'rfa-branch', 'git_common_dir' => '/tmp/shared/.git']);
+
+    expect(searchNames('rfa'))->toBe(['rfa-app', 'other']);
 });
 
-test('rankMatch returns 1 for name prefix', function () {
-    expect(ListProjectsAction::rankMatch('rfa-app', 'main', '/tmp/rfa', 'rfa'))->toBe(1);
+test('ranks word-boundary above substring', function () {
+    Project::factory()->create(['name' => 'farfalla', 'git_common_dir' => '/tmp/shared/.git']);
+    Project::factory()->create(['name' => 'my-rfa-tool', 'git_common_dir' => '/tmp/shared/.git']);
+
+    expect(searchNames('rfa'))->toBe(['my-rfa-tool', 'farfalla']);
 });
 
-test('rankMatch returns 2 for name word-start', function () {
-    expect(ListProjectsAction::rankMatch('my-rfa-tool', 'main', '/tmp/x', 'rfa'))->toBe(2);
+test('ranks branch match above path-only match', function () {
+    Project::factory()->create(['name' => 'path-match', 'path' => '/tmp/rfa-stuff', 'git_common_dir' => '/tmp/shared/.git']);
+    Project::factory()->create(['name' => 'branch-match', 'branch' => 'rfa-fix', 'git_common_dir' => '/tmp/shared/.git']);
+
+    expect(searchNames('rfa'))->toBe(['branch-match', 'path-match']);
 });
 
-test('rankMatch returns 3 for branch exact or prefix', function () {
-    expect(ListProjectsAction::rankMatch('other', 'rfa', '/tmp/x', 'rfa'))->toBe(3);
-    expect(ListProjectsAction::rankMatch('other', 'rfa-branch', '/tmp/x', 'rfa'))->toBe(3);
+test('search is case insensitive', function () {
+    Project::factory()->create(['name' => 'RFA']);
+
+    expect(searchNames('rfa'))->toBe(['RFA']);
 });
 
-test('rankMatch returns 4 for branch word-start', function () {
-    expect(ListProjectsAction::rankMatch('other', 'fix-rfa-bug', '/tmp/x', 'rfa'))->toBe(4);
-});
+test('equal-rank projects sort alphabetically by name', function () {
+    Project::factory()->create(['name' => 'zeta-rfa', 'git_common_dir' => '/tmp/shared/.git']);
+    Project::factory()->create(['name' => 'alpha-rfa', 'git_common_dir' => '/tmp/shared/.git']);
 
-test('rankMatch returns 5 for path word-start', function () {
-    expect(ListProjectsAction::rankMatch('other', 'main', '/tmp/rfa-proj', 'rfa'))->toBe(5);
-});
-
-test('rankMatch returns 6 for name substring', function () {
-    expect(ListProjectsAction::rankMatch('farfalla', 'main', '/tmp/x', 'rfa'))->toBe(6);
-});
-
-test('rankMatch returns 7 for branch substring', function () {
-    expect(ListProjectsAction::rankMatch('other', 'xrfay', '/tmp/x', 'rfa'))->toBe(7);
-});
-
-test('rankMatch returns 8 for path substring', function () {
-    expect(ListProjectsAction::rankMatch('other', 'main', '/tmp/xrfay', 'rfa'))->toBe(8);
-});
-
-test('rankMatch returns PHP_INT_MAX for no match', function () {
-    expect(ListProjectsAction::rankMatch('other', 'main', '/tmp/x', 'zzz'))->toBe(PHP_INT_MAX);
-});
-
-test('rankMatch is case insensitive', function () {
-    expect(ListProjectsAction::rankMatch('RFA', 'main', '/tmp/x', 'rfa'))->toBe(0);
-    expect(ListProjectsAction::rankMatch('rfa', 'main', '/tmp/x', 'RFA'))->toBe(0);
+    expect(searchNames('rfa'))->toBe(['alpha-rfa', 'zeta-rfa']);
 });
 
 // -- handle with search --
 
 test('handle filters projects by search', function () {
-    Project::create(['slug' => 'rfa', 'name' => 'rfa', 'path' => '/tmp/rfa', 'git_common_dir' => '/tmp/rfa/.git', 'is_worktree' => false, 'branch' => 'main']);
-    Project::create(['slug' => 'unrelated', 'name' => 'unrelated', 'path' => '/tmp/unrelated', 'git_common_dir' => '/tmp/unrelated/.git', 'is_worktree' => false, 'branch' => 'main']);
+    Project::factory()->create(['name' => 'rfa']);
+    Project::factory()->create(['name' => 'unrelated']);
 
     $result = app(ListProjectsAction::class)->handle('recent', 'rfa');
-    $names = collect($result['groups'])->flatten(1)->pluck('name')->all();
 
-    expect($names)->toBe(['rfa'])
+    expect(searchNames('rfa'))->toBe(['rfa'])
         ->and($result['total'])->toBe(2);
 });
 
 test('handle ranks exact match above substring', function () {
-    Project::create(['slug' => 'farfalla', 'name' => 'farfalla', 'path' => '/tmp/farfalla', 'git_common_dir' => '/tmp/farfalla/.git', 'is_worktree' => false, 'branch' => 'main']);
-    Project::create(['slug' => 'rfa', 'name' => 'rfa', 'path' => '/tmp/rfa', 'git_common_dir' => '/tmp/rfa/.git', 'is_worktree' => false, 'branch' => 'main']);
+    Project::factory()->create(['name' => 'farfalla']);
+    Project::factory()->create(['name' => 'rfa']);
 
-    $result = app(ListProjectsAction::class)->handle('recent', 'rfa');
-    $names = collect($result['groups'])->flatten(1)->pluck('name')->all();
-
-    expect($names)->toBe(['rfa', 'farfalla']);
+    expect(searchNames('rfa'))->toBe(['rfa', 'farfalla']);
 });
 
 test('handle returns all projects when search is empty', function () {
-    Project::create(['slug' => 'a', 'name' => 'Alpha', 'path' => '/tmp/a', 'git_common_dir' => '/tmp/a/.git', 'is_worktree' => false, 'branch' => 'main']);
-    Project::create(['slug' => 'b', 'name' => 'Beta', 'path' => '/tmp/b', 'git_common_dir' => '/tmp/b/.git', 'is_worktree' => false, 'branch' => 'main']);
+    Project::factory()->create(['name' => 'Alpha']);
+    Project::factory()->create(['name' => 'Beta']);
 
     $result = app(ListProjectsAction::class)->handle('recent', '');
 

--- a/tests/Unit/Actions/ListProjectsActionTest.php
+++ b/tests/Unit/Actions/ListProjectsActionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use App\Actions\ListProjectsAction;
+use App\Models\Project;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+// -- rankMatch --
+
+test('rankMatch returns 0 for exact name match', function () {
+    expect(ListProjectsAction::rankMatch('rfa', 'main', '/tmp/rfa', 'rfa'))->toBe(0);
+});
+
+test('rankMatch returns 1 for name prefix', function () {
+    expect(ListProjectsAction::rankMatch('rfa-app', 'main', '/tmp/rfa', 'rfa'))->toBe(1);
+});
+
+test('rankMatch returns 2 for name word-start', function () {
+    expect(ListProjectsAction::rankMatch('my-rfa-tool', 'main', '/tmp/x', 'rfa'))->toBe(2);
+});
+
+test('rankMatch returns 3 for branch exact or prefix', function () {
+    expect(ListProjectsAction::rankMatch('other', 'rfa', '/tmp/x', 'rfa'))->toBe(3);
+    expect(ListProjectsAction::rankMatch('other', 'rfa-branch', '/tmp/x', 'rfa'))->toBe(3);
+});
+
+test('rankMatch returns 4 for branch word-start', function () {
+    expect(ListProjectsAction::rankMatch('other', 'fix-rfa-bug', '/tmp/x', 'rfa'))->toBe(4);
+});
+
+test('rankMatch returns 5 for path word-start', function () {
+    expect(ListProjectsAction::rankMatch('other', 'main', '/tmp/rfa-proj', 'rfa'))->toBe(5);
+});
+
+test('rankMatch returns 6 for name substring', function () {
+    expect(ListProjectsAction::rankMatch('farfalla', 'main', '/tmp/x', 'rfa'))->toBe(6);
+});
+
+test('rankMatch returns 7 for branch substring', function () {
+    expect(ListProjectsAction::rankMatch('other', 'xrfay', '/tmp/x', 'rfa'))->toBe(7);
+});
+
+test('rankMatch returns 8 for path substring', function () {
+    expect(ListProjectsAction::rankMatch('other', 'main', '/tmp/xrfay', 'rfa'))->toBe(8);
+});
+
+test('rankMatch returns PHP_INT_MAX for no match', function () {
+    expect(ListProjectsAction::rankMatch('other', 'main', '/tmp/x', 'zzz'))->toBe(PHP_INT_MAX);
+});
+
+test('rankMatch is case insensitive', function () {
+    expect(ListProjectsAction::rankMatch('RFA', 'main', '/tmp/x', 'rfa'))->toBe(0);
+    expect(ListProjectsAction::rankMatch('rfa', 'main', '/tmp/x', 'RFA'))->toBe(0);
+});
+
+// -- handle with search --
+
+test('handle filters projects by search', function () {
+    Project::create(['slug' => 'rfa', 'name' => 'rfa', 'path' => '/tmp/rfa', 'git_common_dir' => '/tmp/rfa/.git', 'is_worktree' => false, 'branch' => 'main']);
+    Project::create(['slug' => 'unrelated', 'name' => 'unrelated', 'path' => '/tmp/unrelated', 'git_common_dir' => '/tmp/unrelated/.git', 'is_worktree' => false, 'branch' => 'main']);
+
+    $result = app(ListProjectsAction::class)->handle('recent', 'rfa');
+    $names = collect($result['groups'])->flatten(1)->pluck('name')->all();
+
+    expect($names)->toBe(['rfa'])
+        ->and($result['total'])->toBe(2);
+});
+
+test('handle ranks exact match above substring', function () {
+    Project::create(['slug' => 'farfalla', 'name' => 'farfalla', 'path' => '/tmp/farfalla', 'git_common_dir' => '/tmp/farfalla/.git', 'is_worktree' => false, 'branch' => 'main']);
+    Project::create(['slug' => 'rfa', 'name' => 'rfa', 'path' => '/tmp/rfa', 'git_common_dir' => '/tmp/rfa/.git', 'is_worktree' => false, 'branch' => 'main']);
+
+    $result = app(ListProjectsAction::class)->handle('recent', 'rfa');
+    $names = collect($result['groups'])->flatten(1)->pluck('name')->all();
+
+    expect($names)->toBe(['rfa', 'farfalla']);
+});
+
+test('handle returns all projects when search is empty', function () {
+    Project::create(['slug' => 'a', 'name' => 'Alpha', 'path' => '/tmp/a', 'git_common_dir' => '/tmp/a/.git', 'is_worktree' => false, 'branch' => 'main']);
+    Project::create(['slug' => 'b', 'name' => 'Beta', 'path' => '/tmp/b', 'git_common_dir' => '/tmp/b/.git', 'is_worktree' => false, 'branch' => 'main']);
+
+    $result = app(ListProjectsAction::class)->handle('recent', '');
+
+    expect($result['total'])->toBe(2);
+});

--- a/tests/Unit/Actions/RestoreSessionActionTest.php
+++ b/tests/Unit/Actions/RestoreSessionActionTest.php
@@ -37,7 +37,7 @@ test('restores comments and tracks orphaned paths', function () {
             ['id' => 'c-1', 'file' => 'exists.php', 'fileId' => 'old-id'],
             ['id' => 'c-2', 'file' => 'gone.php', 'fileId' => 'old-id-2'],
         ],
-        'viewed_files' => ['exists.php' => 'somehash'],
+        'reviewed_files' => ['exists.php' => 'somehash'],
         'global_comment' => 'hello',
     ]);
 
@@ -67,7 +67,7 @@ test('remaps fileId to current file list', function () {
         'comments' => [
             ['id' => 'c-1', 'file' => 'f.php', 'fileId' => 'stale-id'],
         ],
-        'viewed_files' => [],
+        'reviewed_files' => [],
         'global_comment' => '',
     ]);
 
@@ -92,7 +92,7 @@ test('keys by project_id when provided', function () {
         'repo_path' => '/tmp/test-proj',
         'project_id' => $project->id,
         'comments' => [['id' => 'c-1', 'file' => 'f.php', 'fileId' => 'x']],
-        'viewed_files' => [],
+        'reviewed_files' => [],
         'global_comment' => 'from project',
     ]);
 
@@ -111,7 +111,7 @@ test('migrates legacy indexed array to associative with fresh fingerprints', fun
     ReviewSession::create([
         'repo_path' => $repoPath,
         'comments' => [],
-        'viewed_files' => ['a.php', 'b.php', 'gone.php'],
+        'reviewed_files' => ['a.php', 'b.php', 'gone.php'],
         'global_comment' => '',
     ]);
 
@@ -141,7 +141,7 @@ test('unmarks reviewed file when fingerprint mismatches', function () {
     ReviewSession::create([
         'repo_path' => $repoPath,
         'comments' => [],
-        'viewed_files' => ['a.php' => 'old-hash', 'b.php' => 'still-good'],
+        'reviewed_files' => ['a.php' => 'old-hash', 'b.php' => 'still-good'],
         'global_comment' => '',
     ]);
 
@@ -172,7 +172,7 @@ test('skips fingerprint validation for immutable targets', function () {
         'repo_path' => $repoPath,
         'context_fingerprint' => $target->contextKey(),
         'comments' => [],
-        'viewed_files' => ['a.php' => ''],
+        'reviewed_files' => ['a.php' => ''],
         'global_comment' => '',
     ]);
 

--- a/tests/Unit/Actions/SaveSessionActionTest.php
+++ b/tests/Unit/Actions/SaveSessionActionTest.php
@@ -26,13 +26,13 @@ test('creates session when none exists', function () {
 
     expect($session)->not->toBeNull();
     expect($session->comments)->toBe($comments);
-    expect($session->viewed_files)->toBe($reviewedFiles);
+    expect($session->reviewed_files)->toBe($reviewedFiles);
     expect($session->global_comment)->toBe($globalComment);
 });
 
 test('updates existing session', function () {
     $repoPath = '/tmp/'.$this->faker->word();
-    ReviewSession::create(['repo_path' => $repoPath, 'comments' => [], 'viewed_files' => [], 'global_comment' => '']);
+    ReviewSession::create(['repo_path' => $repoPath, 'comments' => [], 'reviewed_files' => [], 'global_comment' => '']);
 
     $newComments = [['id' => 'c-2', 'file' => 'a.php', 'body' => 'updated']];
     $reviewedFiles = ['a.php' => 'hash-a'];
@@ -42,7 +42,7 @@ test('updates existing session', function () {
     $session = ReviewSession::where('repo_path', $repoPath)->first();
     expect(ReviewSession::where('repo_path', $repoPath)->count())->toBe(1);
     expect($session->comments)->toBe($newComments);
-    expect($session->viewed_files)->toBe($reviewedFiles);
+    expect($session->reviewed_files)->toBe($reviewedFiles);
 });
 
 test('keys by project_id when provided', function () {

--- a/tests/Unit/Actions/ToggleReviewedActionTest.php
+++ b/tests/Unit/Actions/ToggleReviewedActionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Actions\ToggleViewedAction;
+use App\Actions\ToggleReviewedAction;
 use App\Services\GitDiffService;
 use Faker\Factory as Faker;
 use Tests\TestCase;
@@ -21,7 +21,7 @@ beforeEach(function () {
     $mock->shouldReceive('fileDiffFingerprint')->andReturn('mock-hash');
     app()->instance(GitDiffService::class, $mock);
 
-    $this->action = app(ToggleViewedAction::class);
+    $this->action = app(ToggleReviewedAction::class);
 });
 
 test('adds file to reviewed list with fingerprint', function () {

--- a/tests/Unit/Console/BenchmarkPerformanceCommandTest.php
+++ b/tests/Unit/Console/BenchmarkPerformanceCommandTest.php
@@ -93,7 +93,7 @@ test('benchmark command does not delete app projects or review sessions', functi
         'repo_path' => '/tmp/keep-me',
         'project_id' => $project->id,
         'context_fingerprint' => 'working',
-        'viewed_files' => ['app.php' => 'hash'],
+        'reviewed_files' => ['app.php' => 'hash'],
         'comments' => [['id' => 'comment-1', 'file' => 'app.php']],
         'global_comment' => 'Keep this session',
     ]);

--- a/tests/Unit/Livewire/DashboardPageTest.php
+++ b/tests/Unit/Livewire/DashboardPageTest.php
@@ -108,6 +108,83 @@ test('renders search input and keyboard hints', function () {
         ->assertSee('1 project');
 });
 
+// -- Server-side search --
+
+test('search filters projects by name', function () {
+    Project::create([
+        'slug' => 'rfa',
+        'name' => 'rfa',
+        'path' => '/tmp/rfa',
+        'git_common_dir' => '/tmp/rfa/.git',
+        'is_worktree' => false,
+        'branch' => 'main',
+    ]);
+
+    Project::create([
+        'slug' => 'farfalla',
+        'name' => 'farfalla',
+        'path' => '/tmp/farfalla',
+        'git_common_dir' => '/tmp/farfalla/.git',
+        'is_worktree' => false,
+        'branch' => 'main',
+    ]);
+
+    Project::create([
+        'slug' => 'unrelated',
+        'name' => 'unrelated',
+        'path' => '/tmp/unrelated',
+        'git_common_dir' => '/tmp/unrelated/.git',
+        'is_worktree' => false,
+        'branch' => 'main',
+    ]);
+
+    Livewire::test('pages::dashboard-page')
+        ->set('search', 'rfa')
+        ->assertSee('rfa')
+        ->assertSee('farfalla')
+        ->assertDontSee('unrelated');
+});
+
+test('search shows match count', function () {
+    Project::create([
+        'slug' => 'rfa',
+        'name' => 'rfa',
+        'path' => '/tmp/rfa',
+        'git_common_dir' => '/tmp/rfa/.git',
+        'is_worktree' => false,
+        'branch' => 'main',
+    ]);
+
+    Project::create([
+        'slug' => 'other',
+        'name' => 'other',
+        'path' => '/tmp/other',
+        'git_common_dir' => '/tmp/other/.git',
+        'is_worktree' => false,
+        'branch' => 'main',
+    ]);
+
+    Livewire::test('pages::dashboard-page')
+        ->set('search', 'rfa')
+        ->assertSee('1/2 projects');
+});
+
+test('search with no results shows no matching projects', function () {
+    Project::create([
+        'slug' => 'my-app',
+        'name' => 'My App',
+        'path' => '/tmp/my-app',
+        'git_common_dir' => '/tmp/my-app/.git',
+        'is_worktree' => false,
+        'branch' => 'main',
+    ]);
+
+    Livewire::test('pages::dashboard-page')
+        ->set('search', 'zzzzzzz')
+        ->assertSee('No matching projects')
+        ->assertSee('0/1 project');
+});
+
 // -- registerProject (drag-and-drop) --
 
 test('registerProject registers a git repo and redirects to its review page', function () {

--- a/tests/Unit/Livewire/DashboardPageTest.php
+++ b/tests/Unit/Livewire/DashboardPageTest.php
@@ -82,7 +82,7 @@ test('shows comment count when project has review comments', function () {
         'project_id' => $project->id,
         'repo_path' => '/tmp/my-app',
         'context_fingerprint' => 'abc123',
-        'viewed_files' => [],
+        'reviewed_files' => [],
         'comments' => [
             ['id' => 1, 'body' => 'Fix this'],
             ['id' => 2, 'body' => 'And this'],

--- a/tests/Unit/Livewire/ReviewPageTest.php
+++ b/tests/Unit/Livewire/ReviewPageTest.php
@@ -41,7 +41,7 @@ beforeEach(function () {
     {
         public function __construct(private Project $project) {}
 
-        public function handle(string $slug): ?array
+        public function handle(string $slug, bool $touch = false): ?array
         {
             return $this->project->toArray();
         }


### PR DESCRIPTION
Replace the plain substring filter with a ranked scorer that orders
results by match quality: exact name > name prefix > word-start >
substring. Uses CSS order on group wrappers for visual reordering
without changing DOM structure, and fixes the visibleProjects getter
so keyboard navigation follows the ranked visual order.

https://claude.ai/code/session_017S4TRufJqMbQCcwNPNTJGd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-driven search with relevance ranking, total-match count, and a “No matching projects” empty state
  * Keyboard: Escape clears search; Enter opens selected project or first match

* **Style**
  * Updated sort control to icon + labels; improved layout/spacing for project groups

* **Tests**
  * Added unit and browser tests for search ranking, keyboard navigation, and server-side search behavior

* **Chores**
  * Review flow now updates project timestamp on open
  * Session persistence key renamed to reviewed_files and migration added

* **Documentation**
  * Added Local Desktop App guidance favoring server-side logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->