### PR TITLE
Silently recover from post-sleep 419s

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,8 @@ DB_CONNECTION=sqlite
 # DB_PASSWORD=
 
 SESSION_DRIVER=database
-SESSION_LIFETIME=120
+# 1 year; single-user loopback desktop app, lifetime is UX not security.
+SESSION_LIFETIME=525600
 SESSION_ENCRYPT=false
 SESSION_PATH=/
 SESSION_DOMAIN=null

--- a/public/js/session-recovery.js
+++ b/public/js/session-recovery.js
@@ -1,0 +1,13 @@
+// JS timers freeze during macOS sleep, so the <livewire:keepalive> poll
+// can't bump the session before wake. If a 419 slips through, replace
+// Livewire's built-in "page expired" confirm() with a silent reload.
+document.addEventListener('livewire:init', () => {
+    Livewire.interceptRequest(({ onError }) => {
+        onError(({ response, preventDefault }) => {
+            if (response.status === 419) {
+                preventDefault();
+                window.location.reload();
+            }
+        });
+    });
+});

--- a/public/js/session-recovery.js
+++ b/public/js/session-recovery.js
@@ -1,13 +1,27 @@
 // JS timers freeze during macOS sleep, so the <livewire:keepalive> poll
 // can't bump the session before wake. If a 419 slips through, replace
 // Livewire's built-in "page expired" confirm() with a silent reload.
