### PR TITLE
Add keyboard shortcut (⌘R) for refreshing the review page

### DIFF
--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1002,12 +1002,12 @@ new #[Layout('layouts.app')] class extends Component
             {{-- Expand/Collapse toggle --}}
             <div class="grid place-items-center">
                 <flux:button variant="ghost" size="sm" icon="expand-all" icon:variant="outline"
-                    tooltip="Expand all (Shift+E)"
+                    tooltip="Expand all · ⇧E" aria-label="Expand all (⇧E)"
                     class="col-start-1 row-start-1"
                     @click="$store.settings.collapseAll = false; $dispatch('expand-all-files')"
                     x-show="$store.settings.collapseAll" x-cloak />
                 <flux:button variant="ghost" size="sm" icon="collapse-all" icon:variant="outline"
-                    tooltip="Collapse all (Shift+C)"
+                    tooltip="Collapse all · ⇧C" aria-label="Collapse all (⇧C)"
                     class="col-start-1 row-start-1"
                     @click="$store.settings.collapseAll = true; $dispatch('collapse-all-files')"
                     x-show="!$store.settings.collapseAll" />
@@ -1038,9 +1038,9 @@ new #[Layout('layouts.app')] class extends Component
                     refresh() {
                         window.location.reload();
                     }
-                }" x-init="startPolling()" @fingerprint-reset.window="fingerprint = null; hasChanges = false" class="relative flex items-center">
+                }" x-init="startPolling(); $store.keymap.register('⌘R', () => refresh(), { allowInEditable: true })" @fingerprint-reset.window="fingerprint = null; hasChanges = false" class="relative flex items-center">
                     <flux:button variant="ghost" size="sm" icon="arrow-path" icon:variant="outline"
-                        tooltip="Refresh page" @click="refresh()" />
+                        tooltip="Refresh page · ⌘R" aria-label="Refresh page (⌘R)" @click="refresh()" />
                     <span x-show="hasChanges" x-cloak
                         class="absolute -top-0.5 -right-0.5 flex h-2.5 w-2.5">
                         <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-400 opacity-75"></span>

--- a/tests/Browser/RefreshShortcutTest.php
+++ b/tests/Browser/RefreshShortcutTest.php
@@ -1,0 +1,56 @@
+<?php
+
+beforeEach(function () {
+    $this->setUpTestRepo();
+});
+
+test('the header shows a refresh button labelled with the ⌘R shortcut', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $page->page()->getByLabel('Refresh page · ⌘R')->first()->waitFor();
+    expect($page->page()->getByLabel('Refresh page · ⌘R')->count())->toBeGreaterThan(0);
+});
+
+test('pressing ⌘R triggers the refresh handler', function () {
+    $page = $this->visitAndLoad($this->projectUrl());
+
+    // Wait for the refresh control (and therefore its x-init keymap registration) to mount.
+    $page->page()->getByLabel('Refresh page · ⌘R')->first()->waitFor();
+
+    // Swap the Alpine component's refresh() for a counter so we don't actually
+    // reload the document mid-test (window.location.reload is read-only and
+    // can't be stubbed).
+    $page->page()->evaluate(<<<'JS'
+        window.__refreshCalls = 0;
+        const el = document.querySelector('[data-testid="change-polling"]');
+        Alpine.$data(el).refresh = () => { window.__refreshCalls += 1; };
+    JS);
+
+    $page->page()->locator('body')->press('Meta+r');
+
+    $page->page()->waitForFunction('window.__refreshCalls >= 1');
+    expect($page->page()->evaluate('window.__refreshCalls'))->toBeGreaterThan(0);
+});
+
+test('⌘R fires even while a comment input is focused', function () {
+    $page = $this->visitAndLoad($this->projectUrl());
+
+    $page->page()->getByLabel('Refresh page · ⌘R')->first()->waitFor();
+
+    // Open a comment form so an input is focused.
+    $page->page()->getByTestId('diff-line-number')->first()->click();
+    $input = $page->page()->getByPlaceholder('Write a comment', false);
+    $input->waitFor();
+    $input->focus();
+
+    $page->page()->evaluate(<<<'JS'
+        window.__refreshCalls = 0;
+        const el = document.querySelector('[data-testid="change-polling"]');
+        Alpine.$data(el).refresh = () => { window.__refreshCalls += 1; };
+    JS);
+
+    $input->press('Meta+r');
+
+    $page->page()->waitForFunction('window.__refreshCalls >= 1');
+    expect($page->page()->evaluate('window.__refreshCalls'))->toBeGreaterThan(0);
+});

--- a/tests/Browser/RefreshShortcutTest.php
+++ b/tests/Browser/RefreshShortcutTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Pest\Browser\Api\PendingAwaitablePage;
+
 beforeEach(function () {
     $this->setUpTestRepo();
 });
