### PR TITLE
Implement native find-in-page search with DOM highlighting

### DIFF
--- a/config/theme.php
+++ b/config/theme.php
@@ -14,6 +14,8 @@ return [
             'green' => '22 163 74',
             'red' => '220 38 38',
             'draft' => '245 158 11',
+            'search-match' => '253 224 71',
+            'search-match-current' => '251 146 60',
         ],
         'dark' => [
             'bg' => '9 9 11',
@@ -26,6 +28,8 @@ return [
             'green' => '74 222 128',
             'red' => '248 113 113',
             'draft' => '251 191 36',
+            'search-match' => '161 98 7',
+            'search-match-current' => '234 88 12',
         ],
     ],
 

--- a/public/js/page-search.js
+++ b/public/js/page-search.js
@@ -1,27 +1,166 @@
 // Alpine component for global find-in-page search (Cmd/Ctrl+F)
+//
+// Wraps every match in the document with <span class="rfa-search-match"> so
+// all matches are highlighted at once. The active match additionally gets the
+// `rfa-search-match--current` modifier (stronger background + badge showing
+// "N of total" rendered via CSS ::after).
 (function () {
+    const MATCH_CLASS = 'rfa-search-match';
+    const CURRENT_CLASS = 'rfa-search-match--current';
+    const SKIP_SELECTOR = 'script,style,noscript,iframe,input,textarea,[data-search-ignore]';
+
+    function escapeRegex(value) {
+        return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+
     function init() {
         Alpine.data('pageSearch', () => ({
             open: false,
             query: '',
+            totalMatches: 0,
+            currentMatch: 0,
+            matchElements: [],
 
             handleKeydown(e) {
                 if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
                     e.preventDefault();
                     this.open = true;
-                    this.$nextTick(() => this.$refs.input?.select());
+                    this.$nextTick(() => {
+                        this.$refs.input?.select();
+                        if (this.query) {
+                            this.refresh();
+                        }
+                    });
                 }
             },
 
+            onQueryInput() {
+                this.refresh();
+            },
+
+            refresh() {
+                this.clearMarks();
+                if (!this.query) {
+                    this.totalMatches = 0;
+                    this.currentMatch = 0;
+                    return;
+                }
+                this.matchElements = this.markMatches(this.query);
+                this.totalMatches = this.matchElements.length;
+                this.currentMatch = this.totalMatches > 0 ? 1 : 0;
+                this.updateCurrent(true);
+            },
+
             find(backwards) {
-                if (!this.query) return;
-                window.find(this.query, false, backwards, true);
+                if (this.totalMatches === 0) {
+                    if (this.query) {
+                        this.refresh();
+                    }
+                    return;
+                }
+                if (backwards) {
+                    this.currentMatch = this.currentMatch <= 1 ? this.totalMatches : this.currentMatch - 1;
+                } else {
+                    this.currentMatch = this.currentMatch >= this.totalMatches ? 1 : this.currentMatch + 1;
+                }
+                this.updateCurrent(true);
+            },
+
+            updateCurrent(scroll) {
+                const badge = `${this.currentMatch} of ${this.totalMatches}`;
+                this.matchElements.forEach((el, i) => {
+                    const isCurrent = (i + 1) === this.currentMatch;
+                    el.classList.toggle(CURRENT_CLASS, isCurrent);
+                    if (isCurrent) {
+                        el.setAttribute('data-match-number', badge);
+                        if (scroll) {
+                            el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+                        }
+                    } else {
+                        el.removeAttribute('data-match-number');
+                    }
+                });
             },
 
             close() {
+                this.clearMarks();
                 this.open = false;
                 this.query = '';
-                window.getSelection()?.removeAllRanges();
+                this.totalMatches = 0;
+                this.currentMatch = 0;
+            },
+
+            clearMarks() {
+                const existing = document.querySelectorAll('.' + MATCH_CLASS);
+                existing.forEach(el => {
+                    const parent = el.parentNode;
+                    if (!parent) return;
+                    parent.replaceChild(document.createTextNode(el.textContent), el);
+                    parent.normalize();
+                });
+                this.matchElements = [];
+            },
+
+            markMatches(query) {
+                const pattern = new RegExp(escapeRegex(query), 'gi');
+                const needle = query.toLowerCase();
+                const walker = document.createTreeWalker(
+                    document.body,
+                    NodeFilter.SHOW_TEXT,
+                    {
+                        acceptNode(node) {
+                            if (!node.nodeValue || !node.nodeValue.length) {
+                                return NodeFilter.FILTER_REJECT;
+                            }
+                            const parent = node.parentElement;
+                            if (!parent || parent.closest(SKIP_SELECTOR)) {
+                                return NodeFilter.FILTER_REJECT;
+                            }
+                            // Use a lowercase substring check for filtering to
+                            // avoid mutating the shared regex's lastIndex.
+                            return node.nodeValue.toLowerCase().includes(needle)
+                                ? NodeFilter.FILTER_ACCEPT
+                                : NodeFilter.FILTER_REJECT;
+                        },
+                    }
+                );
+
+                const textNodes = [];
+                let node;
+                while ((node = walker.nextNode())) {
+                    textNodes.push(node);
+                }
+
+                const matches = [];
+                textNodes.forEach(textNode => {
+                    const text = textNode.nodeValue;
+                    pattern.lastIndex = 0;
+                    const fragments = [];
+                    let cursor = 0;
+                    let match;
+                    while ((match = pattern.exec(text)) !== null) {
+                        if (match.index > cursor) {
+                            fragments.push(document.createTextNode(text.slice(cursor, match.index)));
+                        }
+                        const span = document.createElement('span');
+                        span.className = MATCH_CLASS;
+                        span.textContent = match[0];
+                        fragments.push(span);
+                        matches.push(span);
+                        cursor = match.index + match[0].length;
+                        if (match[0].length === 0) {
+                            pattern.lastIndex++;
+                        }
+                    }
+                    if (fragments.length === 0) return;
+                    if (cursor < text.length) {
+                        fragments.push(document.createTextNode(text.slice(cursor)));
+                    }
+                    const parent = textNode.parentNode;
+                    fragments.forEach(fragment => parent.insertBefore(fragment, textNode));
+                    parent.removeChild(textNode);
+                });
+                return matches;
             },
         }));
     }

--- a/public/js/page-search.js
+++ b/public/js/page-search.js
@@ -110,6 +110,14 @@
                             if (!parent || parent.closest(SKIP_SELECTOR)) {
                                 return NodeFilter.FILTER_REJECT;
                             }
+                            // Skip collapsed/hidden sections (x-show, [hidden],
+                            // display:none ancestors) so the counter and
+                            // next/prev navigation only target visible matches.
+                            if (typeof parent.checkVisibility === 'function'
+                                ? !parent.checkVisibility()
+                                : parent.offsetParent === null) {
+                                return NodeFilter.FILTER_REJECT;
+                            }
                             // Substring check (not pattern.test) avoids
                             // mutating the shared regex's lastIndex.
                             return node.nodeValue.toLowerCase().includes(needle)

--- a/public/js/page-search.js
+++ b/public/js/page-search.js
@@ -111,11 +111,13 @@
                                 return NodeFilter.FILTER_REJECT;
                             }
                             // Skip collapsed/hidden sections (x-show, [hidden],
-                            // display:none ancestors) so the counter and
-                            // next/prev navigation only target visible matches.
-                            if (typeof parent.checkVisibility === 'function'
-                                ? !parent.checkVisibility()
-                                : parent.offsetParent === null) {
+                            // display:none, visibility:hidden, opacity:0) so
+                            // the counter and next/prev navigation only target
+                            // visible matches.
+                            if (!parent.checkVisibility({
+                                checkOpacity: true,
+                                checkVisibilityCSS: true,
+                            })) {
                                 return NodeFilter.FILTER_REJECT;
                             }
                             // Substring check (not pattern.test) avoids

--- a/public/js/page-search.js
+++ b/public/js/page-search.js
@@ -34,7 +34,9 @@
 
             refresh() {
                 this.clearMarks();
-                if (!this.query) {
+                // Treat whitespace-only queries as empty so pressing space
+                // doesn't wrap every whitespace run on the page.
+                if (!/\S/.test(this.query)) {
                     this.currentMatch = 0;
                     return;
                 }

--- a/public/js/page-search.js
+++ b/public/js/page-search.js
@@ -1,9 +1,4 @@
 // Alpine component for global find-in-page search (Cmd/Ctrl+F)
-//
-// Wraps every match in the document with <span class="rfa-search-match"> so
-// all matches are highlighted at once. The active match additionally gets the
-// `rfa-search-match--current` modifier (stronger background + badge showing
-// "N of total" rendered via CSS ::after).
 (function () {
     const MATCH_CLASS = 'rfa-search-match';
     const CURRENT_CLASS = 'rfa-search-match--current';
@@ -17,7 +12,6 @@
         Alpine.data('pageSearch', () => ({
             open: false,
             query: '',
-            totalMatches: 0,
             currentMatch: 0,
             matchElements: [],
 
@@ -41,33 +35,32 @@
             refresh() {
                 this.clearMarks();
                 if (!this.query) {
-                    this.totalMatches = 0;
                     this.currentMatch = 0;
                     return;
                 }
                 this.matchElements = this.markMatches(this.query);
-                this.totalMatches = this.matchElements.length;
-                this.currentMatch = this.totalMatches > 0 ? 1 : 0;
+                this.currentMatch = this.matchElements.length > 0 ? 1 : 0;
                 this.updateCurrent(true);
             },
 
             find(backwards) {
-                if (this.totalMatches === 0) {
+                const total = this.matchElements.length;
+                if (total === 0) {
                     if (this.query) {
                         this.refresh();
                     }
                     return;
                 }
                 if (backwards) {
-                    this.currentMatch = this.currentMatch <= 1 ? this.totalMatches : this.currentMatch - 1;
+                    this.currentMatch = this.currentMatch <= 1 ? total : this.currentMatch - 1;
                 } else {
-                    this.currentMatch = this.currentMatch >= this.totalMatches ? 1 : this.currentMatch + 1;
+                    this.currentMatch = this.currentMatch >= total ? 1 : this.currentMatch + 1;
                 }
                 this.updateCurrent(true);
             },
 
             updateCurrent(scroll) {
-                const badge = `${this.currentMatch} of ${this.totalMatches}`;
+                const badge = `${this.currentMatch} of ${this.matchElements.length}`;
                 this.matchElements.forEach((el, i) => {
                     const isCurrent = (i + 1) === this.currentMatch;
                     el.classList.toggle(CURRENT_CLASS, isCurrent);
@@ -86,18 +79,19 @@
                 this.clearMarks();
                 this.open = false;
                 this.query = '';
-                this.totalMatches = 0;
                 this.currentMatch = 0;
             },
 
             clearMarks() {
                 const existing = document.querySelectorAll('.' + MATCH_CLASS);
+                const parents = new Set();
                 existing.forEach(el => {
                     const parent = el.parentNode;
                     if (!parent) return;
                     parent.replaceChild(document.createTextNode(el.textContent), el);
-                    parent.normalize();
+                    parents.add(parent);
                 });
+                parents.forEach(parent => parent.normalize());
                 this.matchElements = [];
             },
 
@@ -116,8 +110,8 @@
                             if (!parent || parent.closest(SKIP_SELECTOR)) {
                                 return NodeFilter.FILTER_REJECT;
                             }
-                            // Use a lowercase substring check for filtering to
-                            // avoid mutating the shared regex's lastIndex.
+                            // Substring check (not pattern.test) avoids
+                            // mutating the shared regex's lastIndex.
                             return node.nodeValue.toLowerCase().includes(needle)
                                 ? NodeFilter.FILTER_ACCEPT
                                 : NodeFilter.FILTER_REJECT;

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -152,10 +152,7 @@
             letter-spacing: -0.04em;
         }
 
-        /* Find-in-page: highlight every match, give the current one a distinct
-           treatment plus a floating badge with the match number. Backgrounds
-           use theme tokens so colors work in both light and dark mode; text
-           color stays inherited so syntax highlighting still shows through. */
+        /* Text color stays inherited so syntax highlighting still shows through. */
         .rfa-search-match {
             background: rgb(var(--gh-search-match) / 0.55);
             border-radius: 2px;
@@ -205,7 +202,7 @@
                @keydown.shift.enter.prevent="find(true)"
                @keydown.escape.prevent="close()">
         <span x-show="query" class="text-gh-muted text-xs font-mono tabular-nums shrink-0 min-w-[3rem] text-right"
-              x-text="totalMatches === 0 ? 'No results' : currentMatch + ' of ' + totalMatches"></span>
+              x-text="matchElements.length === 0 ? 'No results' : currentMatch + ' of ' + matchElements.length"></span>
         <button @click="find(true)" class="text-gh-muted hover:text-gh-text p-0.5" title="Previous (Shift+Enter)">
             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -10,6 +10,7 @@
     <script src="/js/settings-store.js"></script>
     <script src="/js/overlays-store.js"></script>
     <script src="/js/keymap-store.js"></script>
+    <script src="/js/page-search.js"></script>
     <script>
         tailwind.config = {
             darkMode: 'class',
@@ -223,7 +224,6 @@
     <livewire:keepalive />
     {{ $slot }}
     @fluxScripts
-    <script src="/js/page-search.js"></script>
     @browser
         @includeIf('partials.instruckt')
     @endbrowser

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -199,10 +199,10 @@
                placeholder="Find in page..."
                class="bg-transparent text-gh-text text-sm font-mono outline-none w-56 placeholder:text-gh-muted"
                @input="onQueryInput()"
-               @keydown.enter.prevent="find(false)"
-               @keydown.shift.enter.prevent="find(true)"
+               @keydown.enter.prevent="find($event.shiftKey)"
                @keydown.escape.prevent="close()">
-        <span x-show="query" class="text-gh-muted text-xs font-mono tabular-nums shrink-0 min-w-[3rem] text-right"
+        <span x-show="query" role="status" aria-live="polite" aria-atomic="true"
+              class="text-gh-muted text-xs font-mono tabular-nums shrink-0 min-w-[3rem] text-right"
               x-text="matchElements.length === 0 ? 'No results' : currentMatch + ' of ' + matchElements.length"></span>
         <button @click="find(true)" class="text-gh-muted hover:text-gh-text p-0.5" title="Previous (Shift+Enter)">
             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -151,12 +151,47 @@
             font-family: 'Space Grotesk', system-ui, sans-serif !important;
             letter-spacing: -0.04em;
         }
+
+        /* Find-in-page: highlight every match, give the current one a distinct
+           treatment plus a floating badge with the match number. Backgrounds
+           use theme tokens so colors work in both light and dark mode; text
+           color stays inherited so syntax highlighting still shows through. */
+        .rfa-search-match {
+            background: rgb(var(--gh-search-match) / 0.55);
+            border-radius: 2px;
+            box-shadow: 0 0 0 1px rgb(var(--gh-search-match) / 0.7);
+        }
+        .rfa-search-match--current {
+            background: rgb(var(--gh-search-match-current) / 0.85);
+            box-shadow: 0 0 0 2px rgb(var(--gh-search-match-current));
+            position: relative;
+            z-index: 1;
+        }
+        .rfa-search-match--current::after {
+            content: attr(data-match-number);
+            position: absolute;
+            top: 100%;
+            left: 50%;
+            transform: translate(-50%, 6px);
+            background: rgb(var(--gh-accent));
+            color: rgb(var(--gh-bg));
+            font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
+            font-size: 10px;
+            font-weight: 500;
+            line-height: 1;
+            padding: 3px 6px;
+            border-radius: 4px;
+            white-space: nowrap;
+            pointer-events: none;
+            box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+            z-index: 2;
+        }
     </style>
     @fluxAppearance
 </head>
 <body class="bg-gh-bg text-gh-text min-h-screen font-display text-sm antialiased">
     {{-- Find-in-page search bar (Cmd/Ctrl+F) --}}
-    <div x-data="pageSearch" x-show="open" x-cloak
+    <div x-data="pageSearch" x-show="open" x-cloak data-search-ignore
          @keydown.window="handleKeydown($event)"
          class="fixed top-2 right-4 z-[9999] flex items-center gap-1.5 bg-gh-surface border border-gh-border rounded-lg shadow-lg px-3 py-1.5">
         <svg class="w-4 h-4 text-gh-muted shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -165,9 +200,12 @@
         <input x-ref="input" type="text" x-model="query"
                placeholder="Find in page..."
                class="bg-transparent text-gh-text text-sm font-mono outline-none w-56 placeholder:text-gh-muted"
+               @input="onQueryInput()"
                @keydown.enter.prevent="find(false)"
                @keydown.shift.enter.prevent="find(true)"
                @keydown.escape.prevent="close()">
+        <span x-show="query" class="text-gh-muted text-xs font-mono tabular-nums shrink-0 min-w-[3rem] text-right"
+              x-text="totalMatches === 0 ? 'No results' : currentMatch + ' of ' + totalMatches"></span>
         <button @click="find(true)" class="text-gh-muted hover:text-gh-text p-0.5" title="Previous (Shift+Enter)">
             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />

--- a/tests/Browser/PageSearchTest.php
+++ b/tests/Browser/PageSearchTest.php
@@ -227,6 +227,52 @@ test('close() restores original text so no trace is left in the DOM', function (
     expect($result['singleTextNode'])->toBeTrue();
 });
 
+test('markMatches skips text inside display:none and [hidden] sections', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $result = $page->script(<<<'JS'
+        (() => {
+            const host = document.createElement('div');
+            host.id = '__search_sandbox_hidden';
+
+            const visible = document.createElement('div');
+            visible.textContent = 'hiddentoken';
+            host.appendChild(visible);
+
+            const displayNone = document.createElement('div');
+            displayNone.style.display = 'none';
+            displayNone.textContent = 'hiddentoken';
+            host.appendChild(displayNone);
+
+            const hiddenAttr = document.createElement('div');
+            hiddenAttr.hidden = true;
+            hiddenAttr.textContent = 'hiddentoken';
+            host.appendChild(hiddenAttr);
+
+            document.body.appendChild(host);
+
+            const root = document.querySelector('[x-data="pageSearch"]');
+            const data = Alpine.$data(root);
+
+            data.query = 'hiddentoken';
+            data.refresh();
+
+            const total = document.querySelectorAll('#__search_sandbox_hidden .rfa-search-match').length;
+            const inDisplayNone = displayNone.querySelectorAll('.rfa-search-match').length;
+            const inHiddenAttr = hiddenAttr.querySelectorAll('.rfa-search-match').length;
+
+            data.close();
+            host.remove();
+
+            return { total, inDisplayNone, inHiddenAttr };
+        })()
+    JS);
+
+    expect($result['total'])->toBe(1);
+    expect($result['inDisplayNone'])->toBe(0);
+    expect($result['inHiddenAttr'])->toBe(0);
+});
+
 test('current match badge text tracks navigation', function () {
     $page = $this->visit($this->projectUrl());
 

--- a/tests/Browser/PageSearchTest.php
+++ b/tests/Browser/PageSearchTest.php
@@ -280,13 +280,13 @@ test('current match badge text tracks navigation', function () {
         (() => {
             const host = document.createElement('div');
             host.id = '__search_sandbox_badge';
-            host.textContent = 'x x x';
+            host.textContent = 'xxbadgexx xxbadgexx xxbadgexx';
             document.body.appendChild(host);
 
             const root = document.querySelector('[x-data="pageSearch"]');
             const data = Alpine.$data(root);
 
-            data.query = 'x';
+            data.query = 'xxbadgexx';
             data.refresh();
 
             const badgeAt = () => {

--- a/tests/Browser/PageSearchTest.php
+++ b/tests/Browser/PageSearchTest.php
@@ -4,8 +4,6 @@ beforeEach(function () {
     $this->setUpTestRepo();
 });
 
-// ----- UI-level behavior -----
-
 test('Cmd+F opens the search bar, Escape closes it and clears marks', function () {
     $page = $this->visit($this->projectUrl());
 
@@ -65,11 +63,9 @@ test('Enter advances and Shift+Enter goes back, wrapping at the ends', function 
     $input->press('Shift+Enter');
     $page->assertSee('1 of '.$total);
 
-    // Wraps to last when going back from 1.
     $input->press('Shift+Enter');
     $page->assertSee($total.' of '.$total);
 
-    // Wraps back to 1 when advancing from last.
     $input->press('Enter');
     $page->assertSee('1 of '.$total);
 });
@@ -96,20 +92,14 @@ test('the search bar itself is skipped so the counter text is never wrapped', fu
 
     $page->page()->locator('.rfa-search-match')->first()->waitFor();
 
-    // Now type a query that would otherwise match the counter text ("N of M").
     $input->fill('of');
-    // Even though "of" may appear elsewhere, none of the wrapped matches should
-    // live inside the bar (which is marked data-search-ignore).
     $insideBar = $page->page()->locator('[data-search-ignore] .rfa-search-match')->count();
     expect($insideBar)->toBe(0);
 });
 
-// ----- Direct Alpine-component-level checks -----
-
 test('escapeRegex via markMatches handles regex metacharacters without throwing', function () {
     $page = $this->visit($this->projectUrl());
 
-    // Inject a sandbox element with known content including regex-ish chars.
     $result = $page->script(<<<'JS'
         (() => {
             const host = document.createElement('div');

--- a/tests/Browser/PageSearchTest.php
+++ b/tests/Browser/PageSearchTest.php
@@ -1,0 +1,281 @@
+<?php
+
+beforeEach(function () {
+    $this->setUpTestRepo();
+});
+
+// ----- UI-level behavior -----
+
+test('Cmd+F opens the search bar, Escape closes it and clears marks', function () {
+    $page = $this->visit($this->projectUrl());
+
+    expect($page->page()->getByPlaceholder('Find in page...')->isVisible())->toBeFalse();
+
+    $page->page()->locator('body')->press('Meta+f');
+
+    $input = $page->page()->getByPlaceholder('Find in page...');
+    $input->waitFor();
+    $input->fill('greet');
+
+    $page->page()->locator('.rfa-search-match')->first()->waitFor();
+    expect($page->page()->locator('.rfa-search-match')->count())->toBeGreaterThan(0);
+
+    $input->press('Escape');
+
+    expect($page->page()->locator('.rfa-search-match')->count())->toBe(0);
+    expect($page->page()->getByPlaceholder('Find in page...')->isVisible())->toBeFalse();
+});
+
+test('typing highlights every match, marks the first as current, and shows the counter', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $page->page()->locator('body')->press('Meta+f');
+    $input = $page->page()->getByPlaceholder('Find in page...');
+    $input->waitFor();
+    $input->fill('greet');
+
+    $page->page()->locator('.rfa-search-match')->first()->waitFor();
+
+    $total = $page->page()->locator('.rfa-search-match')->count();
+    expect($total)->toBeGreaterThan(1);
+    expect($page->page()->locator('.rfa-search-match--current')->count())->toBe(1);
+
+    $page->assertSee('1 of '.$total);
+
+    $badge = $page->page()->locator('.rfa-search-match--current')->first()->getAttribute('data-match-number');
+    expect($badge)->toBe('1 of '.$total);
+});
+
+test('Enter advances and Shift+Enter goes back, wrapping at the ends', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $page->page()->locator('body')->press('Meta+f');
+    $input = $page->page()->getByPlaceholder('Find in page...');
+    $input->waitFor();
+    $input->fill('greet');
+
+    $page->page()->locator('.rfa-search-match')->first()->waitFor();
+    $total = $page->page()->locator('.rfa-search-match')->count();
+
+    $page->assertSee('1 of '.$total);
+
+    $input->press('Enter');
+    $page->assertSee('2 of '.$total);
+
+    $input->press('Shift+Enter');
+    $page->assertSee('1 of '.$total);
+
+    // Wraps to last when going back from 1.
+    $input->press('Shift+Enter');
+    $page->assertSee($total.' of '.$total);
+
+    // Wraps back to 1 when advancing from last.
+    $input->press('Enter');
+    $page->assertSee('1 of '.$total);
+});
+
+test('non-matching query shows No results and wraps no nodes', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $page->page()->locator('body')->press('Meta+f');
+    $input = $page->page()->getByPlaceholder('Find in page...');
+    $input->waitFor();
+    $input->fill('zzzzz-no-match-for-this-token');
+
+    $page->assertSee('No results');
+    expect($page->page()->locator('.rfa-search-match')->count())->toBe(0);
+});
+
+test('the search bar itself is skipped so the counter text is never wrapped', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $page->page()->locator('body')->press('Meta+f');
+    $input = $page->page()->getByPlaceholder('Find in page...');
+    $input->waitFor();
+    $input->fill('greet');
+
+    $page->page()->locator('.rfa-search-match')->first()->waitFor();
+
+    // Now type a query that would otherwise match the counter text ("N of M").
+    $input->fill('of');
+    // Even though "of" may appear elsewhere, none of the wrapped matches should
+    // live inside the bar (which is marked data-search-ignore).
+    $insideBar = $page->page()->locator('[data-search-ignore] .rfa-search-match')->count();
+    expect($insideBar)->toBe(0);
+});
+
+// ----- Direct Alpine-component-level checks -----
+
+test('escapeRegex via markMatches handles regex metacharacters without throwing', function () {
+    $page = $this->visit($this->projectUrl());
+
+    // Inject a sandbox element with known content including regex-ish chars.
+    $result = $page->script(<<<'JS'
+        (() => {
+            const host = document.createElement('div');
+            host.id = '__search_sandbox';
+            host.textContent = 'a.b a+b a*b a(b a.b';
+            document.body.appendChild(host);
+
+            const root = document.querySelector('[x-data="pageSearch"]');
+            const data = Alpine.$data(root);
+
+            data.query = 'a.b';
+            data.refresh();
+            const literalMatches = document.querySelectorAll('#__search_sandbox .rfa-search-match').length;
+
+            data.query = 'a+b';
+            data.refresh();
+            const plusMatches = document.querySelectorAll('#__search_sandbox .rfa-search-match').length;
+
+            data.close();
+            host.remove();
+
+            return { literalMatches, plusMatches };
+        })()
+    JS);
+
+    // "a.b" literal should match exactly 2 occurrences (not every 3-char
+    // substring that would match if '.' were treated as regex).
+    expect($result['literalMatches'])->toBe(2);
+    expect($result['plusMatches'])->toBe(1);
+});
+
+test('markMatches is case-insensitive', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $result = $page->script(<<<'JS'
+        (() => {
+            const host = document.createElement('div');
+            host.id = '__search_sandbox_ci';
+            host.textContent = 'Hello hello HELLO hEllO';
+            document.body.appendChild(host);
+
+            const root = document.querySelector('[x-data="pageSearch"]');
+            const data = Alpine.$data(root);
+
+            data.query = 'hello';
+            data.refresh();
+            const count = document.querySelectorAll('#__search_sandbox_ci .rfa-search-match').length;
+
+            data.close();
+            host.remove();
+
+            return count;
+        })()
+    JS);
+
+    expect($result)->toBe(4);
+});
+
+test('refresh() clears old marks before running the new query', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $result = $page->script(<<<'JS'
+        (() => {
+            const host = document.createElement('div');
+            host.id = '__search_sandbox_refresh';
+            host.textContent = 'alpha beta alpha gamma alpha';
+            document.body.appendChild(host);
+
+            const root = document.querySelector('[x-data="pageSearch"]');
+            const data = Alpine.$data(root);
+
+            data.query = 'alpha';
+            data.refresh();
+            const first = document.querySelectorAll('#__search_sandbox_refresh .rfa-search-match').length;
+
+            data.query = 'beta';
+            data.refresh();
+            const second = document.querySelectorAll('#__search_sandbox_refresh .rfa-search-match').length;
+            const oldAlphaStillWrapped = host.innerHTML.includes('class="rfa-search-match">alpha');
+
+            data.close();
+            host.remove();
+
+            return { first, second, oldAlphaStillWrapped };
+        })()
+    JS);
+
+    expect($result['first'])->toBe(3);
+    expect($result['second'])->toBe(1);
+    expect($result['oldAlphaStillWrapped'])->toBeFalse();
+});
+
+test('close() restores original text so no trace is left in the DOM', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $result = $page->script(<<<'JS'
+        (() => {
+            const host = document.createElement('div');
+            host.id = '__search_sandbox_close';
+            const original = 'one two one three one';
+            host.textContent = original;
+            document.body.appendChild(host);
+
+            const root = document.querySelector('[x-data="pageSearch"]');
+            const data = Alpine.$data(root);
+
+            data.query = 'one';
+            data.refresh();
+            const wrappedCount = document.querySelectorAll('#__search_sandbox_close .rfa-search-match').length;
+
+            data.close();
+            const afterClose = document.querySelectorAll('#__search_sandbox_close .rfa-search-match').length;
+            const textPreserved = host.textContent;
+            const singleTextNode = host.childNodes.length === 1 && host.childNodes[0].nodeType === Node.TEXT_NODE;
+
+            host.remove();
+
+            return { wrappedCount, afterClose, textPreserved, singleTextNode, original };
+        })()
+    JS);
+
+    expect($result['wrappedCount'])->toBe(3);
+    expect($result['afterClose'])->toBe(0);
+    expect($result['textPreserved'])->toBe($result['original']);
+    expect($result['singleTextNode'])->toBeTrue();
+});
+
+test('current match badge text tracks navigation', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $result = $page->script(<<<'JS'
+        (() => {
+            const host = document.createElement('div');
+            host.id = '__search_sandbox_badge';
+            host.textContent = 'x x x';
+            document.body.appendChild(host);
+
+            const root = document.querySelector('[x-data="pageSearch"]');
+            const data = Alpine.$data(root);
+
+            data.query = 'x';
+            data.refresh();
+
+            const badgeAt = () => {
+                const current = document.querySelector('#__search_sandbox_badge .rfa-search-match--current');
+                return current ? current.getAttribute('data-match-number') : null;
+            };
+            const currentCount = () =>
+                document.querySelectorAll('#__search_sandbox_badge .rfa-search-match--current').length;
+
+            const initial = badgeAt();
+            const currents = currentCount();
+            data.find(false);
+            const afterNext = badgeAt();
+            data.find(true);
+            const afterPrev = badgeAt();
+
+            data.close();
+            host.remove();
+
+            return { initial, currents, afterNext, afterPrev };
+        })()
+    JS);
+
+    expect($result['currents'])->toBe(1);
+    expect($result['initial'])->toBe('1 of 3');
+    expect($result['afterNext'])->toBe('2 of 3');
+    expect($result['afterPrev'])->toBe('1 of 3');
+});


### PR DESCRIPTION
## Summary
Replace the browser's native `window.find()` API with a custom find-in-page implementation that highlights all matches in the DOM, tracks the current match, and provides visual feedback with a counter badge.

## Key Changes

- **New search highlighting system**: Implemented `markMatches()` method that uses TreeWalker to find all text nodes matching the query, wraps matches in `<span>` elements with CSS classes, and properly handles regex metacharacters via `escapeRegex()`

- **Match navigation**: Added `find()` method with backwards/forwards navigation that wraps around at document boundaries, and `updateCurrent()` to manage the current match state with visual indicators

- **DOM cleanup**: Implemented `clearMarks()` method that restores original text content when closing search, ensuring no trace of search markup remains in the DOM

- **Search bar enhancements**:
  - Added real-time query input handler (`onQueryInput()`) that refreshes matches as user types
  - Added match counter display showing "X of Y" or "No results"
  - Added `data-search-ignore` attribute to prevent search bar text itself from being highlighted
  - Integrated keyboard navigation (Enter/Shift+Enter for next/previous, Escape to close)

- **Styling**: Added CSS for match highlights with distinct styling for current match including:
  - Base match styling with background and border
  - Current match with enhanced visibility and z-index
  - Badge overlay showing match position (e.g., "2 of 5")
  - Theme colors for search matches in config/theme.php

- **Comprehensive test suite**: Added 11 browser tests covering:
  - Open/close behavior with Cmd+F and Escape
  - Match highlighting and counter display
  - Navigation with wrapping
  - Edge cases (no results, regex metacharacters, case-insensitivity)
  - DOM restoration after close
  - Badge text tracking during navigation

## Notable Implementation Details

- Uses case-insensitive regex matching while preserving original text case in highlights
- Skips search bar and certain elements (script, style, iframe, etc.) via TreeWalker filter
- Properly handles regex metacharacters by escaping them before pattern creation
- Maintains match element references for efficient DOM updates during navigation
- Smooth scrolling to current match with `scrollIntoView()`

https://claude.ai/code/session_01XPA9YBWY9ngMP8hdZXL9PF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom in-page search with persistent highlighting, match counter, keyboard navigation (Enter/Shift+Enter), improved Cmd/Ctrl+F behavior, and wrap-around navigation.
  * Whitespace-only queries ignored; literal/reg-exp metacharacters matched safely; ignored/hidden areas excluded from results.
* **Style**
  * Enhanced, theme-aware highlight visuals for matches and the active match.
* **Tests**
  * New end-to-end browser tests covering search, highlighting, navigation, lifecycle, and exclusion rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->