### PR TITLE
Move discard confirmation to toast notification

### DIFF
--- a/resources/views/livewire/undo-toast.blade.php
+++ b/resources/views/livewire/undo-toast.blade.php
@@ -66,16 +66,20 @@
     data-testid="undo-toast"
     class="fixed bottom-20 left-1/2 -translate-x-1/2 z-50"
 >
-    <div class="bg-gh-surface border border-gh-border rounded px-4 py-2.5 font-mono text-xs flex items-center gap-3 shadow-lg">
-        <span x-text="current?.message" class="text-gh-text"></span>
+    <div class="bg-gh-surface border border-gh-border rounded font-mono text-xs flex items-center gap-3 shadow-lg"
+        :class="current?.type === 'discard' ? 'px-5 py-3 min-w-[360px] border-l-2 border-l-amber-500' : 'px-4 py-2.5'">
+        <span x-text="current?.message" class="text-gh-text" :class="current?.type === 'discard' ? 'flex-1' : ''"></span>
         <button @click="undo()" class="text-gh-link hover:underline font-medium" data-testid="undo-button">Undo</button>
+        <template x-if="current?.type === 'discard'">
+            <button @click="dismiss()" class="text-gh-muted hover:text-gh-text font-medium" data-testid="undo-ok-button">OK</button>
+        </template>
         <span class="text-gh-muted" x-text="remaining + 's'"></span>
         {{-- Progress bar --}}
         <div class="w-16 h-0.5 bg-gh-border rounded-full overflow-hidden">
             <div class="h-full bg-gh-muted transition-all duration-1000 ease-linear rounded-full"
                 :style="{ width: (remaining / 10 * 100) + '%' }"></div>
         </div>
-        <button @click="dismiss()" class="text-gh-muted hover:text-gh-text" aria-label="Dismiss">
+        <button @click="dismiss()" class="text-gh-muted hover:text-gh-text" aria-label="Dismiss" x-show="current?.type !== 'discard'">
             <flux:icon icon="x-mark" variant="outline" class="!size-3.5" />
         </button>
     </div>

--- a/resources/views/livewire/undo-toast.blade.php
+++ b/resources/views/livewire/undo-toast.blade.php
@@ -67,7 +67,7 @@
     class="fixed bottom-20 left-1/2 -translate-x-1/2 z-50"
 >
     <div class="bg-gh-surface border border-gh-border rounded font-mono text-xs flex items-center gap-3 shadow-lg"
