### PR TITLE
Improve file review status and action button layout

### DIFF
--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1211,17 +1211,22 @@ new #[Layout('layouts.app')] class extends Component
                             @endif
                             <span class="truncate font-mono" title="{{ $file['path'] }}{{ ($file['isSymlink'] ?? false) ? ' -> ' . $file['symlinkTarget'] : '' }}{{ ($file['lastModified'] ?? null) ? "\nModified " . $file['lastModified'] : '' }}">{{ $file['path'] }}</span>
                         </button>
-                        <flux:icon icon="check" variant="outline" x-show="reviewedFiles['{{ $file['id'] }}']"
-                            class="text-gh-green shrink-0" x-cloak />
-                        @if(! $this->isCommitMode() && $file['status'] !== 'commented')
-                            <button
-                                class="opacity-0 group-hover:opacity-100 transition-opacity text-gh-muted hover:text-gh-text shrink-0 data-loading:pointer-events-none data-loading:opacity-50"
-                                title="Discard changes"
-                                wire:click.stop="discardFileChanges('{{ $file['id'] }}')"
-                            >
-                                <flux:icon icon="arrow-uturn-left" variant="outline" class="!size-3.5" />
-                            </button>
-                        @endif
+                        <span class="shrink-0 size-3.5 flex items-center justify-center">
+                            <flux:icon icon="check" variant="outline"
+                                class="!size-3.5 text-gh-green {{ array_key_exists($file['path'], $reviewedFiles) ? '' : 'invisible' }}"
+                                :class="{ 'invisible': !reviewedFiles['{{ $file['id'] }}'] }" />
+                        </span>
+                        <span class="shrink-0 size-3.5 flex items-center justify-center">
+                            @if(! $this->isCommitMode() && $file['status'] !== 'commented')
+                                <button
+                                    class="opacity-0 group-hover:opacity-100 transition-opacity text-gh-muted hover:text-gh-text data-loading:pointer-events-none data-loading:opacity-50"
+                                    title="Discard changes"
+                                    wire:click.stop="discardFileChanges('{{ $file['id'] }}')"
+                                >
+                                    <flux:icon icon="arrow-uturn-left" variant="outline" class="!size-3.5" />
+                                </button>
+                            @endif
+                        </span>
                         <span class="ml-auto flex gap-1.5 shrink-0 font-mono">
                             @if($file['additions'] > 0)
                                 <span class="text-gh-green">+{{ $file['additions'] }}</span>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1214,7 +1214,7 @@ new #[Layout('layouts.app')] class extends Component
                         <span class="shrink-0 size-3.5 flex items-center justify-center">
                             <flux:icon icon="check" variant="outline"
                                 class="!size-3.5 text-gh-green {{ array_key_exists($file['path'], $reviewedFiles) ? '' : 'invisible' }}"
-                                :class="{ 'invisible': !reviewedFiles['{{ $file['id'] }}'] }" />
+                                ::class="{ 'invisible': !reviewedFiles['{{ $file['id'] }}'] }" />
                         </span>
                         <span class="shrink-0 size-3.5 flex items-center justify-center">
                             @if(! $this->isCommitMode() && $file['status'] !== 'commented')


### PR DESCRIPTION
## Summary
Refactored the file list item layout to improve alignment and visibility of the review status indicator and discard button by wrapping them in fixed-size containers.

## Key Changes
- Wrapped the check icon (review status indicator) in a fixed-size span container (`size-3.5`) with flexbox centering for consistent alignment
- Wrapped the discard button in a separate fixed-size span container with the same dimensions for visual balance
- Updated the check icon visibility logic to use both a Blade conditional (`array_key_exists`) and Alpine.js binding for dual-layer state management
- Adjusted icon sizing to use `!size-3.5` class for explicit sizing within the containers
- Improved spacing consistency by ensuring both action elements occupy the same fixed space

## Implementation Details
- The check icon now uses `invisible` class (instead of `x-show`) for better layout stability, preventing layout shift when toggling visibility
- Both the review indicator and discard button are now contained in `size-3.5` flex containers, ensuring they maintain consistent dimensions regardless of content
- The discard button's `shrink-0` class was moved to the parent span, allowing the button itself to fill the container naturally

https://claude.ai/code/session_01GQbNWxMY3znEAdrmB7PYrL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated review page sidebar so the "reviewed" check displays in a consistent fixed-size area for steadier layout and smoother visibility transitions.
  * Adjusted the "discard changes" button layout into a fixed-size wrapper to keep sidebar spacing stable while preserving the same eligibility rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->