### PR TITLE
Fix session expiration causing "This page has expired" dialog

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -182,6 +182,7 @@
         </button>
     </div>
 
+    <livewire:keepalive />
     {{ $slot }}
     @fluxScripts
     <script src="/js/page-search.js"></script>

--- a/resources/views/livewire/keepalive.blade.php
+++ b/resources/views/livewire/keepalive.blade.php
@@ -6,4 +6,4 @@ new class extends Component {};
 
 ?>
 
-<div wire:poll.3600s.keep-alive class="hidden"></div>
+<div wire:poll.1800s.keep-alive class="hidden"></div>

--- a/resources/views/livewire/keepalive.blade.php
+++ b/resources/views/livewire/keepalive.blade.php
@@ -1,0 +1,9 @@
+<?php
+
+use Livewire\Component;
+
+new class extends Component {};
+
+?>
+
+<div wire:poll.3600s.keep-alive class="hidden"></div>

--- a/tests/Arch/BladeConventionsTest.php
+++ b/tests/Arch/BladeConventionsTest.php
@@ -50,6 +50,12 @@ test('flux:button and flux:input with icon prop use outline variant', function (
     expect($violations)->toBeEmpty();
 });
 
+test('app layout includes keepalive component', function () {
+    $layout = dirname(__DIR__, 2).'/resources/views/layouts/app.blade.php';
+    $content = file_get_contents($layout);
+    expect($content)->toContain('<livewire:keepalive');
+});
+
 test('no hardcoded dark class on html element', function () {
     $violations = [];
     foreach (bladeFiles() as $file) {

--- a/tests/Arch/BladeConventionsTest.php
+++ b/tests/Arch/BladeConventionsTest.php
@@ -56,6 +56,12 @@ test('app layout includes keepalive component', function () {
     expect($content)->toContain('<livewire:keepalive');
 });
 
+test('keepalive component uses wire:poll.keep-alive', function () {
+    $component = dirname(__DIR__, 2).'/resources/views/livewire/keepalive.blade.php';
+    $content = file_get_contents($component);
+    expect($content)->toMatch('/wire:poll\.\d+s\.keep-alive/');
+});
+
 test('no hardcoded dark class on html element', function () {
     $violations = [];
     foreach (bladeFiles() as $file) {


### PR DESCRIPTION
Add a Livewire keepalive component that polls the server every 60 minutes
to prevent the Laravel session from expiring while pages are open. This
stops the 419 CSRF token mismatch that triggers Livewire's built-in
expiration dialog — disruptive for a code review tool where pages stay
open for hours.

The .keep-alive modifier ensures polling continues even when the
NativePHP window is in the background.

https://claude.ai/code/session_01MPgVX5kdEy5GV79pX6oxHA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * A keep-alive component is now rendered on the main layout and runs periodic background polling (every 30 minutes) on every page.

* **Tests**
  * Added tests to verify the keep-alive component is present in the layout and that the polling binding with the expected interval exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->