+//
+// The recent-reload guard prevents an infinite loop if a 419 keeps
+// recurring (e.g. broken session storage): after one silent reload
+// within 10s, fall through to Livewire's default handler so the user
+// sees a surface they can act on instead of a reload spinner.
 document.addEventListener('livewire:init', () => {
     Livewire.interceptRequest(({ onError }) => {
         onError(({ response, preventDefault }) => {
-            if (response.status === 419) {
-                preventDefault();
-                window.location.reload();
+            if (response.status !== 419) {
+                return;
             }
+
+            const key = '__rfa419RecoveryAt';
+            const lastRecoveryAt = Number(sessionStorage.getItem(key) || 0);
+            if (Date.now() - lastRecoveryAt < 10_000) {
+                return;
+            }
+
+            sessionStorage.setItem(key, String(Date.now()));
+            preventDefault();
+            window.location.reload();
         });
     });
 });

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -11,6 +11,7 @@
     <script src="/js/overlays-store.js"></script>
     <script src="/js/keymap-store.js"></script>
     <script src="/js/page-search.js"></script>
+    <script src="/js/session-recovery.js"></script>
     <script>
         tailwind.config = {
             darkMode: 'class',

--- a/tests/Arch/SessionRecoveryTest.php
+++ b/tests/Arch/SessionRecoveryTest.php
@@ -32,7 +32,15 @@ test('session-recovery.js intercepts 419 responses and reloads', function () {
     expect($script)
         ->toContain('livewire:init')
         ->toContain('Livewire.interceptRequest')
-        ->toContain('status === 419')
+        ->toContain('status !== 419')
         ->toContain('preventDefault')
         ->toContain('window.location.reload');
+});
+
+test('session-recovery.js guards against a post-reload 419 loop', function () {
+    $script = file_get_contents(dirname(__DIR__, 2).'/public/js/session-recovery.js');
+
+    expect($script)
+        ->toContain('sessionStorage')
+        ->toContain('__rfa419RecoveryAt');
 });

--- a/tests/Arch/SessionRecoveryTest.php
+++ b/tests/Arch/SessionRecoveryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Post-sleep 419 recovery contract. These three pieces work together:
+ * - long SESSION_LIFETIME so the session rarely expires
+ * - keepalive poll so it never expires while the Mac is awake
+ * - interceptor so any 419 that slips through reloads silently
+ *
+ * If any of the three regresses, 419s leak back to the user as
+ * Livewire's "page has expired" modal.
+ */
+test('.env.example sets a session lifetime of at least 1 week', function () {
+    $env = file_get_contents(dirname(__DIR__, 2).'/.env.example');
+
+    expect($env)->toMatch('/^SESSION_LIFETIME=(\d+)/m');
+
+    preg_match('/^SESSION_LIFETIME=(\d+)/m', $env, $matches);
+
+    $weekInMinutes = 60 * 24 * 7;
+    expect((int) $matches[1])->toBeGreaterThanOrEqual($weekInMinutes);
+});
+
+test('app layout loads session-recovery.js', function () {
+    $layout = file_get_contents(dirname(__DIR__, 2).'/resources/views/layouts/app.blade.php');
+
+    expect($layout)->toContain('/js/session-recovery.js');
+});
+
+test('session-recovery.js intercepts 419 responses and reloads', function () {
+    $script = file_get_contents(dirname(__DIR__, 2).'/public/js/session-recovery.js');
+
+    expect($script)
+        ->toContain('livewire:init')
+        ->toContain('Livewire.interceptRequest')
+        ->toContain('status === 419')
+        ->toContain('preventDefault')
+        ->toContain('window.location.reload');
+});

--- a/tests/Browser/Csrf419RecoveryTest.php
+++ b/tests/Browser/Csrf419RecoveryTest.php
@@ -1,0 +1,83 @@
+<?php
+
+beforeEach(function () {
+    $this->setUpTestRepo();
+});
+
+/**
+ * End-to-end proof that public/js/session-recovery.js beats Livewire's
+ * built-in 419 handler (native confirm() then opt-in reload) to a silent reload.
+ *
+ * Laravel's VerifyCsrfToken middleware bypasses validation when running under
+ * the test suite, so we cannot force a real 419 through the middleware here.
+ * Instead we stub window.fetch to return 419 for the first Livewire update.
+ * The response still flows through Livewire's real client-side request
+ * lifecycle, so the interceptor sees a genuine 419 Response object exactly
+ * the way it will in production. Only the server round-trip is faked.
+ *
+ * Signals:
+ * - beforeunload fires only if the browser actually navigates away. Its
+ *   sessionStorage entry surviving the reload proves the silent reload ran.
+ * - window.confirm is trapped. Livewire's default 419 path calls confirm()
+ *   first; our interceptor's preventDefault() should beat it. If the trap
+ *   fires, the interceptor regressed.
+ *
+ * Note: the Pest-browser wrapper's waitForFunction is not a poll (it's a
+ * single evaluate), so we poll from PHP instead. The loop tolerates the
+ * execution-context-destroyed errors that naturally happen during the reload.
+ */
+function waitForSessionValue($page, string $key, string $expected, float $timeoutSec = 5.0): ?string
+{
+    $deadline = microtime(true) + $timeoutSec;
+    $latest = null;
+
+    while (microtime(true) < $deadline) {
+        try {
+            $latest = $page->page()->evaluate("sessionStorage.getItem('{$key}')");
+            if ($latest === $expected) {
+                return $latest;
+            }
+        } catch (Throwable) {
+            // Navigation in flight destroyed the context. Retry.
+        }
+        usleep(100_000);
+    }
+
+    return $latest;
+}
+
+test('interceptor silently reloads on 419 instead of showing Livewire confirm dialog', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $page->page()->waitForFunction('typeof Livewire !== "undefined"');
+
+    $page->page()->evaluate(<<<'JS'
+        () => {
+            sessionStorage.clear();
+
+            window.addEventListener('beforeunload', () => {
+                sessionStorage.setItem('__csrf419ReloadRan', '1');
+            });
+
+            window.confirm = () => {
+                sessionStorage.setItem('__csrf419Dialog', '1');
+                return false;
+            };
+
+            const origFetch = window.fetch;
+            window.fetch = function (input, init) {
+                const url = typeof input === 'string' ? input : input?.url;
+                if (url && url.includes('/livewire') && url.includes('/update')) {
+                    window.fetch = origFetch;
+                    return Promise.resolve(new Response('', { status: 419 }));
+                }
+                return origFetch.call(this, input, init);
+            };
+        }
+    JS);
+
+    $page->page()->evaluate('() => { Livewire.first().$refresh(); }');
+
+    expect(waitForSessionValue($page, '__csrf419ReloadRan', '1'))->toBe('1');
+    expect($page->page()->evaluate("sessionStorage.getItem('__csrf419Dialog')"))->toBeNull();
+});


### PR DESCRIPTION
## Summary
Silently reload on Livewire 419s instead of showing the "This page has expired" native confirm() dialog, so the Mac waking up from sleep stops being a user-facing error.

## Why
The packaged v0.7.0 build 500'd today on a post-sleep git timeout (fixed separately), and the production logs also show two identical CSRF 419s that both landed in the morning (2026-04-04 08:25 and 2026-04-07 08:32). Pattern: macOS slept overnight, JS timers froze, `<livewire:keepalive>` poll couldn't bump the session, first click after wake hit an expired token and triggered Livewire's modal.

## Solution
Research converged on Livewire 4's `Livewire.interceptRequest` hook as the idiomatic fix for this exact failure. Layered three mechanisms so any single regression reintroduces the modal:

- **Long `SESSION_LIFETIME`**
  - Bumped to 1 year in `.env.example`
  - Single-user loopback desktop app, lifetime is a UX knob not security
- **Keepalive poll** (pre-existing)
  - Covers the "window open, Mac awake" case
- **`session-recovery.js` interceptor**
  - Catches any 419 that slips through
  - `preventDefault()`s Livewire's built-in confirm() then reloads silently
  - Comment drafts persist server-side, so the reload loses no user work

## Changes
- **`public/js/session-recovery.js`** (new)
  - Registers `Livewire.interceptRequest` on `livewire:init`
  - Traps `response.status === 419` and calls `window.location.reload()`
- **`resources/views/layouts/app.blade.php`**
  - Loads the new script in `<head>` alongside other public JS
- **`.env.example`**
  - `SESSION_LIFETIME=120` → `525600` (1 year) with rationale comment
- **`tests/Arch/SessionRecoveryTest.php`** (new)
  - Locks the three-piece contract: env lifetime, layout includes script, script has `interceptRequest`/`status === 419`/`preventDefault`/`window.location.reload`
- **`tests/Browser/Csrf419RecoveryTest.php`** (new)
  - End-to-end Playwright test
  - Stubs `window.fetch` to return 419, fires `$refresh`, asserts silent reload happened and `confirm()` was never called
  - Docblock captures two non-obvious gotchas for the next person: `VerifyCsrfToken` bypasses validation under `runningUnitTests()`, and Pest-browser's `waitForFunction` is a single evaluate (not a poll)

## Testing
```bash
composer test:browser -- --filter='silently reloads'
php -d memory_limit=512M vendor/bin/pest --testsuite=Arch --filter=SessionRecovery
```

Regression-verified: gutting `session-recovery.js` and rerunning the browser test fails in ~6s with "Failed asserting that null is identical to '1'" because `beforeunload` never fires.

## Deployment
- [ ] Migrations: none
- [ ] Cache clear: none (env change picked up on next packaged build via `cp .env.example .env` in release workflow)
- [ ] Monitor: watch for new 419 entries in `~/Library/Application Support/rfa/storage/logs/` — should be zero after this ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Silent session recovery: when a session expires, the app now automatically reloads the page to restore the session instead of showing an error dialog.
  * Added a short guard to prevent repeated reload loops after recovery.

* **Chores**
  * Default session lifetime extended to 1 year.

* **Tests**
  * Added architecture and browser tests validating the recovery flow and reload-guard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->