### PR TITLE
Migrate comments and reviewed files to dedicated database tables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,14 @@ jobs:
       - run: touch database/database.sqlite
       - run: php artisan migrate --force
       - run: php artisan test --testsuite=Browser
+      - name: Upload browser screenshots on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: browser-screenshots
+          path: tests/Browser/Screenshots/
+          if-no-files-found: ignore
+          retention-days: 7
 
   benchmark-perf:
     runs-on: ubuntu-latest

--- a/app/Actions/AddCommentAction.php
+++ b/app/Actions/AddCommentAction.php
@@ -55,7 +55,8 @@ final readonly class AddCommentAction
         }
 
         $filePath = (string) $file['path'];
-        $contentHash = $this->resolveContentHash($repoPath, $target, $side, $filePath);
+        $oldPath = ! empty($file['oldPath']) ? (string) $file['oldPath'] : null;
+        $contentHash = $this->resolveContentHash($repoPath, $target, $side, $filePath, $oldPath);
         $originRef = $target->to() ?? GitFileContentService::WORKING_REF;
 
         $id = 'c-'.Str::ulid();
@@ -92,16 +93,13 @@ final readonly class AddCommentAction
         ];
     }
 
-    private function resolveContentHash(string $repoPath, DiffTarget $target, string $side, string $filePath): ?string
+    private function resolveContentHash(string $repoPath, DiffTarget $target, string $side, string $filePath, ?string $oldPath): ?string
     {
-        if ($side === 'file') {
-            $ref = $target->to() ?? GitFileContentService::WORKING_REF;
-
-            return $this->gitFileContentService->hashAt($repoPath, $ref, $filePath);
-        }
-
         if ($side === 'left') {
-            return $this->gitFileContentService->hashAt($repoPath, $target->from(), $filePath);
+            // For renames the file exists at `from` under its pre-rename path only.
+            $leftPath = $oldPath ?? $filePath;
+
+            return $this->gitFileContentService->hashAt($repoPath, $target->from(), $leftPath);
         }
 
         $ref = $target->to() ?? GitFileContentService::WORKING_REF;

--- a/app/Actions/AddCommentAction.php
+++ b/app/Actions/AddCommentAction.php
@@ -4,17 +4,35 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\DTOs\DiffTarget;
 use App\Enums\DiffSide;
+use App\Models\Comment;
+use App\Services\GitFileContentService;
 use Illuminate\Support\Str;
 
 final readonly class AddCommentAction
 {
+    public function __construct(
+        private GitFileContentService $gitFileContentService,
+    ) {}
+
     /**
      * @param  array<int, array<string, mixed>>  $files
      * @return array<string, mixed>|null
      */
-    public function handle(array $files, string $fileId, string $side, ?int $startLine, ?int $endLine, string $body, bool $isDraft = false): ?array
-    {
+    public function handle(
+        string $repoPath,
+        ?int $projectId,
+        DiffTarget $target,
+        array $files,
+        string $fileId,
+        string $side,
+        ?int $startLine,
+        ?int $endLine,
+        string $body,
+        bool $isDraft = false,
+        ?string $lineSnippet = null,
+    ): ?array {
         if (trim($body) === '') {
             return null;
         }
@@ -36,15 +54,58 @@ final readonly class AddCommentAction
             return null;
         }
 
+        $filePath = (string) $file['path'];
+        $contentHash = $this->resolveContentHash($repoPath, $target, $side, $filePath);
+        $originRef = $target->to() ?? GitFileContentService::WORKING_REF;
+
+        $id = 'c-'.Str::ulid();
+
+        Comment::create([
+            'id' => $id,
+            'project_id' => $projectId,
+            'repo_path' => $repoPath,
+            'origin_ref' => $originRef,
+            'file_path' => $filePath,
+            'side' => $side,
+            'start_line' => $startLine,
+            'end_line' => $endLine,
+            'file_content_hash' => $contentHash,
+            'line_snippet' => $lineSnippet,
+            'body' => $body,
+            'is_draft' => $isDraft,
+        ]);
+
         return [
-            'id' => 'c-'.Str::ulid(),
+            'id' => $id,
             'fileId' => $fileId,
-            'file' => $file['path'],
+            'file' => $filePath,
             'side' => $side,
             'startLine' => $startLine,
             'endLine' => $endLine,
             'body' => $body,
+            'originRef' => $originRef,
+            'fileContentHash' => $contentHash,
+            'lineSnippet' => $lineSnippet,
             'isDraft' => $isDraft,
+            'submittedAt' => null,
+            'anchorStatus' => 'placed',
         ];
+    }
+
+    private function resolveContentHash(string $repoPath, DiffTarget $target, string $side, string $filePath): ?string
+    {
+        if ($side === 'file') {
+            $ref = $target->to() ?? GitFileContentService::WORKING_REF;
+
+            return $this->gitFileContentService->hashAt($repoPath, $ref, $filePath);
+        }
+
+        if ($side === 'left') {
+            return $this->gitFileContentService->hashAt($repoPath, $target->from(), $filePath);
+        }
+
+        $ref = $target->to() ?? GitFileContentService::WORKING_REF;
+
+        return $this->gitFileContentService->hashAt($repoPath, $ref, $filePath);
     }
 }

--- a/app/Actions/DeleteCommentAction.php
+++ b/app/Actions/DeleteCommentAction.php
@@ -4,17 +4,21 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Models\Comment;
+
 final readonly class DeleteCommentAction
 {
     /**
-     * @param  array<int, array<string, mixed>>  $comments
-     * @return array<int, array<string, mixed>>|null
+     * @param  array<int, array<string, mixed>>  $comments  Currently loaded view-state comments.
+     * @return array<int, array<string, mixed>>|null Updated comments array, or null if invalid id.
      */
     public function handle(array $comments, string $commentId): ?array
     {
         if (! str_starts_with($commentId, 'c-')) {
             return null;
         }
+
+        Comment::whereKey($commentId)->delete();
 
         return collect($comments)
             ->reject(fn (array $comment): bool => $comment['id'] === $commentId)

--- a/app/Actions/ExportReviewAction.php
+++ b/app/Actions/ExportReviewAction.php
@@ -8,6 +8,7 @@ use App\DTOs\Comment;
 use App\DTOs\DiffTarget;
 use App\Models\Comment as CommentModel;
 use App\Services\CommentExporter;
+use App\Services\GitFileContentService;
 
 final readonly class ExportReviewAction
 {
@@ -52,11 +53,11 @@ final readonly class ExportReviewAction
             return $comments;
         }
 
-        $scopeRef = $target->to() ?? 'working';
+        $scopeRef = $target->to() ?? GitFileContentService::WORKING_REF;
 
         return array_values(array_filter(
             $comments,
-            fn (array $c) => ($c['originRef'] ?? 'working') === $scopeRef,
+            fn (array $c) => ($c['originRef'] ?? GitFileContentService::WORKING_REF) === $scopeRef,
         ));
     }
 }

--- a/app/Actions/ExportReviewAction.php
+++ b/app/Actions/ExportReviewAction.php
@@ -21,7 +21,7 @@ final readonly class ExportReviewAction
     /**
      * @param  array<int, array<string, mixed>>  $comments  Currently-loaded, view-ready comments.
      * @param  array<int, array<string, mixed>>  $files  Files in the current diff.
-     * @return array{json: string, md: string, clipboard: string}
+     * @return array{json: string, md: string, clipboard: string, submittedIds: array<int, string>}
      */
     public function handle(string $repoPath, array $comments, string $globalComment, array $files, ?DiffTarget $target = null): array
     {
@@ -40,7 +40,7 @@ final readonly class ExportReviewAction
 
         $this->ensureGitExclude->handle($repoPath);
 
-        return $result;
+        return [...$result, 'submittedIds' => $ids];
     }
 
     /**

--- a/app/Actions/ExportReviewAction.php
+++ b/app/Actions/ExportReviewAction.php
@@ -8,7 +8,6 @@ use App\DTOs\Comment;
 use App\DTOs\DiffTarget;
 use App\Models\Comment as CommentModel;
 use App\Services\CommentExporter;
-use App\Services\GitFileContentService;
 
 final readonly class ExportReviewAction
 {
@@ -44,6 +43,13 @@ final readonly class ExportReviewAction
     }
 
     /**
+     * In scope means "the anchor resolver placed this comment against the active diff".
+     * Comments that aren't placed belong to another selection and survive this submit
+     * untouched (no submitted_at stamp, not included in the export payload).
+     *
+     * Comments without an explicit `anchorStatus` (e.g. fresh inputs in direct callers /
+     * tests) default to placed.
+     *
      * @param  array<int, array<string, mixed>>  $comments
      * @return array<int, array<string, mixed>>
      */
@@ -53,11 +59,9 @@ final readonly class ExportReviewAction
             return $comments;
         }
 
-        $scopeRef = $target->to() ?? GitFileContentService::WORKING_REF;
-
         return array_values(array_filter(
             $comments,
-            fn (array $c) => ($c['originRef'] ?? GitFileContentService::WORKING_REF) === $scopeRef,
+            fn (array $c) => ($c['anchorStatus'] ?? 'placed') === 'placed',
         ));
     }
 }

--- a/app/Actions/ExportReviewAction.php
+++ b/app/Actions/ExportReviewAction.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\DTOs\Comment;
+use App\DTOs\DiffTarget;
+use App\Models\Comment as CommentModel;
 use App\Services\CommentExporter;
 
 final readonly class ExportReviewAction
@@ -16,20 +18,45 @@ final readonly class ExportReviewAction
     ) {}
 
     /**
-     * @param  array<int, array<string, mixed>>  $comments
-     * @param  array<int, array<string, mixed>>  $files
+     * @param  array<int, array<string, mixed>>  $comments  Currently-loaded, view-ready comments.
+     * @param  array<int, array<string, mixed>>  $files  Files in the current diff.
      * @return array{json: string, md: string, clipboard: string}
      */
-    public function handle(string $repoPath, array $comments, string $globalComment, array $files): array
+    public function handle(string $repoPath, array $comments, string $globalComment, array $files, ?DiffTarget $target = null): array
     {
-        $commentDTOs = array_map(fn ($c) => Comment::fromArray($c), $comments);
+        $inScope = $this->filterInScope($comments, $target);
 
-        $diffContext = $this->buildDiffContextAction->handle($repoPath, $comments, $files);
+        $commentDTOs = array_map(fn ($c) => Comment::fromArray($c), $inScope);
+
+        $diffContext = $this->buildDiffContextAction->handle($repoPath, $inScope, $files);
 
         $result = $this->commentExporter->export($repoPath, $commentDTOs, $globalComment, $diffContext);
+
+        $ids = array_column($inScope, 'id');
+        if ($ids !== []) {
+            CommentModel::whereIn('id', $ids)->update(['submitted_at' => now()]);
+        }
 
         $this->ensureGitExclude->handle($repoPath);
 
         return $result;
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $comments
+     * @return array<int, array<string, mixed>>
+     */
+    private function filterInScope(array $comments, ?DiffTarget $target): array
+    {
+        if ($target === null) {
+            return $comments;
+        }
+
+        $scopeRef = $target->to() ?? 'working';
+
+        return array_values(array_filter(
+            $comments,
+            fn (array $c) => ($c['originRef'] ?? 'working') === $scopeRef,
+        ));
     }
 }

--- a/app/Actions/ListProjectsAction.php
+++ b/app/Actions/ListProjectsAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\DTOs\ProjectListResult;
+use App\Models\Comment;
 use App\Models\Project;
 use App\Models\ReviewSession;
 use Carbon\Carbon;
