### PR TITLE
Add Working tree row to branch explorer selection drawer

### DIFF
--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -113,18 +113,17 @@ new class extends Component {
                 {{-- Left pane: branches --}}
                 <div class="w-[180px] shrink-0 border-r border-gh-border flex flex-col min-h-0">
                     {{-- Search input --}}
-                    <div class="p-3 border-b border-gh-border">
+                    <div class="px-2 py-3 border-b border-gh-border">
                         <flux:input
                             x-ref="searchInput"
                             x-model.debounce.100ms="search"
                             @input="onSearchChange()"
                             @keydown.escape.stop="handleSearchEscape($event)"
-                            placeholder="Filter branches..."
+                            placeholder="Filter branch"
                             icon="magnifying-glass"
                             icon:variant="outline"
                             size="sm"
                             variant="filled"
-                            clearable
                         />
                     </div>
 

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -201,13 +201,13 @@ new class extends Component {
 
                     {{-- Commits list --}}
                     <div class="overflow-y-auto flex-1">
-                        {{-- Row 0: Working tree. A peer to commits, not a property of a branch. --}}
                         <button
                             type="button"
                             data-testid="working-tree-row"
                             class="w-full text-left px-4 py-2.5 border-b border-gh-border/50 hover:bg-gh-border/20 transition-colors cursor-pointer"
                             @click="viewWorkingTree()"
                             :class="{ 'bg-gh-text/5 border-l-2 border-l-gh-text': activeCommitHash === null }"
+                            :aria-current="activeCommitHash === null ? 'true' : null"
                         >
                             <div class="flex items-start gap-2">
                                 <div class="mt-0.5 size-4 shrink-0 grid place-items-center">
@@ -215,9 +215,7 @@ new class extends Component {
                                 </div>
                                 <div class="min-w-0 flex-1">
                                     <div class="text-xs text-gh-text truncate font-medium tracking-tight">Working tree</div>
-                                    <div class="flex items-center gap-2 mt-0.5">
-                                        <span class="text-[10px] font-mono text-gh-muted">uncommitted changes</span>
-                                    </div>
+                                    <span class="block mt-0.5 text-[10px] font-mono text-gh-muted">uncommitted changes</span>
                                 </div>
                             </div>
                         </button>

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -19,7 +19,7 @@ new class extends Component {
     public ?string $activeCommitHash = null;
 
     #[Locked]
-    public string $selectionLabel = 'working';
+    public string $selectionLabel = 'Working tree';
 
     #[Locked]
     public string $selectionTitle = 'Working tree changes';
@@ -188,22 +188,40 @@ new class extends Component {
                         <span class="text-xs font-semibold tracking-brutal text-gh-text truncate" x-text="selectedBranch || 'Select a branch'"></span>
                         <span class="text-xs font-mono text-gh-muted" x-show="$wire.commits.length > 0" x-text="'(' + $wire.commits.length + ($wire.hasMore ? '+' : '') + ')'"></span>
 
-                        <div class="ml-auto flex items-center gap-2">
-                            <template x-if="selectedHashes.length > 0">
-                                <div class="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-gh-link/10 border border-gh-link/20">
-                                    <span class="text-[10px] text-gh-link font-mono" x-text="selectedHashes.length + ' selected'"></span>
-                                    <button @click="clearSelection()" class="text-gh-link hover:text-gh-link/80" title="Clear selection">
-                                        <flux:icon icon="x-mark" variant="outline" />
-                                    </button>
-                                    <button @click="applySelection()" class="text-[10px] text-gh-link hover:underline font-medium">Apply</button>
-                                </div>
-                            </template>
-                            <flux:button size="xs" variant="ghost" @click="viewWorkingTree()" class="!text-[10px]">Working Tree</flux:button>
-                        </div>
+                        <template x-if="selectedHashes.length > 0">
+                            <div class="ml-auto flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-gh-link/10 border border-gh-link/20">
+                                <span class="text-[10px] text-gh-link font-mono" x-text="selectedHashes.length + ' selected'"></span>
+                                <button @click="clearSelection()" class="text-gh-link hover:text-gh-link/80" title="Clear selection">
+                                    <flux:icon icon="x-mark" variant="outline" />
+                                </button>
+                                <button @click="applySelection()" class="text-[10px] text-gh-link hover:underline font-medium">Apply</button>
+                            </div>
+                        </template>
                     </div>
 
                     {{-- Commits list --}}
                     <div class="overflow-y-auto flex-1">
+                        {{-- Row 0: Working tree. A peer to commits, not a property of a branch. --}}
+                        <button
+                            type="button"
+                            data-testid="working-tree-row"
+                            class="w-full text-left px-4 py-2.5 border-b border-gh-border/50 hover:bg-gh-border/20 transition-colors cursor-pointer"
+                            @click="viewWorkingTree()"
+                            :class="{ 'bg-gh-text/5 border-l-2 border-l-gh-text': activeCommitHash === null }"
+                        >
+                            <div class="flex items-start gap-2">
+                                <div class="mt-0.5 size-4 shrink-0 grid place-items-center">
+                                    <flux:icon icon="pencil-square" variant="outline" class="!size-3.5 text-gh-muted" />
+                                </div>
+                                <div class="min-w-0 flex-1">
+                                    <div class="text-xs text-gh-text truncate font-medium tracking-tight">Working tree</div>
+                                    <div class="flex items-center gap-2 mt-0.5">
+                                        <span class="text-[10px] font-mono text-gh-muted">uncommitted changes</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </button>
+
                         <template x-if="$wire.commits.length === 0">
                             <div class="flex items-center justify-center h-32">
                                 <span class="text-xs text-gh-muted">No commits</span>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -932,7 +932,7 @@ new #[Layout('layouts.app')] class extends Component
                 $shortFrom = $diffFrom === 'HEAD' ? 'HEAD' : substr($diffFrom, 0, 7);
                 $shortTo = $diffTo ? substr($diffTo, 0, 7) : null;
                 if ($diffTo === null) {
-                    $selectionLabel = 'working';
+                    $selectionLabel = 'Working tree';
                     $selectionTitle = 'Working tree changes';
                 } elseif ($diffFrom === $diffTo.'^') {
                     $selectionLabel = $shortTo;

--- a/tests/Browser/CLAUDE.md
+++ b/tests/Browser/CLAUDE.md
@@ -13,6 +13,8 @@
 - Commit history repo: `setUpCommitHistoryRepo()`
 - Dashboard project list: `setUpRegisteredProjects([...])`
 - Use `$this->visitAndLoad($url)` instead of `$this->visit($url)` when the test interacts with lazy-loaded content (e.g. diff line numbers). It waits for all Livewire requests to settle before proceeding, avoiding flaky timeouts under load.
+- `visitAndLoad()` only waits for `networkidle`, which can fire before a lazy `x-intersect.once` Livewire round-trip has actually injected its DOM. If the test then triggers a synchronous client-side operation that walks the DOM (e.g. find-in-page highlighting) and expects results immediately, add an explicit wait for concrete content (`getByTestId('diff-line-number')->first()->waitFor()` or a text locator) right after `visitAndLoad()`. See `tests/Browser/PageSearchTest.php` for the pattern.
+- Prefer `waitFor(['state' => 'hidden'])` over `isVisible()->toBeFalse()` when asserting that an Alpine `x-show` element has closed. `isVisible()` is synchronous and races the DOM update; `waitFor` auto-retries.
 
 ## Selector Priority
 

--- a/tests/Browser/CommitSwitchingTest.php
+++ b/tests/Browser/CommitSwitchingTest.php
@@ -164,7 +164,7 @@ test('escape in branch explorer filter clears input before closing panel', funct
 
     $page->page()->locator('button:has(span:text("main"))')->click();
 
-    $filterInput = $page->page()->getByPlaceholder('Filter branches...');
+    $filterInput = $page->page()->getByPlaceholder('Filter branch');
     $filterInput->waitFor();
     $page->page()->locator('text=Add greet function')->waitFor();
 
@@ -172,7 +172,7 @@ test('escape in branch explorer filter clears input before closing panel', funct
     $filterInput->press('Escape');
 
     expect($filterInput->inputValue())->toBe('');
-    expect($page->script("document.activeElement?.getAttribute('placeholder')"))->not->toBe('Filter branches...');
+    expect($page->script("document.activeElement?.getAttribute('placeholder')"))->not->toBe('Filter branch');
     expect($filterInput->isVisible())->toBeTrue();
 
     $page->page()->locator('body')->press('Escape');

--- a/tests/Browser/PageSearchTest.php
+++ b/tests/Browser/PageSearchTest.php
@@ -4,8 +4,21 @@ beforeEach(function () {
     $this->setUpTestRepo();
 });
 
+/**
+ * Wait for at least one diff line to render. `visitAndLoad()` only waits for
+ * networkidle, which can fire before the lazy-loaded diff has filled the DOM.
+ * The page-search tests fill the input and expect matches immediately, so
+ * they need a deterministic signal that the content they're about to search
+ * is actually present before pressing Cmd+F.
+ */
+function waitForDiffsLoaded($page): void
+{
+    $page->page()->getByTestId('diff-line-number')->first()->waitFor();
+}
+
 test('Cmd+F opens the search bar, Escape closes it and clears marks', function () {
     $page = $this->visitAndLoad($this->projectUrl());
+    waitForDiffsLoaded($page);
 
     expect($page->page()->getByPlaceholder('Find in page...')->isVisible())->toBeFalse();
 
@@ -26,6 +39,7 @@ test('Cmd+F opens the search bar, Escape closes it and clears marks', function (
 
 test('typing highlights every match, marks the first as current, and shows the counter', function () {
     $page = $this->visitAndLoad($this->projectUrl());
+    waitForDiffsLoaded($page);
 
     $page->page()->locator('body')->press('Meta+f');
     $input = $page->page()->getByPlaceholder('Find in page...');
@@ -46,6 +60,7 @@ test('typing highlights every match, marks the first as current, and shows the c
 
 test('Enter advances and Shift+Enter goes back, wrapping at the ends', function () {
     $page = $this->visitAndLoad($this->projectUrl());
+    waitForDiffsLoaded($page);
 
     $page->page()->locator('body')->press('Meta+f');
     $input = $page->page()->getByPlaceholder('Find in page...');
@@ -72,6 +87,7 @@ test('Enter advances and Shift+Enter goes back, wrapping at the ends', function 
 
 test('non-matching query shows No results and wraps no nodes', function () {
     $page = $this->visitAndLoad($this->projectUrl());
+    waitForDiffsLoaded($page);
 
     $page->page()->locator('body')->press('Meta+f');
     $input = $page->page()->getByPlaceholder('Find in page...');
@@ -84,6 +100,7 @@ test('non-matching query shows No results and wraps no nodes', function () {
 
 test('the search bar itself is skipped so the counter text is never wrapped', function () {
     $page = $this->visitAndLoad($this->projectUrl());
+    waitForDiffsLoaded($page);
 
     $page->page()->locator('body')->press('Meta+f');
     $input = $page->page()->getByPlaceholder('Find in page...');

--- a/tests/Browser/PageSearchTest.php
+++ b/tests/Browser/PageSearchTest.php
@@ -5,7 +5,7 @@ beforeEach(function () {
 });
 
 test('Cmd+F opens the search bar, Escape closes it and clears marks', function () {
-    $page = $this->visit($this->projectUrl());
+    $page = $this->visitAndLoad($this->projectUrl());
 
     expect($page->page()->getByPlaceholder('Find in page...')->isVisible())->toBeFalse();
 
@@ -20,12 +20,12 @@ test('Cmd+F opens the search bar, Escape closes it and clears marks', function (
 
     $input->press('Escape');
 
+    $page->page()->getByPlaceholder('Find in page...')->waitFor(['state' => 'hidden']);
     expect($page->page()->locator('.rfa-search-match')->count())->toBe(0);
-    expect($page->page()->getByPlaceholder('Find in page...')->isVisible())->toBeFalse();
 });
 
 test('typing highlights every match, marks the first as current, and shows the counter', function () {
-    $page = $this->visit($this->projectUrl());
+    $page = $this->visitAndLoad($this->projectUrl());
 
     $page->page()->locator('body')->press('Meta+f');
     $input = $page->page()->getByPlaceholder('Find in page...');
@@ -45,7 +45,7 @@ test('typing highlights every match, marks the first as current, and shows the c
 });
 
 test('Enter advances and Shift+Enter goes back, wrapping at the ends', function () {
-    $page = $this->visit($this->projectUrl());
+    $page = $this->visitAndLoad($this->projectUrl());
 
     $page->page()->locator('body')->press('Meta+f');
     $input = $page->page()->getByPlaceholder('Find in page...');
@@ -71,7 +71,7 @@ test('Enter advances and Shift+Enter goes back, wrapping at the ends', function 
 });
 
 test('non-matching query shows No results and wraps no nodes', function () {
-    $page = $this->visit($this->projectUrl());
+    $page = $this->visitAndLoad($this->projectUrl());
 
     $page->page()->locator('body')->press('Meta+f');
     $input = $page->page()->getByPlaceholder('Find in page...');
@@ -83,7 +83,7 @@ test('non-matching query shows No results and wraps no nodes', function () {
 });
 
 test('the search bar itself is skipped so the counter text is never wrapped', function () {
-    $page = $this->visit($this->projectUrl());
+    $page = $this->visitAndLoad($this->projectUrl());
 
     $page->page()->locator('body')->press('Meta+f');
     $input = $page->page()->getByPlaceholder('Find in page...');

--- a/tests/Browser/SelectionBadgeTest.php
+++ b/tests/Browser/SelectionBadgeTest.php
@@ -1,12 +1,12 @@
 <?php
 
-test('selection badge reads "working" when viewing the working tree', function () {
+test('selection badge reads "Working tree" when viewing the working tree', function () {
     $this->setUpTestRepo();
 
     $page = $this->visit($this->projectUrl());
 
     $page->page()->getByLabel('Open selection drawer')->waitFor();
-    expect($page->page()->getByLabel('Open selection drawer')->innerText())->toContain('working');
+    expect($page->page()->getByLabel('Open selection drawer')->innerText())->toContain('Working tree');
 });
 
 test('selection badge reads the short SHA in single-commit mode', function () {

--- a/tests/Browser/SelectionBadgeTest.php
+++ b/tests/Browser/SelectionBadgeTest.php
@@ -38,6 +38,6 @@ test('clicking the selection badge opens the branch-explorer panel', function ()
     $page = $this->visit($this->projectUrl());
     $page->page()->getByLabel('Open selection drawer')->click();
 
-    $page->page()->getByPlaceholder('Filter branches...')->waitFor();
+    $page->page()->getByPlaceholder('Filter branch')->waitFor();
     $page->assertSee('Add greet function');
 });

--- a/tests/Browser/SelectionWorkingTreeRowTest.php
+++ b/tests/Browser/SelectionWorkingTreeRowTest.php
@@ -6,7 +6,7 @@ test('branch-explorer panel shows a Working tree row at the top of the commit li
     $page = $this->visit($this->projectUrl());
 
     $page->page()->getByLabel('Open selection drawer')->click();
-    $page->page()->getByPlaceholder('Filter branches...')->waitFor();
+    $page->page()->getByPlaceholder('Filter branch')->waitFor();
 
     $row = $page->page()->getByTestId('working-tree-row');
     $row->waitFor();

--- a/tests/Browser/SelectionWorkingTreeRowTest.php
+++ b/tests/Browser/SelectionWorkingTreeRowTest.php
@@ -11,6 +11,9 @@ test('branch-explorer panel shows a Working tree row at the top of the commit li
     $row = $page->page()->getByTestId('working-tree-row');
     $row->waitFor();
     expect($row->innerText())->toContain('Working tree');
+
+    $firstRow = $page->page()->locator('[data-testid="working-tree-row"], [data-testid="commit-row"]')->first();
+    expect($firstRow->getAttribute('data-testid'))->toBe('working-tree-row');
 });
 
 test('Working tree row shows active state when viewing the working tree', function () {

--- a/tests/Browser/SelectionWorkingTreeRowTest.php
+++ b/tests/Browser/SelectionWorkingTreeRowTest.php
@@ -1,0 +1,53 @@
+<?php
+
+test('branch-explorer panel shows a Working tree row at the top of the commit list', function () {
+    $this->setUpCommitHistoryRepo();
+
+    $page = $this->visit($this->projectUrl());
+
+    $page->page()->getByLabel('Open selection drawer')->click();
+    $page->page()->getByPlaceholder('Filter branches...')->waitFor();
+
+    $row = $page->page()->getByTestId('working-tree-row');
+    $row->waitFor();
+    expect($row->innerText())->toContain('Working tree');
+});
+
+test('Working tree row shows active state when viewing the working tree', function () {
+    $this->setUpCommitHistoryRepo();
+
+    $page = $this->visit($this->projectUrl());
+
+    $page->page()->getByLabel('Open selection drawer')->click();
+    $page->page()->getByTestId('working-tree-row')->waitFor();
+
+    $classes = $page->page()->getByTestId('working-tree-row')->getAttribute('class');
+    expect($classes)->toContain('border-l-gh-text');
+});
+
+test('Working tree row has no active state when viewing a commit', function () {
+    $this->setUpCommitHistoryRepo();
+
+    $page = $this->visit($this->projectUrl().'/c/'.$this->commitHashes[1]);
+    $page->page()->getByTestId('commit-context-bar')->waitFor();
+
+    $page->page()->getByLabel('Open selection drawer')->click();
+    $page->page()->getByTestId('working-tree-row')->waitFor();
+
+    $classes = $page->page()->getByTestId('working-tree-row')->getAttribute('class');
+    expect($classes)->not->toContain('border-l-gh-text');
+});
+
+test('clicking the Working tree row navigates back to the working tree', function () {
+    $this->setUpCommitHistoryRepo();
+
+    $page = $this->visit($this->projectUrl().'/c/'.$this->commitHashes[1]);
+    $page->page()->getByTestId('commit-context-bar')->waitFor();
+
+    $page->page()->getByLabel('Open selection drawer')->click();
+    $page->page()->getByTestId('working-tree-row')->waitFor();
+    $page->page()->getByTestId('working-tree-row')->click();
+
+    $page->assertDontSee('Add type hints and utils');
+    expect($page->page()->getByTestId('commit-context-bar')->count())->toBe(0);
+});

--- a/tests/Browser/SelectionWorkingTreeRowTest.php
+++ b/tests/Browser/SelectionWorkingTreeRowTest.php
@@ -21,8 +21,7 @@ test('Working tree row shows active state when viewing the working tree', functi
     $page->page()->getByLabel('Open selection drawer')->click();
     $page->page()->getByTestId('working-tree-row')->waitFor();
 
-    $classes = $page->page()->getByTestId('working-tree-row')->getAttribute('class');
-    expect($classes)->toContain('border-l-gh-text');
+    expect($page->page()->getByTestId('working-tree-row')->getAttribute('aria-current'))->toBe('true');
 });
 
 test('Working tree row has no active state when viewing a commit', function () {
@@ -34,8 +33,7 @@ test('Working tree row has no active state when viewing a commit', function () {
     $page->page()->getByLabel('Open selection drawer')->click();
     $page->page()->getByTestId('working-tree-row')->waitFor();
 
-    $classes = $page->page()->getByTestId('working-tree-row')->getAttribute('class');
-    expect($classes)->not->toContain('border-l-gh-text');
+    expect($page->page()->getByTestId('working-tree-row')->getAttribute('aria-current'))->toBeNull();
 });
 
 test('clicking the Working tree row navigates back to the working tree', function () {


### PR DESCRIPTION
## Summary
This PR adds a dedicated "Working tree" row to the top of the commit list in the branch explorer selection drawer, making it easier for users to navigate back to the working tree view.

## Key Changes
- **New Working tree row component**: Added a prominent button at the top of the commits list in the branch explorer that displays "Working tree" with an icon and "uncommitted changes" subtitle
- **Active state indicator**: The working tree row shows an active state (with `aria-current="true"` and visual styling) when viewing the working tree, and no active state when viewing a specific commit
- **Navigation functionality**: Clicking the working tree row navigates back to the working tree view from any commit view
- **Updated selection label**: Changed the selection label from "working" to "Working tree" for consistency and improved readability across the UI
- **Removed redundant button**: Removed the separate "Working Tree" button that was previously in the header, consolidating the functionality into the new row

## Implementation Details
- The working tree row uses a pencil-square icon to visually distinguish it from commit rows
- The row is styled with hover effects and a left border indicator when active
- The `activeCommitHash === null` condition is used to determine if the working tree is currently being viewed
- All existing tests have been updated to reflect the new "Working tree" label, and comprehensive new tests verify the row's behavior in different states

https://claude.ai/code/session_014D1imL9GQjnZCdCwrWptva

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Working tree" row button to the branch explorer drawer for quick navigation.

* **UI/UX Improvements**
  * Updated selection label to "Working tree" and refined branch filter placeholder to "Filter branch".
  * Commits header now shows selection controls only when relevant; added accessible selection styling for the working-tree row.

* **Tests**
  * Added and updated browser tests covering the working-tree row, selection badge, and related UI flows.

* **Documentation**
  * Clarified test guidance for waiting on dynamic DOM updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->