### PR TITLE
Toggle inline comment form when re-clicking same line with empty input

### DIFF
--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -57,6 +57,18 @@
                     this.focusCommentInput();
                     return;
                 }
+                // Toggle: re-clicking the same line with an empty form closes it.
+                if (
+                    this.showForm
+                    && !this.editingCommentId
+                    && this.formSide === side
+                    && this.formLine === lineNum
+                    && this.formEndLine === lineNum
+                    && this.formBody.trim() === ''
+                ) {
+                    this.cancelForm();
+                    return;
+                }
                 // Check for existing draft comment on this line
                 const comments = this.$wire.fileComments || [];
                 const existingDraft = comments.find(c => c.isDraft && c.side === side && c.startLine !== null && lineNum >= c.startLine && lineNum <= (c.endLine ?? c.startLine));

--- a/tests/Browser/InlineCommentTest.php
+++ b/tests/Browser/InlineCommentTest.php
@@ -58,7 +58,7 @@ test('escape on empty comment form closes it', function () {
 });
 
 test('clicking the same line number again with an empty input closes the form', function () {
-    $page = $this->visit($this->projectUrl());
+    $page = $this->visitAndLoad($this->projectUrl());
 
     $page->page()->getByTestId('diff-line-number')->first()->click();
     $page->assertSee('Cancel');
@@ -69,7 +69,7 @@ test('clicking the same line number again with an empty input closes the form', 
 });
 
 test('clicking the same line number again with a non-empty input keeps the form open', function () {
-    $page = $this->visit($this->projectUrl());
+    $page = $this->visitAndLoad($this->projectUrl());
 
     $page->page()->getByTestId('diff-line-number')->first()->click();
     $page->page()->getByPlaceholder('Write a comment', false)->fill('In progress draft');

--- a/tests/Browser/InlineCommentTest.php
+++ b/tests/Browser/InlineCommentTest.php
@@ -57,6 +57,29 @@ test('escape on empty comment form closes it', function () {
     $page->assertDontSee('Cancel');
 });
 
+test('clicking the same line number again with an empty input closes the form', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $page->page()->getByTestId('diff-line-number')->first()->click();
+    $page->assertSee('Cancel');
+
+    $page->page()->getByTestId('diff-line-number')->first()->click();
+
+    $page->assertDontSee('Cancel');
+});
+
+test('clicking the same line number again with a non-empty input keeps the form open', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $page->page()->getByTestId('diff-line-number')->first()->click();
+    $page->page()->getByPlaceholder('Write a comment', false)->fill('In progress draft');
+
+    $page->page()->getByTestId('diff-line-number')->first()->click();
+
+    $page->assertSee('Cancel');
+    expect($page->page()->getByPlaceholder('Write a comment', false)->inputValue())->toBe('In progress draft');
+});
+
 test('shift+click selects a line range', function () {
     $page = $this->visit($this->projectUrl());
 


### PR DESCRIPTION
## Summary

- Clicking a line number opens the inline comment form. Clicking the same line again now closes it when the input is empty, giving users a quick way to dismiss an accidental open without reaching for Cancel/Escape.
- A non-empty input is preserved across re-clicks so an in-progress draft isn't lost.
- Edit mode (`editingCommentId`) is excluded from the toggle so re-clicking the line of an existing comment under edit doesn't accidentally close the editor.

## Test plan

- [x] `composer test` (Core) — 648 passing
- [x] `composer test:types` (PHPStan) — clean
- [x] `vendor/bin/pint --dirty` — clean
- [ ] CI `test-browser` — two new browser tests added in `tests/Browser/InlineCommentTest.php`:
  - `clicking the same line number again with an empty input closes the form`
  - `clicking the same line number again with a non-empty input keeps the form open`

https://claude.ai/code/session_01DztkFdZd2wMrxLRvM1iWZz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clicking the same line number again now closes an empty inline comment form, preventing orphaned empty forms.
  * Comment forms that contain text remain open when the same line number is clicked again, preserving drafts.

* **Tests**
  * Added browser tests to verify empty forms close and non-empty drafts persist when clicking the same line number repeatedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->