### PR TITLE
Update clipboard prompt text from "review" to "address"

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Auto-updates work normally after that (handled by Electron, independent of code 
 The exported `.md` file is ready to paste into AI tools:
 
 ```
-review my comments on these changes in @.rfa/{timestamp}_comments_{hash}.md
+address my comments on these changes in @.rfa/{timestamp}_comments_{hash}.md
 ```
 
 ## Terminal Helper

--- a/app/Services/CommentExporter.php
+++ b/app/Services/CommentExporter.php
@@ -52,7 +52,7 @@ class CommentExporter
         return [
             'json' => $disk->path("{$basename}.json"),
             'md' => $disk->path("{$basename}.md"),
-            'clipboard' => "review my comments on these changes in @.rfa/{$basename}.md",
+            'clipboard' => "address my comments on these changes in @.rfa/{$basename}.md",
         ];
     }
 }

--- a/tests/Unit/CommentExporterTest.php
+++ b/tests/Unit/CommentExporterTest.php
@@ -79,7 +79,7 @@ test('exports Markdown with file grouping', function () {
 test('returns clipboard text', function () {
     $result = $this->exporter->export($this->tmpDir, [], 'test');
 
-    expect($result['clipboard'])->toMatch('/^review my comments on these changes in @\.rfa\/\d{8}_\d{6}_comments_.*\.md$/');
+    expect($result['clipboard'])->toMatch('/^address my comments on these changes in @\.rfa\/\d{8}_\d{6}_comments_.*\.md$/');
 });
 
 test('creates .rfa directory if missing', function () {


### PR DESCRIPTION
## Summary
Updated the clipboard prompt text generated when exporting comments to use more action-oriented language that better reflects the intent of addressing feedback.

## Changes
- Updated the clipboard text prompt from "review my comments on these changes" to "address my comments on these changes" in:
  - `README.md` - documentation example
  - `app/Services/CommentExporter.php` - the actual implementation
  - `tests/Unit/CommentExporterTest.php` - corresponding test assertion

## Details
This change improves the clarity of the exported prompt by using "address" instead of "review", which better conveys that the comments are actionable items to be resolved rather than just reviewed. The change is consistent across documentation, implementation, and tests.

https://claude.ai/code/session_01Kt3NDhuGVPAu86A7yzgboP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology in exported comment instructions from "review my comments" to "address my comments" for consistency across all references.

* **Tests**
  * Updated unit tests to validate the revised comment export messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->