### PR TITLE
Update diff view menu icons to use outline variants

### DIFF
--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -276,13 +276,13 @@ new class extends Component {
                     <flux:dropdown position="bottom" align="end">
                         <flux:button icon="ellipsis-vertical" icon:variant="outline" variant="ghost" size="sm" aria-label="Copy content" />
                         <flux:menu>
-                            <flux:menu.item icon="code-bracket" @click="$wire.copyContent('diff')">
+                            <flux:menu.item icon="code-bracket" icon:variant="outline" @click="$wire.copyContent('diff')">
                                 Copy diff
                             </flux:menu.item>
-                            <flux:menu.item icon="document-minus" @click="$wire.copyContent('original')" :disabled="$isAdded">
+                            <flux:menu.item icon="minus" icon:variant="outline" @click="$wire.copyContent('original')" :disabled="$isAdded">
                                 Copy original
                             </flux:menu.item>
-                            <flux:menu.item icon="document-plus" @click="$wire.copyContent('new')" :disabled="$isDeleted">
+                            <flux:menu.item icon="plus" icon:variant="outline" @click="$wire.copyContent('new')" :disabled="$isDeleted">
                                 Copy new
                             </flux:menu.item>
                         </flux:menu>

--- a/tests/Arch/BladeConventionsTest.php
+++ b/tests/Arch/BladeConventionsTest.php
@@ -3,7 +3,7 @@
 /**
  * Blade template conventions:
  * - flux:icon must use variant="outline" (outline stroke icons, not solid)
- * - flux:button/input with icon= must use icon:variant="outline"
+ * - flux:button/input/menu.item with icon= must use icon:variant="outline"
  * - No hardcoded class="dark" on <html> (use Flux's @fluxAppearance)
  */
 function bladeFiles(): array
@@ -36,11 +36,11 @@ test('flux:icon uses outline variant', function () {
     expect($violations)->toBeEmpty();
 });
 
-test('flux:button and flux:input with icon prop use outline variant', function () {
+test('flux:button, flux:input and flux:menu.item with icon prop use outline variant', function () {
     $violations = [];
     foreach (bladeFiles() as $file) {
         $content = file_get_contents($file);
-        preg_match_all('/(<flux:(?:button|input)\b[^>]*?>)/s', $content, $matches);
+        preg_match_all('/(<flux:(?:button|input|menu\.item)\b[^>]*?>)/s', $content, $matches);
         foreach ($matches[1] as $tag) {
             if (preg_match('/\bicon="/', $tag) && ! str_contains($tag, 'icon:variant="outline"')) {
                 $violations[] = basename($file).": {$tag}";


### PR DESCRIPTION
## Summary
Updated the copy content menu items in the diff view to use outline icon variants and simplified icon names for better visual consistency.

## Key Changes
- Added `icon:variant="outline"` to all three menu items (Copy diff, Copy original, Copy new)
- Changed `document-minus` icon to `minus` for the "Copy original" menu item
- Changed `document-plus` icon to `plus` for the "Copy new" menu item
- Kept `code-bracket` icon for the "Copy diff" menu item with outline variant

## Implementation Details
These changes improve the visual hierarchy and consistency of the diff view's action menu by using outline icon variants throughout, while also simplifying the icon names to more generic alternatives that better align with the Flux UI design system.

https://claude.ai/code/session_01KLgPhHFXwSBMf6edLpyjjK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dropdown menu icons for copy actions in the toolbar with consistent outline icon styling. Icon types have been refreshed for improved visual clarity and design consistency while maintaining all copy functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->