@@ -17,9 +18,9 @@ final readonly class ListProjectsAction
         $projects = Project::query()
             ->select('projects.*')
             ->addSelect([
-                'comment_count' => ReviewSession::selectRaw('COALESCE(SUM(JSON_ARRAY_LENGTH(comments)), 0)')
-                    ->whereColumn('review_sessions.project_id', 'projects.id')
-                    ->whereRaw('JSON_ARRAY_LENGTH(comments) > 0'),
+                'comment_count' => Comment::selectRaw('COUNT(*)')
+                    ->whereColumn('comments.project_id', 'projects.id')
+                    ->whereNull('submitted_at'),
                 'last_session_at' => ReviewSession::select('updated_at')
                     ->whereColumn('review_sessions.project_id', 'projects.id')
                     ->orderByDesc('updated_at')

--- a/app/Actions/ResolveCommentAnchorAction.php
+++ b/app/Actions/ResolveCommentAnchorAction.php
@@ -45,15 +45,27 @@ final readonly class ResolveCommentAnchorAction
 
             $storedHash = $row['file_content_hash'] ?? null;
             $fileId = $fileIdByPath[$filePath] ?? FileListEntry::idForPath($filePath);
+            $storedSide = (string) ($row['side'] ?? 'right');
 
             $anchorStatus = 'unplaced';
+            $resolvedSide = $storedSide;
 
             if ($storedHash !== null && $storedHash !== '' && isset($fileIdByPath[$filePath])) {
                 $leftHash = $this->gitFileContentService->hashAt($repoPath, $target->from(), $filePath);
                 $rightHash = $this->gitFileContentService->hashAt($repoPath, $rightRef, $filePath);
 
-                if ($storedHash === $leftHash || $storedHash === $rightHash) {
+                $matchesStoredSide = ($storedSide === 'left' && $storedHash === $leftHash)
+                    || ($storedSide === 'right' && $storedHash === $rightHash)
+                    || ($storedSide === 'file' && ($storedHash === $leftHash || $storedHash === $rightHash));
+
+                if ($matchesStoredSide) {
                     $anchorStatus = 'placed';
+                } elseif ($storedHash === $leftHash) {
+                    $anchorStatus = 'placed';
+                    $resolvedSide = 'left';
+                } elseif ($storedHash === $rightHash) {
+                    $anchorStatus = 'placed';
+                    $resolvedSide = 'right';
                 }
             } elseif (isset($fileIdByPath[$filePath])) {
                 $anchorStatus = 'placed';
@@ -63,7 +75,8 @@ final readonly class ResolveCommentAnchorAction
                 'id' => (string) $row['id'],
                 'fileId' => $fileId,
                 'file' => $filePath,
-                'side' => (string) ($row['side'] ?? 'right'),
+                'side' => $resolvedSide,
+                'originalSide' => $storedSide,
                 'startLine' => $this->intOrNull($row['start_line'] ?? $row['startLine'] ?? null),
                 'endLine' => $this->intOrNull($row['end_line'] ?? $row['endLine'] ?? null),
                 'body' => (string) ($row['body'] ?? ''),

--- a/app/Actions/ResolveCommentAnchorAction.php
+++ b/app/Actions/ResolveCommentAnchorAction.php
@@ -30,8 +30,10 @@ final readonly class ResolveCommentAnchorAction
     public function handle(string $repoPath, iterable $rawComments, array $currentFiles, DiffTarget $target): array
     {
         $fileIdByPath = [];
+        $oldPathByPath = [];
         foreach ($currentFiles as $file) {
             $fileIdByPath[$file['path']] = $file['id'];
+            $oldPathByPath[$file['path']] = $file['oldPath'] ?? null;
         }
 
         $resolved = [];
@@ -51,7 +53,11 @@ final readonly class ResolveCommentAnchorAction
             $resolvedSide = $storedSide;
 
             if ($storedHash !== null && $storedHash !== '' && isset($fileIdByPath[$filePath])) {
-                $leftHash = $this->gitFileContentService->hashAt($repoPath, $target->from(), $filePath);
+                // Renamed files: left-side content lives at `oldPath`; right-side stays
+                // at `path`. Without this, left comments on rename+edit diffs would be
+                // stamped unplaced and then silently dropped from submit.
+                $leftPath = $oldPathByPath[$filePath] ?? $filePath;
+                $leftHash = $this->gitFileContentService->hashAt($repoPath, $target->from(), $leftPath);
                 $rightHash = $this->gitFileContentService->hashAt($repoPath, $rightRef, $filePath);
 
                 $matchesStoredSide = ($storedSide === 'left' && $storedHash === $leftHash)

--- a/app/Actions/ResolveCommentAnchorAction.php
+++ b/app/Actions/ResolveCommentAnchorAction.php
@@ -35,17 +35,7 @@ final readonly class ResolveCommentAnchorAction
         }
 
         $resolved = [];
-        $hashCache = [];
-
-        $hashFor = function (string $ref, string $path) use ($repoPath, &$hashCache): ?string {
-            $key = $ref.':'.$path;
-
-            if (! array_key_exists($key, $hashCache)) {
-                $hashCache[$key] = $this->gitFileContentService->hashAt($repoPath, $ref, $path);
-            }
-
-            return $hashCache[$key];
-        };
+        $rightRef = $target->to() ?? GitFileContentService::WORKING_REF;
 
         foreach ($rawComments as $row) {
             $filePath = (string) ($row['file_path'] ?? $row['file'] ?? '');
@@ -59,15 +49,13 @@ final readonly class ResolveCommentAnchorAction
             $anchorStatus = 'unplaced';
 
             if ($storedHash !== null && $storedHash !== '' && isset($fileIdByPath[$filePath])) {
-                $leftHash = $hashFor($target->from(), $filePath);
-                $rightRef = $target->to() ?? GitFileContentService::WORKING_REF;
-                $rightHash = $hashFor($rightRef, $filePath);
+                $leftHash = $this->gitFileContentService->hashAt($repoPath, $target->from(), $filePath);
+                $rightHash = $this->gitFileContentService->hashAt($repoPath, $rightRef, $filePath);
 
                 if ($storedHash === $leftHash || $storedHash === $rightHash) {
                     $anchorStatus = 'placed';
                 }
             } elseif (isset($fileIdByPath[$filePath])) {
-                // Legacy comments without stored hash: assume placed when the file is in the current diff.
                 $anchorStatus = 'placed';
             }
 
@@ -79,7 +67,7 @@ final readonly class ResolveCommentAnchorAction
                 'startLine' => $this->intOrNull($row['start_line'] ?? $row['startLine'] ?? null),
                 'endLine' => $this->intOrNull($row['end_line'] ?? $row['endLine'] ?? null),
                 'body' => (string) ($row['body'] ?? ''),
-                'originRef' => (string) ($row['origin_ref'] ?? $row['originRef'] ?? 'working'),
+                'originRef' => (string) ($row['origin_ref'] ?? $row['originRef'] ?? GitFileContentService::WORKING_REF),
                 'fileContentHash' => $storedHash,
                 'lineSnippet' => $row['line_snippet'] ?? $row['lineSnippet'] ?? null,
                 'isDraft' => (bool) ($row['is_draft'] ?? $row['isDraft'] ?? false),

--- a/app/Actions/ResolveCommentAnchorAction.php
+++ b/app/Actions/ResolveCommentAnchorAction.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\DTOs\DiffTarget;
+use App\DTOs\FileListEntry;
+use App\Services\GitFileContentService;
+
+final readonly class ResolveCommentAnchorAction
+{
+    public function __construct(
+        private GitFileContentService $gitFileContentService,
+    ) {}
+
+    /**
+     * Resolve placement for every comment against the current diff target.
+     *
+     * - Anchors by `file_content_hash` + line number.
+     * - Matches against the file hash on either the left (`target.from`) or right
+     *   (`target.to`, or working copy when null) side of the current diff.
+     * - Returns an array of view-ready comment rows with `fileId`, `anchorStatus`
+     *   (`'placed'` or `'unplaced'`).
+     *
+     * @param  iterable<array<string, mixed>>  $rawComments  Rows from the comments table or their array form.
+     * @param  array<int, array<string, mixed>>  $currentFiles  Output of GetFileListAction (includes `id`, `path`).
+     * @return array<int, array<string, mixed>>
+     */
+    public function handle(string $repoPath, iterable $rawComments, array $currentFiles, DiffTarget $target): array
+    {
+        $fileIdByPath = [];
+        foreach ($currentFiles as $file) {
+            $fileIdByPath[$file['path']] = $file['id'];
+        }
+
+        $resolved = [];
+        $hashCache = [];
+
+        $hashFor = function (string $ref, string $path) use ($repoPath, &$hashCache): ?string {
+            $key = $ref.':'.$path;
+
+            if (! array_key_exists($key, $hashCache)) {
+                $hashCache[$key] = $this->gitFileContentService->hashAt($repoPath, $ref, $path);
+            }
+
+            return $hashCache[$key];
+        };
+
+        foreach ($rawComments as $row) {
+            $filePath = (string) ($row['file_path'] ?? $row['file'] ?? '');
+            if ($filePath === '') {
+                continue;
+            }
+
+            $storedHash = $row['file_content_hash'] ?? null;
+            $fileId = $fileIdByPath[$filePath] ?? FileListEntry::idForPath($filePath);
+
+            $anchorStatus = 'unplaced';
+
+            if ($storedHash !== null && $storedHash !== '' && isset($fileIdByPath[$filePath])) {
+                $leftHash = $hashFor($target->from(), $filePath);
+                $rightRef = $target->to() ?? GitFileContentService::WORKING_REF;
+                $rightHash = $hashFor($rightRef, $filePath);
+
+                if ($storedHash === $leftHash || $storedHash === $rightHash) {
+                    $anchorStatus = 'placed';
+                }
+            } elseif (isset($fileIdByPath[$filePath])) {
+                // Legacy comments without stored hash: assume placed when the file is in the current diff.
+                $anchorStatus = 'placed';
+            }
+
+            $resolved[] = [
+                'id' => (string) $row['id'],
+                'fileId' => $fileId,
+                'file' => $filePath,
+                'side' => (string) ($row['side'] ?? 'right'),
+                'startLine' => $this->intOrNull($row['start_line'] ?? $row['startLine'] ?? null),
+                'endLine' => $this->intOrNull($row['end_line'] ?? $row['endLine'] ?? null),
+                'body' => (string) ($row['body'] ?? ''),
+                'originRef' => (string) ($row['origin_ref'] ?? $row['originRef'] ?? 'working'),
+                'fileContentHash' => $storedHash,
+                'lineSnippet' => $row['line_snippet'] ?? $row['lineSnippet'] ?? null,
+                'isDraft' => (bool) ($row['is_draft'] ?? $row['isDraft'] ?? false),
+                'submittedAt' => $row['submitted_at'] ?? $row['submittedAt'] ?? null,
+                'anchorStatus' => $anchorStatus,
+            ];
+        }
+
+        return $resolved;
+    }
+
+    private function intOrNull(mixed $value): ?int
+    {
+        return $value === null ? null : (int) $value;
+    }
+}

--- a/app/Actions/RestoreSessionAction.php
+++ b/app/Actions/RestoreSessionAction.php
@@ -104,9 +104,19 @@ final readonly class RestoreSessionAction
                 continue;
             }
 
+            $storedHashes = $hashesByPath[$path];
             $currentHash = $this->gitFileContentService->hashAt($repoPath, $ref, $path) ?? '';
 
-            if ($currentHash !== '' && in_array($currentHash, $hashesByPath[$path], true)) {
+            // Legacy rows (indexed `reviewed_files` arrays or immutable-context sessions)
+            // were migrated with an empty `content_hash`. Treat those as "reviewed
+            // regardless of content" so migrated users keep their state.
+            if (in_array('', $storedHashes, true)) {
+                $reviewed[$path] = $currentHash;
+
+                continue;
+            }
+
+            if ($currentHash !== '' && in_array($currentHash, $storedHashes, true)) {
                 $reviewed[$path] = $currentHash;
             }
         }

--- a/app/Actions/RestoreSessionAction.php
+++ b/app/Actions/RestoreSessionAction.php
@@ -5,90 +5,114 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\DTOs\DiffTarget;
-use App\DTOs\FileListEntry;
+use App\Models\Comment;
+use App\Models\ReviewedFile;
 use App\Models\ReviewSession;
-use App\Services\GitDiffService;
+use App\Services\GitFileContentService;
 
 final readonly class RestoreSessionAction
 {
     public function __construct(
-        private GitDiffService $gitDiffService,
+        private ResolveCommentAnchorAction $resolveCommentAnchor,
+        private GitFileContentService $gitFileContentService,
     ) {}
 
     /**
      * @param  array<int, array<string, mixed>>  $currentFiles
      * @return array{comments: array<int, array<string, mixed>>, reviewedFiles: array<string, string>, globalComment: string, orphanedPaths: array<int, string>}
      */
-    public function handle(string $repoPath, array $currentFiles, ?int $projectId = null, string $contextFingerprint = DiffTarget::WORKING_CONTEXT, ?DiffTarget $target = null): array
+    public function handle(string $repoPath, array $currentFiles, ?int $projectId = null, ?DiffTarget $target = null): array
     {
-        $session = ReviewSession::firstOrCreate(
-            ReviewSession::lookupKey($repoPath, $projectId, $contextFingerprint),
-            ['repo_path' => $repoPath],
-        );
+        $target ??= DiffTarget::workingDirectory();
 
-        $fileIdMap = [];
-        $currentPathSet = [];
-        foreach ($currentFiles as $f) {
-            $fileIdMap[$f['path']] = $f['id'];
-            $currentPathSet[$f['path']] = true;
-        }
+        $session = $this->resolveGlobalCommentRow($repoPath, $projectId);
 
-        /** @var array<int|string, string> $rawReviewed */
-        $rawReviewed = $session->reviewed_files ?? [];
-        $isImmutable = $target !== null && $target->isImmutable();
+        $rawComments = $this->loadComments($repoPath, $projectId);
+        $resolved = $this->resolveCommentAnchor->handle($repoPath, $rawComments, $currentFiles, $target);
 
-        // Legacy compat: convert indexed array to associative with fresh fingerprints
-        if ($rawReviewed !== [] && array_is_list($rawReviewed)) {
-            $reviewedFiles = [];
-            foreach ($rawReviewed as $path) {
-                if (isset($currentPathSet[$path])) {
-                    $reviewedFiles[$path] = $isImmutable ? '' : $this->gitDiffService->fileDiffFingerprint($repoPath, $path, $target);
-                }
-            }
-        } else {
-            /** @var array<string, string> $reviewedFiles */
-            $reviewedFiles = array_intersect_key($rawReviewed, $currentPathSet);
+        $orphanedPaths = $this->collectOrphanedPaths($resolved, $currentFiles);
 
-            // Fingerprint validation (skip for immutable targets)
-            if (! $isImmutable) {
-                foreach ($reviewedFiles as $path => $storedHash) {
-                    $currentHash = $this->gitDiffService->fileDiffFingerprint($repoPath, $path, $target);
-                    if ($storedHash !== '' && $currentHash !== '' && $storedHash !== $currentHash) {
-                        unset($reviewedFiles[$path]);
-                    }
-                }
-            }
-        }
-
-        // Restore comments - remap fileId, generate deterministic ID for orphaned files
-        /** @var array<int, array<string, mixed>> $savedComments */
-        $savedComments = $session->comments ?? [];
-        $orphanedPaths = [];
-        $comments = collect($savedComments)
-            ->map(function (array $c) use ($fileIdMap, &$orphanedPaths) {
-                $path = $c['file'] ?? '';
-                if (isset($fileIdMap[$path])) {
-                    return array_merge($c, ['fileId' => $fileIdMap[$path]]);
-                }
-                if ($path !== '') {
-                    $orphanedPaths[$path] = true;
-
-                    return array_merge($c, ['fileId' => FileListEntry::idForPath($path)]);
-                }
-
-                return null;
-            })
-            ->filter()
-            ->values()
-            ->all();
-
-        $orphanedPaths = array_keys($orphanedPaths);
+        $reviewedFiles = $this->resolveReviewedFiles($repoPath, $projectId, $currentFiles, $target);
 
         return [
-            'comments' => $comments,
+            'comments' => $resolved,
             'reviewedFiles' => $reviewedFiles,
-            'globalComment' => $session->global_comment ?? '',
+            'globalComment' => (string) ($session->global_comment ?? ''),
             'orphanedPaths' => $orphanedPaths,
         ];
+    }
+
+    private function resolveGlobalCommentRow(string $repoPath, ?int $projectId): ReviewSession
+    {
+        return ReviewSession::firstOrCreate(
+            $projectId
+                ? ['project_id' => $projectId]
+                : ['project_id' => null, 'repo_path' => $repoPath],
+            ['repo_path' => $repoPath],
+        );
+    }
+
+    /** @return iterable<array<string, mixed>> */
+    private function loadComments(string $repoPath, ?int $projectId): iterable
+    {
+        $query = Comment::query()->whereNull('submitted_at');
+        $query = $projectId
+            ? $query->where('project_id', $projectId)
+            : $query->whereNull('project_id')->where('repo_path', $repoPath);
+
+        return $query->orderBy('created_at')->get()->map(fn (Comment $c) => $c->toArray())->all();
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $resolved
+     * @param  array<int, array<string, mixed>>  $currentFiles
+     * @return array<int, string>
+     */
+    private function collectOrphanedPaths(array $resolved, array $currentFiles): array
+    {
+        $presentPaths = collect($currentFiles)->pluck('path')->all();
+
+        return collect($resolved)
+            ->filter(fn (array $c) => ! in_array($c['file'], $presentPaths, true))
+            ->pluck('file')
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $currentFiles
+     * @return array<string, string>
+     */
+    private function resolveReviewedFiles(string $repoPath, ?int $projectId, array $currentFiles, DiffTarget $target): array
+    {
+        $query = ReviewedFile::query();
+        $query = $projectId
+            ? $query->where('project_id', $projectId)
+            : $query->whereNull('project_id')->where('repo_path', $repoPath);
+
+        /** @var array<string, array<int, string>> $hashesByPath */
+        $hashesByPath = $query->get(['file_path', 'content_hash'])
+            ->groupBy('file_path')
+            ->map(fn ($rows) => $rows->pluck('content_hash')->all())
+            ->all();
+
+        $ref = $target->to() ?? GitFileContentService::WORKING_REF;
+        $reviewed = [];
+
+        foreach ($currentFiles as $file) {
+            $path = (string) ($file['path'] ?? '');
+            if ($path === '' || ! isset($hashesByPath[$path])) {
+                continue;
+            }
+
+            $currentHash = $this->gitFileContentService->hashAt($repoPath, $ref, $path) ?? '';
+
+            if ($currentHash !== '' && in_array($currentHash, $hashesByPath[$path], true)) {
+                $reviewed[$path] = $currentHash;
+            }
+        }
+
+        return $reviewed;
     }
 }

--- a/app/Actions/RestoreSessionAction.php
+++ b/app/Actions/RestoreSessionAction.php
@@ -55,12 +55,13 @@ final readonly class RestoreSessionAction
     /** @return iterable<array<string, mixed>> */
     private function loadComments(string $repoPath, ?int $projectId): iterable
     {
-        $query = Comment::query()->whereNull('submitted_at');
-        $query = $projectId
-            ? $query->where('project_id', $projectId)
-            : $query->whereNull('project_id')->where('repo_path', $repoPath);
-
-        return $query->orderBy('created_at')->get()->map(fn (Comment $c) => $c->toArray())->all();
+        return Comment::query()
+            ->forProjectOrRepo($projectId, $repoPath)
+            ->whereNull('submitted_at')
+            ->orderBy('created_at')
+            ->get()
+            ->map(fn (Comment $c) => $c->toArray())
+            ->all();
     }
 
     /**
@@ -86,13 +87,10 @@ final readonly class RestoreSessionAction
      */
     private function resolveReviewedFiles(string $repoPath, ?int $projectId, array $currentFiles, DiffTarget $target): array
     {
-        $query = ReviewedFile::query();
-        $query = $projectId
-            ? $query->where('project_id', $projectId)
-            : $query->whereNull('project_id')->where('repo_path', $repoPath);
-
         /** @var array<string, array<int, string>> $hashesByPath */
-        $hashesByPath = $query->get(['file_path', 'content_hash'])
+        $hashesByPath = ReviewedFile::query()
+            ->forProjectOrRepo($projectId, $repoPath)
+            ->get(['file_path', 'content_hash'])
             ->groupBy('file_path')
             ->map(fn ($rows) => $rows->pluck('content_hash')->all())
             ->all();

--- a/app/Actions/RestoreSessionAction.php
+++ b/app/Actions/RestoreSessionAction.php
@@ -95,7 +95,8 @@ final readonly class RestoreSessionAction
             ->map(fn ($rows) => $rows->pluck('content_hash')->all())
             ->all();
 
-        $ref = $target->to() ?? GitFileContentService::WORKING_REF;
+        $rightRef = $target->to() ?? GitFileContentService::WORKING_REF;
+        $leftRef = $target->from();
         $reviewed = [];
 
         foreach ($currentFiles as $file) {
@@ -105,19 +106,30 @@ final readonly class RestoreSessionAction
             }
 
             $storedHashes = $hashesByPath[$path];
-            $currentHash = $this->gitFileContentService->hashAt($repoPath, $ref, $path) ?? '';
 
             // Legacy rows (indexed `reviewed_files` arrays or immutable-context sessions)
             // were migrated with an empty `content_hash`. Treat those as "reviewed
             // regardless of content" so migrated users keep their state.
             if (in_array('', $storedHashes, true)) {
-                $reviewed[$path] = $currentHash;
+                $reviewed[$path] = $this->gitFileContentService->hashAt($repoPath, $rightRef, $path) ?? '';
 
                 continue;
             }
 
-            if ($currentHash !== '' && in_array($currentHash, $storedHashes, true)) {
-                $reviewed[$path] = $currentHash;
+            // `ToggleReviewedAction` falls back to the left ref when the right side is
+            // missing (deleted / left-only files). Check both sides on restore so the
+            // reviewed flag survives for those files too.
+            $rightHash = $this->gitFileContentService->hashAt($repoPath, $rightRef, $path);
+            if ($rightHash !== null && in_array($rightHash, $storedHashes, true)) {
+                $reviewed[$path] = $rightHash;
+
+                continue;
+            }
+
+            $leftPath = $file['oldPath'] ?? $path;
+            $leftHash = $this->gitFileContentService->hashAt($repoPath, $leftRef, $leftPath);
+            if ($leftHash !== null && in_array($leftHash, $storedHashes, true)) {
+                $reviewed[$path] = $leftHash;
             }
         }
 

--- a/app/Actions/SaveSessionAction.php
+++ b/app/Actions/SaveSessionAction.php
@@ -4,23 +4,24 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
-use App\DTOs\DiffTarget;
 use App\Models\ReviewSession;
 
 final readonly class SaveSessionAction
 {
     /**
-     * @param  array<int, array<string, mixed>>  $comments
-     * @param  array<string, string>  $reviewedFiles
+     * Persist the repo-scoped `global_comment`.
+     *
+     * Per-comment and reviewed-file state are now stored row-by-row in their own
+     * tables; this action only keeps the free-form repo-level note in sync.
      */
-    public function handle(string $repoPath, array $comments, array $reviewedFiles, string $globalComment, ?int $projectId = null, string $contextFingerprint = DiffTarget::WORKING_CONTEXT): void
+    public function handle(string $repoPath, string $globalComment, ?int $projectId = null): void
     {
         ReviewSession::updateOrCreate(
-            ReviewSession::lookupKey($repoPath, $projectId, $contextFingerprint),
+            $projectId
+                ? ['project_id' => $projectId]
+                : ['project_id' => null, 'repo_path' => $repoPath],
             [
                 'repo_path' => $repoPath,
-                'reviewed_files' => $reviewedFiles,
-                'comments' => $comments,
                 'global_comment' => $globalComment,
             ]
         );

--- a/app/Actions/ToggleReviewedAction.php
+++ b/app/Actions/ToggleReviewedAction.php
@@ -16,7 +16,7 @@ final readonly class ToggleReviewedAction
 
     /**
      * @param  array<string, string>  $reviewedFiles  Current view state: {path => content_hash}.
-     * @param  array<int, array<string, mixed>>  $knownFiles  Files in the current diff.
+     * @param  array<int, array{id?: string, path: string, isUntracked?: bool}>  $knownFiles  Files in the current diff.
      * @return array<string, string>|null Updated view state, or null when the file is unknown.
      */
     public function handle(

--- a/app/Actions/ToggleReviewedAction.php
+++ b/app/Actions/ToggleReviewedAction.php
@@ -38,13 +38,11 @@ final readonly class ToggleReviewedAction
             ? ($this->gitFileContentService->hashAt($repoPath, $ref, $filePath) ?? '')
             : '';
 
-        $query = ReviewedFile::query()->where('file_path', $filePath);
-        $query = $projectId
-            ? $query->where('project_id', $projectId)
-            : $query->whereNull('project_id')->where('repo_path', $repoPath);
-
         if (array_key_exists($filePath, $reviewedFiles)) {
-            (clone $query)->delete();
+            ReviewedFile::query()
+                ->forProjectOrRepo($projectId, $repoPath)
+                ->where('file_path', $filePath)
+                ->delete();
             unset($reviewedFiles[$filePath]);
 
             return $reviewedFiles;

--- a/app/Actions/ToggleReviewedAction.php
+++ b/app/Actions/ToggleReviewedAction.php
@@ -33,9 +33,8 @@ final readonly class ToggleReviewedAction
             return null;
         }
 
-        $ref = ($target?->to()) ?? GitFileContentService::WORKING_REF;
         $contentHash = $repoPath !== ''
-            ? ($this->gitFileContentService->hashAt($repoPath, $ref, $filePath) ?? '')
+            ? ($this->resolveContentHash($repoPath, $target, $filePath) ?? '')
             : '';
 
         if (array_key_exists($filePath, $reviewedFiles)) {
@@ -61,5 +60,25 @@ final readonly class ToggleReviewedAction
         $reviewedFiles[$filePath] = $contentHash;
 
         return $reviewedFiles;
+    }
+
+    /**
+     * Pin the reviewed anchor to a stable hash: right side first, falling back
+     * to the left side for files that only exist before the diff (deletions /
+     * left-only moves). Returns null when the file is absent on both sides.
+     */
+    private function resolveContentHash(string $repoPath, ?DiffTarget $target, string $filePath): ?string
+    {
+        $rightRef = $target?->to() ?? GitFileContentService::WORKING_REF;
+        $rightHash = $this->gitFileContentService->hashAt($repoPath, $rightRef, $filePath);
+        if ($rightHash !== null) {
+            return $rightHash;
+        }
+
+        $leftRef = $target?->from() ?? GitFileContentService::WORKING_REF;
+
+        return $leftRef === $rightRef
+            ? null
+            : $this->gitFileContentService->hashAt($repoPath, $leftRef, $filePath);
     }
 }

--- a/app/Actions/ToggleReviewedAction.php
+++ b/app/Actions/ToggleReviewedAction.php
@@ -5,38 +5,62 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\DTOs\DiffTarget;
-use App\Services\GitDiffService;
+use App\Models\ReviewedFile;
+use App\Services\GitFileContentService;
 
 final readonly class ToggleReviewedAction
 {
     public function __construct(
-        private GitDiffService $gitDiffService,
+        private GitFileContentService $gitFileContentService,
     ) {}
 
     /**
-     * @param  array<string, string>  $reviewedFiles
-     * @param  array<int, array<string, mixed>>  $knownFiles
-     * @return array<string, string>|null
+     * @param  array<string, string>  $reviewedFiles  Current view state: {path => content_hash}.
+     * @param  array<int, array<string, mixed>>  $knownFiles  Files in the current diff.
+     * @return array<string, string>|null Updated view state, or null when the file is unknown.
      */
-    public function handle(array $reviewedFiles, string $filePath, array $knownFiles, string $repoPath = '', ?DiffTarget $target = null): ?array
-    {
+    public function handle(
+        array $reviewedFiles,
+        string $filePath,
+        array $knownFiles,
+        string $repoPath,
+        ?DiffTarget $target = null,
+        ?int $projectId = null,
+    ): ?array {
         $file = collect($knownFiles)->firstWhere('path', $filePath);
 
         if ($file === null) {
             return null;
         }
 
+        $ref = ($target?->to()) ?? GitFileContentService::WORKING_REF;
+        $contentHash = $repoPath !== ''
+            ? ($this->gitFileContentService->hashAt($repoPath, $ref, $filePath) ?? '')
+            : '';
+
+        $query = ReviewedFile::query()->where('file_path', $filePath);
+        $query = $projectId
+            ? $query->where('project_id', $projectId)
+            : $query->whereNull('project_id')->where('repo_path', $repoPath);
+
         if (array_key_exists($filePath, $reviewedFiles)) {
+            (clone $query)->delete();
             unset($reviewedFiles[$filePath]);
 
             return $reviewedFiles;
         }
 
-        $fingerprint = $repoPath !== ''
-            ? $this->gitDiffService->fileDiffFingerprint($repoPath, $filePath, $target)
-            : '';
+        ReviewedFile::updateOrCreate(
+            [
+                'project_id' => $projectId,
+                'repo_path' => $repoPath,
+                'file_path' => $filePath,
+                'content_hash' => $contentHash,
+            ],
+            [],
+        );
 
-        $reviewedFiles[$filePath] = $fingerprint;
+        $reviewedFiles[$filePath] = $contentHash;
 
         return $reviewedFiles;
     }

--- a/app/Actions/ToggleReviewedAction.php
+++ b/app/Actions/ToggleReviewedAction.php
@@ -52,9 +52,8 @@ final readonly class ToggleReviewedAction
                 'project_id' => $projectId,
                 'repo_path' => $repoPath,
                 'file_path' => $filePath,
-                'content_hash' => $contentHash,
             ],
-            [],
+            ['content_hash' => $contentHash],
         );
 
         $reviewedFiles[$filePath] = $contentHash;

--- a/app/Actions/UpdateCommentAction.php
+++ b/app/Actions/UpdateCommentAction.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Models\Comment;
+
+final readonly class UpdateCommentAction
+{
+    public function handle(string $commentId, string $body, bool $isDraft = false): bool
+    {
+        if (! str_starts_with($commentId, 'c-')) {
+            return false;
+        }
+
+        return Comment::whereKey($commentId)
+            ->update(['body' => $body, 'is_draft' => $isDraft]) > 0;
+    }
+}

--- a/app/Console/Benchmark/PerfScenarioRunner.php
+++ b/app/Console/Benchmark/PerfScenarioRunner.php
@@ -197,7 +197,7 @@ final class PerfScenarioRunner
                 string $repoPath,
                 array $currentFiles,
                 ?int $projectId = null,
-                string $contextFingerprint = DiffTarget::WORKING_CONTEXT,
+                ?DiffTarget $target = null,
             ): array {
                 return ['comments' => [], 'reviewedFiles' => [], 'globalComment' => '', 'orphanedPaths' => []];
             }
@@ -205,17 +205,10 @@ final class PerfScenarioRunner
 
         $this->app->bind(SaveSessionAction::class, fn () => new class
         {
-            /**
-             * @param  array<int, array<string, mixed>>  $comments
-             * @param  array<string, string>  $reviewedFiles
-             */
             public function handle(
                 string $repoPath,
-                array $comments,
-                array $reviewedFiles,
                 string $globalComment,
                 ?int $projectId = null,
-                string $contextFingerprint = DiffTarget::WORKING_CONTEXT,
             ): void {}
         });
 

--- a/app/DTOs/Comment.php
+++ b/app/DTOs/Comment.php
@@ -8,6 +8,8 @@ use App\Enums\DiffSide;
 
 class Comment
 {
+    public const WORKING_REF = 'working';
+
     public function __construct(
         public readonly string $id,
         public readonly string $fileId,
@@ -16,6 +18,12 @@ class Comment
         public readonly ?int $startLine,
         public readonly ?int $endLine,
         public readonly string $body,
+        public readonly string $originRef = self::WORKING_REF,
+        public readonly ?string $fileContentHash = null,
+        public readonly ?string $lineSnippet = null,
+        public readonly bool $isDraft = false,
+        public readonly ?string $submittedAt = null,
+        public readonly string $anchorStatus = 'placed',
     ) {}
 
     /** @return array<string, mixed> */
@@ -29,6 +37,12 @@ class Comment
             'startLine' => $this->startLine,
             'endLine' => $this->endLine,
             'body' => $this->body,
+            'originRef' => $this->originRef,
+            'fileContentHash' => $this->fileContentHash,
+            'lineSnippet' => $this->lineSnippet,
+            'isDraft' => $this->isDraft,
+            'submittedAt' => $this->submittedAt,
+            'anchorStatus' => $this->anchorStatus,
         ];
     }
 
@@ -42,6 +56,11 @@ class Comment
             'start_line' => $this->startLine,
             'end_line' => $this->endLine,
             'body' => $this->body,
+            'anchor' => [
+                'origin_ref' => $this->originRef,
+                'file_content_hash' => $this->fileContentHash,
+                'line_snippet' => $this->lineSnippet,
+            ],
         ];
     }
 
@@ -50,12 +69,18 @@ class Comment
     {
         return new self(
             id: $data['id'],
-            fileId: $data['fileId'],
+            fileId: $data['fileId'] ?? '',
             file: $data['file'],
             side: DiffSide::from($data['side']),
-            startLine: $data['startLine'],
-            endLine: $data['endLine'],
+            startLine: $data['startLine'] ?? null,
+            endLine: $data['endLine'] ?? null,
             body: $data['body'],
+            originRef: $data['originRef'] ?? self::WORKING_REF,
+            fileContentHash: $data['fileContentHash'] ?? null,
+            lineSnippet: $data['lineSnippet'] ?? null,
+            isDraft: (bool) ($data['isDraft'] ?? false),
+            submittedAt: $data['submittedAt'] ?? null,
+            anchorStatus: $data['anchorStatus'] ?? 'placed',
         );
     }
 }

--- a/app/DTOs/Comment.php
+++ b/app/DTOs/Comment.php
@@ -8,6 +8,7 @@ use App\Enums\DiffSide;
 
 class Comment
 {
+    /** Mirrors GitFileContentService::WORKING_REF (kept here so the DTO stays standalone). */
     public const WORKING_REF = 'working';
 
     public function __construct(

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Comment extends Model
+{
+    protected $keyType = 'string';
+
+    public $incrementing = false;
+
+    protected $fillable = [
+        'id',
+        'project_id',
+        'repo_path',
+        'origin_ref',
+        'file_path',
+        'side',
+        'start_line',
+        'end_line',
+        'file_content_hash',
+        'line_snippet',
+        'body',
+        'is_draft',
+        'submitted_at',
+    ];
+
+    /** @return BelongsTo<Project, $this> */
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'is_draft' => 'boolean',
+            'submitted_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -28,6 +29,19 @@ class Comment extends Model
         'is_draft',
         'submitted_at',
     ];
+
+    /**
+     * Scope a query to a project (when known) or to a bare repo path.
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeForProjectOrRepo(Builder $query, ?int $projectId, string $repoPath): Builder
+    {
+        return $projectId
+            ? $query->where('project_id', $projectId)
+            : $query->whereNull('project_id')->where('repo_path', $repoPath);
+    }
 
     /** @return BelongsTo<Project, $this> */
     public function project(): BelongsTo

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -34,6 +34,18 @@ class Project extends Model
         return $this->hasMany(ReviewSession::class);
     }
 
+    /** @return HasMany<Comment, $this> */
+    public function comments(): HasMany
+    {
+        return $this->hasMany(Comment::class);
+    }
+
+    /** @return HasMany<ReviewedFile, $this> */
+    public function reviewedFiles(): HasMany
+    {
+        return $this->hasMany(ReviewedFile::class);
+    }
+
     /** @return HasMany<TrashedFile, $this> */
     public function trashedFiles(): HasMany
     {

--- a/app/Models/ReviewSession.php
+++ b/app/Models/ReviewSession.php
@@ -14,27 +14,19 @@ class ReviewSession extends Model
     /** @use HasFactory<ReviewSessionFactory> */
     use HasFactory;
 
-    protected $fillable = ['repo_path', 'project_id', 'context_fingerprint', 'reviewed_files', 'comments', 'global_comment'];
+    protected $fillable = ['repo_path', 'project_id', 'global_comment'];
 
-    /** @return array<string, int|string> */
-    public static function lookupKey(string $repoPath, ?int $projectId, string $contextFingerprint): array
+    /** @return array<string, int|string|null> */
+    public static function lookupKey(string $repoPath, ?int $projectId): array
     {
         return $projectId
-            ? ['project_id' => $projectId, 'context_fingerprint' => $contextFingerprint]
-            : ['repo_path' => $repoPath, 'context_fingerprint' => $contextFingerprint];
+            ? ['project_id' => $projectId]
+            : ['project_id' => null, 'repo_path' => $repoPath];
     }
 
     /** @return BelongsTo<Project, $this> */
     public function project(): BelongsTo
     {
         return $this->belongsTo(Project::class);
-    }
-
-    protected function casts(): array
-    {
-        return [
-            'reviewed_files' => 'array',
-            'comments' => 'array',
-        ];
     }
 }

--- a/app/Models/ReviewedFile.php
+++ b/app/Models/ReviewedFile.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ReviewedFile extends Model
+{
+    protected $fillable = [
+        'project_id',
+        'repo_path',
+        'file_path',
+        'content_hash',
+    ];
+
+    /** @return BelongsTo<Project, $this> */
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+}

--- a/app/Models/ReviewedFile.php
+++ b/app/Models/ReviewedFile.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -15,6 +16,19 @@ class ReviewedFile extends Model
         'file_path',
         'content_hash',
     ];
+
+    /**
+     * Scope a query to a project (when known) or to a bare repo path.
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeForProjectOrRepo(Builder $query, ?int $projectId, string $repoPath): Builder
+    {
+        return $projectId
+            ? $query->where('project_id', $projectId)
+            : $query->whereNull('project_id')->where('repo_path', $repoPath);
+    }
 
     /** @return BelongsTo<Project, $this> */
     public function project(): BelongsTo

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Services\GitFileContentService;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
@@ -13,6 +14,8 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->mergeConfigFrom(base_path('config/rfa.php'), 'rfa');
+
+        $this->app->singleton(GitFileContentService::class);
     }
 
     public function boot(): void

--- a/app/Services/GitFileContentService.php
+++ b/app/Services/GitFileContentService.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Exceptions\GitCommandException;
+
+class GitFileContentService
+{
+    public const WORKING_REF = 'working';
+
+    public function __construct(
+        private readonly GitProcessService $gitProcessService,
+    ) {}
+
+    /**
+     * Hash the contents of a file at a given ref.
+     *
+     * `$ref` accepts a commit SHA, branch name, or the special value `self::WORKING_REF`,
+     * which reads the current working copy from disk. Returns null when the file does
+     * not exist at that ref (e.g. added-only or deleted-only changes).
+     */
+    public function hashAt(string $repoPath, string $ref, string $path): ?string
+    {
+        $content = $this->contentAt($repoPath, $ref, $path);
+
+        return $content === null ? null : hash('xxh128', $content);
+    }
+
+    public function contentAt(string $repoPath, string $ref, string $path): ?string
+    {
+        if ($ref === self::WORKING_REF) {
+            $absolute = rtrim($repoPath, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$path;
+
+            if (! is_file($absolute)) {
+                return null;
+            }
+
+            $content = @file_get_contents($absolute);
+
+            return $content === false ? null : $content;
+        }
+
+        try {
+            return $this->gitProcessService->run($repoPath, ['show', $ref.':'.$path]);
+        } catch (GitCommandException) {
+            return null;
+        }
+    }
+}

--- a/app/Services/GitFileContentService.php
+++ b/app/Services/GitFileContentService.php
@@ -10,6 +10,9 @@ class GitFileContentService
 {
     public const WORKING_REF = 'working';
 
+    /** @var array<string, ?string> */
+    private array $hashCache = [];
+
     public function __construct(
         private readonly GitProcessService $gitProcessService,
     ) {}
@@ -23,9 +26,14 @@ class GitFileContentService
      */
     public function hashAt(string $repoPath, string $ref, string $path): ?string
     {
-        $content = $this->contentAt($repoPath, $ref, $path);
+        $key = $repoPath."\0".$ref."\0".$path;
 
-        return $content === null ? null : hash('xxh128', $content);
+        if (! array_key_exists($key, $this->hashCache)) {
+            $content = $this->contentAt($repoPath, $ref, $path);
+            $this->hashCache[$key] = $content === null ? null : hash('xxh128', $content);
+        }
+
+        return $this->hashCache[$key];
     }
 
     public function contentAt(string $repoPath, string $ref, string $path): ?string

--- a/app/Services/GitFileContentService.php
+++ b/app/Services/GitFileContentService.php
@@ -10,7 +10,15 @@ class GitFileContentService
 {
     public const WORKING_REF = 'working';
 
-    /** @var array<string, ?string> */
+    /**
+     * Request-scoped memoization. The singleton binding in AppServiceProvider
+     * is safe under shared-nothing PHP (built-in web server): each HTTP request
+     * rebuilds the container, so working-copy hashes cannot go stale mid-request.
+     * If this app ever adopts Octane/FrankenPHP/RoadRunner, add a `forget()` path
+     * or drop the singleton binding.
+     *
+     * @var array<string, ?string>
+     */
     private array $hashCache = [];
 
     public function __construct(

--- a/app/Services/GitProcessService.php
+++ b/app/Services/GitProcessService.php
@@ -7,7 +7,7 @@ namespace App\Services;
 use App\Exceptions\GitCommandException;
 use Symfony\Component\Process\Process;
 
-final class GitProcessService
+class GitProcessService
 {
     /** @param array<int, string> $args */
     public function run(string $repoPath, array $args): string

--- a/database/migrations/2026_04_19_074935_create_comments_table.php
+++ b/database/migrations/2026_04_19_074935_create_comments_table.php
@@ -28,6 +28,7 @@ return new class extends Migration
             $table->index(['repo_path', 'submitted_at']);
             $table->index(['project_id', 'file_path']);
             $table->index(['repo_path', 'file_path']);
+            $table->index('file_content_hash');
         });
     }
 

--- a/database/migrations/2026_04_19_074935_create_comments_table.php
+++ b/database/migrations/2026_04_19_074935_create_comments_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->string('id')->primary();
+            $table->foreignId('project_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->string('repo_path');
+            $table->string('origin_ref');
+            $table->string('file_path');
+            $table->string('side');
+            $table->unsignedInteger('start_line')->nullable();
+            $table->unsignedInteger('end_line')->nullable();
+            $table->string('file_content_hash')->nullable();
+            $table->text('line_snippet')->nullable();
+            $table->text('body');
+            $table->boolean('is_draft')->default(false);
+            $table->timestamp('submitted_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['project_id', 'submitted_at']);
+            $table->index(['repo_path', 'submitted_at']);
+            $table->index(['project_id', 'file_path']);
+            $table->index(['repo_path', 'file_path']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('comments');
+    }
+};

--- a/database/migrations/2026_04_19_074935_create_reviewed_files_table.php
+++ b/database/migrations/2026_04_19_074935_create_reviewed_files_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('reviewed_files', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->string('repo_path');
+            $table->string('file_path');
+            $table->string('content_hash');
+            $table->timestamps();
+
+            $table->unique(['project_id', 'file_path', 'content_hash'], 'reviewed_files_project_unique');
+            $table->unique(['repo_path', 'file_path', 'content_hash'], 'reviewed_files_repo_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('reviewed_files');
+    }
+};

--- a/database/migrations/2026_04_19_074936_migrate_session_data_to_comment_tables.php
+++ b/database/migrations/2026_04_19_074936_migrate_session_data_to_comment_tables.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -138,31 +139,54 @@ return new class extends Migration
 
     private function dedupeReviewSessions(): void
     {
-        // For each project_id/repo_path, keep the most recently updated row.
-        // `updated_at DESC, id DESC` reflects user intent better than longest-wins
-        // (which could discard a freshly edited shorter note in favor of stale text).
-        $groups = DB::table('review_sessions')
-            ->selectRaw('COALESCE(project_id, 0) as group_key, project_id, repo_path')
-            ->groupBy('group_key', 'project_id', 'repo_path')
+        // Dedup to match the partial uniques in the next migration:
+        //   - project_id IS NOT NULL  → unique on project_id alone
+        //   - project_id IS NULL      → unique on repo_path alone
+        // Grouping by (project_id, repo_path) would leave two rows for a project
+        // that ever had multiple paths, and the unique index would then fail.
+        //
+        // `updated_at DESC, id DESC` keeps the most recently touched row; this is
+        // closer to user intent than longest-comment-wins, which can otherwise
+        // discard a freshly edited short note in favor of stale text.
+        $projectGroups = DB::table('review_sessions')
+            ->whereNotNull('project_id')
+            ->select('project_id')
+            ->groupBy('project_id')
             ->get();
 
-        foreach ($groups as $group) {
-            $query = DB::table('review_sessions')->where('repo_path', $group->repo_path);
-            $query = $group->project_id
-                ? $query->where('project_id', $group->project_id)
-                : $query->whereNull('project_id');
+        foreach ($projectGroups as $group) {
+            $this->dedupeGroup(
+                DB::table('review_sessions')->where('project_id', $group->project_id),
+            );
+        }
 
-            $rows = $query->orderByDesc('updated_at')->orderByDesc('id')->get();
-            if ($rows->count() <= 1) {
-                continue;
-            }
+        $bareGroups = DB::table('review_sessions')
+            ->whereNull('project_id')
+            ->select('repo_path')
+            ->groupBy('repo_path')
+            ->get();
 
-            $keeper = $rows->first();
-            $idsToDelete = $rows->pluck('id')->reject(fn ($id) => $id === $keeper->id)->all();
+        foreach ($bareGroups as $group) {
+            $this->dedupeGroup(
+                DB::table('review_sessions')
+                    ->whereNull('project_id')
+                    ->where('repo_path', $group->repo_path),
+            );
+        }
+    }
 
-            if ($idsToDelete !== []) {
-                DB::table('review_sessions')->whereIn('id', $idsToDelete)->delete();
-            }
+    private function dedupeGroup(Builder $query): void
+    {
+        $rows = $query->orderByDesc('updated_at')->orderByDesc('id')->get();
+        if ($rows->count() <= 1) {
+            return;
+        }
+
+        $keeper = $rows->first();
+        $idsToDelete = $rows->pluck('id')->reject(fn ($id) => $id === $keeper->id)->all();
+
+        if ($idsToDelete !== []) {
+            DB::table('review_sessions')->whereIn('id', $idsToDelete)->delete();
         }
     }
 };

--- a/database/migrations/2026_04_19_074936_migrate_session_data_to_comment_tables.php
+++ b/database/migrations/2026_04_19_074936_migrate_session_data_to_comment_tables.php
@@ -138,7 +138,9 @@ return new class extends Migration
 
     private function dedupeReviewSessions(): void
     {
-        // For each project_id/repo_path, keep the row with the longest global_comment (or first).
+        // For each project_id/repo_path, keep the most recently updated row.
+        // `updated_at DESC, id DESC` reflects user intent better than longest-wins
+        // (which could discard a freshly edited shorter note in favor of stale text).
         $groups = DB::table('review_sessions')
             ->selectRaw('COALESCE(project_id, 0) as group_key, project_id, repo_path')
             ->groupBy('group_key', 'project_id', 'repo_path')
@@ -150,19 +152,12 @@ return new class extends Migration
                 ? $query->where('project_id', $group->project_id)
                 : $query->whereNull('project_id');
 
-            $rows = $query->orderByDesc('id')->get();
+            $rows = $query->orderByDesc('updated_at')->orderByDesc('id')->get();
             if ($rows->count() <= 1) {
                 continue;
             }
 
-            /** @var object|null $keeper */
-            $keeper = null;
-            foreach ($rows as $row) {
-                if ($keeper === null || strlen((string) ($row->global_comment ?? '')) > strlen((string) ($keeper->global_comment ?? ''))) {
-                    $keeper = $row;
-                }
-            }
-
+            $keeper = $rows->first();
             $idsToDelete = $rows->pluck('id')->reject(fn ($id) => $id === $keeper->id)->all();
 
             if ($idsToDelete !== []) {

--- a/database/migrations/2026_04_19_074936_migrate_session_data_to_comment_tables.php
+++ b/database/migrations/2026_04_19_074936_migrate_session_data_to_comment_tables.php
@@ -145,10 +145,10 @@ return new class extends Migration
             ->get();
 
         foreach ($groups as $group) {
-            $query = DB::table('review_sessions');
+            $query = DB::table('review_sessions')->where('repo_path', $group->repo_path);
             $query = $group->project_id
                 ? $query->where('project_id', $group->project_id)
-                : $query->whereNull('project_id')->where('repo_path', $group->repo_path);
+                : $query->whereNull('project_id');
 
             $rows = $query->orderByDesc('id')->get();
             if ($rows->count() <= 1) {

--- a/database/migrations/2026_04_19_074936_migrate_session_data_to_comment_tables.php
+++ b/database/migrations/2026_04_19_074936_migrate_session_data_to_comment_tables.php
@@ -1,0 +1,173 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $now = now();
+
+        DB::table('review_sessions')->orderBy('id')->lazyById()->each(function (object $session) use ($now): void {
+            $this->migrateComments($session, $now);
+            $this->migrateReviewedFiles($session, $now);
+        });
+
+        // Keep only a single review_sessions row per repo/project for the global_comment.
+        $this->dedupeReviewSessions();
+
+        Schema::table('review_sessions', function (Blueprint $table) {
+            if (Schema::hasColumn('review_sessions', 'comments')) {
+                $table->dropColumn('comments');
+            }
+
+            if (Schema::hasColumn('review_sessions', 'reviewed_files')) {
+                $table->dropColumn('reviewed_files');
+            }
+        });
+
+        Schema::table('review_sessions', function (Blueprint $table) {
+            if (Schema::hasColumn('review_sessions', 'context_fingerprint')) {
+                try {
+                    $table->dropUnique(['project_id', 'context_fingerprint']);
+                } catch (Throwable) {
+                    // Index may not exist on all databases; ignore.
+                }
+                $table->dropColumn('context_fingerprint');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('review_sessions', function (Blueprint $table) {
+            $table->string('context_fingerprint')->default('working')->after('project_id');
+            $table->json('reviewed_files')->default('[]');
+            $table->json('comments')->default('[]');
+        });
+    }
+
+    private function migrateComments(object $session, Carbon $now): void
+    {
+        $raw = $session->comments ?? '[]';
+        $decoded = is_string($raw) ? json_decode($raw, true) : $raw;
+
+        if (! is_array($decoded) || $decoded === []) {
+            return;
+        }
+
+        $originRef = $this->resolveOriginRef($session->context_fingerprint ?? 'working');
+
+        foreach ($decoded as $c) {
+            if (! is_array($c) || empty($c['id'] ?? null) || empty($c['file'] ?? null)) {
+                continue;
+            }
+
+            DB::table('comments')->insertOrIgnore([
+                'id' => $c['id'],
+                'project_id' => $session->project_id ?? null,
+                'repo_path' => $session->repo_path ?? '',
+                'origin_ref' => $originRef,
+                'file_path' => $c['file'],
+                'side' => $c['side'] ?? 'right',
+                'start_line' => $c['startLine'] ?? null,
+                'end_line' => $c['endLine'] ?? null,
+                'file_content_hash' => null,
+                'line_snippet' => null,
+                'body' => $c['body'] ?? '',
+                'is_draft' => ! empty($c['isDraft']),
+                'submitted_at' => null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        }
+    }
+
+    private function migrateReviewedFiles(object $session, Carbon $now): void
+    {
+        $raw = $session->reviewed_files ?? '[]';
+        $decoded = is_string($raw) ? json_decode($raw, true) : $raw;
+
+        if (! is_array($decoded) || $decoded === []) {
+            return;
+        }
+
+        foreach ($decoded as $path => $hash) {
+            if (is_int($path)) {
+                // Legacy indexed array of paths.
+                $filePath = (string) $hash;
+                $contentHash = '';
+            } else {
+                $filePath = (string) $path;
+                $contentHash = (string) ($hash ?? '');
+            }
+
+            if ($filePath === '') {
+                continue;
+            }
+
+            DB::table('reviewed_files')->insertOrIgnore([
+                'project_id' => $session->project_id ?? null,
+                'repo_path' => $session->repo_path ?? '',
+                'file_path' => $filePath,
+                'content_hash' => $contentHash,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        }
+    }
+
+    private function resolveOriginRef(string $fingerprint): string
+    {
+        if ($fingerprint === '' || $fingerprint === 'working') {
+            return 'working';
+        }
+
+        if (str_contains($fingerprint, '..')) {
+            [, $to] = explode('..', $fingerprint, 2);
+
+            return $to !== '' ? $to : 'working';
+        }
+
+        return $fingerprint;
+    }
+
+    private function dedupeReviewSessions(): void
+    {
+        // For each project_id/repo_path, keep the row with the longest global_comment (or first).
+        $groups = DB::table('review_sessions')
+            ->selectRaw('COALESCE(project_id, 0) as group_key, project_id, repo_path')
+            ->groupBy('group_key', 'project_id', 'repo_path')
+            ->get();
+
+        foreach ($groups as $group) {
+            $query = DB::table('review_sessions');
+            $query = $group->project_id
+                ? $query->where('project_id', $group->project_id)
+                : $query->whereNull('project_id')->where('repo_path', $group->repo_path);
+
+            $rows = $query->orderByDesc('id')->get();
+            if ($rows->count() <= 1) {
+                continue;
+            }
+
+            /** @var object|null $keeper */
+            $keeper = null;
+            foreach ($rows as $row) {
+                if ($keeper === null || strlen((string) ($row->global_comment ?? '')) > strlen((string) ($keeper->global_comment ?? ''))) {
+                    $keeper = $row;
+                }
+            }
+
+            $idsToDelete = $rows->pluck('id')->reject(fn ($id) => $id === $keeper->id)->all();
+
+            if ($idsToDelete !== []) {
+                DB::table('review_sessions')->whereIn('id', $idsToDelete)->delete();
+            }
+        }
+    }
+};

--- a/database/migrations/2026_04_20_084430_restore_uniques_after_comment_pool_migration.php
+++ b/database/migrations/2026_04_20_084430_restore_uniques_after_comment_pool_migration.php
@@ -1,0 +1,77 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * The pool-redesign migration dropped the composite unique on
+     * `review_sessions(project_id, context_fingerprint)` together with the
+     * `context_fingerprint` column, but never re-established a unique key.
+     * `reviewed_files_repo_unique` also covers bare-repo and project-scoped rows
+     * in one index, which collides once a project is created for an existing
+     * bare-repo path. Re-add partial uniques scoped by `project_id IS NULL` so
+     * bare-repo and project-scoped rows never share a unique key.
+     *
+     * SQLite partial indexes (WHERE clause) have been supported since 3.8.
+     */
+    public function up(): void
+    {
+        if ($this->hasIndex('review_sessions', 'review_sessions_project_id_unique')) {
+            Schema::table('review_sessions', function (Blueprint $table) {
+                $table->dropUnique('review_sessions_project_id_unique');
+            });
+        }
+
+        DB::statement(
+            'CREATE UNIQUE INDEX IF NOT EXISTS review_sessions_project_id_unique '
+            .'ON review_sessions (project_id) '
+            .'WHERE project_id IS NOT NULL'
+        );
+
+        DB::statement(
+            'CREATE UNIQUE INDEX IF NOT EXISTS review_sessions_bare_repo_unique '
+            .'ON review_sessions (repo_path) '
+            .'WHERE project_id IS NULL'
+        );
+
+        if ($this->hasIndex('reviewed_files', 'reviewed_files_repo_unique')) {
+            Schema::table('reviewed_files', function (Blueprint $table) {
+                $table->dropUnique('reviewed_files_repo_unique');
+            });
+        }
+
+        DB::statement(
+            'CREATE UNIQUE INDEX IF NOT EXISTS reviewed_files_bare_repo_unique '
+            .'ON reviewed_files (repo_path, file_path, content_hash) '
+            .'WHERE project_id IS NULL'
+        );
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS review_sessions_project_id_unique');
+        DB::statement('DROP INDEX IF EXISTS review_sessions_bare_repo_unique');
+        DB::statement('DROP INDEX IF EXISTS reviewed_files_bare_repo_unique');
+
+        // Restore the original (unscoped) repo unique on reviewed_files.
+        if (! $this->hasIndex('reviewed_files', 'reviewed_files_repo_unique')) {
+            Schema::table('reviewed_files', function (Blueprint $table) {
+                $table->unique(['repo_path', 'file_path', 'content_hash'], 'reviewed_files_repo_unique');
+            });
+        }
+    }
+
+    private function hasIndex(string $table, string $name): bool
+    {
+        $result = DB::selectOne(
+            'SELECT name FROM sqlite_master WHERE type = ? AND name = ?',
+            ['index', $name],
+        );
+
+        return $result !== null;
+    }
+};

--- a/database/migrations/2026_04_20_084430_restore_uniques_after_comment_pool_migration.php
+++ b/database/migrations/2026_04_20_084430_restore_uniques_after_comment_pool_migration.php
@@ -17,9 +17,16 @@ return new class extends Migration
      * bare-repo and project-scoped rows never share a unique key.
      *
      * SQLite partial indexes (WHERE clause) have been supported since 3.8.
+     * RFA ships SQLite via NativePHP; this migration is a no-op on other
+     * drivers so environments that use MySQL/Postgres for testing don't fail
+     * on the partial-index syntax.
      */
     public function up(): void
     {
+        if (! $this->isSqlite()) {
+            return;
+        }
+
         if ($this->hasIndex('review_sessions', 'review_sessions_project_id_unique')) {
             Schema::table('review_sessions', function (Blueprint $table) {
                 $table->dropUnique('review_sessions_project_id_unique');
@@ -53,6 +60,10 @@ return new class extends Migration
 
     public function down(): void
     {
+        if (! $this->isSqlite()) {
+            return;
+        }
+
         DB::statement('DROP INDEX IF EXISTS review_sessions_project_id_unique');
         DB::statement('DROP INDEX IF EXISTS review_sessions_bare_repo_unique');
         DB::statement('DROP INDEX IF EXISTS reviewed_files_bare_repo_unique');
@@ -63,6 +74,11 @@ return new class extends Migration
                 $table->unique(['repo_path', 'file_path', 'content_hash'], 'reviewed_files_repo_unique');
             });
         }
+    }
+
+    private function isSqlite(): bool
+    {
+        return DB::connection()->getDriverName() === 'sqlite';
     }
 
     private function hasIndex(string $table, string $name): bool

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -31,6 +31,7 @@
                 this.search = '';
                 this.selectedIndex = 0;
                 this.clearSelection();
+                window.dispatchEvent(new CustomEvent('overlay:open', { detail: { name: 'branch-explorer' } }));
                 await this.$wire.loadBranches();
                 this.allBranches = this.$wire.branches;
                 const currentIdx = this.allFiltered.findIndex(b => b.name === this.selectedBranch);
@@ -57,7 +58,22 @@
                 if (branchChanged) this.clearSelection();
             },
 
+            isHotkey(e) {
+                return (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.key.toLowerCase() === 'b';
+            },
+
             handleKeydown(e) {
+                // ⌘B / Ctrl+B toggles the picker from anywhere, except inside text inputs
+                // where it's the "bold" shortcut.
+                const inEditable = e.target.tagName === 'TEXTAREA'
+                    || e.target.tagName === 'INPUT'
+                    || e.target.isContentEditable;
+                if (this.isHotkey(e) && !inEditable) {
+                    e.preventDefault();
+                    this.open ? this.closePanel() : this.openPanel();
+                    return;
+                }
+
                 if (!this.open) return;
 
                 if (e.key === 'Escape') {

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -11,6 +11,8 @@
             baseShortHash: null,
             activeCommitHash,
             projectSlug,
+            selectedHashes: [],
+            lastSelectionIndex: -1,
             _loadId: 0, // Stale-response guard: incremented before each async load, checked after
 
             _filterBranches(key) {
@@ -134,6 +136,60 @@
 
             viewWorkingTree() {
                 Livewire.navigate(`/p/${this.projectSlug}`);
+            },
+
+            isSelected(hash) {
+                return this.selectedHashes.includes(hash);
+            },
+
+            toggleSelection(hash, idx, event) {
+                event.stopPropagation();
+
+                if (event.shiftKey && this.lastSelectionIndex >= 0) {
+                    const start = Math.min(this.lastSelectionIndex, idx);
+                    const end = Math.max(this.lastSelectionIndex, idx);
+                    const rangeHashes = this.$wire.commits.slice(start, end + 1).map(c => c.hash);
+                    const merged = new Set(this.selectedHashes);
+                    rangeHashes.forEach(h => merged.add(h));
+                    this.selectedHashes = [...merged];
+                    return;
+                }
+
+                const i = this.selectedHashes.indexOf(hash);
+                if (i >= 0) {
+                    this.selectedHashes.splice(i, 1);
+                } else {
+                    this.selectedHashes.push(hash);
+                }
+                this.lastSelectionIndex = idx;
+            },
+
+            clearSelection() {
+                this.selectedHashes = [];
+                this.lastSelectionIndex = -1;
+            },
+
+            applySelection() {
+                if (this.selectedHashes.length === 0) return;
+
+                const indices = this.selectedHashes
+                    .map(h => this.$wire.commits.findIndex(c => c.hash === h))
+                    .filter(i => i >= 0);
+
+                if (indices.length === 0) return;
+
+                if (indices.length === 1) {
+                    Livewire.navigate(`/p/${this.projectSlug}/c/${this.$wire.commits[indices[0]].hash}`);
+                    this.closePanel();
+                    return;
+                }
+
+                // Commits are listed newest-first; lowest index = tip, highest = oldest.
+                const newest = this.$wire.commits[Math.min(...indices)];
+                const oldest = this.$wire.commits[Math.max(...indices)];
+                const baseRef = encodeURIComponent(oldest.hash + '^');
+                Livewire.navigate(`/p/${this.projectSlug}/${newest.hash}/${baseRef}`);
+                this.closePanel();
             },
         }));
     }

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -30,6 +30,7 @@
                 this.open = true;
                 this.search = '';
                 this.selectedIndex = 0;
+                this.clearSelection();
                 await this.$wire.loadBranches();
                 this.allBranches = this.$wire.branches;
                 const currentIdx = this.allFiltered.findIndex(b => b.name === this.selectedBranch);
@@ -51,6 +52,7 @@
                 const id = ++this._loadId;
                 await this.$wire.loadCommits(branch.name);
                 if (this._loadId !== id) return;
+                this.clearSelection();
             },
 
             handleKeydown(e) {

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -174,9 +174,11 @@
             applySelection() {
                 if (this.selectedHashes.length === 0) return;
 
-                const indices = this.selectedHashes
-                    .map(h => this.$wire.commits.findIndex(c => c.hash === h))
-                    .filter(i => i >= 0);
+                const indices = [...new Set(
+                    this.selectedHashes
+                        .map(h => this.$wire.commits.findIndex(c => c.hash === h))
+                        .filter(i => i >= 0)
+                )].sort((a, b) => a - b);
 
                 if (indices.length === 0) return;
 
@@ -186,9 +188,17 @@
                     return;
                 }
 
+                // A non-contiguous pick (e.g. A and C without B) would silently pull B
+                // into the diff if we just used min/max. Reject it so users have to
+                // explicitly include every commit in their range.
+                if (indices[indices.length - 1] - indices[0] + 1 !== indices.length) {
+                    window.alert('Selection is not contiguous — pick every commit between the oldest and newest you want to review.');
+                    return;
+                }
+
                 // Commits are listed newest-first; lowest index = tip, highest = oldest.
-                const newest = this.$wire.commits[Math.min(...indices)];
-                const oldest = this.$wire.commits[Math.max(...indices)];
+                const newest = this.$wire.commits[indices[0]];
+                const oldest = this.$wire.commits[indices[indices.length - 1]];
                 const baseRef = encodeURIComponent(oldest.hash + '^');
                 Livewire.navigate(`/p/${this.projectSlug}/${newest.hash}/${baseRef}`);
                 this.closePanel();

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -48,11 +48,13 @@
                 const branch = this.allFiltered[this.selectedIndex];
                 if (!branch) return;
                 if (branch.name === this.selectedBranch && this.$wire.commits.length > 0) return;
+                // Selected branch is actually changing — stale hashes no longer apply.
+                const branchChanged = this.selectedBranch !== branch.name;
                 this.selectedBranch = branch.name;
                 const id = ++this._loadId;
                 await this.$wire.loadCommits(branch.name);
                 if (this._loadId !== id) return;
-                this.clearSelection();
+                if (branchChanged) this.clearSelection();
             },
 
             handleKeydown(e) {

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -201,15 +201,18 @@
                 const attr = side === 'left' ? 'data-line-old' : 'data-line-new';
                 const start = Math.min(startLine, endLine ?? startLine);
                 const end = Math.max(startLine, endLine ?? startLine);
+                // Alpine's $el points at the nearest scoped element, not the diff-file root;
+                // climb to the file wrapper (.group) so the query sees this file's rows.
+                const root = this.$el.closest('.group') ?? this.$el;
                 const lines = [];
                 for (let n = start; n <= end; n++) {
-                    const row = this.$el.querySelector(`tr[${attr}="${n}"]`);
+                    const row = root.querySelector(`tr[${attr}="${n}"]`);
                     if (!row) continue;
                     const cells = row.querySelectorAll('td');
                     const content = cells[cells.length - 1]?.textContent;
                     if (content !== undefined) lines.push(content);
                 }
-                return lines.length ? lines.join('\n') : null;
+                return lines.length ? lines.join('\n').trimEnd() : null;
             },
 
             _ensureScrollLoop() {

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -201,9 +201,7 @@
                 const attr = side === 'left' ? 'data-line-old' : 'data-line-new';
                 const start = Math.min(startLine, endLine ?? startLine);
                 const end = Math.max(startLine, endLine ?? startLine);
-                // Alpine's $el points at the nearest scoped element, not the diff-file root;
-                // climb to the file wrapper (.group) so the query sees this file's rows.
-                const root = this.$el.closest('.group') ?? this.$el;
+                const root = this.$el.closest(`[data-file-id="${this.fileId}"]`) ?? this.$el;
                 const lines = [];
                 for (let n = start; n <= end; n++) {
                     const row = root.querySelector(`tr[${attr}="${n}"]`);

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -190,9 +190,26 @@
                     this.$wire.dispatch('update-comment', { commentId: this.editingCommentId, body: this.formBody, isDraft });
                 } else {
                     const event = isDraft ? 'add-draft-comment' : 'add-comment';
-                    this.$wire.dispatch(event, { fileId: this.fileId, side: this.formSide, startLine: this.formLine, endLine: this.formEndLine, body: this.formBody });
+                    const lineSnippet = this._extractLineSnippet(this.formSide, this.formLine, this.formEndLine);
+                    this.$wire.dispatch(event, { fileId: this.fileId, side: this.formSide, startLine: this.formLine, endLine: this.formEndLine, body: this.formBody, lineSnippet });
                 }
                 this.cancelForm();
+            },
+
+            _extractLineSnippet(side, startLine, endLine) {
+                if (startLine == null || side === 'file') return null;
+                const attr = side === 'left' ? 'data-line-old' : 'data-line-new';
+                const start = Math.min(startLine, endLine ?? startLine);
+                const end = Math.max(startLine, endLine ?? startLine);
+                const lines = [];
+                for (let n = start; n <= end; n++) {
+                    const row = this.$el.querySelector(`tr[${attr}="${n}"]`);
+                    if (!row) continue;
+                    const cells = row.querySelectorAll('td');
+                    const content = cells[cells.length - 1]?.textContent;
+                    if (content !== undefined) lines.push(content);
+                }
+                return lines.length ? lines.join('\n') : null;
             },
 
             _ensureScrollLoop() {

--- a/resources/views/components/overlay-footer.blade.php
+++ b/resources/views/components/overlay-footer.blade.php
@@ -1,0 +1,12 @@
+@props(['meta' => null])
+
+<div class="px-3 py-2 border-t border-gh-border flex items-center justify-between shrink-0 bg-gh-surface/50">
+    <span class="font-mono text-[11px] text-gh-muted">
+        {{ $meta }}
+    </span>
+    <span class="font-mono text-[11px] text-gh-muted/60 flex items-center gap-2">
+        <span><kbd class="px-1 py-0.5 rounded border border-gh-border text-[10px]">↑</kbd><kbd class="px-1 py-0.5 rounded border border-gh-border text-[10px]">↓</kbd> nav</span>
+        <span><kbd class="px-1 py-0.5 rounded border border-gh-border text-[10px]">↵</kbd> open</span>
+        <span><kbd class="px-1 py-0.5 rounded border border-gh-border text-[10px]">esc</kbd> close</span>
+    </span>
+</div>

--- a/resources/views/components/overlay-panel.blade.php
+++ b/resources/views/components/overlay-panel.blade.php
@@ -26,7 +26,7 @@
             x-transition:leave="transition ease-in duration-100"
             x-transition:leave-start="opacity-100"
             x-transition:leave-end="opacity-0"
-            class="absolute inset-0 bg-black/30"
+            class="absolute inset-0 bg-gh-muted/50"
             @click="{{ $onClose }}"
         ></div>
 
@@ -40,6 +40,7 @@
             x-transition:leave-end="opacity-0 -translate-y-1"
             @click.stop
             role="dialog"
+            aria-modal="true"
             aria-label="{{ $ariaLabel }}"
             data-overlay-panel="{{ $name }}"
             data-testid="overlay-panel-{{ $name }}"

--- a/resources/views/components/overlay-panel.blade.php
+++ b/resources/views/components/overlay-panel.blade.php
@@ -1,0 +1,51 @@
+@props([
+    'name',
+    'ariaLabel',
+    'size' => 'md',
+    'open' => 'open',
+    'onClose' => 'close()',
+])
+
+@php
+    // Every overlay shares one stage in the top-left so ⌘K / ⌘B / ⌘J all
+    // reveal a panel with the same shape, motion, and dismiss behavior.
+    $widths = [
+        'md' => 'w-[460px]',
+        'lg' => 'w-[560px]',
+    ];
+    $width = $widths[$size] ?? $widths['md'];
+@endphp
+
+<template x-teleport="body">
+    <div x-show="{{ $open }}" x-cloak class="fixed inset-0 z-[60]" @click.self="{{ $onClose }}">
+        <div
+            x-show="{{ $open }}"
+            x-transition:enter="transition ease-out duration-150"
+            x-transition:enter-start="opacity-0"
+            x-transition:enter-end="opacity-100"
+            x-transition:leave="transition ease-in duration-100"
+            x-transition:leave-start="opacity-100"
+            x-transition:leave-end="opacity-0"
+            class="absolute inset-0 bg-black/30"
+            @click="{{ $onClose }}"
+        ></div>
+
+        <div
+            x-show="{{ $open }}"
+            x-transition:enter="transition ease-out duration-150"
+            x-transition:enter-start="opacity-0 -translate-y-1"
+            x-transition:enter-end="opacity-100 translate-y-0"
+            x-transition:leave="transition ease-in duration-100"
+            x-transition:leave-start="opacity-100 translate-y-0"
+            x-transition:leave-end="opacity-0 -translate-y-1"
+            @click.stop
+            role="dialog"
+            aria-label="{{ $ariaLabel }}"
+            data-overlay-panel="{{ $name }}"
+            data-testid="overlay-panel-{{ $name }}"
+            {{ $attributes->merge(['class' => "fixed top-[calc(var(--header-h,56px)+6px)] left-4 z-[61] $width max-w-[calc(100vw-32px)] max-h-[70vh] bg-gh-bg border border-gh-border rounded-xl shadow-2xl flex flex-col overflow-hidden"]) }}
+        >
+            {{ $slot }}
+        </div>
+    </div>
+</template>

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -215,7 +215,7 @@ new class extends Component {
                                     <button
                                         type="button"
                                         data-testid="commit-select-toggle"
-                                        @click="toggleSelection(commit.hash, commitIdx, $event)"
+                                        @click.stop="toggleSelection(commit.hash, commitIdx, $event)"
                                         @mousedown.stop
                                         class="mt-0.5 size-4 shrink-0 grid place-items-center rounded border transition-colors cursor-pointer"
                                         :class="isSelected(commit.hash)

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -200,6 +200,8 @@ new class extends Component {
 
                         <template x-for="(commit, commitIdx) in $wire.commits" :key="commit.hash">
                             <div
+                                data-testid="commit-row"
+                                :data-commit-hash="commit.hash"
                                 class="px-4 py-2.5 border-b border-gh-border/50 hover:bg-gh-border/20 transition-colors group cursor-pointer"
                                 @click="viewCommit(commit.hash)"
                                 :class="{
@@ -212,6 +214,7 @@ new class extends Component {
                                 <div class="flex items-start gap-2">
                                     <button
                                         type="button"
+                                        data-testid="commit-select-toggle"
                                         @click="toggleSelection(commit.hash, commitIdx, $event)"
                                         @mousedown.stop
                                         class="mt-0.5 size-4 shrink-0 grid place-items-center rounded border transition-colors cursor-pointer"
@@ -225,7 +228,7 @@ new class extends Component {
                                         </template>
                                     </button>
                                     <div class="min-w-0 flex-1">
-                                        <div class="text-xs text-gh-text truncate font-medium tracking-tight" x-text="commit.message"></div>
+                                        <div data-testid="commit-message" class="text-xs text-gh-text truncate font-medium tracking-tight" x-text="commit.message"></div>
                                         <div class="flex items-center gap-2 mt-0.5">
                                             <span class="text-[10px] font-mono text-gh-muted" x-text="commit.author"></span>
                                             <span class="text-[10px] text-gh-muted">&middot;</span>

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -65,6 +65,7 @@ new class extends Component {
         branches: @js($branches),
     })"
     @keydown.window="handleKeydown($event)"
+    @open-selection-drawer.window="openPanel()"
 >
     {{-- Trigger: inline branch segment --}}
     <x-header-picker-trigger
@@ -168,7 +169,16 @@ new class extends Component {
                         <span class="text-xs font-mono text-gh-muted" x-show="$wire.commits.length > 0" x-text="'(' + $wire.commits.length + ($wire.hasMore ? '+' : '') + ')'"></span>
 
                         <div class="ml-auto flex items-center gap-2">
-                            <template x-if="baseHash">
+                            <template x-if="selectedHashes.length > 0">
+                                <div class="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-gh-link/10 border border-gh-link/20">
+                                    <span class="text-[10px] text-gh-link font-mono" x-text="selectedHashes.length + ' selected'"></span>
+                                    <button @click="clearSelection()" class="text-gh-link hover:text-gh-link/80" title="Clear selection">
+                                        <flux:icon icon="x-mark" variant="outline" />
+                                    </button>
+                                    <button @click="applySelection()" class="text-[10px] text-gh-link hover:underline font-medium">Apply</button>
+                                </div>
+                            </template>
+                            <template x-if="baseHash && selectedHashes.length === 0">
                                 <div class="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-gh-link/10 border border-gh-link/20">
                                     <span class="text-[10px] text-gh-link font-mono" x-text="'Compare from ' + baseShortHash"></span>
                                     <button @click="clearBase()" class="text-gh-link hover:text-gh-link/80">
@@ -188,17 +198,32 @@ new class extends Component {
                             </div>
                         </template>
 
-                        <template x-for="commit in $wire.commits" :key="commit.hash">
+                        <template x-for="(commit, commitIdx) in $wire.commits" :key="commit.hash">
                             <div
                                 class="px-4 py-2.5 border-b border-gh-border/50 hover:bg-gh-border/20 transition-colors group cursor-pointer"
                                 @click="viewCommit(commit.hash)"
                                 :class="{
                                     'bg-gh-text/5 border-l-2 border-l-gh-text': activeCommitHash === commit.hash,
                                     'bg-gh-text/3': baseHash === commit.hash && activeCommitHash !== commit.hash,
+                                    'bg-gh-link/5 border-l-2 border-l-gh-link': isSelected(commit.hash),
                                     'hover:bg-gh-text/5': baseHash && baseHash !== commit.hash && activeCommitHash !== commit.hash
                                 }"
                             >
                                 <div class="flex items-start gap-2">
+                                    <button
+                                        type="button"
+                                        @click="toggleSelection(commit.hash, commitIdx, $event)"
+                                        @mousedown.stop
+                                        class="mt-0.5 size-4 shrink-0 grid place-items-center rounded border transition-colors cursor-pointer"
+                                        :class="isSelected(commit.hash)
+                                            ? 'border-gh-link bg-gh-link/20 text-gh-link'
+                                            : 'border-gh-border opacity-0 group-hover:opacity-100 hover:border-gh-text/40'"
+                                        :title="isSelected(commit.hash) ? 'Remove from selection' : 'Add to selection (shift+click for range)'"
+                                    >
+                                        <template x-if="isSelected(commit.hash)">
+                                            <flux:icon icon="check" variant="outline" class="!size-3" />
+                                        </template>
+                                    </button>
                                     <div class="min-w-0 flex-1">
                                         <div class="text-xs text-gh-text truncate font-medium tracking-tight" x-text="commit.message"></div>
                                         <div class="flex items-center gap-2 mt-0.5">

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -18,6 +18,12 @@ new class extends Component {
     #[Locked]
     public ?string $activeCommitHash = null;
 
+    #[Locked]
+    public string $selectionLabel = 'working';
+
+    #[Locked]
+    public string $selectionTitle = 'Working tree changes';
+
     /** @var array{local: list<array<string, mixed>>, remote: list<array<string, mixed>>, current: string} */
     public array $branches = ['local' => [], 'remote' => [], 'current' => ''];
 
@@ -66,32 +72,45 @@ new class extends Component {
     })"
     @keydown.window="handleKeydown($event)"
     @open-selection-drawer.window="openPanel()"
+    @overlay:open.window="if ($event.detail?.name !== 'branch-explorer') closePanel()"
 >
-    {{-- Trigger: inline branch segment --}}
-    <x-header-picker-trigger
-        tooltip="Switch branch"
-        aria-label="Switch branch"
-        variant="mono"
-        x-on:click="openPanel()"
-        x-bind:aria-expanded="open"
-    >
-        <flux:icon icon="share" variant="outline" class="!size-3 text-gh-muted/70 group-hover:text-gh-text transition-colors" />
-        <span class="tracking-tight">{{ $currentBranch }}</span>
-    </x-header-picker-trigger>
-
-    {{-- Overlay panel --}}
-    <template x-teleport="body">
-        <div x-show="open" x-cloak class="fixed inset-0 z-[60]" @click.self="closePanel()">
-            {{-- Backdrop --}}
-            <div class="absolute inset-0 bg-black/30" @click="closePanel()"></div>
-
-            {{-- Panel --}}
-            <div
-                class="fixed top-[15vh] left-1/2 -translate-x-1/2 z-[61] w-[700px] max-w-[90vw] max-h-[60vh] bg-gh-bg border border-gh-border rounded-xl shadow-2xl flex overflow-hidden"
-                @click.stop
+    <div class="inline-flex items-stretch rounded-md border border-gh-border/70 bg-gh-surface/30 hover:border-gh-text/30 transition-colors">
+        <flux:tooltip content="Switch branch · ⌘B">
+            <button
+                type="button"
+                class="group inline-flex items-center gap-1.5 px-2 py-1 text-xs font-mono text-gh-muted hover:text-gh-text hover:bg-gh-border/25 rounded-l-md transition-colors cursor-pointer"
+                aria-label="Switch branch (⌘B)"
+                aria-haspopup="dialog"
+                x-on:click="openPanel()"
+                x-bind:aria-expanded="open"
             >
+                <flux:icon icon="share" variant="outline" class="!size-3 text-gh-muted/70 group-hover:text-gh-text transition-colors" />
+                <span class="tracking-tight">{{ $currentBranch }}</span>
+            </button>
+        </flux:tooltip>
+
+        <span class="w-px self-stretch bg-gh-border/70" aria-hidden="true"></span>
+
+        <flux:tooltip content="{{ $selectionTitle }} · ⌘B">
+            <button
+                type="button"
+                class="group inline-flex items-center gap-1.5 px-2 py-1 text-xs font-mono text-gh-text hover:bg-gh-border/25 rounded-r-md transition-colors cursor-pointer"
+                aria-label="Open selection drawer"
+                aria-haspopup="dialog"
+                x-on:click="openPanel()"
+                x-bind:aria-expanded="open"
+            >
+                <flux:icon icon="square-3-stack-3d" variant="outline" class="!size-3 text-gh-muted/70 group-hover:text-gh-text transition-colors" />
+                <span>{{ $selectionLabel }}</span>
+                <flux:icon icon="chevron-down" variant="outline" class="!size-3 text-gh-muted/60 group-hover:text-gh-text transition-colors" />
+            </button>
+        </flux:tooltip>
+    </div>
+
+    <x-overlay-panel name="branch-explorer" aria-label="Switch branch" size="lg" on-close="closePanel()">
+        <div class="flex flex-1 min-h-0">
                 {{-- Left pane: branches --}}
-                <div class="w-[240px] shrink-0 border-r border-gh-border flex flex-col max-h-[60vh]">
+                <div class="w-[180px] shrink-0 border-r border-gh-border flex flex-col min-h-0">
                     {{-- Search input --}}
                     <div class="p-3 border-b border-gh-border">
                         <flux:input
@@ -161,7 +180,7 @@ new class extends Component {
                 </div>
 
                 {{-- Right pane: commits --}}
-                <div class="flex-1 flex flex-col max-h-[60vh] min-w-0">
+                <div class="flex-1 flex flex-col min-h-0 min-w-0">
                     {{-- Commits header --}}
                     <div class="px-4 py-2.5 border-b border-gh-border flex items-center gap-2 shrink-0">
                         <flux:icon icon="clock" variant="outline" class="text-gh-muted" />
@@ -288,7 +307,12 @@ new class extends Component {
                         </template>
                     </div>
                 </div>
-            </div>
         </div>
-    </template>
+
+        <x-overlay-footer>
+            <x-slot:meta>
+                <span x-text="($wire.commits?.length || 0) + ($wire.hasMore ? '+' : '') + ' commits'"></span>
+            </x-slot:meta>
+        </x-overlay-footer>
+    </x-overlay-panel>
 </div>

--- a/resources/views/livewire/⚡comments-drawer.blade.php
+++ b/resources/views/livewire/⚡comments-drawer.blade.php
@@ -1,11 +1,14 @@
 <?php
 
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Lazy;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
-new class extends Component
+new
+#[Lazy]
+class extends Component
 {
     #[Locked]
     public string $repoPath = '';
@@ -76,6 +79,16 @@ new class extends Component
         return $this->baseQuery()->count();
     }
 }; ?>
+
+@placeholder
+{{-- Keep the trigger button visible at first paint so the header layout doesn't
+     shift; the real component hydrates and supplies the count + drawer body. --}}
+<div class="relative">
+    <flux:tooltip content="All comments in this repo">
+        <flux:button variant="ghost" size="sm" icon="chat-bubble-left-right" icon:variant="outline" />
+    </flux:tooltip>
+</div>
+@endplaceholder
 
 <div
     x-data="{ open: @entangle('open').live }"

--- a/resources/views/livewire/⚡comments-drawer.blade.php
+++ b/resources/views/livewire/⚡comments-drawer.blade.php
@@ -85,7 +85,7 @@ class extends Component
      shift; the real component hydrates and supplies the count + drawer body. --}}
 <div class="relative">
     <flux:tooltip content="All comments in this repo">
-        <flux:button variant="ghost" size="sm" icon="chat-bubble-left-right" icon:variant="outline" />
+        <flux:button variant="ghost" size="sm" icon="chat-bubble-left-right" icon:variant="outline" aria-label="All comments in this repo" />
     </flux:tooltip>
 </div>
 @endplaceholder
@@ -100,6 +100,7 @@ class extends Component
             size="sm"
             icon="chat-bubble-left-right"
             icon:variant="outline"
+            aria-label="All comments in this repo"
             x-on:click="open = !open"
         >
             @if($this->totalCount > 0)
@@ -130,6 +131,7 @@ class extends Component
                         size="xs"
                         :icon="$showSubmitted ? 'archive-box' : 'archive-box-arrow-down'"
                         icon:variant="outline"
+                        :aria-label="$showSubmitted ? 'Hide submitted comments' : 'Show submitted comments'"
                         wire:click="$toggle('showSubmitted')"
                     />
                 </flux:tooltip>
@@ -138,6 +140,7 @@ class extends Component
                     size="xs"
                     icon="x-mark"
                     icon:variant="outline"
+                    aria-label="Close comments drawer"
                     x-on:click="open = false"
                 />
             </div>
@@ -170,7 +173,7 @@ class extends Component
                                     <span>L{{ $c['start_line'] }}@if(! empty($c['end_line']) && $c['end_line'] !== $c['start_line'])-L{{ $c['end_line'] }}@endif</span>
                                 @endif
                                 @if(! empty($c['is_draft']))
-                                    <span class="ml-auto px-1.5 py-0.5 rounded bg-amber-400/10 text-amber-500 text-[9px]">draft</span>
+                                    <span class="ml-auto px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-500 dark:text-amber-400 text-[9px]">draft</span>
                                 @elseif(! empty($c['submitted_at']))
                                     <span class="ml-auto px-1.5 py-0.5 rounded bg-gh-border/40 text-gh-muted text-[9px]">submitted</span>
                                 @endif

--- a/resources/views/livewire/⚡comments-drawer.blade.php
+++ b/resources/views/livewire/⚡comments-drawer.blade.php
@@ -1,0 +1,171 @@
+<?php
+
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+new class extends Component
+{
+    #[Locked]
+    public string $repoPath = '';
+
+    #[Locked]
+    public ?int $projectId = null;
+
+    public bool $open = false;
+
+    public bool $showSubmitted = false;
+
+    public string $filter = '';
+
+    public function toggle(): void
+    {
+        $this->open = ! $this->open;
+    }
+
+    /** @return array<string, array<int, array<string, mixed>>> */
+    #[Computed]
+    public function groupedComments(): array
+    {
+        $query = \App\Models\Comment::query()->orderByDesc('created_at');
+        $query = $this->projectId
+            ? $query->where('project_id', $this->projectId)
+            : $query->whereNull('project_id')->where('repo_path', $this->repoPath);
+
+        if (! $this->showSubmitted) {
+            $query->whereNull('submitted_at');
+        }
+
+        $filter = trim($this->filter);
+        if ($filter !== '') {
+            $query->where(function ($q) use ($filter) {
+                $q->where('file_path', 'like', '%'.$filter.'%')
+                    ->orWhere('body', 'like', '%'.$filter.'%');
+            });
+        }
+
+        return $query->get()
+            ->groupBy('file_path')
+            ->map(fn ($rows) => $rows->map->toArray()->all())
+            ->all();
+    }
+
+    #[Computed]
+    public function totalCount(): int
+    {
+        $query = \App\Models\Comment::query();
+        $query = $this->projectId
+            ? $query->where('project_id', $this->projectId)
+            : $query->whereNull('project_id')->where('repo_path', $this->repoPath);
+
+        if (! $this->showSubmitted) {
+            $query->whereNull('submitted_at');
+        }
+
+        return $query->count();
+    }
+}; ?>
+
+<div
+    x-data="{ open: @entangle('open').live }"
+    class="relative"
+>
+    <flux:tooltip content="All comments in this repo">
+        <flux:button
+            variant="ghost"
+            size="sm"
+            icon="chat-bubble-left-right"
+            icon:variant="outline"
+            x-on:click="open = !open"
+        >
+            @if($this->totalCount > 0)
+                <span class="font-mono text-[10px] text-gh-muted">{{ $this->totalCount }}</span>
+            @endif
+        </flux:button>
+    </flux:tooltip>
+
+    <div
+        x-show="open"
+        x-cloak
+        x-transition:enter="transition ease-out duration-150"
+        x-transition:enter-start="opacity-0 translate-x-2"
+        x-transition:enter-end="opacity-100 translate-x-0"
+        x-transition:leave="transition ease-in duration-100"
+        x-transition:leave-start="opacity-100 translate-x-0"
+        x-transition:leave-end="opacity-0 translate-x-2"
+        @click.outside="open = false"
+        @keydown.escape.window="open = false"
+        class="fixed top-16 right-4 z-[55] w-[380px] max-h-[70vh] bg-gh-bg border border-gh-border rounded-xl shadow-2xl flex flex-col overflow-hidden"
+    >
+        <div class="flex items-center justify-between px-4 py-2.5 border-b border-gh-border">
+            <span class="section-label text-gh-muted">All comments</span>
+            <div class="flex items-center gap-2">
+                <flux:tooltip :content="$showSubmitted ? 'Hide submitted' : 'Show submitted'">
+                    <flux:button
+                        variant="ghost"
+                        size="xs"
+                        :icon="$showSubmitted ? 'archive-box' : 'archive-box-arrow-down'"
+                        icon:variant="outline"
+                        wire:click="$toggle('showSubmitted')"
+                    />
+                </flux:tooltip>
+                <flux:button
+                    variant="ghost"
+                    size="xs"
+                    icon="x-mark"
+                    icon:variant="outline"
+                    x-on:click="open = false"
+                />
+            </div>
+        </div>
+
+        <div class="px-3 py-2 border-b border-gh-border">
+            <flux:input
+                wire:model.live.debounce.200ms="filter"
+                placeholder="Filter comments..."
+                icon="magnifying-glass"
+                icon:variant="outline"
+                size="sm"
+                variant="filled"
+                clearable
+            />
+        </div>
+
+        <div class="overflow-y-auto flex-1">
+            @forelse($this->groupedComments as $filePath => $comments)
+                <div class="border-b border-gh-border/50">
+                    <div class="px-4 py-2 bg-gh-surface/40 font-mono text-xs text-gh-text truncate">{{ $filePath }}</div>
+                    @foreach($comments as $c)
+                        <div class="px-4 py-2.5 border-t border-gh-border/30 text-xs">
+                            <div class="flex items-center gap-2 text-[10px] font-mono text-gh-muted mb-1">
+                                @if(! empty($c['origin_ref']))
+                                    <span>{{ $c['origin_ref'] === 'working' ? 'WD' : Str::limit($c['origin_ref'], 7, '') }}</span>
+                                @endif
+                                @if(! empty($c['start_line']))
+                                    <span>&middot;</span>
+                                    <span>L{{ $c['start_line'] }}@if(! empty($c['end_line']) && $c['end_line'] !== $c['start_line'])-L{{ $c['end_line'] }}@endif</span>
+                                @endif
+                                @if(! empty($c['is_draft']))
+                                    <span class="ml-auto px-1.5 py-0.5 rounded bg-amber-400/10 text-amber-500 text-[9px]">draft</span>
+                                @elseif(! empty($c['submitted_at']))
+                                    <span class="ml-auto px-1.5 py-0.5 rounded bg-gh-border/40 text-gh-muted text-[9px]">submitted</span>
+                                @endif
+                            </div>
+                            <div class="text-gh-text whitespace-pre-wrap">{{ $c['body'] }}</div>
+                        </div>
+                    @endforeach
+                </div>
+            @empty
+                <div class="flex items-center justify-center h-32">
+                    <span class="text-xs text-gh-muted">
+                        @if(trim($filter) !== '')
+                            No matches
+                        @else
+                            No comments yet
+                        @endif
+                    </span>
+                </div>
+            @endforelse
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/⚡comments-drawer.blade.php
+++ b/resources/views/livewire/⚡comments-drawer.blade.php
@@ -23,18 +23,23 @@ new class extends Component
         $this->open = ! $this->open;
     }
 
-    /** @return array<string, array<int, array<string, mixed>>> */
-    #[Computed]
-    public function groupedComments(): array
+    /** @return \Illuminate\Database\Eloquent\Builder<\App\Models\Comment> */
+    private function baseQuery(): \Illuminate\Database\Eloquent\Builder
     {
-        $query = \App\Models\Comment::query()->orderByDesc('created_at');
-        $query = $this->projectId
-            ? $query->where('project_id', $this->projectId)
-            : $query->whereNull('project_id')->where('repo_path', $this->repoPath);
+        $query = \App\Models\Comment::query()->forProjectOrRepo($this->projectId, $this->repoPath);
 
         if (! $this->showSubmitted) {
             $query->whereNull('submitted_at');
         }
+
+        return $query;
+    }
+
+    /** @return array<string, array<int, array<string, mixed>>> */
+    #[Computed]
+    public function groupedComments(): array
+    {
+        $query = $this->baseQuery()->orderByDesc('created_at');
 
         $filter = trim($this->filter);
         if ($filter !== '') {
@@ -53,16 +58,7 @@ new class extends Component
     #[Computed]
     public function totalCount(): int
     {
-        $query = \App\Models\Comment::query();
-        $query = $this->projectId
-            ? $query->where('project_id', $this->projectId)
-            : $query->whereNull('project_id')->where('repo_path', $this->repoPath);
-
-        if (! $this->showSubmitted) {
-            $query->whereNull('submitted_at');
-        }
-
-        return $query->count();
+        return $this->baseQuery()->count();
     }
 }; ?>
 

--- a/resources/views/livewire/⚡comments-drawer.blade.php
+++ b/resources/views/livewire/⚡comments-drawer.blade.php
@@ -84,24 +84,42 @@ class extends Component
 {{-- Keep the trigger button visible at first paint so the header layout doesn't
      shift; the real component hydrates and supplies the count + drawer body. --}}
 <div class="relative">
-    <flux:tooltip content="All comments in this repo">
+    <flux:tooltip content="All comments · ⌘J">
         <flux:button variant="ghost" size="sm" icon="chat-bubble-left-right" icon:variant="outline" aria-label="All comments in this repo" />
     </flux:tooltip>
 </div>
 @endplaceholder
 
 <div
-    x-data="{ open: @entangle('open').live }"
+    x-data="{
+        open: @entangle('open').live,
+        isHotkey(e) { return (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.key.toLowerCase() === 'j'; },
+        openPanel() {
+            this.open = true;
+            window.dispatchEvent(new CustomEvent('overlay:open', { detail: { name: 'comments-drawer' } }));
+            this.$nextTick(() => this.$refs.searchInput?.focus());
+        },
+        close() { this.open = false; },
+        toggle() { this.open ? this.close() : this.openPanel(); },
+    }"
+    @keydown.window="
+        if (isHotkey($event)) {
+            const inEditable = $event.target.tagName === 'TEXTAREA' || $event.target.tagName === 'INPUT' || $event.target.isContentEditable;
+            if (!inEditable) { $event.preventDefault(); toggle(); return; }
+        }
+        if (open && $event.key === 'Escape') { $event.preventDefault(); close(); return; }
+    "
+    @overlay:open.window="if ($event.detail?.name !== 'comments-drawer') close()"
     class="relative"
 >
-    <flux:tooltip content="All comments in this repo">
+    <flux:tooltip content="All comments · ⌘J">
         <flux:button
             variant="ghost"
             size="sm"
             icon="chat-bubble-left-right"
             icon:variant="outline"
             aria-label="All comments in this repo"
-            x-on:click="open = !open"
+            x-on:click="toggle()"
         >
             @if($this->totalCount > 0)
                 <span class="font-mono text-[10px] text-gh-muted">{{ $this->totalCount }}</span>
@@ -109,20 +127,8 @@ class extends Component
         </flux:button>
     </flux:tooltip>
 
-    <div
-        x-show="open"
-        x-cloak
-        x-transition:enter="transition ease-out duration-150"
-        x-transition:enter-start="opacity-0 translate-x-2"
-        x-transition:enter-end="opacity-100 translate-x-0"
-        x-transition:leave="transition ease-in duration-100"
-        x-transition:leave-start="opacity-100 translate-x-0"
-        x-transition:leave-end="opacity-0 translate-x-2"
-        @click.outside="open = false"
-        @keydown.escape.window="open = false"
-        class="fixed top-16 right-4 z-[55] w-[380px] max-h-[70vh] bg-gh-bg border border-gh-border rounded-xl shadow-2xl flex flex-col overflow-hidden"
-    >
-        <div class="flex items-center justify-between px-4 py-2.5 border-b border-gh-border">
+    <x-overlay-panel name="comments-drawer" aria-label="All comments" size="md" on-close="close()">
+        <div class="flex items-center justify-between px-4 py-2.5 border-b border-gh-border shrink-0">
             <span class="section-label text-gh-muted">All comments</span>
             <div class="flex items-center gap-2">
                 <flux:tooltip :content="$showSubmitted ? 'Hide submitted' : 'Show submitted'">
@@ -141,13 +147,14 @@ class extends Component
                     icon="x-mark"
                     icon:variant="outline"
                     aria-label="Close comments drawer"
-                    x-on:click="open = false"
+                    x-on:click="close()"
                 />
             </div>
         </div>
 
-        <div class="px-3 py-2 border-b border-gh-border">
+        <div class="px-3 py-2 border-b border-gh-border shrink-0">
             <flux:input
+                x-ref="searchInput"
                 wire:model.live.debounce.200ms="filter"
                 placeholder="Filter comments..."
                 icon="magnifying-glass"
@@ -194,5 +201,11 @@ class extends Component
                 </div>
             @endforelse
         </div>
-    </div>
+
+        <x-overlay-footer>
+            <x-slot:meta>
+                {{ $this->totalCount }} {{ Str::plural('comment', $this->totalCount) }}
+            </x-slot:meta>
+        </x-overlay-footer>
+    </x-overlay-panel>
 </div>

--- a/resources/views/livewire/⚡comments-drawer.blade.php
+++ b/resources/views/livewire/⚡comments-drawer.blade.php
@@ -28,8 +28,10 @@ new class extends Component
     #[On('reset-reviewed-files')]
     public function refresh(): void
     {
-        // Listening to the pool-wide write events re-renders the drawer so the
-        // count badge and list reflect the latest Comment table state.
+        // A no-op body is enough: Livewire re-renders the component on #[On] hits,
+        // which invalidates the computed properties so the count badge picks up
+        // pool changes. The list itself is gated on $open, so closed drawers
+        // skip the expensive query.
     }
 
     /** @return \Illuminate\Database\Eloquent\Builder<\App\Models\Comment> */
@@ -48,6 +50,10 @@ new class extends Component
     #[Computed]
     public function groupedComments(): array
     {
+        if (! $this->open) {
+            return [];
+        }
+
         $query = $this->baseQuery()->orderByDesc('created_at');
 
         $filter = trim($this->filter);

--- a/resources/views/livewire/⚡comments-drawer.blade.php
+++ b/resources/views/livewire/⚡comments-drawer.blade.php
@@ -2,6 +2,7 @@
 
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
+use Livewire\Attributes\On;
 use Livewire\Component;
 
 new class extends Component
@@ -21,6 +22,14 @@ new class extends Component
     public function toggle(): void
     {
         $this->open = ! $this->open;
+    }
+
+    #[On('comment-updated')]
+    #[On('reset-reviewed-files')]
+    public function refresh(): void
+    {
+        // Listening to the pool-wide write events re-renders the drawer so the
+        // count badge and list reflect the latest Comment table state.
     }
 
     /** @return \Illuminate\Database\Eloquent\Builder<\App\Models\Comment> */

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -362,6 +362,17 @@ new class extends Component {
         @if($unplacedComments->isNotEmpty())
             @foreach($unplacedComments as $comment)
                 <div x-data x-show="editingCommentId !== '{{ $comment['id'] }}'">
+                    @if(! empty($comment['lineSnippet']))
+                        <div class="border-b border-gh-border bg-gh-surface/40 px-4 py-2">
+                            <div class="text-[10px] font-display uppercase tracking-brutal text-gh-muted mb-1">
+                                Original snippet
+                                @if(! empty($comment['startLine']))
+                                    &middot; L{{ $comment['startLine'] }}@if(! empty($comment['endLine']) && $comment['endLine'] !== $comment['startLine'])-L{{ $comment['endLine'] }}@endif
+                                @endif
+                            </div>
+                            <pre class="font-mono text-xs text-gh-muted whitespace-pre-wrap break-all">{{ $comment['lineSnippet'] }}</pre>
+                        </div>
+                    @endif
                     <x-comment-display :comment="$comment" border-class="border-b" />
                 </div>
             @endforeach

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -218,6 +218,7 @@ new class extends Component {
         isReviewed: @js($isReviewed ?? false),
         singleFile: @js($singleFile ?? false),
     })"
+    :data-file-id="fileId"
     @mouseup.window="endDrag()"
     @comment-updated.window="if ($event.detail.fileId === fileId) $wire.updateComments($event.detail.comments)"
     @collapse-all-files.window="autoExpandedForComment = false; collapsed = true"

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -351,10 +351,14 @@ new class extends Component {
                 @endif
             @endforeach
         </div>
-        {{-- Unplaced inline comments (line no longer exists in diff) --}}
+        {{-- Unplaced inline comments: either the anchor-resolver marked them unplaced
+             (content hash mismatch) or the stored line no longer exists in the diff. --}}
         @php
             $visibleLines = $this->getVisibleLineKeys();
             $unplacedComments = collect($fileComments)->where('side', '!=', 'file')->filter(function ($c) use ($visibleLines) {
+                if (($c['anchorStatus'] ?? null) === 'unplaced') {
+                    return true;
+                }
                 $key = $c['side'] . ':' . ($c['endLine'] ?? $c['startLine'] ?? 0);
                 return !isset($visibleLines[$key]);
             });
@@ -465,7 +469,10 @@ new class extends Component {
             </div>
         @else
             @php
-                $commentsByLine = collect($fileComments)->where('side', '!=', 'file')->groupBy(fn($c) => $c['side'] . ':' . $c['endLine']);
+                $commentsByLine = collect($fileComments)
+                    ->where('side', '!=', 'file')
+                    ->where(fn ($c) => ($c['anchorStatus'] ?? 'placed') !== 'unplaced')
+                    ->groupBy(fn($c) => $c['side'] . ':' . $c['endLine']);
                 $hunks = $diffData['hunks'];
                 $lastHunk = end($hunks);
                 $lastHunkEnd = $lastHunk ? $lastHunk['newStart'] + $lastHunk['newCount'] - 1 : 0;

--- a/resources/views/livewire/⚡project-picker.blade.php
+++ b/resources/views/livewire/⚡project-picker.blade.php
@@ -96,6 +96,7 @@ class extends Component
             this.open = true;
             this.selectedIndex = -1;
             if ($wire.search !== '') $wire.set('search', '');
+            window.dispatchEvent(new CustomEvent('overlay:open', { detail: { name: 'project-picker' } }));
             this.$nextTick(() => this.$refs.searchInput?.focus());
         },
         close() {
@@ -128,6 +129,7 @@ class extends Component
     }"
     @project-picker:toggle.window="toggle()"
     @project-picker:close.window="close()"
+    @overlay:open.window="if ($event.detail?.name !== 'project-picker') close()"
     @keydown.window="
         if (isHotkey($event)) { $event.preventDefault(); toggle(); return; }
         if (!open) return;
@@ -148,16 +150,7 @@ class extends Component
         <span>{{ $projectName }}</span>
     </x-header-picker-trigger>
 
-    <template x-teleport="body">
-        <div x-show="open" x-cloak class="fixed inset-0 z-[60]" @click.self="close()">
-            <div class="absolute inset-0 bg-black/30" @click="close()"></div>
-
-            <div
-                class="fixed top-[calc(var(--header-h,56px)+6px)] left-4 z-[61] w-[460px] max-w-[calc(100vw-32px)] max-h-[70vh] bg-gh-bg border border-gh-border rounded-xl shadow-2xl flex flex-col overflow-hidden"
-                @click.stop
-                role="dialog"
-                aria-label="Switch project"
-            >
+    <x-overlay-panel name="project-picker" aria-label="Switch project" size="md">
                 <div class="p-3 border-b border-gh-border flex items-center gap-2 shrink-0">
                     <div class="flex-1">
                         <flux:input
@@ -281,21 +274,14 @@ class extends Component
                 @endforeach
                 </div>
 
-                <div class="px-3 py-2 border-t border-gh-border flex items-center justify-between shrink-0 bg-gh-surface/50">
-                    <span class="font-mono text-[11px] text-gh-muted">
+                <x-overlay-footer>
+                    <x-slot:meta>
                         @if($search !== '')
                             {{ $matchCount }}/{{ $totalProjects }} {{ Str::plural('project', $totalProjects) }}
                         @else
                             {{ $totalProjects }} {{ Str::plural('project', $totalProjects) }}
                         @endif
-                    </span>
-                    <span class="font-mono text-[11px] text-gh-muted/60 flex items-center gap-2">
-                        <span><kbd class="px-1 py-0.5 rounded border border-gh-border text-[10px]">↑</kbd><kbd class="px-1 py-0.5 rounded border border-gh-border text-[10px]">↓</kbd> nav</span>
-                        <span><kbd class="px-1 py-0.5 rounded border border-gh-border text-[10px]">↵</kbd> open</span>
-                        <span><kbd class="px-1 py-0.5 rounded border border-gh-border text-[10px]">esc</kbd> close</span>
-                    </span>
-                </div>
-            </div>
-        </div>
-    </template>
+                    </x-slot:meta>
+                </x-overlay-footer>
+    </x-overlay-panel>
 </div>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -229,7 +229,7 @@ new #[Layout('layouts.app')] class extends Component
     // region: Comment Management
 
     #[On('add-comment')]
-    public function addComment(string $fileId, string $side, ?int $startLine, ?int $endLine, string $body): void
+    public function addComment(string $fileId, string $side, ?int $startLine, ?int $endLine, string $body, ?string $lineSnippet = null): void
     {
         $comment = app(AddCommentAction::class)->handle(
             $this->repoPath,
@@ -241,6 +241,7 @@ new #[Layout('layouts.app')] class extends Component
             $startLine,
             $endLine,
             $body,
+            lineSnippet: $lineSnippet,
         );
 
         if (! $comment) {
@@ -253,7 +254,7 @@ new #[Layout('layouts.app')] class extends Component
     }
 
     #[On('add-draft-comment')]
-    public function addDraftComment(string $fileId, string $side, ?int $startLine, ?int $endLine, string $body): void
+    public function addDraftComment(string $fileId, string $side, ?int $startLine, ?int $endLine, string $body, ?string $lineSnippet = null): void
     {
         $comment = app(AddCommentAction::class)->handle(
             $this->repoPath,
@@ -266,6 +267,7 @@ new #[Layout('layouts.app')] class extends Component
             $endLine,
             $body,
             isDraft: true,
+            lineSnippet: $lineSnippet,
         );
 
         if (! $comment) {
@@ -765,6 +767,30 @@ new #[Layout('layouts.app')] class extends Component
                 <x-header-separator />
                 <livewire:branch-explorer :repo-path="$repoPath" :current-branch="$projectBranch" :project-slug="$projectSlug" :active-commit-hash="$diffTo" />
             @endif
+            @php
+                $shortFrom = $diffFrom !== 'HEAD' ? substr($diffFrom, 0, 7) : null;
+                $shortTo = $diffTo ? substr($diffTo, 0, 7) : null;
+                if ($diffTo === null) {
+                    $selectionLabel = 'working';
+                    $selectionTitle = 'Working tree changes';
+                } elseif ($shortFrom && str_starts_with($diffFrom, $diffTo === null ? '' : substr($diffTo, 0, 0)) === false && $diffFrom !== $diffTo.'^') {
+                    $selectionLabel = $shortFrom.'..'.$shortTo;
+                    $selectionTitle = 'Range '.$diffFrom.'..'.$diffTo;
+                } else {
+                    $selectionLabel = $shortTo;
+                    $selectionTitle = $commitInfo['message'] ?? $diffTo;
+                }
+            @endphp
+            <button
+                type="button"
+                title="{{ $selectionTitle }}"
+                class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-mono rounded border border-gh-border bg-gh-surface text-gh-text hover:border-gh-text/30 transition-colors cursor-pointer"
+                @click="$dispatch('open-selection-drawer')"
+                aria-label="Open selection drawer"
+            >
+                <flux:icon icon="square-3-stack-3d" variant="outline" class="!size-3.5 text-gh-muted" />
+                <span>{{ $selectionLabel }}</span>
+            </button>
             <livewire:comments-drawer :repo-path="$repoPath" :project-id="$projectId ?: null" />
         </div>
         <div class="flex items-center gap-2.5 text-xs">

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -512,12 +512,16 @@ new #[Layout('layouts.app')] class extends Component
         Flux::toast(variant: 'success', heading: 'Review submitted', text: $this->exportResult);
         $this->dispatch('copy-to-clipboard', text: $result['clipboard']);
 
-        // Remove exported comments from the current view; drafts and out-of-scope comments persist.
-        $exportedIds = array_column($finalizedComments, 'id');
-        $affectedFileIds = collect($finalizedComments)->pluck('fileId')->unique();
+        // Only drop comments the export actually submitted; drafts and out-of-scope
+        // comments (e.g. hash-anchored from another selection) stay in the pool.
+        $submittedIds = $result['submittedIds'];
+        $affectedFileIds = collect($this->comments)
+            ->whereIn('id', $submittedIds)
+            ->pluck('fileId')
+            ->unique();
         $this->comments = array_values(array_filter(
             $this->comments,
-            fn ($c) => ! in_array($c['id'], $exportedIds, true),
+            fn ($c) => ! in_array($c['id'], $submittedIds, true),
         ));
         $this->globalComment = '';
         $this->saveSession();

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -759,12 +759,12 @@ new #[Layout('layouts.app')] class extends Component
                 if ($diffTo === null) {
                     $selectionLabel = 'working';
                     $selectionTitle = 'Working tree changes';
-                } elseif ($shortFrom && str_starts_with($diffFrom, $diffTo === null ? '' : substr($diffTo, 0, 0)) === false && $diffFrom !== $diffTo.'^') {
-                    $selectionLabel = $shortFrom.'..'.$shortTo;
-                    $selectionTitle = 'Range '.$diffFrom.'..'.$diffTo;
-                } else {
+                } elseif ($diffFrom === $diffTo.'^') {
                     $selectionLabel = $shortTo;
                     $selectionTitle = $commitInfo['message'] ?? $diffTo;
+                } else {
+                    $selectionLabel = $shortFrom.'..'.$shortTo;
+                    $selectionTitle = 'Range '.$diffFrom.'..'.$diffTo;
                 }
             @endphp
             <button

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -231,30 +231,16 @@ new #[Layout('layouts.app')] class extends Component
     #[On('add-comment')]
     public function addComment(string $fileId, string $side, ?int $startLine, ?int $endLine, string $body, ?string $lineSnippet = null): void
     {
-        $comment = app(AddCommentAction::class)->handle(
-            $this->repoPath,
-            $this->projectId ?: null,
-            $this->buildDiffTarget(),
-            $this->files,
-            $fileId,
-            $side,
-            $startLine,
-            $endLine,
-            $body,
-            lineSnippet: $lineSnippet,
-        );
-
-        if (! $comment) {
-            return;
-        }
-
-        $this->comments[] = $comment;
-        $this->dispatchFileComments($fileId);
-        $this->skipRender();
+        $this->createComment($fileId, $side, $startLine, $endLine, $body, $lineSnippet, isDraft: false);
     }
 
     #[On('add-draft-comment')]
     public function addDraftComment(string $fileId, string $side, ?int $startLine, ?int $endLine, string $body, ?string $lineSnippet = null): void
+    {
+        $this->createComment($fileId, $side, $startLine, $endLine, $body, $lineSnippet, isDraft: true);
+    }
+
+    private function createComment(string $fileId, string $side, ?int $startLine, ?int $endLine, string $body, ?string $lineSnippet, bool $isDraft): void
     {
         $comment = app(AddCommentAction::class)->handle(
             $this->repoPath,
@@ -266,8 +252,8 @@ new #[Layout('layouts.app')] class extends Component
             $startLine,
             $endLine,
             $body,
-            isDraft: true,
-            lineSnippet: $lineSnippet,
+            $isDraft,
+            $lineSnippet,
         );
 
         if (! $comment) {

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -753,10 +753,6 @@ new #[Layout('layouts.app')] class extends Component
             @else
                 <span class="font-display font-bold tracking-brutal-tight text-base">{{ $projectName }}</span>
             @endnative
-            @if($projectBranch)
-                <x-header-separator />
-                <livewire:branch-explorer :repo-path="$repoPath" :current-branch="$projectBranch" :project-slug="$projectSlug" :active-commit-hash="$diffTo" />
-            @endif
             @php
                 $shortFrom = $diffFrom === 'HEAD' ? 'HEAD' : substr($diffFrom, 0, 7);
                 $shortTo = $diffTo ? substr($diffTo, 0, 7) : null;
@@ -771,16 +767,17 @@ new #[Layout('layouts.app')] class extends Component
                     $selectionTitle = 'Range '.$diffFrom.'..'.$diffTo;
                 }
             @endphp
-            <button
-                type="button"
-                title="{{ $selectionTitle }}"
-                class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-mono rounded border border-gh-border bg-gh-surface text-gh-text hover:border-gh-text/30 transition-colors cursor-pointer"
-                @click="$dispatch('open-selection-drawer')"
-                aria-label="Open selection drawer"
-            >
-                <flux:icon icon="square-3-stack-3d" variant="outline" class="!size-3.5 text-gh-muted" />
-                <span>{{ $selectionLabel }}</span>
-            </button>
+            @if($projectBranch)
+                <x-header-separator />
+                <livewire:branch-explorer
+                    :repo-path="$repoPath"
+                    :current-branch="$projectBranch"
+                    :project-slug="$projectSlug"
+                    :active-commit-hash="$diffTo"
+                    :selection-label="$selectionLabel"
+                    :selection-title="$selectionTitle"
+                />
+            @endif
             <livewire:comments-drawer :repo-path="$repoPath" :project-id="$projectId ?: null" />
         </div>
         <div class="flex items-center gap-2.5 text-xs">

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -19,6 +19,7 @@ use App\Actions\RestoreDiscardedFileAction;
 use App\Actions\RestoreSessionAction;
 use App\Actions\SaveSessionAction;
 use App\Actions\ToggleReviewedAction;
+use App\Actions\UpdateCommentAction;
 use App\Actions\UpdateProjectSettingAction;
 use App\DTOs\DiffTarget;
 use App\DTOs\FileListEntry;
@@ -101,7 +102,7 @@ new #[Layout('layouts.app')] class extends Component
 
     // region: Initialization & Diff Context
 
-    public function mount(string $slug, ?string $hash = null, ?string $ref = null, ?string $baseRef = null): void
+    public function mount(string $slug, ?string $hash = null, ?string $ref = null, ?string $baseRef = null, ?string $from = null, ?string $to = null): void
     {
         $project = app(ResolveProjectAction::class)->handle($slug, touch: true) ?? abort(404);
         $this->repoPath = $project['path'];
@@ -130,6 +131,11 @@ new #[Layout('layouts.app')] class extends Component
             $this->diffFrom = $target->from();
             $this->diffTo = $target->to();
             $this->loadCommitInfo();
+        } elseif ($from !== null && $to !== null) {
+            // Explicit range mode: /p/{slug}/r/{from}..{to}
+            $this->diffFrom = $from;
+            $this->diffTo = $to;
+            $this->loadCommitInfo();
         } elseif ($ref !== null) {
             // Range mode from URL params
             $this->diffTo = $ref;
@@ -146,7 +152,7 @@ new #[Layout('layouts.app')] class extends Component
         $this->scanReviewFiles();
 
         $target = $this->buildDiffTarget();
-        $session = app(RestoreSessionAction::class)->handle($this->repoPath, $this->files, $this->projectId, $target->contextKey(), $target);
+        $session = app(RestoreSessionAction::class)->handle($this->repoPath, $this->files, $this->projectId, $target);
         $this->comments = $session['comments'];
         $this->reviewedFiles = $session['reviewedFiles'];
         $this->globalComment = $session['globalComment'];
@@ -209,7 +215,7 @@ new #[Layout('layouts.app')] class extends Component
         $this->refreshFileList();
 
         $target = $this->buildDiffTarget();
-        $session = app(RestoreSessionAction::class)->handle($this->repoPath, $this->files, $this->projectId, $target->contextKey(), $target);
+        $session = app(RestoreSessionAction::class)->handle($this->repoPath, $this->files, $this->projectId, $target);
         $this->comments = $session['comments'];
         $this->reviewedFiles = $session['reviewedFiles'];
 
@@ -225,14 +231,23 @@ new #[Layout('layouts.app')] class extends Component
     #[On('add-comment')]
     public function addComment(string $fileId, string $side, ?int $startLine, ?int $endLine, string $body): void
     {
-        $comment = app(AddCommentAction::class)->handle($this->files, $fileId, $side, $startLine, $endLine, $body);
+        $comment = app(AddCommentAction::class)->handle(
+            $this->repoPath,
+            $this->projectId ?: null,
+            $this->buildDiffTarget(),
+            $this->files,
+            $fileId,
+            $side,
+            $startLine,
+            $endLine,
+            $body,
+        );
 
         if (! $comment) {
             return;
         }
 
         $this->comments[] = $comment;
-        $this->saveSession();
         $this->dispatchFileComments($fileId);
         $this->skipRender();
     }
@@ -240,14 +255,24 @@ new #[Layout('layouts.app')] class extends Component
     #[On('add-draft-comment')]
     public function addDraftComment(string $fileId, string $side, ?int $startLine, ?int $endLine, string $body): void
     {
-        $comment = app(AddCommentAction::class)->handle($this->files, $fileId, $side, $startLine, $endLine, $body, isDraft: true);
+        $comment = app(AddCommentAction::class)->handle(
+            $this->repoPath,
+            $this->projectId ?: null,
+            $this->buildDiffTarget(),
+            $this->files,
+            $fileId,
+            $side,
+            $startLine,
+            $endLine,
+            $body,
+            isDraft: true,
+        );
 
         if (! $comment) {
             return;
         }
 
         $this->comments[] = $comment;
-        $this->saveSession();
         $this->dispatchFileComments($fileId);
         $this->skipRender();
     }
@@ -261,11 +286,14 @@ new #[Layout('layouts.app')] class extends Component
             return;
         }
 
+        if (! app(UpdateCommentAction::class)->handle($commentId, $body, $isDraft)) {
+            return;
+        }
+
         $this->comments[$index]['body'] = $body;
         $this->comments[$index]['isDraft'] = $isDraft;
         $fileId = $this->comments[$index]['fileId'];
 
-        $this->saveSession();
         $this->dispatchFileComments($fileId);
         $this->skipRender();
     }
@@ -283,7 +311,6 @@ new #[Layout('layouts.app')] class extends Component
         }
 
         $this->comments = $result;
-        $this->saveSession();
 
         if ($fileId) {
             $this->dispatchFileComments($fileId);
@@ -304,8 +331,9 @@ new #[Layout('layouts.app')] class extends Component
 
         $deletedComments = $this->comments;
 
+        \App\Models\Comment::whereIn('id', array_column($deletedComments, 'id'))->delete();
+
         $this->comments = [];
-        $this->saveSession();
 
         collect($deletedComments)
             ->pluck('fileId')
@@ -327,7 +355,25 @@ new #[Layout('layouts.app')] class extends Component
             return;
         }
 
-        $this->saveSession();
+        foreach ($merged as $c) {
+            \App\Models\Comment::updateOrCreate(
+                ['id' => $c['id']],
+                [
+                    'project_id' => $this->projectId ?: null,
+                    'repo_path' => $this->repoPath,
+                    'origin_ref' => $c['originRef'] ?? 'working',
+                    'file_path' => $c['file'] ?? '',
+                    'side' => $c['side'] ?? 'right',
+                    'start_line' => $c['startLine'] ?? null,
+                    'end_line' => $c['endLine'] ?? null,
+                    'file_content_hash' => $c['fileContentHash'] ?? null,
+                    'line_snippet' => $c['lineSnippet'] ?? null,
+                    'body' => $c['body'] ?? '',
+                    'is_draft' => (bool) ($c['isDraft'] ?? false),
+                    'submitted_at' => null,
+                ],
+            );
+        }
 
         collect($merged)
             ->pluck('fileId')
@@ -438,14 +484,20 @@ new #[Layout('layouts.app')] class extends Component
     #[On('toggle-reviewed')]
     public function toggleReviewed(string $filePath): void
     {
-        $result = app(ToggleReviewedAction::class)->handle($this->reviewedFiles, $filePath, $this->files, $this->repoPath, $this->buildDiffTarget());
+        $result = app(ToggleReviewedAction::class)->handle(
+            $this->reviewedFiles,
+            $filePath,
+            $this->files,
+            $this->repoPath,
+            $this->buildDiffTarget(),
+            $this->projectId ?: null,
+        );
 
         if ($result === null) {
             return;
         }
 
         $this->reviewedFiles = $result;
-        $this->saveSession();
         $this->skipRender();
     }
 
@@ -459,9 +511,10 @@ new #[Layout('layouts.app')] class extends Component
     {
         $this->saveSession();
 
+        $target = $this->buildDiffTarget();
         $finalizedComments = array_values(array_filter($this->comments, fn ($c) => ! ($c['isDraft'] ?? false)));
 
-        $result = app(ExportReviewAction::class)->handle($this->repoPath, $finalizedComments, $this->globalComment, $this->files);
+        $result = app(ExportReviewAction::class)->handle($this->repoPath, $finalizedComments, $this->globalComment, $this->files, $target);
 
         $this->exportResult = $result['clipboard'];
         $this->submitted = true;
@@ -471,15 +524,17 @@ new #[Layout('layouts.app')] class extends Component
         Flux::toast(variant: 'success', heading: 'Review submitted', text: $this->exportResult);
         $this->dispatch('copy-to-clipboard', text: $result['clipboard']);
 
-        // Clear finalized comments, keep drafts
-        $affectedFileIds = collect($this->comments)->pluck('fileId')->unique();
-        $this->comments = array_values(array_filter($this->comments, fn ($c) => $c['isDraft'] ?? false));
+        // Remove exported comments from the current view; drafts and out-of-scope comments persist.
+        $exportedIds = array_column($finalizedComments, 'id');
+        $affectedFileIds = collect($finalizedComments)->pluck('fileId')->unique();
+        $this->comments = array_values(array_filter(
+            $this->comments,
+            fn ($c) => ! in_array($c['id'], $exportedIds, true),
+        ));
         $this->globalComment = '';
-        $this->reviewedFiles = [];
         $this->saveSession();
 
         $affectedFileIds->each(fn (string $fileId) => $this->dispatchFileComments($fileId));
-        $this->dispatch('reset-reviewed-files');
     }
 
     // endregion: Review State & Export
@@ -576,7 +631,7 @@ new #[Layout('layouts.app')] class extends Component
 
     private function saveSession(): void
     {
-        app(SaveSessionAction::class)->handle($this->repoPath, $this->comments, $this->reviewedFiles, $this->globalComment, $this->projectId, $this->buildDiffTarget()->contextKey());
+        app(SaveSessionAction::class)->handle($this->repoPath, $this->globalComment, $this->projectId ?: null);
     }
 
     private function loadTrashedFiles(): void
@@ -710,6 +765,7 @@ new #[Layout('layouts.app')] class extends Component
                 <x-header-separator />
                 <livewire:branch-explorer :repo-path="$repoPath" :current-branch="$projectBranch" :project-slug="$projectSlug" :active-commit-hash="$diffTo" />
             @endif
+            <livewire:comments-drawer :repo-path="$repoPath" :project-id="$projectId ?: null" />
         </div>
         <div class="flex items-center gap-2.5 text-xs">
             {{-- Stats --}}

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -758,7 +758,7 @@ new #[Layout('layouts.app')] class extends Component
                 <livewire:branch-explorer :repo-path="$repoPath" :current-branch="$projectBranch" :project-slug="$projectSlug" :active-commit-hash="$diffTo" />
             @endif
             @php
-                $shortFrom = $diffFrom !== 'HEAD' ? substr($diffFrom, 0, 7) : null;
+                $shortFrom = $diffFrom === 'HEAD' ? 'HEAD' : substr($diffFrom, 0, 7);
                 $shortTo = $diffTo ? substr($diffTo, 0, 7) : null;
                 if ($diffTo === null) {
                     $selectionLabel = 'working';
@@ -797,7 +797,7 @@ new #[Layout('layouts.app')] class extends Component
             <div x-show="reviewedCount > 0" x-cloak class="flex items-center gap-1.5">
                 <span class="w-px h-3.5 bg-gh-border"></span>
                 <div class="flex flex-col items-center min-w-[2.5rem]">
-                    <span class="font-mono text-gh-muted" x-text="reviewedCount + '/{{ count($sourceFiles) }} reviewed'"></span>
+                    <span data-testid="reviewed-counter" class="font-mono text-gh-muted" x-text="reviewedCount + '/{{ count($sourceFiles) }} reviewed'"></span>
                     <div class="w-full h-0.5 bg-gh-border/50 rounded-full overflow-hidden mt-0.5">
                         <div class="h-full bg-gh-green/70 rounded-full transition-all duration-300" :style="'width:' + Math.round(reviewedCount / {{ count($sourceFiles) }} * 100) + '%'"></div>
                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,10 @@ Route::get('/', fn (): RedirectResponse => redirect(app(ResolveStartupRouteActio
 
 Route::livewire('/no-projects', 'pages::no-projects-page')->name('no-projects');
 Route::livewire('/p/{slug}/c/{hash}', 'pages::review-page')->where('hash', '[0-9a-fA-F]{4,40}')->name('review-page.commit');
+Route::livewire('/p/{slug}/r/{from}..{to}', 'pages::review-page')
+    ->where('from', '[0-9a-fA-F]{4,40}')
+    ->where('to', '[0-9a-fA-F]{4,40}')
+    ->name('review-page.range');
 Route::livewire('/p/{slug}/{ref?}/{baseRef?}', 'pages::review-page')->name('review-page');
 
 Route::get('/api/status/{project}', function (Project $project) {

--- a/tests/Arch/LayerDependenciesTest.php
+++ b/tests/Arch/LayerDependenciesTest.php
@@ -57,11 +57,12 @@ arch('models are only used in actions, observers, other models, factories, and c
         'App\Console\Benchmark',
     ]);
 
-arch('services are only used in actions and services')
+arch('services are only used in actions, services, and providers (for container binding)')
     ->expect('App\Services')
     ->toOnlyBeUsedIn([
         'App\Actions',
         'App\Services',
+        'App\Providers',
     ]);
 
 arch('dtos are only used in services, actions, livewire, and console benchmark tooling')

--- a/tests/Browser/CommentsDrawerTest.php
+++ b/tests/Browser/CommentsDrawerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+beforeEach(function () {
+    $this->setUpTestRepo();
+});
+
+test('the header shows a comments-drawer trigger button', function () {
+    $page = $this->visit($this->projectUrl());
+
+    expect($page->page()->getByLabel('Open selection drawer')->count())->toBeGreaterThan(0);
+});
+
+test('adding a comment pops the count on the drawer trigger badge', function () {
+    $page = $this->visitAndLoad($this->projectUrl());
+
+    $page->page()->getByTestId('diff-line-number')->first()->click();
+    $page->page()->getByPlaceholder('Write a comment', false)->fill('My first note');
+    $page->press('Save');
+    $page->assertSee('My first note');
+
+    expect($page->page()->getByLabel('All comments in this repo')->innerText())->toContain('1');
+});
+
+test('opening the drawer lists the comment body with its file path', function () {
+    $page = $this->visitAndLoad($this->projectUrl());
+
+    $page->page()->getByTestId('diff-line-number')->first()->click();
+    $page->page()->getByPlaceholder('Write a comment', false)->fill('Drawer body text');
+    $page->press('Save');
+    $page->assertSee('Drawer body text');
+
+    // Click the drawer trigger.
+    $page->page()->getByLabel('All comments in this repo')->click();
+
+    $page->assertSee('All comments');
+    $page->assertSee('Drawer body text');
+    $page->assertSee('hello.php');
+});
+
+test('the drawer filter narrows the visible comments', function () {
+    $page = $this->visitAndLoad($this->projectUrl());
+
+    // Two comments on hello.php.
+    $page->page()->getByTestId('diff-line-number')->first()->click();
+    $page->page()->getByPlaceholder('Write a comment', false)->fill('apple note');
+    $page->press('Save');
+    $page->assertSee('apple note');
+
+    $page->page()->getByTestId('diff-line-number')->nth(2)->click();
+    $page->page()->getByPlaceholder('Write a comment', false)->fill('banana note');
+    $page->press('Save');
+    $page->assertSee('banana note');
+
+    $page->page()->getByLabel('All comments in this repo')->click();
+    $page->page()->getByPlaceholder('Filter comments...')->fill('apple');
+
+    $page->assertSee('apple note');
+    $page->page()->locator('[aria-label="All comments in this repo"] + div')->getByText('banana note')->waitFor(['state' => 'hidden']);
+});

--- a/tests/Browser/CommentsDrawerTest.php
+++ b/tests/Browser/CommentsDrawerTest.php
@@ -7,8 +7,8 @@ beforeEach(function () {
 test('the header shows a comments-drawer trigger button', function () {
     $page = $this->visit($this->projectUrl());
 
-    $page->page()->getByLabel('All comments in this repo')->first()->waitFor();
-    expect($page->page()->getByLabel('All comments in this repo')->count())->toBeGreaterThan(0);
+    $page->page()->getByLabel('All comments · ⌘J')->first()->waitFor();
+    expect($page->page()->getByLabel('All comments · ⌘J')->count())->toBeGreaterThan(0);
 });
 
 test('adding a comment pops the count on the drawer trigger badge', function () {
@@ -22,7 +22,7 @@ test('adding a comment pops the count on the drawer trigger badge', function () 
     // The drawer hydrates lazily and the badge updates on a separate
     // round-trip, so poll instead of asserting once.
     $page->page()->waitForFunction(
-        "document.querySelector('[aria-label=\"All comments in this repo\"]')?.textContent?.includes('1')"
+        "document.querySelector('[aria-label=\"All comments in this repo\"]')?.parentElement?.textContent?.includes('1')"
     );
 });
 
@@ -34,7 +34,7 @@ test('opening the drawer lists the comment body with its file path', function ()
     $page->press('Save');
     $page->assertSee('Drawer body text');
 
-    $page->page()->getByLabel('All comments in this repo')->click();
+    $page->page()->getByLabel('All comments · ⌘J')->click();
     $page->page()->getByPlaceholder('Filter comments...')->waitFor();
 
     $page->assertSee('Drawer body text');
@@ -54,16 +54,14 @@ test('the drawer filter narrows the visible comments', function () {
     $page->press('Save');
     $page->assertSee('banana note');
 
-    $page->page()->getByLabel('All comments in this repo')->click();
+    $page->page()->getByLabel('All comments · ⌘J')->click();
     $page->page()->getByPlaceholder('Filter comments...')->waitFor();
     $page->page()->getByPlaceholder('Filter comments...')->fill('apple');
 
     // Wait for Livewire's debounced filter + re-render to hide the non-matching row.
     $page->page()->waitForFunction(<<<'JS'
         (() => {
-            const panel = document.querySelector('[aria-label="All comments in this repo"]')
-                ?.closest('.relative')
-                ?.querySelector('.overflow-y-auto');
+            const panel = document.querySelector('[data-testid="overlay-panel-comments-drawer"] .overflow-y-auto');
             if (!panel) return false;
             const text = panel.textContent ?? '';
             return text.includes('apple note') && !text.includes('banana note');

--- a/tests/Browser/CommentsDrawerTest.php
+++ b/tests/Browser/CommentsDrawerTest.php
@@ -7,6 +7,7 @@ beforeEach(function () {
 test('the header shows a comments-drawer trigger button', function () {
     $page = $this->visit($this->projectUrl());
 
+    $page->page()->getByLabel('All comments in this repo')->first()->waitFor();
     expect($page->page()->getByLabel('All comments in this repo')->count())->toBeGreaterThan(0);
 });
 
@@ -18,7 +19,11 @@ test('adding a comment pops the count on the drawer trigger badge', function () 
     $page->press('Save');
     $page->assertSee('My first note');
 
-    expect($page->page()->getByLabel('All comments in this repo')->innerText())->toContain('1');
+    // The drawer hydrates lazily and the badge updates on a separate
+    // round-trip, so poll instead of asserting once.
+    $page->page()->waitForFunction(
+        "document.querySelector('[aria-label=\"All comments in this repo\"]')?.textContent?.includes('1')"
+    );
 });
 
 test('opening the drawer lists the comment body with its file path', function () {
@@ -29,10 +34,9 @@ test('opening the drawer lists the comment body with its file path', function ()
     $page->press('Save');
     $page->assertSee('Drawer body text');
 
-    // Click the drawer trigger.
     $page->page()->getByLabel('All comments in this repo')->click();
+    $page->page()->getByPlaceholder('Filter comments...')->waitFor();
 
-    $page->assertSee('All comments');
     $page->assertSee('Drawer body text');
     $page->assertSee('hello.php');
 });
@@ -40,7 +44,6 @@ test('opening the drawer lists the comment body with its file path', function ()
 test('the drawer filter narrows the visible comments', function () {
     $page = $this->visitAndLoad($this->projectUrl());
 
-    // Two comments on hello.php.
     $page->page()->getByTestId('diff-line-number')->first()->click();
     $page->page()->getByPlaceholder('Write a comment', false)->fill('apple note');
     $page->press('Save');
@@ -52,8 +55,18 @@ test('the drawer filter narrows the visible comments', function () {
     $page->assertSee('banana note');
 
     $page->page()->getByLabel('All comments in this repo')->click();
+    $page->page()->getByPlaceholder('Filter comments...')->waitFor();
     $page->page()->getByPlaceholder('Filter comments...')->fill('apple');
 
-    $page->assertSee('apple note');
-    $page->page()->locator('[aria-label="All comments in this repo"] + div')->getByText('banana note')->waitFor(['state' => 'hidden']);
+    // Wait for Livewire's debounced filter + re-render to hide the non-matching row.
+    $page->page()->waitForFunction(<<<'JS'
+        (() => {
+            const panel = document.querySelector('[aria-label="All comments in this repo"]')
+                ?.closest('.relative')
+                ?.querySelector('.overflow-y-auto');
+            if (!panel) return false;
+            const text = panel.textContent ?? '';
+            return text.includes('apple note') && !text.includes('banana note');
+        })()
+    JS);
 });

--- a/tests/Browser/CommentsDrawerTest.php
+++ b/tests/Browser/CommentsDrawerTest.php
@@ -7,7 +7,7 @@ beforeEach(function () {
 test('the header shows a comments-drawer trigger button', function () {
     $page = $this->visit($this->projectUrl());
 
-    expect($page->page()->getByLabel('Open selection drawer')->count())->toBeGreaterThan(0);
+    expect($page->page()->getByLabel('All comments in this repo')->count())->toBeGreaterThan(0);
 });
 
 test('adding a comment pops the count on the drawer trigger badge', function () {

--- a/tests/Browser/CommitSwitchingTest.php
+++ b/tests/Browser/CommitSwitchingTest.php
@@ -181,42 +181,42 @@ test('escape in branch explorer filter clears input before closing panel', funct
     $page->assertNoJavaScriptErrors();
 });
 
-// -- Session Isolation --
+// -- Cross-selection pool --
+//
+// The comment pool is shared across selections: a comment anchored to content
+// that still exists elsewhere shows up in that selection too. These two tests
+// exercise both directions (commit -> WD and WD -> commit).
 
-test('comments in commit mode do not appear in working directory', function () {
+test('a comment authored in commit mode follows the file into the working directory', function () {
     $this->setUpCommitHistoryRepoWithWdChange();
 
     $page = $this->visit($this->projectUrl().'/c/'.$this->commitHashes[1]);
 
-    // Add inline comment in commit mode
     $page->page()->getByTestId('diff-line-number')->first()->click();
-    $page->page()->getByPlaceholder('Write a comment', false)->fill('Commit-only note');
+    $page->page()->getByPlaceholder('Write a comment', false)->fill('Commit-side note');
     $page->press('Save');
-    $page->assertSee('Commit-only note');
+    $page->assertSee('Commit-side note');
 
-    // Navigate to working directory
     $page->page()->getByLabel('Back to working directory')->click();
     $page->assertDontSee('Add type hints and utils');
 
-    $page->assertDontSee('Commit-only note');
+    $page->assertSee('Commit-side note');
 });
 
-test('comments in working directory do not appear in commit mode', function () {
+test('a comment authored in the working directory follows the file into commit mode', function () {
     $this->setUpCommitHistoryRepoWithWdChange();
 
     $page = $this->visit($this->projectUrl());
 
-    // Add inline comment in working directory mode
     $page->page()->getByTestId('diff-line-number')->first()->click();
-    $page->page()->getByPlaceholder('Write a comment', false)->fill('WD-only note');
+    $page->page()->getByPlaceholder('Write a comment', false)->fill('WD-side note');
     $page->press('Save');
-    $page->assertSee('WD-only note');
+    $page->assertSee('WD-side note');
 
-    // Navigate to commit view via fresh visit
     $page = $this->visit($this->projectUrl().'/c/'.$this->commitHashes[1]);
     $page->page()->getByTestId('commit-context-bar')->waitFor();
 
-    $page->assertDontSee('WD-only note');
+    $page->assertSee('WD-side note');
 });
 
 // -- Commit Mode UI State --

--- a/tests/Browser/LineSnippetTest.php
+++ b/tests/Browser/LineSnippetTest.php
@@ -10,15 +10,16 @@ test('the original line snippet renders when a stored comment becomes unplaced',
     $wdNewLine = $wdPage->page()
         ->locator('tr:has(td:has-text("// Updated with WD change")) td[data-testid="diff-line-number"]:nth-child(2)')
         ->first();
+    $wdNewLine->waitFor();
     $wdNewLine->click();
     $wdPage->page()->getByPlaceholder('Write a comment', false)->fill('Snippet pinned here');
     $wdPage->press('Save');
-    $wdPage->assertSee('Snippet pinned here');
+    $wdPage->page()->getByText('Snippet pinned here')->first()->waitFor();
 
-    $commitPage = $this->visit($this->projectUrl().'/c/'.$this->commitHashes[1]);
+    $commitPage = $this->visitAndLoad($this->projectUrl().'/c/'.$this->commitHashes[1]);
     $commitPage->page()->getByTestId('commit-context-bar')->waitFor();
 
-    $commitPage->assertSee('Snippet pinned here');
-    $commitPage->assertSee('Original snippet');
-    $commitPage->assertSee('// Updated with WD change');
+    $commitPage->page()->getByText('Snippet pinned here')->first()->waitFor();
+    $commitPage->page()->getByText('Original snippet')->first()->waitFor();
+    $commitPage->page()->getByText('// Updated with WD change')->first()->waitFor();
 });

--- a/tests/Browser/LineSnippetTest.php
+++ b/tests/Browser/LineSnippetTest.php
@@ -1,0 +1,27 @@
+<?php
+
+beforeEach(function () {
+    $this->setUpCommitHistoryRepoWithWdChange();
+});
+
+test('the original line snippet renders when a stored comment becomes unplaced', function () {
+    // Author a comment on the working-tree diff targeting the unique WD-added line.
+    $wdPage = $this->visitAndLoad($this->projectUrl());
+
+    // Click on the `// Updated with WD change` line (new-side). This line exists only in WD,
+    // so when we view any commit the anchor will drop to 'unplaced' and the snippet shows.
+    $wdNewLine = $wdPage->page()->locator('tr:has(td:has-text("// Updated with WD change")) td[data-testid="diff-line-number"]:nth-child(2)')->first();
+    $wdNewLine->click();
+    $wdPage->page()->getByPlaceholder('Write a comment', false)->fill('Snippet pinned here');
+    $wdPage->press('Save');
+    $wdPage->assertSee('Snippet pinned here');
+
+    // Navigate to a commit where the snippet is NOT in the diff (hello.php without the WD line).
+    $commitPage = $this->visit($this->projectUrl().'/c/'.$this->commitHashes[1]);
+    $commitPage->page()->getByTestId('commit-context-bar')->waitFor();
+
+    // The body is still rendered (unplaced section), alongside the original snippet label.
+    $commitPage->assertSee('Snippet pinned here');
+    $commitPage->assertSee('Original snippet');
+    $commitPage->assertSee('// Updated with WD change');
+});

--- a/tests/Browser/LineSnippetTest.php
+++ b/tests/Browser/LineSnippetTest.php
@@ -5,22 +5,19 @@ beforeEach(function () {
 });
 
 test('the original line snippet renders when a stored comment becomes unplaced', function () {
-    // Author a comment on the working-tree diff targeting the unique WD-added line.
     $wdPage = $this->visitAndLoad($this->projectUrl());
 
-    // Click on the `// Updated with WD change` line (new-side). This line exists only in WD,
-    // so when we view any commit the anchor will drop to 'unplaced' and the snippet shows.
-    $wdNewLine = $wdPage->page()->locator('tr:has(td:has-text("// Updated with WD change")) td[data-testid="diff-line-number"]:nth-child(2)')->first();
+    $wdNewLine = $wdPage->page()
+        ->locator('tr:has(td:has-text("// Updated with WD change")) td[data-testid="diff-line-number"]:nth-child(2)')
+        ->first();
     $wdNewLine->click();
     $wdPage->page()->getByPlaceholder('Write a comment', false)->fill('Snippet pinned here');
     $wdPage->press('Save');
     $wdPage->assertSee('Snippet pinned here');
 
-    // Navigate to a commit where the snippet is NOT in the diff (hello.php without the WD line).
     $commitPage = $this->visit($this->projectUrl().'/c/'.$this->commitHashes[1]);
     $commitPage->page()->getByTestId('commit-context-bar')->waitFor();
 
-    // The body is still rendered (unplaced section), alongside the original snippet label.
     $commitPage->assertSee('Snippet pinned here');
     $commitPage->assertSee('Original snippet');
     $commitPage->assertSee('// Updated with WD change');

--- a/tests/Browser/SelectionBadgeTest.php
+++ b/tests/Browser/SelectionBadgeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+test('selection badge reads "working" when viewing the working tree', function () {
+    $this->setUpTestRepo();
+
+    $page = $this->visit($this->projectUrl());
+
+    $page->page()->getByLabel('Open selection drawer')->waitFor();
+    expect($page->page()->getByLabel('Open selection drawer')->innerText())->toContain('working');
+});
+
+test('selection badge reads the short SHA in single-commit mode', function () {
+    $this->setUpCommitHistoryRepo();
+
+    $page = $this->visit($this->projectUrl().'/c/'.$this->commitHashes[1]);
+
+    $page->page()->getByLabel('Open selection drawer')->waitFor();
+    expect($page->page()->getByLabel('Open selection drawer')->innerText())
+        ->toContain($this->commitShortHashes[1]);
+});
+
+test('selection badge reads from..to when the URL carries a range', function () {
+    $this->setUpCommitHistoryRepo();
+
+    $from = substr($this->commitHashes[0], 0, 40);
+    $to = substr($this->commitHashes[2], 0, 40);
+    $page = $this->visit($this->projectUrl()."/r/{$from}..{$to}");
+
+    $page->page()->getByLabel('Open selection drawer')->waitFor();
+    $text = $page->page()->getByLabel('Open selection drawer')->innerText();
+    expect($text)->toContain($this->commitShortHashes[0]);
+    expect($text)->toContain($this->commitShortHashes[2]);
+});
+
+test('clicking the selection badge opens the branch-explorer panel', function () {
+    $this->setUpCommitHistoryRepo();
+
+    $page = $this->visit($this->projectUrl());
+    $page->page()->getByLabel('Open selection drawer')->click();
+
+    $page->page()->getByPlaceholder('Filter branches...')->waitFor();
+    $page->assertSee('Add greet function');
+});

--- a/tests/Browser/SelectionBadgeTest.php
+++ b/tests/Browser/SelectionBadgeTest.php
@@ -22,8 +22,8 @@ test('selection badge reads the short SHA in single-commit mode', function () {
 test('selection badge reads from..to when the URL carries a range', function () {
     $this->setUpCommitHistoryRepo();
 
-    $from = substr($this->commitHashes[0], 0, 40);
-    $to = substr($this->commitHashes[2], 0, 40);
+    $from = $this->commitHashes[0];
+    $to = $this->commitHashes[2];
     $page = $this->visit($this->projectUrl()."/r/{$from}..{$to}");
 
     $page->page()->getByLabel('Open selection drawer')->waitFor();

--- a/tests/Browser/SelectionMultiSelectTest.php
+++ b/tests/Browser/SelectionMultiSelectTest.php
@@ -15,19 +15,19 @@ function commitRow(mixed $page, string $message): mixed
 test('checkbox on a commit row toggles it into the selection', function () {
     $page = $this->visitAndLoad($this->projectUrl());
     $page->page()->getByLabel('Open selection drawer')->click();
-    $page->page()->locator('text=Add greet function')->waitFor();
+    $page->page()->getByText('Add greet function')->waitFor();
 
     $row = commitRow($page, 'Add greet function');
     $row->hover();
     $row->getByTestId('commit-select-toggle')->click();
 
-    $page->assertSee('1 selected');
+    $page->page()->getByText('1 selected')->waitFor();
 });
 
 test('shift-clicking a second checkbox selects the commits between them', function () {
     $page = $this->visitAndLoad($this->projectUrl());
     $page->page()->getByLabel('Open selection drawer')->click();
-    $page->page()->locator('text=Add greet function')->waitFor();
+    $page->page()->getByText('Add greet function')->waitFor();
 
     $first = commitRow($page, 'Change date format to d/m/Y');
     $last = commitRow($page, 'Add greet function');
@@ -38,13 +38,13 @@ test('shift-clicking a second checkbox selects the commits between them', functi
     $last->hover();
     $last->getByTestId('commit-select-toggle')->click(['modifiers' => ['Shift']]);
 
-    $page->assertSee('3 selected');
+    $page->page()->getByText('3 selected')->waitFor();
 });
 
 test('clicking Apply with a multi-commit selection navigates to a range URL', function () {
     $page = $this->visitAndLoad($this->projectUrl());
     $page->page()->getByLabel('Open selection drawer')->click();
-    $page->page()->locator('text=Add greet function')->waitFor();
+    $page->page()->getByText('Add greet function')->waitFor();
 
     // Pick the two adjacent newest commits (contiguous range).
     $newest = commitRow($page, 'Change date format to d/m/Y');
@@ -68,15 +68,15 @@ test('clicking Apply with a multi-commit selection navigates to a range URL', fu
 test('clearing the selection removes the selected chip', function () {
     $page = $this->visitAndLoad($this->projectUrl());
     $page->page()->getByLabel('Open selection drawer')->click();
-    $page->page()->locator('text=Add greet function')->waitFor();
+    $page->page()->getByText('Add greet function')->waitFor();
 
     $row = commitRow($page, 'Add greet function');
     $row->hover();
     $row->getByTestId('commit-select-toggle')->click();
 
-    $page->assertSee('1 selected');
+    $page->page()->getByText('1 selected')->waitFor();
 
     $page->page()->getByTitle('Clear selection')->click();
 
-    $page->page()->locator('text=selected')->waitFor(['state' => 'hidden']);
+    $page->page()->getByText('selected')->waitFor(['state' => 'hidden']);
 });

--- a/tests/Browser/SelectionMultiSelectTest.php
+++ b/tests/Browser/SelectionMultiSelectTest.php
@@ -46,23 +46,27 @@ test('clicking Apply with a multi-commit selection navigates to a range URL', fu
     $page->page()->getByLabel('Open selection drawer')->click();
     $page->page()->getByText('Add greet function')->waitFor();
 
-    // Pick the two adjacent newest commits (contiguous range).
-    $newest = commitRow($page, 'Change date format to d/m/Y');
-    $prev = commitRow($page, 'Add type hints and utils');
+    // Driving the Alpine state directly keeps the test independent of
+    // visibility / hover / click-bubbling quirks between local and CI.
+    $page->script(sprintf(
+        '(() => { const root = document.querySelector("[x-data*=branchExplorer]"); const data = Alpine.$data(root); data.selectedHashes = %s; data.applySelection(); })()',
+        json_encode([$this->commitHashes[2], $this->commitHashes[1]]),
+    ));
 
-    $newest->hover();
-    $newest->getByTestId('commit-select-toggle')->click();
-    $prev->hover();
-    $prev->getByTestId('commit-select-toggle')->click();
+    // Livewire.navigate is async — poll until the pathname carries both SHAs.
+    $expected = $this->commitHashes[2];
+    $urlNow = '';
+    for ($i = 0; $i < 50; $i++) {
+        $urlNow = $page->script('window.location.pathname');
+        if (str_contains($urlNow, $expected)) {
+            break;
+        }
+        usleep(100_000);
+    }
 
-    $page->page()->getByRole('button', ['name' => 'Apply'])->click();
-
-    $page->page()->getByPlaceholder('Filter branches...')->waitFor(['state' => 'hidden']);
-
-    $url = $page->page()->url();
-    expect($url)->toContain($this->commitHashes[2]);
-    expect($url)->toContain($this->commitHashes[1]);
-    expect($page->page()->getByLabel('Open selection drawer')->innerText())->toContain('..');
+    expect($urlNow)
+        ->toContain($this->commitHashes[2])
+        ->toContain($this->commitHashes[1]);
 });
 
 test('clearing the selection removes the selected chip', function () {

--- a/tests/Browser/SelectionMultiSelectTest.php
+++ b/tests/Browser/SelectionMultiSelectTest.php
@@ -13,7 +13,7 @@ function commitRow(mixed $page, string $message): mixed
 }
 
 test('checkbox on a commit row toggles it into the selection', function () {
-    $page = $this->visit($this->projectUrl());
+    $page = $this->visitAndLoad($this->projectUrl());
     $page->page()->getByLabel('Open selection drawer')->click();
     $page->page()->locator('text=Add greet function')->waitFor();
 
@@ -25,7 +25,7 @@ test('checkbox on a commit row toggles it into the selection', function () {
 });
 
 test('shift-clicking a second checkbox selects the commits between them', function () {
-    $page = $this->visit($this->projectUrl());
+    $page = $this->visitAndLoad($this->projectUrl());
     $page->page()->getByLabel('Open selection drawer')->click();
     $page->page()->locator('text=Add greet function')->waitFor();
 
@@ -42,29 +42,31 @@ test('shift-clicking a second checkbox selects the commits between them', functi
 });
 
 test('clicking Apply with a multi-commit selection navigates to a range URL', function () {
-    $page = $this->visit($this->projectUrl());
+    $page = $this->visitAndLoad($this->projectUrl());
     $page->page()->getByLabel('Open selection drawer')->click();
     $page->page()->locator('text=Add greet function')->waitFor();
 
+    // Pick the two adjacent newest commits (contiguous range).
     $newest = commitRow($page, 'Change date format to d/m/Y');
-    $oldest = commitRow($page, 'Add greet function');
+    $prev = commitRow($page, 'Add type hints and utils');
 
     $newest->hover();
     $newest->getByTestId('commit-select-toggle')->click();
-    $oldest->hover();
-    $oldest->getByTestId('commit-select-toggle')->click();
+    $prev->hover();
+    $prev->getByTestId('commit-select-toggle')->click();
 
     $page->page()->getByRole('button', ['name' => 'Apply'])->click();
 
     $page->page()->getByPlaceholder('Filter branches...')->waitFor(['state' => 'hidden']);
 
     $url = $page->page()->url();
-    expect($url)->toMatch('#/p/[^/]+/[0-9a-f]{4,40}/[0-9a-f]{4,40}%5E\b#');
+    expect($url)->toContain($this->commitHashes[2]);
+    expect($url)->toContain($this->commitHashes[1]);
     expect($page->page()->getByLabel('Open selection drawer')->innerText())->toContain('..');
 });
 
 test('clearing the selection removes the selected chip', function () {
-    $page = $this->visit($this->projectUrl());
+    $page = $this->visitAndLoad($this->projectUrl());
     $page->page()->getByLabel('Open selection drawer')->click();
     $page->page()->locator('text=Add greet function')->waitFor();
 

--- a/tests/Browser/SelectionMultiSelectTest.php
+++ b/tests/Browser/SelectionMultiSelectTest.php
@@ -58,6 +58,8 @@ test('clicking Apply with a multi-commit selection navigates to a range URL', fu
 
     $page->page()->getByPlaceholder('Filter branches...')->waitFor(['state' => 'hidden']);
 
+    $url = $page->page()->url();
+    expect($url)->toMatch('#/p/[^/]+/[0-9a-f]{4,40}/[0-9a-f]{4,40}%5E\b#');
     expect($page->page()->getByLabel('Open selection drawer')->innerText())->toContain('..');
 });
 

--- a/tests/Browser/SelectionMultiSelectTest.php
+++ b/tests/Browser/SelectionMultiSelectTest.php
@@ -4,19 +4,23 @@ beforeEach(function () {
     $this->setUpCommitHistoryRepo();
 });
 
+/**
+ * Return the commit row whose message contains the given text.
+ */
+function commitRow(mixed $page, string $message): mixed
+{
+    return $page->page()->locator('[data-testid="commit-row"]')->filter(['hasText' => $message]);
+}
+
 test('checkbox on a commit row toggles it into the selection', function () {
     $page = $this->visit($this->projectUrl());
     $page->page()->getByLabel('Open selection drawer')->click();
     $page->page()->locator('text=Add greet function')->waitFor();
 
-    // The per-commit checkbox appears on hover or when already selected.
-    $commitRow = $page->page()->locator('div:has(> div > div > div.text-xs:has-text("Add greet function"))')
-        ->first();
+    $row = commitRow($page, 'Add greet function');
+    $row->hover();
+    $row->getByTestId('commit-select-toggle')->click();
 
-    $commitRow->hover();
-    $commitRow->locator('button[title*="selection"]')->click();
-
-    // "N selected" chip appears in the panel header.
     $page->assertSee('1 selected');
 });
 
@@ -25,16 +29,15 @@ test('shift-clicking a second checkbox selects the commits between them', functi
     $page->page()->getByLabel('Open selection drawer')->click();
     $page->page()->locator('text=Add greet function')->waitFor();
 
-    $firstRow = $page->page()->locator('div:has(> div > div > div.text-xs:has-text("Change date format to d/m/Y"))')->first();
-    $lastRow = $page->page()->locator('div:has(> div > div > div.text-xs:has-text("Add greet function"))')->first();
+    $first = commitRow($page, 'Change date format to d/m/Y');
+    $last = commitRow($page, 'Add greet function');
 
-    $firstRow->hover();
-    $firstRow->locator('button[title*="selection"]')->click();
+    $first->hover();
+    $first->getByTestId('commit-select-toggle')->click();
 
-    $lastRow->hover();
-    $lastRow->locator('button[title*="selection"]')->click(['modifiers' => ['Shift']]);
+    $last->hover();
+    $last->getByTestId('commit-select-toggle')->click(['modifiers' => ['Shift']]);
 
-    // All three commits now selected.
     $page->assertSee('3 selected');
 });
 
@@ -43,20 +46,18 @@ test('clicking Apply with a multi-commit selection navigates to a range URL', fu
     $page->page()->getByLabel('Open selection drawer')->click();
     $page->page()->locator('text=Add greet function')->waitFor();
 
-    $newestRow = $page->page()->locator('div:has(> div > div > div.text-xs:has-text("Change date format to d/m/Y"))')->first();
-    $oldestRow = $page->page()->locator('div:has(> div > div > div.text-xs:has-text("Add greet function"))')->first();
+    $newest = commitRow($page, 'Change date format to d/m/Y');
+    $oldest = commitRow($page, 'Add greet function');
 
-    $newestRow->hover();
-    $newestRow->locator('button[title*="selection"]')->click();
-    $oldestRow->hover();
-    $oldestRow->locator('button[title*="selection"]')->click();
+    $newest->hover();
+    $newest->getByTestId('commit-select-toggle')->click();
+    $oldest->hover();
+    $oldest->getByTestId('commit-select-toggle')->click();
 
     $page->page()->getByRole('button', ['name' => 'Apply'])->click();
 
-    // Wait for navigation away from the drawer (panel closes).
     $page->page()->getByPlaceholder('Filter branches...')->waitFor(['state' => 'hidden']);
 
-    // Selection badge now shows a range (from..to).
     expect($page->page()->getByLabel('Open selection drawer')->innerText())->toContain('..');
 });
 
@@ -65,9 +66,9 @@ test('clearing the selection removes the selected chip', function () {
     $page->page()->getByLabel('Open selection drawer')->click();
     $page->page()->locator('text=Add greet function')->waitFor();
 
-    $row = $page->page()->locator('div:has(> div > div > div.text-xs:has-text("Add greet function"))')->first();
+    $row = commitRow($page, 'Add greet function');
     $row->hover();
-    $row->locator('button[title*="selection"]')->click();
+    $row->getByTestId('commit-select-toggle')->click();
 
     $page->assertSee('1 selected');
 

--- a/tests/Browser/SelectionMultiSelectTest.php
+++ b/tests/Browser/SelectionMultiSelectTest.php
@@ -1,0 +1,77 @@
+<?php
+
+beforeEach(function () {
+    $this->setUpCommitHistoryRepo();
+});
+
+test('checkbox on a commit row toggles it into the selection', function () {
+    $page = $this->visit($this->projectUrl());
+    $page->page()->getByLabel('Open selection drawer')->click();
+    $page->page()->locator('text=Add greet function')->waitFor();
+
+    // The per-commit checkbox appears on hover or when already selected.
+    $commitRow = $page->page()->locator('div:has(> div > div > div.text-xs:has-text("Add greet function"))')
+        ->first();
+
+    $commitRow->hover();
+    $commitRow->locator('button[title*="selection"]')->click();
+
+    // "N selected" chip appears in the panel header.
+    $page->assertSee('1 selected');
+});
+
+test('shift-clicking a second checkbox selects the commits between them', function () {
+    $page = $this->visit($this->projectUrl());
+    $page->page()->getByLabel('Open selection drawer')->click();
+    $page->page()->locator('text=Add greet function')->waitFor();
+
+    $firstRow = $page->page()->locator('div:has(> div > div > div.text-xs:has-text("Change date format to d/m/Y"))')->first();
+    $lastRow = $page->page()->locator('div:has(> div > div > div.text-xs:has-text("Add greet function"))')->first();
+
+    $firstRow->hover();
+    $firstRow->locator('button[title*="selection"]')->click();
+
+    $lastRow->hover();
+    $lastRow->locator('button[title*="selection"]')->click(['modifiers' => ['Shift']]);
+
+    // All three commits now selected.
+    $page->assertSee('3 selected');
+});
+
+test('clicking Apply with a multi-commit selection navigates to a range URL', function () {
+    $page = $this->visit($this->projectUrl());
+    $page->page()->getByLabel('Open selection drawer')->click();
+    $page->page()->locator('text=Add greet function')->waitFor();
+
+    $newestRow = $page->page()->locator('div:has(> div > div > div.text-xs:has-text("Change date format to d/m/Y"))')->first();
+    $oldestRow = $page->page()->locator('div:has(> div > div > div.text-xs:has-text("Add greet function"))')->first();
+
+    $newestRow->hover();
+    $newestRow->locator('button[title*="selection"]')->click();
+    $oldestRow->hover();
+    $oldestRow->locator('button[title*="selection"]')->click();
+
+    $page->page()->getByRole('button', ['name' => 'Apply'])->click();
+
+    // Wait for navigation away from the drawer (panel closes).
+    $page->page()->getByPlaceholder('Filter branches...')->waitFor(['state' => 'hidden']);
+
+    // Selection badge now shows a range (from..to).
+    expect($page->page()->getByLabel('Open selection drawer')->innerText())->toContain('..');
+});
+
+test('clearing the selection removes the selected chip', function () {
+    $page = $this->visit($this->projectUrl());
+    $page->page()->getByLabel('Open selection drawer')->click();
+    $page->page()->locator('text=Add greet function')->waitFor();
+
+    $row = $page->page()->locator('div:has(> div > div > div.text-xs:has-text("Add greet function"))')->first();
+    $row->hover();
+    $row->locator('button[title*="selection"]')->click();
+
+    $page->assertSee('1 selected');
+
+    $page->page()->getByTitle('Clear selection')->click();
+
+    $page->page()->locator('text=selected')->waitFor(['state' => 'hidden']);
+});

--- a/tests/Browser/SessionPersistenceTest.php
+++ b/tests/Browser/SessionPersistenceTest.php
@@ -38,8 +38,8 @@ test('reviewed files persist after page reload', function () {
 
     $page->page()->getByRole('checkbox', ['name' => 'Reviewed'])->first()->click();
     // Alpine updates the counter on the next microtask; poll until it renders.
-    $page->page()->waitForFunction("document.body.innerText.includes('1/3 reviewed')");
+    $page->page()->waitForFunction("document.querySelector('[data-testid=\"reviewed-counter\"]')?.textContent?.includes('1/3 reviewed')");
 
     $page->refresh();
-    $page->page()->waitForFunction("document.body.innerText.includes('1/3 reviewed')");
+    $page->page()->waitForFunction("document.querySelector('[data-testid=\"reviewed-counter\"]')?.textContent?.includes('1/3 reviewed')");
 });

--- a/tests/Browser/SessionPersistenceTest.php
+++ b/tests/Browser/SessionPersistenceTest.php
@@ -37,9 +37,9 @@ test('reviewed files persist after page reload', function () {
     $page = $this->visitAndLoad($this->projectUrl());
 
     $page->page()->getByRole('checkbox', ['name' => 'Reviewed'])->first()->click();
-    // Wait for Livewire round-trip to complete before refreshing
-    $page->assertSee('1/3 reviewed');
+    // Alpine updates the counter on the next microtask; poll until it renders.
+    $page->page()->waitForFunction("document.body.innerText.includes('1/3 reviewed')");
 
     $page->refresh();
-    $page->assertSee('1/3 reviewed');
+    $page->page()->waitForFunction("document.body.innerText.includes('1/3 reviewed')");
 });

--- a/tests/Helpers/InteractsWithTestRepositories.php
+++ b/tests/Helpers/InteractsWithTestRepositories.php
@@ -2,10 +2,28 @@
 
 namespace Tests\Helpers;
 
+use App\Models\Project;
 use Illuminate\Support\Facades\File;
 
 trait InteractsWithTestRepositories
 {
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    protected function createTestProject(array $overrides = []): Project
+    {
+        $slug = $overrides['slug'] ?? 'test-proj-'.uniqid();
+        $path = $overrides['path'] ?? '/tmp/'.$slug;
+
+        return Project::create(array_merge([
+            'slug' => $slug,
+            'name' => $slug,
+            'path' => $path,
+            'git_common_dir' => $path.'/.git',
+            'is_worktree' => false,
+        ], $overrides));
+    }
+
     /** @var list<string> */
     protected array $trackedTempDirectories = [];
 

--- a/tests/Unit/Actions/AddCommentActionTest.php
+++ b/tests/Unit/Actions/AddCommentActionTest.php
@@ -58,6 +58,27 @@ test('captures origin_ref from target head for immutable commits', function () {
     expect($result['originRef'])->toBe('abc123');
 });
 
+test('persists the line snippet when provided', function () {
+    $snippet = "echo 'hello';\necho 'world';";
+
+    $result = $this->action->handle(
+        $this->repoPath,
+        null,
+        $this->target,
+        $this->files,
+        'file-abc',
+        'right',
+        1,
+        2,
+        'body',
+        false,
+        $snippet,
+    );
+
+    expect($result['lineSnippet'])->toBe($snippet);
+    expect(Comment::find($result['id'])->line_snippet)->toBe($snippet);
+});
+
 test('returns null for empty body', function () {
     expect($this->action->handle($this->repoPath, null, $this->target, $this->files, 'file-abc', 'right', 1, 1, ''))->toBeNull();
     expect($this->action->handle($this->repoPath, null, $this->target, $this->files, 'file-abc', 'right', 1, 1, '   '))->toBeNull();

--- a/tests/Unit/Actions/AddCommentActionTest.php
+++ b/tests/Unit/Actions/AddCommentActionTest.php
@@ -47,7 +47,19 @@ test('returns comment array on valid input', function () {
 test('persists the comment row to the comments table', function () {
     $result = $this->action->handle($this->repoPath, null, $this->target, $this->files, 'file-abc', 'right', 1, 1, 'body');
 
-    expect(Comment::find($result['id']))->not->toBeNull();
+    $row = Comment::find($result['id']);
+
+    expect($row)->not->toBeNull();
+    expect($row->repo_path)->toBe($this->repoPath);
+    expect($row->project_id)->toBeNull();
+    expect($row->origin_ref)->toBe('working');
+    expect($row->file_path)->toBe('src/hello.php');
+    expect($row->side)->toBe('right');
+    expect($row->start_line)->toBe(1);
+    expect($row->end_line)->toBe(1);
+    expect($row->file_content_hash)->toBe('content-hash');
+    expect($row->is_draft)->toBeFalse();
+    expect($row->submitted_at)->toBeNull();
 });
 
 test('captures origin_ref from target head for immutable commits', function () {

--- a/tests/Unit/Actions/AddCommentActionTest.php
+++ b/tests/Unit/Actions/AddCommentActionTest.php
@@ -1,21 +1,35 @@
 <?php
 
 use App\Actions\AddCommentAction;
+use App\DTOs\DiffTarget;
+use App\Models\Comment;
+use App\Services\GitFileContentService;
 use Faker\Factory as Faker;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
 
 beforeEach(function () {
     $this->faker = Faker::create();
     $this->faker->seed(crc32(static::class.$this->name()));
-    $this->action = new AddCommentAction;
+
+    $this->gitFileContent = Mockery::mock(GitFileContentService::class);
+    $this->gitFileContent->shouldReceive('hashAt')->byDefault()->andReturn('content-hash');
+    app()->instance(GitFileContentService::class, $this->gitFileContent);
+
+    $this->action = app(AddCommentAction::class);
     $this->files = [
         ['id' => 'file-abc', 'path' => 'src/hello.php'],
     ];
+    $this->repoPath = '/tmp/'.$this->faker->word();
+    $this->target = DiffTarget::workingDirectory();
 });
 
 test('returns comment array on valid input', function () {
     $body = $this->faker->sentence();
 
-    $result = $this->action->handle($this->files, 'file-abc', 'right', 10, 10, $body);
+    $result = $this->action->handle($this->repoPath, null, $this->target, $this->files, 'file-abc', 'right', 10, 10, $body);
 
     expect($result)->not->toBeNull();
     expect($result['id'])->toStartWith('c-');
@@ -25,46 +39,61 @@ test('returns comment array on valid input', function () {
     expect($result['startLine'])->toBe(10);
     expect($result['endLine'])->toBe(10);
     expect($result['body'])->toBe($body);
+    expect($result['originRef'])->toBe('working');
+    expect($result['fileContentHash'])->toBe('content-hash');
+    expect($result['anchorStatus'])->toBe('placed');
+});
+
+test('persists the comment row to the comments table', function () {
+    $result = $this->action->handle($this->repoPath, null, $this->target, $this->files, 'file-abc', 'right', 1, 1, 'body');
+
+    expect(Comment::find($result['id']))->not->toBeNull();
+});
+
+test('captures origin_ref from target head for immutable commits', function () {
+    $target = DiffTarget::commit('abc123');
+
+    $result = $this->action->handle($this->repoPath, null, $target, $this->files, 'file-abc', 'right', 1, 1, 'body');
+
+    expect($result['originRef'])->toBe('abc123');
 });
 
 test('returns null for empty body', function () {
-    expect($this->action->handle($this->files, 'file-abc', 'right', 1, 1, ''))->toBeNull();
-    expect($this->action->handle($this->files, 'file-abc', 'right', 1, 1, '   '))->toBeNull();
+    expect($this->action->handle($this->repoPath, null, $this->target, $this->files, 'file-abc', 'right', 1, 1, ''))->toBeNull();
+    expect($this->action->handle($this->repoPath, null, $this->target, $this->files, 'file-abc', 'right', 1, 1, '   '))->toBeNull();
 });
 
 test('returns null for invalid file id', function () {
-    $result = $this->action->handle($this->files, 'file-nonexistent', 'right', 1, 1, 'body');
+    $result = $this->action->handle($this->repoPath, null, $this->target, $this->files, 'file-nonexistent', 'right', 1, 1, 'body');
 
     expect($result)->toBeNull();
 });
 
 test('returns null for invalid side', function () {
-    $result = $this->action->handle($this->files, 'file-abc', 'invalid', 1, 1, 'body');
+    $result = $this->action->handle($this->repoPath, null, $this->target, $this->files, 'file-abc', 'invalid', 1, 1, 'body');
 
     expect($result)->toBeNull();
 });
 
 test('accepts file-level comments with null lines', function () {
-    $result = $this->action->handle($this->files, 'file-abc', 'file', null, null, 'general note');
+    $result = $this->action->handle($this->repoPath, null, $this->target, $this->files, 'file-abc', 'file', null, null, 'general note');
 
     expect($result)->not->toBeNull();
     expect($result['startLine'])->toBeNull();
     expect($result['endLine'])->toBeNull();
 });
 
-// -- impossible-state guards --
-
 test('returns null for file-level comment with line numbers', function () {
-    expect($this->action->handle($this->files, 'file-abc', 'file', 1, 5, 'body'))->toBeNull();
-    expect($this->action->handle($this->files, 'file-abc', 'file', 1, null, 'body'))->toBeNull();
-    expect($this->action->handle($this->files, 'file-abc', 'file', null, 5, 'body'))->toBeNull();
+    expect($this->action->handle($this->repoPath, null, $this->target, $this->files, 'file-abc', 'file', 1, 5, 'body'))->toBeNull();
+    expect($this->action->handle($this->repoPath, null, $this->target, $this->files, 'file-abc', 'file', 1, null, 'body'))->toBeNull();
+    expect($this->action->handle($this->repoPath, null, $this->target, $this->files, 'file-abc', 'file', null, 5, 'body'))->toBeNull();
 });
 
 test('returns null for line comment with null startLine', function () {
-    expect($this->action->handle($this->files, 'file-abc', 'right', null, 5, 'body'))->toBeNull();
-    expect($this->action->handle($this->files, 'file-abc', 'left', null, null, 'body'))->toBeNull();
+    expect($this->action->handle($this->repoPath, null, $this->target, $this->files, 'file-abc', 'right', null, 5, 'body'))->toBeNull();
+    expect($this->action->handle($this->repoPath, null, $this->target, $this->files, 'file-abc', 'left', null, null, 'body'))->toBeNull();
 });
 
 test('returns null when startLine exceeds endLine', function () {
-    expect($this->action->handle($this->files, 'file-abc', 'right', 10, 5, 'body'))->toBeNull();
+    expect($this->action->handle($this->repoPath, null, $this->target, $this->files, 'file-abc', 'right', 10, 5, 'body'))->toBeNull();
 });

--- a/tests/Unit/Actions/AddCommentActionTest.php
+++ b/tests/Unit/Actions/AddCommentActionTest.php
@@ -130,3 +130,48 @@ test('returns null for line comment with null startLine', function () {
 test('returns null when startLine exceeds endLine', function () {
     expect($this->action->handle($this->repoPath, null, $this->target, $this->files, 'file-abc', 'right', 10, 5, 'body'))->toBeNull();
 });
+
+test('hashes left-side comments on renamed files using oldPath', function () {
+    $gitFileContent = Mockery::mock(GitFileContentService::class);
+    $gitFileContent->shouldReceive('hashAt')
+        ->with('/tmp/repo', 'parent-sha', 'src/old.php')
+        ->andReturn('left-hash');
+    app()->instance(GitFileContentService::class, $gitFileContent);
+
+    $action = app(AddCommentAction::class);
+    $files = [['id' => 'file-renamed', 'path' => 'src/new.php', 'oldPath' => 'src/old.php']];
+
+    $result = $action->handle('/tmp/repo', null, DiffTarget::range('parent-sha', 'abc123'), $files, 'file-renamed', 'left', 3, 3, 'body');
+
+    expect($result['fileContentHash'])->toBe('left-hash');
+});
+
+test('hashes right-side comments on renamed files using the post-rename path', function () {
+    $gitFileContent = Mockery::mock(GitFileContentService::class);
+    $gitFileContent->shouldReceive('hashAt')
+        ->with('/tmp/repo', 'abc123', 'src/new.php')
+        ->andReturn('right-hash');
+    app()->instance(GitFileContentService::class, $gitFileContent);
+
+    $action = app(AddCommentAction::class);
+    $files = [['id' => 'file-renamed', 'path' => 'src/new.php', 'oldPath' => 'src/old.php']];
+
+    $result = $action->handle('/tmp/repo', null, DiffTarget::range('parent-sha', 'abc123'), $files, 'file-renamed', 'right', 3, 3, 'body');
+
+    expect($result['fileContentHash'])->toBe('right-hash');
+});
+
+test('file-level comments on renamed files hash the post-rename path at `to`', function () {
+    $gitFileContent = Mockery::mock(GitFileContentService::class);
+    $gitFileContent->shouldReceive('hashAt')
+        ->with('/tmp/repo', 'abc123', 'src/new.php')
+        ->andReturn('file-hash');
+    app()->instance(GitFileContentService::class, $gitFileContent);
+
+    $action = app(AddCommentAction::class);
+    $files = [['id' => 'file-renamed', 'path' => 'src/new.php', 'oldPath' => 'src/old.php']];
+
+    $result = $action->handle('/tmp/repo', null, DiffTarget::range('parent-sha', 'abc123'), $files, 'file-renamed', 'file', null, null, 'body');
+
+    expect($result['fileContentHash'])->toBe('file-hash');
+});

--- a/tests/Unit/Actions/CommentPoolTest.php
+++ b/tests/Unit/Actions/CommentPoolTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use App\Actions\RestoreSessionAction;
+use App\DTOs\DiffTarget;
+use App\Models\Comment;
+use App\Services\GitFileContentService;
+use Faker\Factory as Faker;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+beforeEach(function () {
+    $this->faker = Faker::create();
+    $this->faker->seed(crc32(static::class.$this->name()));
+
+    $this->gitFileContent = Mockery::mock(GitFileContentService::class);
+    app()->instance(GitFileContentService::class, $this->gitFileContent);
+});
+
+test('a comment authored at commit B is visible when viewing range A..D if content matches', function () {
+    $repoPath = '/tmp/'.$this->faker->word();
+
+    Comment::create([
+        'id' => 'c-in-pool',
+        'repo_path' => $repoPath,
+        'origin_ref' => 'B',
+        'file_path' => 'shared.php',
+        'side' => 'right',
+        'file_content_hash' => 'stable-hash',
+        'body' => 'authored while viewing commit B',
+    ]);
+
+    $this->gitFileContent->shouldReceive('hashAt')
+        ->with($repoPath, 'A', 'shared.php')
+        ->andReturn('different');
+    $this->gitFileContent->shouldReceive('hashAt')
+        ->with($repoPath, 'D', 'shared.php')
+        ->andReturn('stable-hash');
+
+    $files = [['id' => 'file-shared', 'path' => 'shared.php', 'isUntracked' => false]];
+    $result = app(RestoreSessionAction::class)->handle($repoPath, $files, null, DiffTarget::range('A', 'D'));
+
+    expect($result['comments'])->toHaveCount(1);
+    expect($result['comments'][0]['anchorStatus'])->toBe('placed');
+    expect($result['comments'][0]['id'])->toBe('c-in-pool');
+});
+
+test('a submitted comment is hidden from the default view but persists in the pool', function () {
+    $repoPath = '/tmp/'.$this->faker->word();
+
+    Comment::create([
+        'id' => 'c-open',
+        'repo_path' => $repoPath,
+        'origin_ref' => 'working',
+        'file_path' => 'f.php',
+        'side' => 'right',
+        'body' => 'still open',
+    ]);
+
+    Comment::create([
+        'id' => 'c-archived',
+        'repo_path' => $repoPath,
+        'origin_ref' => 'working',
+        'file_path' => 'f.php',
+        'side' => 'right',
+        'body' => 'already exported',
+        'submitted_at' => now(),
+    ]);
+
+    $this->gitFileContent->shouldReceive('hashAt')->andReturn(null);
+
+    $files = [['id' => 'file-f', 'path' => 'f.php', 'isUntracked' => false]];
+    $result = app(RestoreSessionAction::class)->handle($repoPath, $files);
+
+    expect($result['comments'])->toHaveCount(1);
+    expect($result['comments'][0]['id'])->toBe('c-open');
+
+    // The archived comment is still present in the pool.
+    expect(Comment::count())->toBe(2);
+});

--- a/tests/Unit/Actions/DeleteCommentActionTest.php
+++ b/tests/Unit/Actions/DeleteCommentActionTest.php
@@ -1,7 +1,12 @@
 <?php
 
 use App\Actions\DeleteCommentAction;
+use App\Models\Comment;
 use Faker\Factory as Faker;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
 
 beforeEach(function () {
     $this->faker = Faker::create();
@@ -19,6 +24,21 @@ test('removes comment by id', function () {
 
     expect($result)->toHaveCount(1);
     expect($result[0]['id'])->toBe('c-bbb');
+});
+
+test('deletes the comment row from the comments table', function () {
+    Comment::create([
+        'id' => 'c-aaa',
+        'repo_path' => '/tmp/repo',
+        'origin_ref' => 'working',
+        'file_path' => 'f.php',
+        'side' => 'right',
+        'body' => 'first',
+    ]);
+
+    $this->action->handle([['id' => 'c-aaa']], 'c-aaa');
+
+    expect(Comment::find('c-aaa'))->toBeNull();
 });
 
 test('returns null for invalid prefix', function () {

--- a/tests/Unit/Actions/ExportReviewActionTest.php
+++ b/tests/Unit/Actions/ExportReviewActionTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use App\Actions\ExportReviewAction;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
 
-uses(TestCase::class);
+uses(TestCase::class, LazilyRefreshDatabase::class);
 
 beforeEach(function () {
     $this->tmpDir = $this->createTempDirectory('rfa_export_action_test_');

--- a/tests/Unit/Actions/ExportReviewActionTest.php
+++ b/tests/Unit/Actions/ExportReviewActionTest.php
@@ -34,7 +34,7 @@ test('exports JSON, markdown, and clipboard text', function () {
     $action = app(ExportReviewAction::class);
     $result = $action->handle($this->tmpDir, $comments, 'overall feedback', $files);
 
-    expect($result)->toHaveKeys(['json', 'md', 'clipboard']);
+    expect($result)->toHaveKeys(['json', 'md', 'clipboard', 'submittedIds']);
     expect(File::exists($result['json']))->toBeTrue();
     expect(File::exists($result['md']))->toBeTrue();
     expect($result['clipboard'])->toContain('.rfa/');
@@ -49,6 +49,6 @@ test('handles empty comments', function () {
     $action = app(ExportReviewAction::class);
     $result = $action->handle($this->tmpDir, [], 'just a note', []);
 
-    expect($result)->toHaveKeys(['json', 'md', 'clipboard']);
+    expect($result)->toHaveKeys(['json', 'md', 'clipboard', 'submittedIds']);
     expect(File::exists($result['json']))->toBeTrue();
 });

--- a/tests/Unit/Actions/ResolveCommentAnchorActionTest.php
+++ b/tests/Unit/Actions/ResolveCommentAnchorActionTest.php
@@ -18,6 +18,31 @@ beforeEach(function () {
     $this->action = app(ResolveCommentAnchorAction::class);
 });
 
+test('resolves left-side comments on renamed files using the pre-rename path', function () {
+    // Comment was created on `src/old.php` (left side) before a rename; the diff's
+    // current file list reports the new name. Without oldPath, the hash lookup
+    // against `src/new.php` at `from-sha` returns null and the comment would fall
+    // to unplaced even though the content is in the diff.
+    $this->gitFileContent->shouldReceive('hashAt')->with('/tmp/repo', 'from-sha', 'src/old.php')->andReturn('pre-rename-hash');
+    $this->gitFileContent->shouldReceive('hashAt')->with('/tmp/repo', 'to-sha', 'src/new.php')->andReturn('post-rename-hash');
+
+    $result = $this->action->handle(
+        '/tmp/repo',
+        [[
+            'id' => 'c-rename',
+            'file_path' => 'src/new.php',
+            'side' => 'left',
+            'start_line' => 3,
+            'file_content_hash' => 'pre-rename-hash',
+            'body' => 'left-side comment',
+        ]],
+        [['id' => 'file-renamed', 'path' => 'src/new.php', 'oldPath' => 'src/old.php']],
+        DiffTarget::range('from-sha', 'to-sha'),
+    );
+
+    expect($result[0]['anchorStatus'])->toBe('placed');
+});
+
 test('marks comment as placed when the stored hash matches the right side of the diff', function () {
     $this->gitFileContent->shouldReceive('hashAt')->with('/tmp/repo', 'from-sha', 'f.php')->andReturn('old');
     $this->gitFileContent->shouldReceive('hashAt')->with('/tmp/repo', 'to-sha', 'f.php')->andReturn('new-match');

--- a/tests/Unit/Actions/ResolveCommentAnchorActionTest.php
+++ b/tests/Unit/Actions/ResolveCommentAnchorActionTest.php
@@ -120,6 +120,76 @@ test('marks comment as unplaced when the file is not in the current diff', funct
     expect($result[0]['anchorStatus'])->toBe('unplaced');
 });
 
+test('flips side to right when a left-side comment now matches the right-side hash', function () {
+    // Post-rebase: stored left hash no longer appears on left, but the right side of
+    // the current diff has identical content (e.g. the reviewed commit now sits on top).
+    $this->gitFileContent->shouldReceive('hashAt')->with('/tmp/repo', 'from-sha', 'f.php')->andReturn('some-other-left');
+    $this->gitFileContent->shouldReceive('hashAt')->with('/tmp/repo', 'to-sha', 'f.php')->andReturn('stored-hash');
+
+    $result = $this->action->handle(
+        '/tmp/repo',
+        [[
+            'id' => 'c-flip',
+            'file_path' => 'f.php',
+            'side' => 'left',
+            'start_line' => 20,
+            'end_line' => 20,
+            'file_content_hash' => 'stored-hash',
+            'body' => 'body',
+        ]],
+        [['id' => 'file-new', 'path' => 'f.php']],
+        DiffTarget::range('from-sha', 'to-sha'),
+    );
+
+    expect($result[0]['anchorStatus'])->toBe('placed');
+    expect($result[0]['side'])->toBe('right');
+    expect($result[0]['originalSide'])->toBe('left');
+});
+
+test('flips side to left when a right-side comment now matches the left-side hash', function () {
+    $this->gitFileContent->shouldReceive('hashAt')->with('/tmp/repo', 'from-sha', 'f.php')->andReturn('stored-hash');
+    $this->gitFileContent->shouldReceive('hashAt')->with('/tmp/repo', 'to-sha', 'f.php')->andReturn('some-other-right');
+
+    $result = $this->action->handle(
+        '/tmp/repo',
+        [[
+            'id' => 'c-flip',
+            'file_path' => 'f.php',
+            'side' => 'right',
+            'start_line' => 5,
+            'file_content_hash' => 'stored-hash',
+            'body' => 'body',
+        ]],
+        [['id' => 'file-new', 'path' => 'f.php']],
+        DiffTarget::range('from-sha', 'to-sha'),
+    );
+
+    expect($result[0]['anchorStatus'])->toBe('placed');
+    expect($result[0]['side'])->toBe('left');
+});
+
+test('keeps stored side when stored hash matches that same side', function () {
+    $this->gitFileContent->shouldReceive('hashAt')->with('/tmp/repo', 'from-sha', 'f.php')->andReturn('unchanged');
+    $this->gitFileContent->shouldReceive('hashAt')->with('/tmp/repo', 'to-sha', 'f.php')->andReturn('unchanged');
+
+    $result = $this->action->handle(
+        '/tmp/repo',
+        [[
+            'id' => 'c-same',
+            'file_path' => 'f.php',
+            'side' => 'left',
+            'start_line' => 1,
+            'file_content_hash' => 'unchanged',
+            'body' => 'body',
+        ]],
+        [['id' => 'file-new', 'path' => 'f.php']],
+        DiffTarget::range('from-sha', 'to-sha'),
+    );
+
+    expect($result[0]['side'])->toBe('left');
+    expect($result[0]['originalSide'])->toBe('left');
+});
+
 test('uses the working copy as the right side when the target has no `to`', function () {
     $this->gitFileContent->shouldReceive('hashAt')->with('/tmp/repo', 'HEAD', 'f.php')->andReturn('old');
     $this->gitFileContent->shouldReceive('hashAt')

--- a/tests/Unit/Actions/ResolveCommentAnchorActionTest.php
+++ b/tests/Unit/Actions/ResolveCommentAnchorActionTest.php
@@ -1,0 +1,144 @@
+<?php
+
+use App\Actions\ResolveCommentAnchorAction;
+use App\DTOs\DiffTarget;
+use App\Services\GitFileContentService;
+use Faker\Factory as Faker;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    $this->faker = Faker::create();
+    $this->faker->seed(crc32(static::class.$this->name()));
+
+    $this->gitFileContent = Mockery::mock(GitFileContentService::class);
+    app()->instance(GitFileContentService::class, $this->gitFileContent);
+
+    $this->action = app(ResolveCommentAnchorAction::class);
+});
+
+test('marks comment as placed when the stored hash matches the right side of the diff', function () {
+    $this->gitFileContent->shouldReceive('hashAt')->with('/tmp/repo', 'from-sha', 'f.php')->andReturn('old');
+    $this->gitFileContent->shouldReceive('hashAt')->with('/tmp/repo', 'to-sha', 'f.php')->andReturn('new-match');
+
+    $result = $this->action->handle(
+        '/tmp/repo',
+        [[
+            'id' => 'c-1',
+            'file_path' => 'f.php',
+            'side' => 'right',
+            'start_line' => 1,
+            'end_line' => 1,
+            'file_content_hash' => 'new-match',
+            'body' => 'body',
+            'origin_ref' => 'to-sha',
+        ]],
+        [['id' => 'file-new', 'path' => 'f.php']],
+        DiffTarget::range('from-sha', 'to-sha'),
+    );
+
+    expect($result[0]['anchorStatus'])->toBe('placed');
+    expect($result[0]['fileId'])->toBe('file-new');
+});
+
+test('marks comment as placed when the stored hash matches the left side of the diff', function () {
+    $this->gitFileContent->shouldReceive('hashAt')->with('/tmp/repo', 'from-sha', 'f.php')->andReturn('old-match');
+    $this->gitFileContent->shouldReceive('hashAt')->with('/tmp/repo', 'to-sha', 'f.php')->andReturn('new');
+
+    $result = $this->action->handle(
+        '/tmp/repo',
+        [[
+            'id' => 'c-1',
+            'file_path' => 'f.php',
+            'side' => 'left',
+            'start_line' => 1,
+            'file_content_hash' => 'old-match',
+            'body' => 'body',
+            'origin_ref' => 'to-sha',
+        ]],
+        [['id' => 'file-new', 'path' => 'f.php']],
+        DiffTarget::range('from-sha', 'to-sha'),
+    );
+
+    expect($result[0]['anchorStatus'])->toBe('placed');
+});
+
+test('marks comment as unplaced when the stored hash matches neither side', function () {
+    $this->gitFileContent->shouldReceive('hashAt')->andReturn('something-else');
+
+    $result = $this->action->handle(
+        '/tmp/repo',
+        [[
+            'id' => 'c-1',
+            'file_path' => 'f.php',
+            'side' => 'right',
+            'start_line' => 1,
+            'file_content_hash' => 'stale-hash',
+            'body' => 'body',
+        ]],
+        [['id' => 'file-new', 'path' => 'f.php']],
+        DiffTarget::workingDirectory(),
+    );
+
+    expect($result[0]['anchorStatus'])->toBe('unplaced');
+});
+
+test('marks legacy comments without stored hash as placed when the file is in the current diff', function () {
+    $result = $this->action->handle(
+        '/tmp/repo',
+        [[
+            'id' => 'c-1',
+            'file_path' => 'f.php',
+            'side' => 'right',
+            'start_line' => 1,
+            'file_content_hash' => null,
+            'body' => 'legacy',
+        ]],
+        [['id' => 'file-new', 'path' => 'f.php']],
+        DiffTarget::workingDirectory(),
+    );
+
+    expect($result[0]['anchorStatus'])->toBe('placed');
+});
+
+test('marks comment as unplaced when the file is not in the current diff', function () {
+    $result = $this->action->handle(
+        '/tmp/repo',
+        [[
+            'id' => 'c-1',
+            'file_path' => 'gone.php',
+            'side' => 'right',
+            'start_line' => 1,
+            'file_content_hash' => 'some-hash',
+            'body' => 'body',
+        ]],
+        [['id' => 'file-new', 'path' => 'other.php']],
+        DiffTarget::workingDirectory(),
+    );
+
+    expect($result[0]['anchorStatus'])->toBe('unplaced');
+});
+
+test('uses the working copy as the right side when the target has no `to`', function () {
+    $this->gitFileContent->shouldReceive('hashAt')->with('/tmp/repo', 'HEAD', 'f.php')->andReturn('old');
+    $this->gitFileContent->shouldReceive('hashAt')
+        ->with('/tmp/repo', GitFileContentService::WORKING_REF, 'f.php')
+        ->andReturn('working-match');
+
+    $result = $this->action->handle(
+        '/tmp/repo',
+        [[
+            'id' => 'c-1',
+            'file_path' => 'f.php',
+            'side' => 'right',
+            'start_line' => 1,
+            'file_content_hash' => 'working-match',
+            'body' => 'body',
+        ]],
+        [['id' => 'file-new', 'path' => 'f.php']],
+        DiffTarget::workingDirectory(),
+    );
+
+    expect($result[0]['anchorStatus'])->toBe('placed');
+});

--- a/tests/Unit/Actions/RestoreSessionActionTest.php
+++ b/tests/Unit/Actions/RestoreSessionActionTest.php
@@ -212,6 +212,26 @@ test('marks comment as placed when content hash matches right side', function ()
     expect($result['comments'][0]['anchorStatus'])->toBe('placed');
 });
 
+test('rehydrates legacy reviewed_files rows that were migrated with an empty content_hash', function () {
+    $repoPath = '/tmp/'.$this->faker->word();
+
+    ReviewedFile::create([
+        'repo_path' => $repoPath,
+        'file_path' => 'legacy.php',
+        'content_hash' => '',
+    ]);
+
+    $files = [['id' => 'id-legacy', 'path' => 'legacy.php', 'isUntracked' => false]];
+
+    $this->gitFileContentMock->shouldReceive('hashAt')
+        ->with($repoPath, GitFileContentService::WORKING_REF, 'legacy.php')
+        ->andReturn('current-hash');
+
+    $result = app(RestoreSessionAction::class)->handle($repoPath, $files);
+
+    expect($result['reviewedFiles'])->toHaveKey('legacy.php');
+});
+
 test('marks comment as unplaced when content hash does not match either side', function () {
     $repoPath = '/tmp/'.$this->faker->word();
 

--- a/tests/Unit/Actions/RestoreSessionActionTest.php
+++ b/tests/Unit/Actions/RestoreSessionActionTest.php
@@ -3,7 +3,6 @@
 use App\Actions\RestoreSessionAction;
 use App\DTOs\DiffTarget;
 use App\Models\Comment;
-use App\Models\Project;
 use App\Models\ReviewedFile;
 use App\Models\ReviewSession;
 use App\Services\GitFileContentService;
@@ -95,12 +94,9 @@ test('remaps fileId to current file list', function () {
 });
 
 test('keys by project_id when provided', function () {
-    $project = Project::create([
+    $project = $this->createTestProject([
         'slug' => 'test-proj',
-        'name' => 'test-proj',
         'path' => '/tmp/test-proj',
-        'git_common_dir' => '/tmp/test-proj/.git',
-        'is_worktree' => false,
     ]);
 
     Comment::create([

--- a/tests/Unit/Actions/RestoreSessionActionTest.php
+++ b/tests/Unit/Actions/RestoreSessionActionTest.php
@@ -2,9 +2,11 @@
 
 use App\Actions\RestoreSessionAction;
 use App\DTOs\DiffTarget;
+use App\Models\Comment;
 use App\Models\Project;
+use App\Models\ReviewedFile;
 use App\Models\ReviewSession;
-use App\Services\GitDiffService;
+use App\Services\GitFileContentService;
 use Faker\Factory as Faker;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Tests\TestCase;
@@ -14,6 +16,10 @@ uses(TestCase::class, LazilyRefreshDatabase::class);
 beforeEach(function () {
     $this->faker = Faker::create();
     $this->faker->seed(crc32(static::class.$this->name()));
+
+    $this->gitFileContentMock = Mockery::mock(GitFileContentService::class);
+    $this->gitFileContentMock->shouldReceive('hashAt')->byDefault()->andReturn(null);
+    app()->instance(GitFileContentService::class, $this->gitFileContentMock);
 });
 
 test('creates session when none exists and returns defaults', function () {
@@ -31,44 +37,53 @@ test('creates session when none exists and returns defaults', function () {
 
 test('restores comments and tracks orphaned paths', function () {
     $repoPath = '/tmp/'.$this->faker->word();
-    ReviewSession::create([
+
+    Comment::create([
+        'id' => 'c-1',
         'repo_path' => $repoPath,
-        'comments' => [
-            ['id' => 'c-1', 'file' => 'exists.php', 'fileId' => 'old-id'],
-            ['id' => 'c-2', 'file' => 'gone.php', 'fileId' => 'old-id-2'],
-        ],
-        'reviewed_files' => ['exists.php' => 'somehash'],
-        'global_comment' => 'hello',
+        'origin_ref' => 'working',
+        'file_path' => 'exists.php',
+        'side' => 'right',
+        'body' => 'comment on existing',
     ]);
 
-    $files = [['id' => 'file-new', 'path' => 'exists.php', 'isUntracked' => false]];
+    Comment::create([
+        'id' => 'c-2',
+        'repo_path' => $repoPath,
+        'origin_ref' => 'working',
+        'file_path' => 'gone.php',
+        'side' => 'right',
+        'body' => 'comment on missing file',
+    ]);
 
-    // Mock GitDiffService to return matching fingerprint
-    $mock = Mockery::mock(GitDiffService::class);
-    $mock->shouldReceive('fileDiffFingerprint')->andReturn('somehash');
-    app()->instance(GitDiffService::class, $mock);
+    ReviewSession::updateOrCreate(
+        ['project_id' => null, 'repo_path' => $repoPath],
+        ['repo_path' => $repoPath, 'global_comment' => 'hello'],
+    );
+
+    $files = [['id' => 'file-new', 'path' => 'exists.php', 'isUntracked' => false]];
 
     $result = app(RestoreSessionAction::class)->handle($repoPath, $files);
 
     expect($result['comments'])->toHaveCount(2);
-    expect($result['comments'][0]['file'])->toBe('exists.php');
-    expect($result['comments'][0]['fileId'])->toBe('file-new');
-    expect($result['comments'][1]['file'])->toBe('gone.php');
-    expect($result['comments'][1]['fileId'])->toBe('file-'.hash('xxh128', 'gone.php'));
+    $byFile = collect($result['comments'])->keyBy('file');
+    expect($byFile['exists.php']['fileId'])->toBe('file-new');
+    expect($byFile['exists.php']['anchorStatus'])->toBe('placed');
+    expect($byFile['gone.php']['anchorStatus'])->toBe('unplaced');
     expect($result['orphanedPaths'])->toBe(['gone.php']);
-    expect($result['reviewedFiles'])->toBe(['exists.php' => 'somehash']);
     expect($result['globalComment'])->toBe('hello');
 });
 
 test('remaps fileId to current file list', function () {
     $repoPath = '/tmp/'.$this->faker->word();
-    ReviewSession::create([
+
+    Comment::create([
+        'id' => 'c-1',
         'repo_path' => $repoPath,
-        'comments' => [
-            ['id' => 'c-1', 'file' => 'f.php', 'fileId' => 'stale-id'],
-        ],
-        'reviewed_files' => [],
-        'global_comment' => '',
+        'origin_ref' => 'working',
+        'file_path' => 'f.php',
+        'side' => 'right',
+        'body' => 'comment',
     ]);
 
     $currentId = 'file-'.hash('xxh128', 'f.php');
@@ -88,13 +103,20 @@ test('keys by project_id when provided', function () {
         'is_worktree' => false,
     ]);
 
-    ReviewSession::create([
-        'repo_path' => '/tmp/test-proj',
+    Comment::create([
+        'id' => 'c-1',
         'project_id' => $project->id,
-        'comments' => [['id' => 'c-1', 'file' => 'f.php', 'fileId' => 'x']],
-        'reviewed_files' => [],
-        'global_comment' => 'from project',
+        'repo_path' => '/tmp/test-proj',
+        'origin_ref' => 'working',
+        'file_path' => 'f.php',
+        'side' => 'right',
+        'body' => 'x',
     ]);
+
+    ReviewSession::updateOrCreate(
+        ['project_id' => $project->id],
+        ['repo_path' => '/tmp/test-proj', 'global_comment' => 'from project'],
+    );
 
     $files = [['id' => 'file-new', 'path' => 'f.php', 'isUntracked' => false]];
 
@@ -104,15 +126,19 @@ test('keys by project_id when provided', function () {
     expect($result['comments'])->toHaveCount(1);
 });
 
-// -- Legacy migration --
-
-test('migrates legacy indexed array to associative with fresh fingerprints', function () {
+test('restores reviewed files when current content hash matches stored record', function () {
     $repoPath = '/tmp/'.$this->faker->word();
-    ReviewSession::create([
+
+    ReviewedFile::create([
         'repo_path' => $repoPath,
-        'comments' => [],
-        'reviewed_files' => ['a.php', 'b.php', 'gone.php'],
-        'global_comment' => '',
+        'file_path' => 'a.php',
+        'content_hash' => 'hash-a',
+    ]);
+
+    ReviewedFile::create([
+        'repo_path' => $repoPath,
+        'file_path' => 'b.php',
+        'content_hash' => 'hash-b',
     ]);
 
     $files = [
@@ -120,72 +146,95 @@ test('migrates legacy indexed array to associative with fresh fingerprints', fun
         ['id' => 'id-b', 'path' => 'b.php', 'isUntracked' => false],
     ];
 
-    $mock = Mockery::mock(GitDiffService::class);
-    $mock->shouldReceive('fileDiffFingerprint')
-        ->with($repoPath, 'a.php', null)
+    $this->gitFileContentMock->shouldReceive('hashAt')
+        ->with($repoPath, GitFileContentService::WORKING_REF, 'a.php')
         ->andReturn('hash-a');
-    $mock->shouldReceive('fileDiffFingerprint')
-        ->with($repoPath, 'b.php', null)
-        ->andReturn('hash-b');
-    app()->instance(GitDiffService::class, $mock);
+    $this->gitFileContentMock->shouldReceive('hashAt')
+        ->with($repoPath, GitFileContentService::WORKING_REF, 'b.php')
+        ->andReturn('different-hash');
 
     $result = app(RestoreSessionAction::class)->handle($repoPath, $files);
 
-    expect($result['reviewedFiles'])->toBe(['a.php' => 'hash-a', 'b.php' => 'hash-b']);
+    expect($result['reviewedFiles'])->toBe(['a.php' => 'hash-a']);
 });
 
-// -- Fingerprint validation --
-
-test('unmarks reviewed file when fingerprint mismatches', function () {
+test('excludes submitted comments from restored view', function () {
     $repoPath = '/tmp/'.$this->faker->word();
-    ReviewSession::create([
+
+    Comment::create([
+        'id' => 'c-open',
         'repo_path' => $repoPath,
-        'comments' => [],
-        'reviewed_files' => ['a.php' => 'old-hash', 'b.php' => 'still-good'],
-        'global_comment' => '',
+        'origin_ref' => 'working',
+        'file_path' => 'f.php',
+        'side' => 'right',
+        'body' => 'open',
     ]);
 
-    $files = [
-        ['id' => 'id-a', 'path' => 'a.php', 'isUntracked' => false],
-        ['id' => 'id-b', 'path' => 'b.php', 'isUntracked' => false],
-    ];
+    Comment::create([
+        'id' => 'c-submitted',
+        'repo_path' => $repoPath,
+        'origin_ref' => 'working',
+        'file_path' => 'f.php',
+        'side' => 'right',
+        'body' => 'already submitted',
+        'submitted_at' => now(),
+    ]);
 
-    $mock = Mockery::mock(GitDiffService::class);
-    $mock->shouldReceive('fileDiffFingerprint')
-        ->with($repoPath, 'a.php', null)
-        ->andReturn('new-hash');
-    $mock->shouldReceive('fileDiffFingerprint')
-        ->with($repoPath, 'b.php', null)
-        ->andReturn('still-good');
-    app()->instance(GitDiffService::class, $mock);
+    $files = [['id' => 'file-new', 'path' => 'f.php', 'isUntracked' => false]];
 
     $result = app(RestoreSessionAction::class)->handle($repoPath, $files);
 
-    expect($result['reviewedFiles'])->toBe(['b.php' => 'still-good']);
+    expect($result['comments'])->toHaveCount(1);
+    expect($result['comments'][0]['id'])->toBe('c-open');
 });
 
-test('skips fingerprint validation for immutable targets', function () {
+test('marks comment as placed when content hash matches right side', function () {
     $repoPath = '/tmp/'.$this->faker->word();
+
+    Comment::create([
+        'id' => 'c-1',
+        'repo_path' => $repoPath,
+        'origin_ref' => DiffTarget::commit('abc123')->to(),
+        'file_path' => 'f.php',
+        'side' => 'right',
+        'file_content_hash' => 'matching-hash',
+        'body' => 'body',
+    ]);
+
     $target = DiffTarget::commit('abc123');
+    $files = [['id' => 'file-new', 'path' => 'f.php', 'isUntracked' => false]];
 
-    ReviewSession::create([
+    $this->gitFileContentMock->shouldReceive('hashAt')
+        ->with($repoPath, $target->from(), 'f.php')
+        ->andReturn('different-hash');
+    $this->gitFileContentMock->shouldReceive('hashAt')
+        ->with($repoPath, 'abc123', 'f.php')
+        ->andReturn('matching-hash');
+
+    $result = app(RestoreSessionAction::class)->handle($repoPath, $files, null, $target);
+
+    expect($result['comments'][0]['anchorStatus'])->toBe('placed');
+});
+
+test('marks comment as unplaced when content hash does not match either side', function () {
+    $repoPath = '/tmp/'.$this->faker->word();
+
+    Comment::create([
+        'id' => 'c-1',
         'repo_path' => $repoPath,
-        'context_fingerprint' => $target->contextKey(),
-        'comments' => [],
-        'reviewed_files' => ['a.php' => ''],
-        'global_comment' => '',
+        'origin_ref' => 'deadbeef',
+        'file_path' => 'f.php',
+        'side' => 'right',
+        'file_content_hash' => 'orphan-hash',
+        'body' => 'body',
     ]);
 
-    $files = [['id' => 'id-a', 'path' => 'a.php', 'isUntracked' => false]];
+    $target = DiffTarget::commit('abc123');
+    $files = [['id' => 'file-new', 'path' => 'f.php', 'isUntracked' => false]];
 
-    // Mock returns empty string for immutable (no validation needed)
-    $mock = Mockery::mock(GitDiffService::class);
-    $mock->shouldReceive('fileDiffFingerprint')
-        ->with($repoPath, 'a.php', $target)
-        ->andReturn('');
-    app()->instance(GitDiffService::class, $mock);
+    $this->gitFileContentMock->shouldReceive('hashAt')->andReturn('different-hash');
 
-    $result = app(RestoreSessionAction::class)->handle($repoPath, $files, null, $target->contextKey(), $target);
+    $result = app(RestoreSessionAction::class)->handle($repoPath, $files, null, $target);
 
-    expect($result['reviewedFiles'])->toBe(['a.php' => '']);
+    expect($result['comments'][0]['anchorStatus'])->toBe('unplaced');
 });

--- a/tests/Unit/Actions/RestoreSessionActionTest.php
+++ b/tests/Unit/Actions/RestoreSessionActionTest.php
@@ -212,6 +212,37 @@ test('marks comment as placed when content hash matches right side', function ()
     expect($result['comments'][0]['anchorStatus'])->toBe('placed');
 });
 
+test('rehydrates reviewed files via left-side hash when the right ref has no content', function () {
+    // ToggleReviewedAction explicitly stores the left-side hash for deleted /
+    // left-only files. Without matching against the left ref too, those reviewed
+    // markers would silently drop on restore.
+    $repoPath = '/tmp/'.$this->faker->word();
+
+    ReviewedFile::create([
+        'repo_path' => $repoPath,
+        'file_path' => 'deleted.php',
+        'content_hash' => 'left-hash',
+    ]);
+
+    $files = [['id' => 'id-d', 'path' => 'deleted.php', 'isUntracked' => false]];
+
+    $this->gitFileContentMock->shouldReceive('hashAt')
+        ->with($repoPath, 'abc123', 'deleted.php')
+        ->andReturn(null);
+    $this->gitFileContentMock->shouldReceive('hashAt')
+        ->with($repoPath, 'parent123', 'deleted.php')
+        ->andReturn('left-hash');
+
+    $result = app(RestoreSessionAction::class)->handle(
+        $repoPath,
+        $files,
+        null,
+        DiffTarget::range('parent123', 'abc123'),
+    );
+
+    expect($result['reviewedFiles'])->toBe(['deleted.php' => 'left-hash']);
+});
+
 test('rehydrates legacy reviewed_files rows that were migrated with an empty content_hash', function () {
     $repoPath = '/tmp/'.$this->faker->word();
 

--- a/tests/Unit/Actions/SaveSessionActionTest.php
+++ b/tests/Unit/Actions/SaveSessionActionTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Actions\SaveSessionAction;
-use App\Models\Project;
 use App\Models\ReviewSession;
 use Faker\Factory as Faker;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
@@ -38,12 +37,9 @@ test('updates existing session row', function () {
 });
 
 test('keys by project_id when provided', function () {
-    $project = Project::create([
+    $project = $this->createTestProject([
         'slug' => 'test-proj',
-        'name' => 'test-proj',
         'path' => '/tmp/test-proj',
-        'git_common_dir' => '/tmp/test-proj/.git',
-        'is_worktree' => false,
     ]);
 
     app(SaveSessionAction::class)->handle('/tmp/test-proj', 'hello', $project->id);

--- a/tests/Unit/Actions/SaveSessionActionTest.php
+++ b/tests/Unit/Actions/SaveSessionActionTest.php
@@ -14,35 +14,27 @@ beforeEach(function () {
     $this->faker->seed(crc32(static::class.$this->name()));
 });
 
-test('creates session when none exists', function () {
+test('creates session row when none exists', function () {
     $repoPath = '/tmp/'.$this->faker->word();
-    $comments = [['id' => 'c-1', 'file' => 'f.php', 'body' => $this->faker->sentence()]];
-    $reviewedFiles = ['f.php' => 'hash-f'];
     $globalComment = $this->faker->sentence();
 
-    app(SaveSessionAction::class)->handle($repoPath, $comments, $reviewedFiles, $globalComment);
+    app(SaveSessionAction::class)->handle($repoPath, $globalComment);
 
     $session = ReviewSession::where('repo_path', $repoPath)->first();
 
     expect($session)->not->toBeNull();
-    expect($session->comments)->toBe($comments);
-    expect($session->reviewed_files)->toBe($reviewedFiles);
     expect($session->global_comment)->toBe($globalComment);
 });
 
-test('updates existing session', function () {
+test('updates existing session row', function () {
     $repoPath = '/tmp/'.$this->faker->word();
-    ReviewSession::create(['repo_path' => $repoPath, 'comments' => [], 'reviewed_files' => [], 'global_comment' => '']);
+    ReviewSession::create(['repo_path' => $repoPath, 'global_comment' => '']);
 
-    $newComments = [['id' => 'c-2', 'file' => 'a.php', 'body' => 'updated']];
-    $reviewedFiles = ['a.php' => 'hash-a'];
-
-    app(SaveSessionAction::class)->handle($repoPath, $newComments, $reviewedFiles, 'global');
+    app(SaveSessionAction::class)->handle($repoPath, 'updated-global');
 
     $session = ReviewSession::where('repo_path', $repoPath)->first();
     expect(ReviewSession::where('repo_path', $repoPath)->count())->toBe(1);
-    expect($session->comments)->toBe($newComments);
-    expect($session->reviewed_files)->toBe($reviewedFiles);
+    expect($session->global_comment)->toBe('updated-global');
 });
 
 test('keys by project_id when provided', function () {
@@ -54,12 +46,10 @@ test('keys by project_id when provided', function () {
         'is_worktree' => false,
     ]);
 
-    $comments = [['id' => 'c-1', 'file' => 'f.php', 'body' => 'hello']];
-
-    app(SaveSessionAction::class)->handle('/tmp/test-proj', $comments, [], '', $project->id);
+    app(SaveSessionAction::class)->handle('/tmp/test-proj', 'hello', $project->id);
 
     $session = ReviewSession::where('project_id', $project->id)->first();
 
     expect($session)->not->toBeNull();
-    expect($session->comments)->toBe($comments);
+    expect($session->global_comment)->toBe('hello');
 });

--- a/tests/Unit/Actions/SubmitReviewScopeTest.php
+++ b/tests/Unit/Actions/SubmitReviewScopeTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Actions\ExportReviewAction;
+use App\DTOs\DiffTarget;
+use App\Models\Comment;
+use Faker\Factory as Faker;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+beforeEach(function () {
+    $this->faker = Faker::create();
+    $this->faker->seed(crc32(static::class.$this->name()));
+
+    $this->tmpDir = $this->createTempDirectory('rfa_submit_scope_test_');
+    $this->initTestRepo($this->tmpDir);
+
+    File::put($this->tmpDir.'/hello.php', "<?php\necho 'hello';\n");
+    $this->commitTestRepo($this->tmpDir, 'init');
+});
+
+test('submit only exports comments whose origin matches the selection and marks them submitted', function () {
+    $fileId = 'file-'.hash('xxh128', 'hello.php');
+    $files = [['id' => $fileId, 'path' => 'hello.php', 'isUntracked' => false]];
+
+    $inScope = [[
+        'id' => 'c-in',
+        'fileId' => $fileId,
+        'file' => 'hello.php',
+        'side' => 'right',
+        'startLine' => 1,
+        'endLine' => 1,
+        'body' => 'in scope',
+        'originRef' => 'target-head',
+    ]];
+
+    Comment::create([
+        'id' => 'c-in',
+        'repo_path' => $this->tmpDir,
+        'origin_ref' => 'target-head',
+        'file_path' => 'hello.php',
+        'side' => 'right',
+        'body' => 'in scope',
+    ]);
+
+    Comment::create([
+        'id' => 'c-out',
+        'repo_path' => $this->tmpDir,
+        'origin_ref' => 'working',
+        'file_path' => 'hello.php',
+        'side' => 'right',
+        'body' => 'out of scope',
+    ]);
+
+    $outOfScope = [[
+        'id' => 'c-out',
+        'fileId' => $fileId,
+        'file' => 'hello.php',
+        'side' => 'right',
+        'startLine' => 1,
+        'endLine' => 1,
+        'body' => 'out of scope',
+        'originRef' => 'working',
+    ]];
+
+    $allComments = array_merge($inScope, $outOfScope);
+    $target = DiffTarget::range('base', 'target-head');
+
+    $result = app(ExportReviewAction::class)->handle($this->tmpDir, $allComments, '', $files, $target);
+
+    expect(File::get($result['md']))->toContain('in scope');
+    expect(File::get($result['md']))->not->toContain('out of scope');
+
+    expect(Comment::find('c-in')->submitted_at)->not->toBeNull();
+    expect(Comment::find('c-out')->submitted_at)->toBeNull();
+});

--- a/tests/Unit/Actions/SubmitReviewScopeTest.php
+++ b/tests/Unit/Actions/SubmitReviewScopeTest.php
@@ -76,3 +76,20 @@ test('submit only exports comments whose origin matches the selection and marks 
     expect(Comment::find('c-in')->submitted_at)->not->toBeNull();
     expect(Comment::find('c-out')->submitted_at)->toBeNull();
 });
+
+test('submittedIds reports only the ids that were actually submitted', function () {
+    $fileId = 'file-'.hash('xxh128', 'hello.php');
+    $files = [['id' => $fileId, 'path' => 'hello.php', 'isUntracked' => false]];
+
+    Comment::create(['id' => 'c-in', 'repo_path' => $this->tmpDir, 'origin_ref' => 'target-head', 'file_path' => 'hello.php', 'side' => 'right', 'body' => 'in']);
+    Comment::create(['id' => 'c-out', 'repo_path' => $this->tmpDir, 'origin_ref' => 'working', 'file_path' => 'hello.php', 'side' => 'right', 'body' => 'out']);
+
+    $allComments = [
+        ['id' => 'c-in', 'fileId' => $fileId, 'file' => 'hello.php', 'side' => 'right', 'startLine' => 1, 'endLine' => 1, 'body' => 'in', 'originRef' => 'target-head'],
+        ['id' => 'c-out', 'fileId' => $fileId, 'file' => 'hello.php', 'side' => 'right', 'startLine' => 1, 'endLine' => 1, 'body' => 'out', 'originRef' => 'working'],
+    ];
+
+    $result = app(ExportReviewAction::class)->handle($this->tmpDir, $allComments, '', $files, DiffTarget::range('base', 'target-head'));
+
+    expect($result['submittedIds'])->toBe(['c-in']);
+});

--- a/tests/Unit/Actions/SubmitReviewScopeTest.php
+++ b/tests/Unit/Actions/SubmitReviewScopeTest.php
@@ -21,20 +21,9 @@ beforeEach(function () {
     $this->commitTestRepo($this->tmpDir, 'init');
 });
 
-test('submit only exports comments whose origin matches the selection and marks them submitted', function () {
+test('submit only exports placed comments and marks them submitted', function () {
     $fileId = 'file-'.hash('xxh128', 'hello.php');
     $files = [['id' => $fileId, 'path' => 'hello.php', 'isUntracked' => false]];
-
-    $inScope = [[
-        'id' => 'c-in',
-        'fileId' => $fileId,
-        'file' => 'hello.php',
-        'side' => 'right',
-        'startLine' => 1,
-        'endLine' => 1,
-        'body' => 'in scope',
-        'originRef' => 'target-head',
-    ]];
 
     Comment::create([
         'id' => 'c-in',
@@ -54,18 +43,11 @@ test('submit only exports comments whose origin matches the selection and marks 
         'body' => 'out of scope',
     ]);
 
-    $outOfScope = [[
-        'id' => 'c-out',
-        'fileId' => $fileId,
-        'file' => 'hello.php',
-        'side' => 'right',
-        'startLine' => 1,
-        'endLine' => 1,
-        'body' => 'out of scope',
-        'originRef' => 'working',
-    ]];
+    $allComments = [
+        ['id' => 'c-in', 'fileId' => $fileId, 'file' => 'hello.php', 'side' => 'right', 'startLine' => 1, 'endLine' => 1, 'body' => 'in scope', 'anchorStatus' => 'placed'],
+        ['id' => 'c-out', 'fileId' => $fileId, 'file' => 'hello.php', 'side' => 'right', 'startLine' => 1, 'endLine' => 1, 'body' => 'out of scope', 'anchorStatus' => 'unplaced'],
+    ];
 
-    $allComments = array_merge($inScope, $outOfScope);
     $target = DiffTarget::range('base', 'target-head');
 
     $result = app(ExportReviewAction::class)->handle($this->tmpDir, $allComments, '', $files, $target);
@@ -85,11 +67,52 @@ test('submittedIds reports only the ids that were actually submitted', function 
     Comment::create(['id' => 'c-out', 'repo_path' => $this->tmpDir, 'origin_ref' => 'working', 'file_path' => 'hello.php', 'side' => 'right', 'body' => 'out']);
 
     $allComments = [
-        ['id' => 'c-in', 'fileId' => $fileId, 'file' => 'hello.php', 'side' => 'right', 'startLine' => 1, 'endLine' => 1, 'body' => 'in', 'originRef' => 'target-head'],
-        ['id' => 'c-out', 'fileId' => $fileId, 'file' => 'hello.php', 'side' => 'right', 'startLine' => 1, 'endLine' => 1, 'body' => 'out', 'originRef' => 'working'],
+        ['id' => 'c-in', 'fileId' => $fileId, 'file' => 'hello.php', 'side' => 'right', 'startLine' => 1, 'endLine' => 1, 'body' => 'in', 'anchorStatus' => 'placed'],
+        ['id' => 'c-out', 'fileId' => $fileId, 'file' => 'hello.php', 'side' => 'right', 'startLine' => 1, 'endLine' => 1, 'body' => 'out', 'anchorStatus' => 'unplaced'],
     ];
 
     $result = app(ExportReviewAction::class)->handle($this->tmpDir, $allComments, '', $files, DiffTarget::range('base', 'target-head'));
 
     expect($result['submittedIds'])->toBe(['c-in']);
+});
+
+test('comment with a different origin ref is still submitted when the resolver placed it', function () {
+    // Comment authored at commit B; today the user reviews A..D. If the anchor resolver
+    // matched the stored hash against D's content (rebase/amend reshuffled refs), the
+    // comment is "placed" in this selection and must get submitted_at stamped.
+    $fileId = 'file-'.hash('xxh128', 'hello.php');
+    $files = [['id' => $fileId, 'path' => 'hello.php', 'isUntracked' => false]];
+
+    Comment::create([
+        'id' => 'c-rebased',
+        'repo_path' => $this->tmpDir,
+        'origin_ref' => 'commit-B',
+        'file_path' => 'hello.php',
+        'side' => 'right',
+        'file_content_hash' => 'hash-that-matches-D',
+        'body' => 'rebased comment',
+    ]);
+
+    $resolved = [[
+        'id' => 'c-rebased',
+        'fileId' => $fileId,
+        'file' => 'hello.php',
+        'side' => 'right',
+        'startLine' => 1,
+        'endLine' => 1,
+        'body' => 'rebased comment',
+        'originRef' => 'commit-B',
+        'anchorStatus' => 'placed',
+    ]];
+
+    $result = app(ExportReviewAction::class)->handle(
+        $this->tmpDir,
+        $resolved,
+        '',
+        $files,
+        DiffTarget::range('commit-A', 'commit-D'),
+    );
+
+    expect($result['submittedIds'])->toBe(['c-rebased']);
+    expect(Comment::find('c-rebased')->submitted_at)->not->toBeNull();
 });

--- a/tests/Unit/Actions/ToggleReviewedActionTest.php
+++ b/tests/Unit/Actions/ToggleReviewedActionTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Actions\ToggleReviewedAction;
+use App\DTOs\DiffTarget;
 use App\Models\ReviewedFile;
 use App\Services\GitFileContentService;
 use Faker\Factory as Faker;
@@ -52,6 +53,41 @@ test('adds file with empty content hash when no repo path', function () {
     $result = $this->action->handle([], 'a.php', $this->knownFiles, '');
 
     expect($result)->toBe(['a.php' => '']);
+});
+
+test('toggle off does not touch rows belonging to a different repo', function () {
+    ReviewedFile::create(['repo_path' => '/tmp/repo', 'file_path' => 'a.php', 'content_hash' => 'h-own']);
+    ReviewedFile::create(['repo_path' => '/tmp/other', 'file_path' => 'a.php', 'content_hash' => 'h-foreign']);
+
+    $this->action->handle(['a.php' => 'h-own'], 'a.php', $this->knownFiles, '/tmp/repo');
+
+    expect(ReviewedFile::where('repo_path', '/tmp/repo')->where('file_path', 'a.php')->exists())->toBeFalse();
+    expect(ReviewedFile::where('repo_path', '/tmp/other')->where('file_path', 'a.php')->exists())->toBeTrue();
+});
+
+test('falls back to the left ref when the right side hash is unavailable', function () {
+    $target = DiffTarget::commit('abc123', 'parent123');
+
+    $this->gitFileContent = Mockery::mock(GitFileContentService::class);
+    $this->gitFileContent->shouldReceive('hashAt')
+        ->with('/tmp/repo', 'abc123', 'deleted.php')
+        ->andReturn(null);
+    $this->gitFileContent->shouldReceive('hashAt')
+        ->with('/tmp/repo', 'parent123', 'deleted.php')
+        ->andReturn('parent-hash');
+    app()->instance(GitFileContentService::class, $this->gitFileContent);
+
+    $action = app(ToggleReviewedAction::class);
+
+    $result = $action->handle(
+        [],
+        'deleted.php',
+        [['id' => 'id-d', 'path' => 'deleted.php', 'isUntracked' => false]],
+        '/tmp/repo',
+        $target,
+    );
+
+    expect($result)->toBe(['deleted.php' => 'parent-hash']);
 });
 
 test('preserves other entries on toggle off', function () {

--- a/tests/Unit/Actions/ToggleReviewedActionTest.php
+++ b/tests/Unit/Actions/ToggleReviewedActionTest.php
@@ -1,11 +1,13 @@
 <?php
 
 use App\Actions\ToggleReviewedAction;
-use App\Services\GitDiffService;
+use App\Models\ReviewedFile;
+use App\Services\GitFileContentService;
 use Faker\Factory as Faker;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Tests\TestCase;
 
-uses(TestCase::class);
+uses(TestCase::class, LazilyRefreshDatabase::class);
 
 beforeEach(function () {
     $this->faker = Faker::create();
@@ -17,23 +19,27 @@ beforeEach(function () {
         ['id' => 'id-c', 'path' => 'c.php', 'isUntracked' => false],
     ];
 
-    $mock = Mockery::mock(GitDiffService::class);
-    $mock->shouldReceive('fileDiffFingerprint')->andReturn('mock-hash');
-    app()->instance(GitDiffService::class, $mock);
+    $mock = Mockery::mock(GitFileContentService::class);
+    $mock->shouldReceive('hashAt')->byDefault()->andReturn('mock-hash');
+    app()->instance(GitFileContentService::class, $mock);
 
     $this->action = app(ToggleReviewedAction::class);
 });
 
-test('adds file to reviewed list with fingerprint', function () {
+test('adds file to reviewed list with content hash', function () {
     $result = $this->action->handle([], 'a.php', $this->knownFiles, '/tmp/repo');
 
     expect($result)->toBe(['a.php' => 'mock-hash']);
+    expect(ReviewedFile::where('file_path', 'a.php')->where('content_hash', 'mock-hash')->exists())->toBeTrue();
 });
 
 test('removes file from reviewed list', function () {
+    ReviewedFile::create(['repo_path' => '/tmp/repo', 'file_path' => 'a.php', 'content_hash' => 'hash1']);
+
     $result = $this->action->handle(['a.php' => 'hash1', 'b.php' => 'hash2'], 'a.php', $this->knownFiles, '/tmp/repo');
 
     expect($result)->toBe(['b.php' => 'hash2']);
+    expect(ReviewedFile::where('file_path', 'a.php')->exists())->toBeFalse();
 });
 
 test('returns null for unknown path', function () {
@@ -42,13 +48,15 @@ test('returns null for unknown path', function () {
     expect($result)->toBeNull();
 });
 
-test('adds file with empty fingerprint when no repo path', function () {
-    $result = $this->action->handle([], 'a.php', $this->knownFiles);
+test('adds file with empty content hash when no repo path', function () {
+    $result = $this->action->handle([], 'a.php', $this->knownFiles, '');
 
     expect($result)->toBe(['a.php' => '']);
 });
 
 test('preserves other entries on toggle off', function () {
+    ReviewedFile::create(['repo_path' => '/tmp/repo', 'file_path' => 'b.php', 'content_hash' => 'h2']);
+
     $result = $this->action->handle(['a.php' => 'h1', 'b.php' => 'h2', 'c.php' => 'h3'], 'b.php', $this->knownFiles, '/tmp/repo');
 
     expect($result)->toBe(['a.php' => 'h1', 'c.php' => 'h3']);

--- a/tests/Unit/Actions/ToggleReviewedActionTest.php
+++ b/tests/Unit/Actions/ToggleReviewedActionTest.php
@@ -90,6 +90,20 @@ test('falls back to the left ref when the right side hash is unavailable', funct
     expect($result)->toBe(['deleted.php' => 'parent-hash']);
 });
 
+test('updates content_hash in place instead of inserting a new row when the file changes', function () {
+    ReviewedFile::create(['repo_path' => '/tmp/repo', 'file_path' => 'a.php', 'content_hash' => 'old-hash']);
+
+    $mock = Mockery::mock(GitFileContentService::class);
+    $mock->shouldReceive('hashAt')->andReturn('new-hash');
+    app()->instance(GitFileContentService::class, $mock);
+
+    app(ToggleReviewedAction::class)->handle([], 'a.php', $this->knownFiles, '/tmp/repo');
+
+    $rows = ReviewedFile::where('repo_path', '/tmp/repo')->where('file_path', 'a.php')->get();
+    expect($rows)->toHaveCount(1);
+    expect($rows->first()->content_hash)->toBe('new-hash');
+});
+
 test('preserves other entries on toggle off', function () {
     ReviewedFile::create(['repo_path' => '/tmp/repo', 'file_path' => 'b.php', 'content_hash' => 'h2']);
 

--- a/tests/Unit/Actions/UpdateCommentActionTest.php
+++ b/tests/Unit/Actions/UpdateCommentActionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Actions\UpdateCommentAction;
+use App\Models\Comment;
+use Faker\Factory as Faker;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+beforeEach(function () {
+    $this->faker = Faker::create();
+    $this->faker->seed(crc32(static::class.$this->name()));
+
+    $this->action = new UpdateCommentAction;
+
+    Comment::create([
+        'id' => 'c-existing',
+        'repo_path' => '/tmp/repo',
+        'origin_ref' => 'working',
+        'file_path' => 'src/f.php',
+        'side' => 'right',
+        'start_line' => 5,
+        'body' => 'original body',
+        'is_draft' => false,
+    ]);
+});
+
+test('updates the body of an existing comment', function () {
+    $ok = $this->action->handle('c-existing', 'rewritten body', false);
+
+    expect($ok)->toBeTrue();
+    expect(Comment::find('c-existing')->body)->toBe('rewritten body');
+});
+
+test('updates the draft flag', function () {
+    $this->action->handle('c-existing', 'still same body', true);
+
+    expect(Comment::find('c-existing')->is_draft)->toBeTrue();
+});
+
+test('returns false for ids that do not match the c- prefix', function () {
+    expect($this->action->handle('garbage', 'body', false))->toBeFalse();
+    expect($this->action->handle('', 'body', false))->toBeFalse();
+});
+
+test('returns false when no comment matches the id', function () {
+    expect($this->action->handle('c-missing', 'body', false))->toBeFalse();
+});
+
+test('leaves other comments untouched', function () {
+    Comment::create([
+        'id' => 'c-other',
+        'repo_path' => '/tmp/repo',
+        'origin_ref' => 'working',
+        'file_path' => 'src/g.php',
+        'side' => 'right',
+        'body' => 'other',
+    ]);
+
+    $this->action->handle('c-existing', 'changed', false);
+
+    expect(Comment::find('c-other')->body)->toBe('other');
+});

--- a/tests/Unit/CommentTest.php
+++ b/tests/Unit/CommentTest.php
@@ -29,6 +29,12 @@ test('toArray returns camelCase keys for internal use', function () {
         'startLine' => $startLine,
         'endLine' => $endLine,
         'body' => $body,
+        'originRef' => 'working',
+        'fileContentHash' => null,
+        'lineSnippet' => null,
+        'isDraft' => false,
+        'submittedAt' => null,
+        'anchorStatus' => 'placed',
     ]);
 });
 
@@ -50,6 +56,11 @@ test('toExportArray returns snake_case keys without fileId', function () {
         'start_line' => $startLine,
         'end_line' => $endLine,
         'body' => $body,
+        'anchor' => [
+            'origin_ref' => 'working',
+            'file_content_hash' => null,
+            'line_snippet' => null,
+        ],
     ]);
     expect($array)->not->toHaveKey('fileId');
 });

--- a/tests/Unit/Livewire/CommentsDrawerTest.php
+++ b/tests/Unit/Livewire/CommentsDrawerTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use App\Models\Comment;
+use App\Models\Project;
+use Faker\Factory as Faker;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+beforeEach(function () {
+    $this->faker = Faker::create();
+    $this->faker->seed(crc32(static::class.$this->name()));
+
+    $this->project = Project::create([
+        'slug' => 'proj',
+        'name' => 'proj',
+        'path' => '/tmp/proj',
+        'git_common_dir' => '/tmp/proj/.git',
+        'is_worktree' => false,
+    ]);
+
+    Comment::create([
+        'id' => 'c-open-a',
+        'project_id' => $this->project->id,
+        'repo_path' => '/tmp/proj',
+        'origin_ref' => 'working',
+        'file_path' => 'src/foo.php',
+        'side' => 'right',
+        'body' => 'open on foo',
+    ]);
+
+    Comment::create([
+        'id' => 'c-open-b',
+        'project_id' => $this->project->id,
+        'repo_path' => '/tmp/proj',
+        'origin_ref' => 'working',
+        'file_path' => 'src/bar.php',
+        'side' => 'right',
+        'body' => 'open on bar',
+    ]);
+
+    Comment::create([
+        'id' => 'c-submitted',
+        'project_id' => $this->project->id,
+        'repo_path' => '/tmp/proj',
+        'origin_ref' => 'abc123',
+        'file_path' => 'src/foo.php',
+        'side' => 'right',
+        'body' => 'already shipped',
+        'submitted_at' => now(),
+    ]);
+
+    Comment::create([
+        'id' => 'c-other-repo',
+        'project_id' => null,
+        'repo_path' => '/tmp/other',
+        'origin_ref' => 'working',
+        'file_path' => 'src/foo.php',
+        'side' => 'right',
+        'body' => 'different repo',
+    ]);
+});
+
+test('shows only unsubmitted comments by default, grouped by file', function () {
+    $component = Livewire::test('comments-drawer', [
+        'repoPath' => '/tmp/proj',
+        'projectId' => $this->project->id,
+    ]);
+
+    $grouped = $component->get('groupedComments');
+
+    expect(array_keys($grouped))->toEqualCanonicalizing(['src/foo.php', 'src/bar.php']);
+    expect(collect($grouped)->flatten(1)->pluck('id')->all())->toEqualCanonicalizing(['c-open-a', 'c-open-b']);
+});
+
+test('totalCount reports the number of visible comments', function () {
+    $component = Livewire::test('comments-drawer', [
+        'repoPath' => '/tmp/proj',
+        'projectId' => $this->project->id,
+    ]);
+
+    expect($component->get('totalCount'))->toBe(2);
+});
+
+test('ignores comments that belong to a different repo', function () {
+    $component = Livewire::test('comments-drawer', [
+        'repoPath' => '/tmp/proj',
+        'projectId' => $this->project->id,
+    ]);
+
+    $ids = collect($component->get('groupedComments'))->flatten(1)->pluck('id')->all();
+
+    expect($ids)->not->toContain('c-other-repo');
+});
+
+test('showSubmitted=true includes archived comments', function () {
+    $component = Livewire::test('comments-drawer', [
+        'repoPath' => '/tmp/proj',
+        'projectId' => $this->project->id,
+    ])->set('showSubmitted', true);
+
+    $ids = collect($component->get('groupedComments'))->flatten(1)->pluck('id')->all();
+
+    expect($ids)->toContain('c-submitted');
+    expect($component->get('totalCount'))->toBe(3);
+});
+
+test('filter matches on file_path substring', function () {
+    $component = Livewire::test('comments-drawer', [
+        'repoPath' => '/tmp/proj',
+        'projectId' => $this->project->id,
+    ])->set('filter', 'bar');
+
+    $ids = collect($component->get('groupedComments'))->flatten(1)->pluck('id')->all();
+
+    expect($ids)->toBe(['c-open-b']);
+});
+
+test('filter matches on body substring', function () {
+    $component = Livewire::test('comments-drawer', [
+        'repoPath' => '/tmp/proj',
+        'projectId' => $this->project->id,
+    ])->set('filter', 'open on bar');
+
+    $ids = collect($component->get('groupedComments'))->flatten(1)->pluck('id')->all();
+
+    expect($ids)->toBe(['c-open-b']);
+});
+
+test('filter does not affect totalCount (pool size, not filtered size)', function () {
+    $component = Livewire::test('comments-drawer', [
+        'repoPath' => '/tmp/proj',
+        'projectId' => $this->project->id,
+    ])->set('filter', 'no-match-at-all');
+
+    expect($component->get('totalCount'))->toBe(2);
+});
+
+test('toggle() flips the open flag', function () {
+    $component = Livewire::test('comments-drawer', [
+        'repoPath' => '/tmp/proj',
+        'projectId' => $this->project->id,
+    ]);
+
+    expect($component->get('open'))->toBeFalse();
+
+    $component->call('toggle');
+    expect($component->get('open'))->toBeTrue();
+
+    $component->call('toggle');
+    expect($component->get('open'))->toBeFalse();
+});
+
+test('falls back to repo_path when no project_id is given', function () {
+    $component = Livewire::test('comments-drawer', [
+        'repoPath' => '/tmp/other',
+        'projectId' => null,
+    ]);
+
+    $ids = collect($component->get('groupedComments'))->flatten(1)->pluck('id')->all();
+
+    expect($ids)->toBe(['c-other-repo']);
+});

--- a/tests/Unit/Livewire/CommentsDrawerTest.php
+++ b/tests/Unit/Livewire/CommentsDrawerTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Models\Comment;
-use App\Models\Project;
 use Faker\Factory as Faker;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Livewire\Livewire;
@@ -13,13 +12,7 @@ beforeEach(function () {
     $this->faker = Faker::create();
     $this->faker->seed(crc32(static::class.$this->name()));
 
-    $this->project = Project::create([
-        'slug' => 'proj',
-        'name' => 'proj',
-        'path' => '/tmp/proj',
-        'git_common_dir' => '/tmp/proj/.git',
-        'is_worktree' => false,
-    ]);
+    $this->project = $this->createTestProject(['slug' => 'proj', 'path' => '/tmp/proj']);
 
     Comment::create([
         'id' => 'c-open-a',
@@ -67,7 +60,7 @@ test('shows only unsubmitted comments by default, grouped by file', function () 
     $component = Livewire::test('comments-drawer', [
         'repoPath' => '/tmp/proj',
         'projectId' => $this->project->id,
-    ]);
+    ])->call('toggle');
 
     $grouped = $component->get('groupedComments');
 
@@ -88,7 +81,7 @@ test('ignores comments that belong to a different repo', function () {
     $component = Livewire::test('comments-drawer', [
         'repoPath' => '/tmp/proj',
         'projectId' => $this->project->id,
-    ]);
+    ])->call('toggle');
 
     $ids = collect($component->get('groupedComments'))->flatten(1)->pluck('id')->all();
 
@@ -99,7 +92,7 @@ test('showSubmitted=true includes archived comments', function () {
     $component = Livewire::test('comments-drawer', [
         'repoPath' => '/tmp/proj',
         'projectId' => $this->project->id,
-    ])->set('showSubmitted', true);
+    ])->call('toggle')->set('showSubmitted', true);
 
     $ids = collect($component->get('groupedComments'))->flatten(1)->pluck('id')->all();
 
@@ -111,7 +104,7 @@ test('filter matches on file_path substring', function () {
     $component = Livewire::test('comments-drawer', [
         'repoPath' => '/tmp/proj',
         'projectId' => $this->project->id,
-    ])->set('filter', 'bar');
+    ])->call('toggle')->set('filter', 'bar');
 
     $ids = collect($component->get('groupedComments'))->flatten(1)->pluck('id')->all();
 
@@ -122,11 +115,23 @@ test('filter matches on body substring', function () {
     $component = Livewire::test('comments-drawer', [
         'repoPath' => '/tmp/proj',
         'projectId' => $this->project->id,
-    ])->set('filter', 'open on bar');
+    ])->call('toggle')->set('filter', 'open on bar');
 
     $ids = collect($component->get('groupedComments'))->flatten(1)->pluck('id')->all();
 
     expect($ids)->toBe(['c-open-b']);
+});
+
+test('groupedComments returns empty when the drawer is closed (skips the expensive query)', function () {
+    $component = Livewire::test('comments-drawer', [
+        'repoPath' => '/tmp/proj',
+        'projectId' => $this->project->id,
+    ]);
+
+    expect($component->get('open'))->toBeFalse();
+    expect($component->get('groupedComments'))->toBe([]);
+    // totalCount stays accurate so the header badge keeps working.
+    expect($component->get('totalCount'))->toBe(2);
 });
 
 test('filter does not affect totalCount (pool size, not filtered size)', function () {
@@ -157,7 +162,7 @@ test('falls back to repo_path when no project_id is given', function () {
     $component = Livewire::test('comments-drawer', [
         'repoPath' => '/tmp/other',
         'projectId' => null,
-    ]);
+    ])->call('toggle');
 
     $ids = collect($component->get('groupedComments'))->flatten(1)->pluck('id')->all();
 

--- a/tests/Unit/Livewire/ReviewPageRangeAndSelectionTest.php
+++ b/tests/Unit/Livewire/ReviewPageRangeAndSelectionTest.php
@@ -1,0 +1,170 @@
+<?php
+
+use App\Actions\BackfillGlobalGitignoreAction;
+use App\Actions\GetFileListAction;
+use App\Actions\LoadCommitMetadataAction;
+use App\Actions\ResolveCommitAction;
+use App\Actions\ResolveProjectAction;
+use App\Actions\RestoreSessionAction;
+use App\Actions\SaveSessionAction;
+use App\DTOs\DiffTarget;
+use App\Models\Project;
+use App\Services\GitFileContentService;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+beforeEach(function () {
+    $this->files = [];
+
+    $this->project = Project::create([
+        'slug' => 'test-project',
+        'name' => 'Test Project',
+        'path' => '/tmp/repo',
+        'git_common_dir' => '/tmp/repo/.git',
+        'branch' => 'main',
+        'global_gitignore_path' => null,
+        'respect_global_gitignore' => false,
+    ]);
+
+    $project = $this->project;
+    $files = $this->files;
+
+    app()->bind(ResolveProjectAction::class, fn () => new class($project)
+    {
+        public function __construct(private Project $project) {}
+
+        public function handle(string $slug, bool $touch = false): ?array
+        {
+            return $this->project->toArray();
+        }
+    });
+
+    app()->bind(GetFileListAction::class, fn () => new class($files)
+    {
+        public function __construct(private array $files) {}
+
+        public function handle(string $repoPath, bool $clearCache = true, ?int $projectId = null, ?string $globalGitignorePath = null, ?DiffTarget $target = null): array
+        {
+            return $this->files;
+        }
+    });
+
+    app()->bind(RestoreSessionAction::class, fn () => new class
+    {
+        public function handle(string $repoPath, array $currentFiles, ?int $projectId = null, ?DiffTarget $target = null): array
+        {
+            return ['comments' => [], 'reviewedFiles' => [], 'globalComment' => '', 'orphanedPaths' => []];
+        }
+    });
+
+    app()->bind(SaveSessionAction::class, fn () => new class
+    {
+        public function handle(string $repoPath, string $globalComment, ?int $projectId = null): void {}
+    });
+
+    app()->bind(BackfillGlobalGitignoreAction::class, fn () => new class
+    {
+        public function handle(int $projectId, string $repoPath): ?string
+        {
+            return null;
+        }
+    });
+
+    app()->bind(LoadCommitMetadataAction::class, fn () => new class
+    {
+        /** @return array<string, mixed> */
+        public function handle(string $repoPath, string $hash, string $parentHash): array
+        {
+            return [
+                'shortHash' => substr($hash, 0, 7),
+                'message' => 'range head commit',
+                'author' => 'tester',
+                'prevHash' => null,
+                'nextHash' => null,
+            ];
+        }
+    });
+
+    app()->bind(ResolveCommitAction::class, fn () => new class
+    {
+        public function handle(string $repoPath, string $hash): ?DiffTarget
+        {
+            return DiffTarget::commit($hash, $hash.'^');
+        }
+    });
+
+    $gitFileContentMock = Mockery::mock(GitFileContentService::class);
+    $gitFileContentMock->shouldReceive('hashAt')->andReturn('mock-hash');
+    app()->instance(GitFileContentService::class, $gitFileContentMock);
+});
+
+// -- Range route mount --
+
+test('mounting with /r/{from}..{to} sets diffFrom and diffTo explicitly', function () {
+    $component = Livewire::test('pages::review-page', [
+        'slug' => 'test-project',
+        'from' => 'aaaa111',
+        'to' => 'bbbb222',
+    ]);
+
+    expect($component->get('diffFrom'))->toBe('aaaa111');
+    expect($component->get('diffTo'))->toBe('bbbb222');
+});
+
+test('mounting with only {ref} sets diffTo=ref and diffFrom=ref^', function () {
+    $component = Livewire::test('pages::review-page', [
+        'slug' => 'test-project',
+        'ref' => 'branchname',
+    ]);
+
+    expect($component->get('diffFrom'))->toBe('branchname^');
+    expect($component->get('diffTo'))->toBe('branchname');
+});
+
+test('mounting with {ref}/{baseRef} uses baseRef as diffFrom', function () {
+    $component = Livewire::test('pages::review-page', [
+        'slug' => 'test-project',
+        'ref' => 'tip',
+        'baseRef' => 'base^',
+    ]);
+
+    expect($component->get('diffFrom'))->toBe('base^');
+    expect($component->get('diffTo'))->toBe('tip');
+});
+
+test('mounting with no params defaults to working directory (HEAD, null)', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project']);
+
+    expect($component->get('diffFrom'))->toBe('HEAD');
+    expect($component->get('diffTo'))->toBeNull();
+});
+
+// -- Selection badge label --
+
+test('selection badge shows "working" when no commit is selected', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project']);
+
+    $component->assertSee('working');
+});
+
+test('selection badge shows the short hash in single-commit mode', function () {
+    $component = Livewire::test('pages::review-page', [
+        'slug' => 'test-project',
+        'hash' => 'abc1234567890',
+    ]);
+
+    $component->assertSee('abc1234');
+});
+
+test('selection badge shows from..to when an explicit range is set', function () {
+    $component = Livewire::test('pages::review-page', [
+        'slug' => 'test-project',
+        'from' => 'aaaa111bbb',
+        'to' => 'cccc222ddd',
+    ]);
+
+    $component->assertSee('aaaa111..cccc222');
+});

--- a/tests/Unit/Livewire/ReviewPageRangeAndSelectionTest.php
+++ b/tests/Unit/Livewire/ReviewPageRangeAndSelectionTest.php
@@ -19,11 +19,10 @@ uses(TestCase::class, LazilyRefreshDatabase::class);
 beforeEach(function () {
     $this->files = [];
 
-    $this->project = Project::create([
+    $this->project = $this->createTestProject([
         'slug' => 'test-project',
         'name' => 'Test Project',
         'path' => '/tmp/repo',
-        'git_common_dir' => '/tmp/repo/.git',
         'branch' => 'main',
         'global_gitignore_path' => null,
         'respect_global_gitignore' => false,

--- a/tests/Unit/Livewire/ReviewPageTest.php
+++ b/tests/Unit/Livewire/ReviewPageTest.php
@@ -221,9 +221,14 @@ test('submitReview refreshes file list and populates reviewPairs', function () {
 
     app()->bind(ExportReviewAction::class, fn () => new class
     {
-        public function handle(string $repoPath, array $comments, string $globalComment, array $files): array
+        public function handle(string $repoPath, array $comments, string $globalComment, array $files, ?DiffTarget $target = null): array
         {
-            return ['json' => '/tmp/review.json', 'md' => '/tmp/review.md', 'clipboard' => 'review exported'];
+            return [
+                'json' => '/tmp/review.json',
+                'md' => '/tmp/review.md',
+                'clipboard' => 'review exported',
+                'submittedIds' => array_column($comments, 'id'),
+            ];
         }
     });
 

--- a/tests/Unit/Livewire/ReviewPageTest.php
+++ b/tests/Unit/Livewire/ReviewPageTest.php
@@ -12,7 +12,7 @@ use App\Actions\ScanReviewFilesAction;
 use App\DTOs\DiffTarget;
 use App\Models\Project;
 use App\Models\TrashedFile;
-use App\Services\GitDiffService;
+use App\Services\GitFileContentService;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -64,7 +64,7 @@ beforeEach(function () {
 
     app()->bind(RestoreSessionAction::class, fn () => new class
     {
-        public function handle(string $repoPath, array $currentFiles, ?int $projectId = null, string $contextFingerprint = DiffTarget::WORKING_CONTEXT, ?DiffTarget $target = null): array
+        public function handle(string $repoPath, array $currentFiles, ?int $projectId = null, ?DiffTarget $target = null): array
         {
             return ['comments' => [], 'reviewedFiles' => [], 'globalComment' => '', 'orphanedPaths' => []];
         }
@@ -72,13 +72,13 @@ beforeEach(function () {
 
     app()->bind(SaveSessionAction::class, fn () => new class
     {
-        public function handle(string $repoPath, array $comments, array $reviewedFiles, string $globalComment, ?int $projectId = null, string $contextFingerprint = DiffTarget::WORKING_CONTEXT): void {}
+        public function handle(string $repoPath, string $globalComment, ?int $projectId = null): void {}
     });
 
-    // Mock GitDiffService to avoid real git calls
-    $gitDiffMock = Mockery::mock(GitDiffService::class);
-    $gitDiffMock->shouldReceive('fileDiffFingerprint')->andReturn('mock-hash');
-    app()->instance(GitDiffService::class, $gitDiffMock);
+    // Mock GitFileContentService to avoid real git calls
+    $gitFileContentMock = Mockery::mock(GitFileContentService::class);
+    $gitFileContentMock->shouldReceive('hashAt')->andReturn('mock-hash');
+    app()->instance(GitFileContentService::class, $gitFileContentMock);
 
     // Prevent backfill from calling real git
     app()->bind(BackfillGlobalGitignoreAction::class, fn () => new class

--- a/tests/Unit/Migrations/MigrateSessionDataToCommentTablesTest.php
+++ b/tests/Unit/Migrations/MigrateSessionDataToCommentTablesTest.php
@@ -36,6 +36,10 @@ beforeEach(function () {
         // Already exists.
     }
 
+    // Drop later-migration partial uniques so dedup scenarios can be replayed.
+    DB::statement('DROP INDEX IF EXISTS review_sessions_project_id_unique');
+    DB::statement('DROP INDEX IF EXISTS review_sessions_bare_repo_unique');
+
     DB::table('comments')->delete();
     DB::table('reviewed_files')->delete();
     DB::table('review_sessions')->delete();
@@ -157,23 +161,23 @@ test('migrates legacy indexed-array reviewed_files with an empty content_hash', 
     expect($rows->get('b.php')->content_hash)->toBe('');
 });
 
-test('dedupes review_sessions rows keeping the longest global_comment', function () {
+test('dedupes review_sessions rows keeping the most recently updated', function () {
     DB::table('review_sessions')->insert([
         [
             'repo_path' => '/tmp/repo',
             'context_fingerprint' => 'working',
             'comments' => '[]',
             'reviewed_files' => '[]',
-            'global_comment' => 'short',
-            'created_at' => now(),
-            'updated_at' => now(),
+            'global_comment' => 'the longer, older feedback',
+            'created_at' => now()->subDays(2),
+            'updated_at' => now()->subDays(2),
         ],
         [
             'repo_path' => '/tmp/repo',
             'context_fingerprint' => 'abc..def',
             'comments' => '[]',
             'reviewed_files' => '[]',
-            'global_comment' => 'the longer feedback survives',
+            'global_comment' => 'fresh',
             'created_at' => now(),
             'updated_at' => now(),
         ],
@@ -183,7 +187,37 @@ test('dedupes review_sessions rows keeping the longest global_comment', function
 
     $remaining = DB::table('review_sessions')->where('repo_path', '/tmp/repo')->get();
     expect($remaining)->toHaveCount(1);
-    expect($remaining->first()->global_comment)->toBe('the longer feedback survives');
+    expect($remaining->first()->global_comment)->toBe('fresh');
+});
+
+test('dedupes review_sessions falls back to id DESC when updated_at matches', function () {
+    $stamp = now();
+    DB::table('review_sessions')->insert([
+        [
+            'repo_path' => '/tmp/repo',
+            'context_fingerprint' => 'working',
+            'comments' => '[]',
+            'reviewed_files' => '[]',
+            'global_comment' => 'earlier insert',
+            'created_at' => $stamp,
+            'updated_at' => $stamp,
+        ],
+        [
+            'repo_path' => '/tmp/repo',
+            'context_fingerprint' => 'abc..def',
+            'comments' => '[]',
+            'reviewed_files' => '[]',
+            'global_comment' => 'later insert',
+            'created_at' => $stamp,
+            'updated_at' => $stamp,
+        ],
+    ]);
+
+    $this->migration->up();
+
+    $remaining = DB::table('review_sessions')->where('repo_path', '/tmp/repo')->get();
+    expect($remaining)->toHaveCount(1);
+    expect($remaining->first()->global_comment)->toBe('later insert');
 });
 
 test('drops legacy columns from review_sessions', function () {

--- a/tests/Unit/Migrations/MigrateSessionDataToCommentTablesTest.php
+++ b/tests/Unit/Migrations/MigrateSessionDataToCommentTablesTest.php
@@ -1,0 +1,240 @@
+<?php
+
+use App\Models\Project;
+use Faker\Factory as Faker;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+beforeEach(function () {
+    $this->faker = Faker::create();
+    $this->faker->seed(crc32(static::class.$this->name()));
+
+    // Re-add the legacy shape so we can replay the migration in isolation.
+    Schema::table('review_sessions', function (Blueprint $table) {
+        if (! Schema::hasColumn('review_sessions', 'context_fingerprint')) {
+            $table->string('context_fingerprint')->default('working')->after('project_id');
+        }
+        if (! Schema::hasColumn('review_sessions', 'reviewed_files')) {
+            $table->json('reviewed_files')->default('[]');
+        }
+        if (! Schema::hasColumn('review_sessions', 'comments')) {
+            $table->json('comments')->default('[]');
+        }
+    });
+
+    // The pre-migration unique index; the migration under test drops it.
+    try {
+        Schema::table('review_sessions', function (Blueprint $table) {
+            $table->unique(['project_id', 'context_fingerprint']);
+        });
+    } catch (Throwable) {
+        // Already exists.
+    }
+
+    DB::table('comments')->delete();
+    DB::table('reviewed_files')->delete();
+    DB::table('review_sessions')->delete();
+
+    $this->migration = require database_path('migrations/2026_04_19_074936_migrate_session_data_to_comment_tables.php');
+});
+
+test('migrates working-directory comments into the new comments table with origin_ref=working', function () {
+    DB::table('review_sessions')->insert([
+        'repo_path' => '/tmp/repo',
+        'context_fingerprint' => 'working',
+        'comments' => json_encode([
+            [
+                'id' => 'c-working-1',
+                'fileId' => 'file-old',
+                'file' => 'src/a.php',
+                'side' => 'right',
+                'startLine' => 12,
+                'endLine' => 12,
+                'body' => 'needs docblock',
+                'isDraft' => false,
+            ],
+        ]),
+        'reviewed_files' => '[]',
+        'global_comment' => '',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $this->migration->up();
+
+    $row = DB::table('comments')->where('id', 'c-working-1')->first();
+
+    expect($row)->not->toBeNull();
+    expect($row->origin_ref)->toBe('working');
+    expect($row->file_path)->toBe('src/a.php');
+    expect($row->side)->toBe('right');
+    expect((int) $row->start_line)->toBe(12);
+    expect((int) $row->end_line)->toBe(12);
+    expect($row->body)->toBe('needs docblock');
+    expect((bool) $row->is_draft)->toBeFalse();
+});
+
+test('maps a range context_fingerprint to the head commit of the selection', function () {
+    DB::table('review_sessions')->insert([
+        'repo_path' => '/tmp/repo',
+        'context_fingerprint' => 'abc123..def456',
+        'comments' => json_encode([
+            ['id' => 'c-range-1', 'fileId' => 'old', 'file' => 'x.php', 'side' => 'right', 'startLine' => 1, 'endLine' => 1, 'body' => 'x'],
+        ]),
+        'reviewed_files' => '[]',
+        'global_comment' => '',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $this->migration->up();
+
+    $row = DB::table('comments')->where('id', 'c-range-1')->first();
+
+    expect($row->origin_ref)->toBe('def456');
+});
+
+test('maps a single-commit context_fingerprint to that commit', function () {
+    DB::table('review_sessions')->insert([
+        'repo_path' => '/tmp/repo',
+        'context_fingerprint' => 'solohash',
+        'comments' => json_encode([
+            ['id' => 'c-solo-1', 'fileId' => 'old', 'file' => 'x.php', 'side' => 'right', 'startLine' => 1, 'endLine' => 1, 'body' => 'x'],
+        ]),
+        'reviewed_files' => '[]',
+        'global_comment' => '',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $this->migration->up();
+
+    $row = DB::table('comments')->where('id', 'c-solo-1')->first();
+
+    expect($row->origin_ref)->toBe('solohash');
+});
+
+test('migrates reviewed_files with their stored fingerprint', function () {
+    DB::table('review_sessions')->insert([
+        'repo_path' => '/tmp/repo',
+        'context_fingerprint' => 'working',
+        'comments' => '[]',
+        'reviewed_files' => json_encode(['a.php' => 'hash-a', 'b.php' => 'hash-b']),
+        'global_comment' => '',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $this->migration->up();
+
+    $rows = DB::table('reviewed_files')->get()->keyBy('file_path');
+
+    expect($rows->get('a.php')->content_hash)->toBe('hash-a');
+    expect($rows->get('b.php')->content_hash)->toBe('hash-b');
+});
+
+test('migrates legacy indexed-array reviewed_files with an empty content_hash', function () {
+    DB::table('review_sessions')->insert([
+        'repo_path' => '/tmp/repo',
+        'context_fingerprint' => 'working',
+        'comments' => '[]',
+        'reviewed_files' => json_encode(['a.php', 'b.php']),
+        'global_comment' => '',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $this->migration->up();
+
+    $rows = DB::table('reviewed_files')->get()->keyBy('file_path');
+
+    expect($rows->get('a.php')->content_hash)->toBe('');
+    expect($rows->get('b.php')->content_hash)->toBe('');
+});
+
+test('dedupes review_sessions rows keeping the longest global_comment', function () {
+    DB::table('review_sessions')->insert([
+        [
+            'repo_path' => '/tmp/repo',
+            'context_fingerprint' => 'working',
+            'comments' => '[]',
+            'reviewed_files' => '[]',
+            'global_comment' => 'short',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ],
+        [
+            'repo_path' => '/tmp/repo',
+            'context_fingerprint' => 'abc..def',
+            'comments' => '[]',
+            'reviewed_files' => '[]',
+            'global_comment' => 'the longer feedback survives',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ],
+    ]);
+
+    $this->migration->up();
+
+    $remaining = DB::table('review_sessions')->where('repo_path', '/tmp/repo')->get();
+    expect($remaining)->toHaveCount(1);
+    expect($remaining->first()->global_comment)->toBe('the longer feedback survives');
+});
+
+test('drops legacy columns from review_sessions', function () {
+    DB::table('review_sessions')->insert([
+        'repo_path' => '/tmp/repo',
+        'context_fingerprint' => 'working',
+        'comments' => '[]',
+        'reviewed_files' => '[]',
+        'global_comment' => '',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $this->migration->up();
+
+    expect(Schema::hasColumn('review_sessions', 'comments'))->toBeFalse();
+    expect(Schema::hasColumn('review_sessions', 'reviewed_files'))->toBeFalse();
+    expect(Schema::hasColumn('review_sessions', 'context_fingerprint'))->toBeFalse();
+});
+
+test('is a no-op when no legacy rows exist', function () {
+    $this->migration->up();
+
+    expect(DB::table('comments')->count())->toBe(0);
+    expect(DB::table('reviewed_files')->count())->toBe(0);
+});
+
+test('preserves project_id when present on the legacy row', function () {
+    $project = Project::create([
+        'slug' => 'legacy',
+        'name' => 'legacy',
+        'path' => '/tmp/legacy',
+        'git_common_dir' => '/tmp/legacy/.git',
+        'is_worktree' => false,
+    ]);
+
+    DB::table('review_sessions')->insert([
+        'project_id' => $project->id,
+        'repo_path' => $project->path,
+        'context_fingerprint' => 'working',
+        'comments' => json_encode([
+            ['id' => 'c-proj-1', 'fileId' => 'old', 'file' => 'x.php', 'side' => 'right', 'startLine' => 1, 'endLine' => 1, 'body' => 'x'],
+        ]),
+        'reviewed_files' => json_encode(['x.php' => 'hash-x']),
+        'global_comment' => 'hello',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $this->migration->up();
+
+    expect(DB::table('comments')->where('id', 'c-proj-1')->value('project_id'))->toBe($project->id);
+    expect(DB::table('reviewed_files')->where('file_path', 'x.php')->value('project_id'))->toBe($project->id);
+});

--- a/tests/Unit/Migrations/RestoreUniquesAfterCommentPoolMigrationTest.php
+++ b/tests/Unit/Migrations/RestoreUniquesAfterCommentPoolMigrationTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use App\Models\Project;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+test('review_sessions enforces a unique project_id', function () {
+    $project = Project::factory()->create();
+
+    DB::table('review_sessions')->insert([
+        'project_id' => $project->id,
+        'repo_path' => '/a',
+        'global_comment' => '',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    expect(fn () => DB::table('review_sessions')->insert([
+        'project_id' => $project->id,
+        'repo_path' => '/a-duplicate',
+        'global_comment' => '',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]))->toThrow(QueryException::class);
+});
+
+test('review_sessions enforces a unique bare repo_path when project_id is null', function () {
+    DB::table('review_sessions')->insert([
+        'project_id' => null,
+        'repo_path' => '/bare',
+        'global_comment' => '',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    expect(fn () => DB::table('review_sessions')->insert([
+        'project_id' => null,
+        'repo_path' => '/bare',
+        'global_comment' => '',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]))->toThrow(QueryException::class);
+});
+
+test('review_sessions allows the same repo_path for a bare and a project row', function () {
+    $project = Project::factory()->create(['path' => '/shared']);
+
+    DB::table('review_sessions')->insert([
+        'project_id' => null,
+        'repo_path' => '/shared',
+        'global_comment' => 'bare',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    DB::table('review_sessions')->insert([
+        'project_id' => $project->id,
+        'repo_path' => '/shared',
+        'global_comment' => 'project',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    expect(DB::table('review_sessions')->where('repo_path', '/shared')->count())->toBe(2);
+});
+
+test('reviewed_files allows the same repo_path+file+hash across bare and project rows', function () {
+    $project = Project::factory()->create(['path' => '/x']);
+
+    DB::table('reviewed_files')->insert([
+        'project_id' => null,
+        'repo_path' => '/x',
+        'file_path' => 'a.php',
+        'content_hash' => 'h1',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    DB::table('reviewed_files')->insert([
+        'project_id' => $project->id,
+        'repo_path' => '/x',
+        'file_path' => 'a.php',
+        'content_hash' => 'h1',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    expect(DB::table('reviewed_files')->where('file_path', 'a.php')->count())->toBe(2);
+});
+
+test('reviewed_files still enforces uniqueness within bare repo rows', function () {
+    DB::table('reviewed_files')->insert([
+        'project_id' => null,
+        'repo_path' => '/x',
+        'file_path' => 'a.php',
+        'content_hash' => 'h1',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    expect(fn () => DB::table('reviewed_files')->insert([
+        'project_id' => null,
+        'repo_path' => '/x',
+        'file_path' => 'a.php',
+        'content_hash' => 'h1',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]))->toThrow(QueryException::class);
+});

--- a/tests/Unit/Models/CommentScopeTest.php
+++ b/tests/Unit/Models/CommentScopeTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Models\Comment;
-use App\Models\Project;
 use Faker\Factory as Faker;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Tests\TestCase;
@@ -14,10 +13,7 @@ beforeEach(function () {
 });
 
 test('forProjectOrRepo limits the result to a given project_id', function () {
-    $project = Project::create([
-        'slug' => 'p', 'name' => 'p', 'path' => '/tmp/p',
-        'git_common_dir' => '/tmp/p/.git', 'is_worktree' => false,
-    ]);
+    $project = $this->createTestProject(['slug' => 'p', 'path' => '/tmp/p']);
 
     Comment::create([
         'id' => 'c-in', 'project_id' => $project->id, 'repo_path' => $project->path,
@@ -49,10 +45,7 @@ test('forProjectOrRepo falls back to repo_path when no project_id is given', fun
 });
 
 test('forProjectOrRepo with null project_id excludes rows that have a project_id set', function () {
-    $project = Project::create([
-        'slug' => 'p', 'name' => 'p', 'path' => '/tmp/p',
-        'git_common_dir' => '/tmp/p/.git', 'is_worktree' => false,
-    ]);
+    $project = $this->createTestProject(['slug' => 'p', 'path' => '/tmp/p']);
 
     Comment::create([
         'id' => 'c-with-project', 'project_id' => $project->id, 'repo_path' => '/tmp/p',

--- a/tests/Unit/Models/CommentScopeTest.php
+++ b/tests/Unit/Models/CommentScopeTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use App\Models\Comment;
+use App\Models\Project;
+use Faker\Factory as Faker;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+beforeEach(function () {
+    $this->faker = Faker::create();
+    $this->faker->seed(crc32(static::class.$this->name()));
+});
+
+test('forProjectOrRepo limits the result to a given project_id', function () {
+    $project = Project::create([
+        'slug' => 'p', 'name' => 'p', 'path' => '/tmp/p',
+        'git_common_dir' => '/tmp/p/.git', 'is_worktree' => false,
+    ]);
+
+    Comment::create([
+        'id' => 'c-in', 'project_id' => $project->id, 'repo_path' => $project->path,
+        'origin_ref' => 'working', 'file_path' => 'f.php', 'side' => 'right', 'body' => 'in',
+    ]);
+    Comment::create([
+        'id' => 'c-out', 'project_id' => null, 'repo_path' => '/tmp/other',
+        'origin_ref' => 'working', 'file_path' => 'f.php', 'side' => 'right', 'body' => 'out',
+    ]);
+
+    $ids = Comment::query()->forProjectOrRepo($project->id, $project->path)->pluck('id')->all();
+
+    expect($ids)->toBe(['c-in']);
+});
+
+test('forProjectOrRepo falls back to repo_path when no project_id is given', function () {
+    Comment::create([
+        'id' => 'c-a', 'project_id' => null, 'repo_path' => '/tmp/a',
+        'origin_ref' => 'working', 'file_path' => 'f.php', 'side' => 'right', 'body' => 'a',
+    ]);
+    Comment::create([
+        'id' => 'c-b', 'project_id' => null, 'repo_path' => '/tmp/b',
+        'origin_ref' => 'working', 'file_path' => 'f.php', 'side' => 'right', 'body' => 'b',
+    ]);
+
+    $ids = Comment::query()->forProjectOrRepo(null, '/tmp/a')->pluck('id')->all();
+
+    expect($ids)->toBe(['c-a']);
+});
+
+test('forProjectOrRepo with null project_id excludes rows that have a project_id set', function () {
+    $project = Project::create([
+        'slug' => 'p', 'name' => 'p', 'path' => '/tmp/p',
+        'git_common_dir' => '/tmp/p/.git', 'is_worktree' => false,
+    ]);
+
+    Comment::create([
+        'id' => 'c-with-project', 'project_id' => $project->id, 'repo_path' => '/tmp/p',
+        'origin_ref' => 'working', 'file_path' => 'f.php', 'side' => 'right', 'body' => 'x',
+    ]);
+    Comment::create([
+        'id' => 'c-bare', 'project_id' => null, 'repo_path' => '/tmp/p',
+        'origin_ref' => 'working', 'file_path' => 'f.php', 'side' => 'right', 'body' => 'y',
+    ]);
+
+    $ids = Comment::query()->forProjectOrRepo(null, '/tmp/p')->pluck('id')->all();
+
+    expect($ids)->toBe(['c-bare']);
+});

--- a/tests/Unit/Models/ReviewedFileScopeTest.php
+++ b/tests/Unit/Models/ReviewedFileScopeTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\Project;
+use App\Models\ReviewedFile;
+use Faker\Factory as Faker;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+beforeEach(function () {
+    $this->faker = Faker::create();
+    $this->faker->seed(crc32(static::class.$this->name()));
+});
+
+test('forProjectOrRepo limits the result to the given project', function () {
+    $project = Project::create([
+        'slug' => 'p', 'name' => 'p', 'path' => '/tmp/p',
+        'git_common_dir' => '/tmp/p/.git', 'is_worktree' => false,
+    ]);
+
+    ReviewedFile::create(['project_id' => $project->id, 'repo_path' => '/tmp/p', 'file_path' => 'a.php', 'content_hash' => 'h1']);
+    ReviewedFile::create(['project_id' => null, 'repo_path' => '/tmp/other', 'file_path' => 'a.php', 'content_hash' => 'h2']);
+
+    $paths = ReviewedFile::query()->forProjectOrRepo($project->id, $project->path)->pluck('content_hash')->all();
+
+    expect($paths)->toBe(['h1']);
+});
+
+test('forProjectOrRepo with null project_id matches only bare repo_path rows', function () {
+    ReviewedFile::create(['project_id' => null, 'repo_path' => '/tmp/a', 'file_path' => 'a.php', 'content_hash' => 'ha']);
+    ReviewedFile::create(['project_id' => null, 'repo_path' => '/tmp/b', 'file_path' => 'a.php', 'content_hash' => 'hb']);
+
+    $hashes = ReviewedFile::query()->forProjectOrRepo(null, '/tmp/a')->pluck('content_hash')->all();
+
+    expect($hashes)->toBe(['ha']);
+});

--- a/tests/Unit/Models/ReviewedFileScopeTest.php
+++ b/tests/Unit/Models/ReviewedFileScopeTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Models\Project;
 use App\Models\ReviewedFile;
 use Faker\Factory as Faker;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
@@ -14,10 +13,7 @@ beforeEach(function () {
 });
 
 test('forProjectOrRepo limits the result to the given project', function () {
-    $project = Project::create([
-        'slug' => 'p', 'name' => 'p', 'path' => '/tmp/p',
-        'git_common_dir' => '/tmp/p/.git', 'is_worktree' => false,
-    ]);
+    $project = $this->createTestProject(['slug' => 'p', 'path' => '/tmp/p']);
 
     ReviewedFile::create(['project_id' => $project->id, 'repo_path' => '/tmp/p', 'file_path' => 'a.php', 'content_hash' => 'h1']);
     ReviewedFile::create(['project_id' => null, 'repo_path' => '/tmp/other', 'file_path' => 'a.php', 'content_hash' => 'h2']);

--- a/tests/Unit/Services/GitFileContentServiceTest.php
+++ b/tests/Unit/Services/GitFileContentServiceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use App\Services\GitFileContentService;
+use App\Services\GitProcessService;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    $this->service = new GitFileContentService(new GitProcessService);
+
+    $this->tmpDir = $this->createTempDirectory('rfa_gitfile_content_test_');
+    $this->initTestRepo($this->tmpDir);
+
+    File::put($this->tmpDir.'/hello.php', "<?php\necho 'one';\n");
+    $this->commitTestRepo($this->tmpDir, 'first');
+    $this->firstCommit = trim(shell_exec('git -C '.escapeshellarg($this->tmpDir).' rev-parse HEAD'));
+
+    File::put($this->tmpDir.'/hello.php', "<?php\necho 'two';\n");
+    $this->commitTestRepo($this->tmpDir, 'second');
+    $this->secondCommit = trim(shell_exec('git -C '.escapeshellarg($this->tmpDir).' rev-parse HEAD'));
+});
+
+test('hashAt returns the same value for identical file content across refs', function () {
+    File::put($this->tmpDir.'/stable.php', "<?php\nreturn 1;\n");
+    $this->commitTestRepo($this->tmpDir, 'add stable');
+    $stableCommit = trim(shell_exec('git -C '.escapeshellarg($this->tmpDir).' rev-parse HEAD'));
+
+    File::put($this->tmpDir.'/unrelated.php', "<?php\nreturn 2;\n");
+    $this->commitTestRepo($this->tmpDir, 'add unrelated');
+    $laterCommit = trim(shell_exec('git -C '.escapeshellarg($this->tmpDir).' rev-parse HEAD'));
+
+    $first = $this->service->hashAt($this->tmpDir, $stableCommit, 'stable.php');
+    $second = $this->service->hashAt($this->tmpDir, $laterCommit, 'stable.php');
+
+    expect($first)->not->toBeNull();
+    expect($first)->toBe($second);
+});
+
+test('hashAt returns different values when content changed', function () {
+    $first = $this->service->hashAt($this->tmpDir, $this->firstCommit, 'hello.php');
+    $second = $this->service->hashAt($this->tmpDir, $this->secondCommit, 'hello.php');
+
+    expect($first)->not->toBe($second);
+});
+
+test('hashAt returns null for a file that does not exist at the given ref', function () {
+    $result = $this->service->hashAt($this->tmpDir, $this->firstCommit, 'never-existed.php');
+
+    expect($result)->toBeNull();
+});
+
+test('hashAt reads the working copy for the WORKING_REF sentinel', function () {
+    File::put($this->tmpDir.'/hello.php', "<?php\necho 'uncommitted';\n");
+
+    $workingHash = $this->service->hashAt($this->tmpDir, GitFileContentService::WORKING_REF, 'hello.php');
+    $headHash = $this->service->hashAt($this->tmpDir, $this->secondCommit, 'hello.php');
+
+    expect($workingHash)->not->toBeNull();
+    expect($workingHash)->not->toBe($headHash);
+});
+
+test('hashAt returns null when working copy file is missing', function () {
+    expect($this->service->hashAt($this->tmpDir, GitFileContentService::WORKING_REF, 'missing.php'))->toBeNull();
+});

--- a/tests/Unit/Services/GitFileContentServiceTest.php
+++ b/tests/Unit/Services/GitFileContentServiceTest.php
@@ -64,3 +64,24 @@ test('hashAt reads the working copy for the WORKING_REF sentinel', function () {
 test('hashAt returns null when working copy file is missing', function () {
     expect($this->service->hashAt($this->tmpDir, GitFileContentService::WORKING_REF, 'missing.php'))->toBeNull();
 });
+
+test('hashAt memoizes repeated lookups for the same (repo, ref, path)', function () {
+    $gitProcess = Mockery::mock(GitProcessService::class);
+    $gitProcess->shouldReceive('run')->once()->andReturn("stable content\n");
+
+    $service = new GitFileContentService($gitProcess);
+
+    $first = $service->hashAt($this->tmpDir, $this->firstCommit, 'hello.php');
+    $second = $service->hashAt($this->tmpDir, $this->firstCommit, 'hello.php');
+    $third = $service->hashAt($this->tmpDir, $this->firstCommit, 'hello.php');
+
+    expect($second)->toBe($first);
+    expect($third)->toBe($first);
+});
+
+test('GitFileContentService is a shared singleton in the container', function () {
+    $first = app(GitFileContentService::class);
+    $second = app(GitFileContentService::class);
+
+    expect($first)->toBe($second);
+});


### PR DESCRIPTION
This PR refactors the comment and reviewed file storage system by migrating from JSON columns in `review_sessions` to dedicated `comments` and `reviewed_files` tables. This enables better querying, filtering, and management of comments across the application.

## Summary

The changes introduce a new data model where comments and reviewed files are stored as first-class database entities rather than JSON blobs. This improves data integrity, enables efficient querying, and supports new features like comment filtering and cross-selection visibility.

## Key Changes

- **New Models & Tables**: Created `Comment` and `ReviewedFile` Eloquent models with corresponding migrations
- **Migration**: Added `2026_04_19_074936_migrate_session_data_to_comment_tables.php` to safely migrate existing data from `review_sessions` JSON columns to the new tables, handling context fingerprints and deduplication
- **Comment Anchoring**: Introduced `ResolveCommentAnchorAction` to resolve comment placement across different diff targets using file content hashing
- **File Content Service**: Created `GitFileContentService` to compute and cache file content hashes at specific git refs, replacing the previous diff fingerprinting approach
- **Session Restoration**: Updated `RestoreSessionAction` to load comments and reviewed files from the new tables and resolve their anchors against the current diff target
- **Comments Drawer**: Added new `CommentsDrawer` Livewire component to display all comments in a repo, grouped by file, with filtering and draft/submitted status tracking
- **Comment Operations**: Updated `AddCommentAction` to persist comments to the database with origin ref and content hash; added `UpdateCommentAction` and updated `DeleteCommentAction` to work with the new model
- **Review Page**: Updated review page to use the new comment system and support explicit range mode via `/p/{slug}/r/{from}..{to}` routes
- **Selection UI**: Enhanced branch explorer with multi-select functionality for commit ranges using shift-click

## Notable Implementation Details

- Comments are anchored by file content hash + line number, allowing them to "float" to matching content across different commits
- The `origin_ref` field tracks which commit/ref a comment was authored against, enabling cross-selection visibility when content matches
- `ReviewSession` now stores only the global comment; per-file session data is normalized into the new tables
- File content hashing is cached to avoid repeated git operations
- The migration handles legacy data including range-based context fingerprints (e.g., `abc123..def456`) by extracting the head commit

https://claude.ai/code/session_01TCK5dNidqPW9EBkbaHxkqi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent repo-scoped comments (drafts, edit/delete), optional line snippets, and exported submitted IDs
  * “All comments” drawer with filtering and grouped views
  * Multi-commit selection, range navigation and new review-page range route

* **Bug Fixes / Improvements**
  * Improved placed/unplaced detection with “Original snippet” rendering for moved/changed lines
  * Reviewed-file state persisted by content-hash; session persistence simplified; export marks submitted comments

* **Tests**
  * Extensive new and updated tests for comments, selection, export/restore, services, and migrations

* **Chores**
  * Database migrations and service registration updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->