### PR TITLE
Bootstrap dependencies in remote Claude Code sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -36,7 +36,12 @@ if [ -f composer.json ]; then
   fi
 fi
 
-if [ -f package.json ] && [ ! -d node_modules ]; then
+if [ -f package.json ]; then
+  # Run unconditionally: npm install is idempotent and a fast no-op when
+  # node_modules already matches the lockfile. Skipping the install when
+  # node_modules merely exists risks using a stale cache (e.g. from a
+  # different commit) that's missing the playwright binary the next step
+  # depends on.
   echo "Installing npm dependencies..."
   npm install
 fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,3 +9,43 @@ if command -v lefthook >/dev/null 2>&1; then
 else
   echo "Warning: lefthook not found. Git hooks (pre-commit lint, pre-push types) will not run."
 fi
+
+# ── Bootstrap (remote sessions only) ─────────────────────────────
+# Local sessions are expected to manage their own deps. In Claude Code on
+# the web the container starts empty, so ensure composer/npm/playwright
+# are ready before the agent runs anything.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Composer-plugins (including pestphp/pest-plugin, whose post-autoload-dump
+# hook writes vendor/pest-plugins.json that Pest needs to discover the
+# browser plugin) are silently skipped when composer runs as root unless
+# this is set. Missing pest-plugins.json makes every browser test fail with
+# a bare "sendText() on null" because the WebSocket never opens.
+export COMPOSER_ALLOW_SUPERUSER=1
+
+if [ -f composer.json ]; then
+  if [ ! -f vendor/autoload.php ]; then
+    echo "Installing Composer dependencies..."
+    composer install --no-interaction --prefer-dist
+  elif [ ! -f vendor/pest-plugins.json ]; then
+    # vendor/ was cached from an install that ran without superuser; the
+    # post-autoload hook was skipped. Regenerate to write the plugin file.
+    composer dump-autoload --no-interaction
+  fi
+fi
+
+if [ -f package.json ] && [ ! -d node_modules ]; then
+  echo "Installing npm dependencies..."
+  npm install
+fi
+
+# Install the chromium build that matches the installed Playwright. The
+# cloud image pre-seeds PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers with an
+# older chromium; Playwright will install the matching revision alongside
+# it and skip the download on subsequent runs.
+if [ -f node_modules/.bin/playwright ]; then
+  echo "Ensuring Playwright chromium is installed..."
+  npx --no-install playwright install chromium
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "devDependencies": {
                 "instruckt": "^0.4.30",
-                "playwright": "^1.58.2"
+                "playwright": "^1.59.1"
             }
         },
         "node_modules/@types/react": {
@@ -102,13 +102,13 @@
             "license": "MIT"
         },
         "node_modules/playwright": {
-            "version": "1.59.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.0.tgz",
-            "integrity": "sha512-wihGScriusvATUxmhfENxg0tj1vHEFeIwxlnPFKQTOQVd7aG08mUfvvniRP/PtQOC+2Bs52kBOC/Up1jTXeIbw==",
+            "version": "1.59.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+            "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.59.0"
+                "playwright-core": "1.59.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -121,9 +121,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.59.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.0.tgz",
-            "integrity": "sha512-PW/X/IoZ6BMUUy8rpwHEZ8Kc0IiLIkgKYGNFaMs5KmQhcfLILNx9yCQD0rnWeWfz1PNeqcFP1BsihQhDOBCwZw==",
+            "version": "1.59.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+            "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
     "private": true,
     "devDependencies": {
         "instruckt": "^0.4.30",
-        "playwright": "^1.58.2"
+        "playwright": "^1.59.1"
     }
 }


### PR DESCRIPTION
## Summary
Add automatic dependency bootstrapping for remote Claude Code sessions to ensure Composer, npm, and Playwright are ready before the agent runs.

## Key Changes
- **Conditional bootstrap logic**: Only runs in remote Claude Code environments (`CLAUDE_CODE_REMOTE=true`), allowing local sessions to manage their own dependencies
- **Composer installation**: Automatically installs Composer dependencies if `vendor/autoload.php` is missing, with `COMPOSER_ALLOW_SUPERUSER=1` to ensure Composer plugins (like pest-plugin) run correctly in containerized environments
- **Autoload regeneration**: Re-runs `composer dump-autoload` if `vendor/pest-plugins.json` is missing, fixing cases where vendor/ was cached from a non-superuser install
- **npm installation**: Automatically installs npm dependencies if `node_modules/` doesn't exist
- **Playwright setup**: Ensures the correct Chromium build matching the installed Playwright version is available, leveraging pre-seeded browser cache when available

## Implementation Details
The bootstrap logic is added to the session-start hook and includes safeguards to avoid redundant operations:
- Checks for existing artifacts (`vendor/autoload.php`, `node_modules/`, `vendor/pest-plugins.json`) before running installations
- Provides user feedback via echo statements for long-running operations
- Addresses a specific issue where missing `pest-plugins.json` causes browser tests to fail with "sendText() on null" errors

Also updates Playwright to ^1.59.1 for compatibility.

https://claude.ai/code/session_018VEZuGWgRy47VcJ81xc3AN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved remote development session setup with automated dependency initialization for Composer, npm, and Playwright browser installation.
  * Updated Playwright development dependency to version 1.59.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->