@@ -9,7 +11,7 @@ beforeEach(function () {
  * reload the document mid-test. window.location.reload itself is read-only
  * and can't be stubbed, so we swap the caller instead.
  */
-function stubRefreshCounter($page): void
+function stubRefreshCounter(PendingAwaitablePage $page): void
 {
     $page->page()->evaluate(<<<'JS'
         window.__refreshCalls = 0;

--- a/tests/Browser/RefreshShortcutTest.php
+++ b/tests/Browser/RefreshShortcutTest.php
@@ -4,6 +4,20 @@ beforeEach(function () {
     $this->setUpTestRepo();
 });
 
+/**
+ * Replace the Alpine refresh() with a counter so Meta+R doesn't actually
+ * reload the document mid-test. window.location.reload itself is read-only
+ * and can't be stubbed, so we swap the caller instead.
+ */
+function stubRefreshCounter($page): void
+{
+    $page->page()->evaluate(<<<'JS'
+        window.__refreshCalls = 0;
+        const el = document.querySelector('[data-testid="change-polling"]');
+        Alpine.$data(el).refresh = () => { window.__refreshCalls += 1; };
+    JS);
+}
+
 test('the header shows a refresh button labelled with the ⌘R shortcut', function () {
     $page = $this->visit($this->projectUrl());
 
@@ -14,17 +28,10 @@ test('the header shows a refresh button labelled with the ⌘R shortcut', functi
 test('pressing ⌘R triggers the refresh handler', function () {
     $page = $this->visitAndLoad($this->projectUrl());
 
-    // Wait for the refresh control (and therefore its x-init keymap registration) to mount.
+    // Waiting for the button confirms the x-init keymap registration ran.
     $page->page()->getByLabel('Refresh page · ⌘R')->first()->waitFor();
 
-    // Swap the Alpine component's refresh() for a counter so we don't actually
-    // reload the document mid-test (window.location.reload is read-only and
-    // can't be stubbed).
-    $page->page()->evaluate(<<<'JS'
-        window.__refreshCalls = 0;
-        const el = document.querySelector('[data-testid="change-polling"]');
-        Alpine.$data(el).refresh = () => { window.__refreshCalls += 1; };
-    JS);
+    stubRefreshCounter($page);
 
     $page->page()->locator('body')->press('Meta+r');
 
@@ -37,17 +44,12 @@ test('⌘R fires even while a comment input is focused', function () {
 
     $page->page()->getByLabel('Refresh page · ⌘R')->first()->waitFor();
 
-    // Open a comment form so an input is focused.
     $page->page()->getByTestId('diff-line-number')->first()->click();
     $input = $page->page()->getByPlaceholder('Write a comment', false);
     $input->waitFor();
     $input->focus();
 
-    $page->page()->evaluate(<<<'JS'
-        window.__refreshCalls = 0;
-        const el = document.querySelector('[data-testid="change-polling"]');
-        Alpine.$data(el).refresh = () => { window.__refreshCalls += 1; };
-    JS);
+    stubRefreshCounter($page);
 
     $input->press('Meta+r');
 


### PR DESCRIPTION
## Summary
This PR adds keyboard shortcut support for refreshing the review page, allowing users to press ⌘R (Meta+R) to trigger a page refresh. The implementation includes comprehensive browser tests to ensure the shortcut works correctly in various scenarios.

## Key Changes
- **Added RefreshShortcutTest.php**: New browser test suite with three test cases:
  - Verifies the refresh button displays the ⌘R shortcut label
  - Confirms pressing ⌘R triggers the refresh handler
  - Ensures ⌘R works even when a comment input field is focused
  
- **Updated review-page.blade.php**:
  - Registered the ⌘R keyboard shortcut in the Alpine component's `x-init` directive with `allowInEditable: true` to allow the shortcut to work in editable fields
  - Updated the refresh button's tooltip and aria-label to display "Refresh page · ⌘R"
  - Updated expand/collapse button tooltips and aria-labels to use consistent keyboard shortcut formatting (e.g., "Expand all · ⇧E")

## Implementation Details
- The keyboard shortcut is registered using the existing `$store.keymap` system with the `allowInEditable: true` option, enabling the refresh action to work even when focus is on a comment input field
- Tests use a stubbed refresh counter to prevent actual page reloads during test execution, since `window.location.reload` cannot be directly mocked
- Tooltip formatting was standardized across buttons to use the "Label · Shortcut" pattern for consistency

https://claude.ai/code/session_01JJJPepmZ6kzt588cuJ5snK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ⌘R keyboard shortcut for refreshing the page in working-tree mode.
* **Accessibility**
  * Improved tooltip text and aria-labels for bulk expand/collapse and the refresh button to reflect Shift/⌘ shortcuts.
* **Tests**
  * Added browser tests confirming the refresh shortcut is registered, triggers refresh, and still works while typing comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->