-        :class="current?.type === 'discard' ? 'px-5 py-3 min-w-[360px] border-l-2 border-l-amber-500' : 'px-4 py-2.5'">
+        :class="current?.type === 'discard' ? 'px-5 py-3 min-w-[360px] border-l-2 border-l-gh-accent' : 'px-4 py-2.5'">
         <span x-text="current?.message" class="text-gh-text" :class="current?.type === 'discard' ? 'flex-1' : ''"></span>
         <button @click="undo()" class="text-gh-link hover:underline font-medium" data-testid="undo-button">Undo</button>
         <template x-if="current?.type === 'discard'">

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -295,14 +295,7 @@ new class extends Component {
                         icon:variant="outline"
                         variant="ghost"
                         size="sm"
-                        @click="
-                            @if(count($fileComments) > 0)
-                                if (confirm('Discard changes to {{ basename($file['path']) }} and remove {{ count($fileComments) }} comment{{ count($fileComments) === 1 ? '' : 's' }}? You can restore from Trash for 30 minutes.'))
-                            @else
-                                if (confirm('Discard all changes to {{ basename($file['path']) }}? You can restore from Trash for 30 minutes.'))
-                            @endif
-                                $dispatch('discard-file', { fileId: @js($file['id']) })
-                        "
+                        @click="$dispatch('discard-file', { fileId: @js($file['id']) })"
                     />
                 @endif
             </div>

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -295,7 +295,8 @@ new class extends Component {
                         icon:variant="outline"
                         variant="ghost"
                         size="sm"
-                        @click="$dispatch('discard-file', { fileId: @js($file['id']) })"
+                        class="data-loading:pointer-events-none data-loading:opacity-50"
+                        wire:click="$dispatch('discard-file', { fileId: @js($file['id']) })"
                     />
                 @endif
             </div>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -912,9 +912,9 @@ new #[Layout('layouts.app')] class extends Component
                             class="text-gh-green shrink-0" x-cloak />
                         @if(! $this->isCommitMode() && $file['status'] !== 'commented')
                             <button
-                                class="opacity-0 group-hover:opacity-100 transition-opacity text-gh-muted hover:text-gh-text shrink-0"
+                                class="opacity-0 group-hover:opacity-100 transition-opacity text-gh-muted hover:text-gh-text shrink-0 data-loading:pointer-events-none data-loading:opacity-50"
                                 title="Discard changes"
-                                @click.stop="$wire.discardFileChanges('{{ $file['id'] }}')"
+                                wire:click.stop="discardFileChanges('{{ $file['id'] }}')"
                             >
                                 <flux:icon icon="arrow-uturn-left" variant="outline" class="!size-3.5" />
                             </button>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -386,7 +386,11 @@ new #[Layout('layouts.app')] class extends Component
         $this->saveSession();
         $this->loadTrashedFiles();
 
-        $this->dispatch('undo-available', type: 'discard', payload: $trashRecord->id, message: 'Changes discarded');
+        $commentCount = count($fileComments);
+        $message = $commentCount > 0
+            ? 'Discarded '.basename($file['path']).' — '.$commentCount.' comment'.($commentCount === 1 ? '' : 's').' removed'
+            : 'Discarded '.basename($file['path']);
+        $this->dispatch('undo-available', type: 'discard', payload: $trashRecord->id, message: $message);
         $this->dispatch('fingerprint-reset');
     }
 
@@ -910,15 +914,7 @@ new #[Layout('layouts.app')] class extends Component
                             <button
                                 class="opacity-0 group-hover:opacity-100 transition-opacity text-gh-muted hover:text-gh-text shrink-0"
                                 title="Discard changes"
-                                @click.stop="
-                                    @php $commentCount = count($this->groupedComments[$file['id']] ?? []); @endphp
-                                    @if($commentCount > 0)
-                                        if (confirm('Discard changes to {{ basename($file['path']) }} and remove {{ $commentCount }} comment{{ $commentCount === 1 ? '' : 's' }}? You can restore from Trash for 30 minutes.'))
-                                    @else
-                                        if (confirm('Discard all changes to {{ basename($file['path']) }}? You can restore from Trash for 30 minutes.'))
-                                    @endif
-                                        $wire.discardFileChanges('{{ $file['id'] }}')
-                                "
+                                @click.stop="$wire.discardFileChanges('{{ $file['id'] }}')"
                             >
                                 <flux:icon icon="arrow-uturn-left" variant="outline" class="!size-3.5" />
                             </button>

--- a/tests/Unit/Livewire/DiffFileTest.php
+++ b/tests/Unit/Livewire/DiffFileTest.php
@@ -188,15 +188,12 @@ test('discard button hidden for commented status', function () {
     expect($html)->not->toContain('discard-file');
 });
 
-test('discard confirm mentions comment count', function () {
-    $comments = [
-        ['id' => 'c1', 'fileId' => $this->file['id'], 'file' => 'src/Test.php', 'side' => 'file', 'startLine' => null, 'endLine' => null, 'body' => 'A'],
-        ['id' => 'c2', 'fileId' => $this->file['id'], 'file' => 'src/Test.php', 'side' => 'file', 'startLine' => null, 'endLine' => null, 'body' => 'B'],
-    ];
+test('discard button dispatches directly without confirm', function () {
+    $html = mountDiffFile($this->file, loadDiff: false)->html();
 
-    $html = mountDiffFile($this->file, $comments, loadDiff: false)->html();
-
-    expect($html)->toContain('remove 2 comments');
+    expect($html)
+        ->toContain('discard-file')
+        ->not->toContain('confirm(');
 });
 
 test('collapse event handlers reset autoExpandedForComment', function () {

--- a/tests/Unit/Livewire/ReviewPageTest.php
+++ b/tests/Unit/Livewire/ReviewPageTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Actions\BackfillGlobalGitignoreAction;
+use App\Actions\CleanExpiredTrashAction;
+use App\Actions\DiscardFileChangesAction;
 use App\Actions\ExportReviewAction;
 use App\Actions\GetFileListAction;
 use App\Actions\ResolveProjectAction;
@@ -9,6 +11,7 @@ use App\Actions\SaveSessionAction;
 use App\Actions\ScanReviewFilesAction;
 use App\DTOs\DiffTarget;
 use App\Models\Project;
+use App\Models\TrashedFile;
 use App\Services\GitDiffService;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Livewire\Livewire;
@@ -348,5 +351,79 @@ test('deleteComment dispatches undo-available with deleted comment', function ()
     $component->assertDispatched('undo-available', fn ($name, $params) => $params['type'] === 'delete'
         && count($params['payload']) === 1
         && $params['payload'][0]['id'] === $commentId
+    );
+});
+
+// -- Discard file undo-available --
+
+test('discardFileChanges dispatches undo-available with file name', function () {
+    $trashRecord = TrashedFile::create([
+        'project_id' => $this->project->id,
+        'file_path' => 'src/Foo.php',
+        'file_status' => 'modified',
+        'expires_at' => now()->addMinutes(30),
+    ]);
+
+    app()->bind(DiscardFileChangesAction::class, fn () => new class($trashRecord)
+    {
+        public function __construct(private TrashedFile $record) {}
+
+        public function handle(string $repoPath, string $path, string $status, int $projectId, ?string $oldPath = null, bool $isUntracked = false, bool $isSymlink = false, array $comments = []): TrashedFile
+        {
+            return $this->record;
+        }
+    });
+
+    app()->bind(CleanExpiredTrashAction::class, fn () => new class
+    {
+        public function handle(int $projectId): array
+        {
+            return [];
+        }
+    });
+
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('discard-file', fileId: 'abc123');
+
+    $component->assertDispatched('undo-available', fn ($name, $params) => $params['type'] === 'discard'
+        && $params['payload'] === $trashRecord->id
+        && str_contains($params['message'], 'Foo.php')
+    );
+});
+
+test('discardFileChanges includes comment count in undo message', function () {
+    $trashRecord = TrashedFile::create([
+        'project_id' => $this->project->id,
+        'file_path' => 'src/Foo.php',
+        'file_status' => 'modified',
+        'expires_at' => now()->addMinutes(30),
+    ]);
+
+    app()->bind(DiscardFileChangesAction::class, fn () => new class($trashRecord)
+    {
+        public function __construct(private TrashedFile $record) {}
+
+        public function handle(string $repoPath, string $path, string $status, int $projectId, ?string $oldPath = null, bool $isUntracked = false, bool $isSymlink = false, array $comments = []): TrashedFile
+        {
+            return $this->record;
+        }
+    });
+
+    app()->bind(CleanExpiredTrashAction::class, fn () => new class
+    {
+        public function handle(int $projectId): array
+        {
+            return [];
+        }
+    });
+
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('add-comment', fileId: 'abc123', side: 'right', startLine: 1, endLine: 1, body: 'Review note')
+        ->dispatch('add-comment', fileId: 'abc123', side: 'right', startLine: 5, endLine: 5, body: 'Another note')
+        ->dispatch('discard-file', fileId: 'abc123');
+
+    $component->assertDispatched('undo-available', fn ($name, $params) => $params['type'] === 'discard'
+        && str_contains($params['message'], 'Foo.php')
+        && str_contains($params['message'], '2 comments removed')
     );
 });


### PR DESCRIPTION
## Summary
Refactored the file discard workflow to move the confirmation dialog from a browser `confirm()` prompt to a toast notification with undo capability. This provides a better user experience with more context about what's being discarded.

## Key Changes
- **Removed inline confirmation dialogs**: Eliminated `confirm()` prompts from both the review page and diff file components that were asking users to confirm discarding changes and removing comments
- **Enhanced discard message**: Updated `discardFileChanges()` method to generate contextual messages that include the filename and comment count (e.g., "Discarded Test.php — 2 comments removed")
- **Improved undo toast styling**: Modified the undo toast component to display discard notifications with:
  - Amber left border to visually distinguish discard actions
  - Larger padding and minimum width for better readability
  - Additional "OK" button for discard notifications (in addition to "Undo")
  - Conditional display of close button (hidden for discard notifications)
- **Simplified button handlers**: Removed complex conditional logic from click handlers, making them cleaner and more maintainable
- **Updated tests**: Changed test expectations to verify the button dispatches directly without confirmation prompts

## Implementation Details
The discard action now follows this flow:
1. User clicks discard button (no confirmation)
2. Changes are immediately discarded and moved to trash
3. Toast notification appears with details about what was discarded and comment count
4. User can either "Undo" to restore or "OK" to dismiss
5. Toast auto-dismisses after 10 seconds

This approach is more forgiving since users can undo within 30 minutes from the trash, eliminating the need for a blocking confirmation dialog.

https://claude.ai/code/session_01CZjsqgPhF9BqcvhsTkzP4H

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved discard toast: conditional layout and styling, dynamic message showing comment count, and an explicit “OK” action shown only for discard toasts.

* **Refactor**
  * Simplified discard flow: removed client-side confirmation prompts, unified the discard trigger, and added loading/disabled state to the discard control.

* **Tests**
  * Added/updated unit tests covering the discard flow, undo notification dispatch, and message contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->