### PR TITLE
Add copy-to-clipboard functionality for comments

### DIFF
--- a/resources/CLAUDE.md
+++ b/resources/CLAUDE.md
@@ -95,7 +95,7 @@ ReviewPage (`resources/views/pages/⚡review-page.blade.php`) renders N DiffFile
 | `delete-comment` | DiffFile Alpine -> parent | ReviewPage `#[On]` | `{commentId}` |
 | `toggle-reviewed` | DiffFile Alpine -> parent | ReviewPage `#[On]` | `{filePath}` |
 | `comment-updated` | ReviewPage PHP dispatch | DiffFile Alpine `@window` | `{fileId, comments}` |
-| `copy-to-clipboard` | DiffFile Alpine/PHP, ReviewPage PHP | ReviewPage Alpine `@window` | `{text}` |
+| `copy-to-clipboard` | DiffFile Alpine/PHP, ReviewPage PHP, comment-display, comments-drawer | ReviewPage Alpine `@window` | `{text, toast?}` (if `toast` string is set, a success toast with that text shows on success) |
 | `file-reviewed-changed` | DiffFile Alpine `$dispatch` | ReviewPage Alpine `@window` | `{id, reviewed}` |
 | `collapse-all-files` | ReviewPage Alpine `$dispatch` | DiffFile Alpine `@window` | none |
 | `expand-all-files` | ReviewPage Alpine `$dispatch` | DiffFile Alpine `@window` | none |

--- a/resources/views/components/comment-display.blade.php
+++ b/resources/views/components/comment-display.blade.php
@@ -26,11 +26,7 @@
                     variant="ghost"
                     size="xs"
                     aria-label="Copy comment"
-                    x-on:click.stop="
-                        navigator.clipboard.writeText(@js($comment['body'])).then(() => {
-                            window.Flux && Flux.toast({ text: 'Copied', variant: 'success' });
-                        }).catch(() => {});
-                    "
+                    x-on:click.stop="$dispatch('copy-to-clipboard', { text: @js($comment['body']), toast: 'Copied' })"
                     class="hover:!text-gh-accent"
                     data-testid="copy-comment"
                 />

--- a/resources/views/components/comment-display.blade.php
+++ b/resources/views/components/comment-display.blade.php
@@ -1,37 +1,52 @@
 {{-- Parent Alpine scope contract: editComment(), $wire (for delete-comment dispatch) --}}
 @props(['comment', 'borderClass' => 'border-y'])
 
-@php $isDraft = $comment['isDraft'] ?? false; @endphp
+@php
+    $isDraft = $comment['isDraft'] ?? false;
+    $startLine = $comment['startLine'] ?? null;
+    $endLine = $comment['endLine'] ?? null;
+@endphp
 
 <div
-    class="{{ $isDraft ? 'draft-indicator' : 'comment-indicator' }} bg-gh-surface/80 {{ $borderClass }} border-gh-border px-4 py-2 {{ $isDraft ? 'cursor-pointer' : '' }}"
-    @if($isDraft)
-        x-on:click="editComment(@js($comment))"
-        data-testid="draft-comment"
-    @endif
+    class="group {{ $isDraft ? 'draft-indicator' : 'comment-indicator' }} bg-gh-surface/80 {{ $borderClass }} border-gh-border px-4 py-2"
+    @if($isDraft) data-testid="draft-comment" @endif
 >
     <div class="flex items-start justify-between gap-2">
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-2 min-w-0">
             @if($isDraft)
                 <span class="text-[10px] font-mono font-medium text-gh-draft uppercase tracking-wider">Draft</span>
             @endif
             <flux:text size="sm" class="whitespace-pre-wrap">{{ $comment['body'] }}</flux:text>
         </div>
-        <div class="flex items-center gap-0.5 shrink-0">
-            @unless($isDraft)
-                <flux:tooltip content="Edit comment">
-                    <flux:button
-                        icon="pencil-square"
-                        icon:variant="outline"
-                        variant="ghost"
-                        size="xs"
-                        aria-label="Edit comment"
-                        x-on:click.stop="editComment(@js($comment))"
-                        class="hover:!text-gh-accent"
-                        data-testid="edit-comment"
-                    />
-                </flux:tooltip>
-            @endunless
+        <div class="flex items-center gap-0.5 shrink-0 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+            <flux:tooltip content="Copy comment">
+                <flux:button
+                    icon="clipboard-document"
+                    icon:variant="outline"
+                    variant="ghost"
+                    size="xs"
+                    aria-label="Copy comment"
+                    x-on:click.stop="
+                        navigator.clipboard.writeText(@js($comment['body'])).then(() => {
+                            window.Flux && Flux.toast({ text: 'Copied', variant: 'success' });
+                        }).catch(() => {});
+                    "
+                    class="hover:!text-gh-accent"
+                    data-testid="copy-comment"
+                />
+            </flux:tooltip>
+            <flux:tooltip content="Edit comment">
+                <flux:button
+                    icon="pencil-square"
+                    icon:variant="outline"
+                    variant="ghost"
+                    size="xs"
+                    aria-label="Edit comment"
+                    x-on:click.stop="editComment(@js($comment))"
+                    class="hover:!text-gh-accent"
+                    data-testid="edit-comment"
+                />
+            </flux:tooltip>
             <flux:tooltip content="Delete comment">
                 <flux:button
                     icon="x-mark"
@@ -45,7 +60,13 @@
             </flux:tooltip>
         </div>
     </div>
-    @if(($comment['startLine'] ?? null) !== ($comment['endLine'] ?? null) && ($comment['endLine'] ?? null) !== null)
-        <flux:text variant="subtle" size="sm" class="!text-[10px] mt-1">Lines {{ $comment['startLine'] }}-{{ $comment['endLine'] }}</flux:text>
+    @if($startLine !== null)
+        <flux:text variant="subtle" size="sm" class="!text-[10px] mt-1">
+            @if($endLine !== null && $endLine !== $startLine)
+                Lines {{ $startLine }}-{{ $endLine }}
+            @else
+                Line {{ $startLine }}
+            @endif
+        </flux:text>
     @endif
 </div>

--- a/resources/views/livewire/⚡comments-drawer.blade.php
+++ b/resources/views/livewire/⚡comments-drawer.blade.php
@@ -167,7 +167,7 @@ class extends Component
                 <div class="border-b border-gh-border/50">
                     <div class="px-4 py-2 bg-gh-surface/40 font-mono text-xs text-gh-text truncate">{{ $filePath }}</div>
                     @foreach($comments as $c)
-                        <div x-data class="group px-4 py-2.5 border-t border-gh-border/30 text-xs">
+                        <div class="group px-4 py-2.5 border-t border-gh-border/30 text-xs">
                             <div class="flex items-center gap-2 text-[10px] font-mono text-gh-muted mb-1">
                                 @if(! empty($c['origin_ref']))
                                     <span>{{ $c['origin_ref'] === 'working' ? 'WD' : Str::limit($c['origin_ref'], 7, '') }}</span>
@@ -189,11 +189,7 @@ class extends Component
                                             variant="ghost"
                                             size="xs"
                                             aria-label="Copy comment"
-                                            x-on:click="
-                                                navigator.clipboard.writeText(@js($c['body'])).then(() => {
-                                                    window.Flux && Flux.toast({ text: 'Copied', variant: 'success' });
-                                                }).catch(() => {});
-                                            "
+                                            x-on:click="$dispatch('copy-to-clipboard', { text: @js($c['body']), toast: 'Copied' })"
                                             class="opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity hover:!text-gh-accent"
                                         />
                                     </flux:tooltip>

--- a/resources/views/livewire/⚡comments-drawer.blade.php
+++ b/resources/views/livewire/⚡comments-drawer.blade.php
@@ -167,7 +167,7 @@ class extends Component
                 <div class="border-b border-gh-border/50">
                     <div class="px-4 py-2 bg-gh-surface/40 font-mono text-xs text-gh-text truncate">{{ $filePath }}</div>
                     @foreach($comments as $c)
-                        <div class="px-4 py-2.5 border-t border-gh-border/30 text-xs">
+                        <div x-data class="group px-4 py-2.5 border-t border-gh-border/30 text-xs">
                             <div class="flex items-center gap-2 text-[10px] font-mono text-gh-muted mb-1">
                                 @if(! empty($c['origin_ref']))
                                     <span>{{ $c['origin_ref'] === 'working' ? 'WD' : Str::limit($c['origin_ref'], 7, '') }}</span>
@@ -176,11 +176,28 @@ class extends Component
                                     <span>&middot;</span>
                                     <span>L{{ $c['start_line'] }}@if(! empty($c['end_line']) && $c['end_line'] !== $c['start_line'])-L{{ $c['end_line'] }}@endif</span>
                                 @endif
-                                @if(! empty($c['is_draft']))
-                                    <span class="ml-auto px-1.5 py-0.5 rounded bg-gh-draft/10 text-gh-draft text-[9px]">draft</span>
-                                @elseif(! empty($c['submitted_at']))
-                                    <span class="ml-auto px-1.5 py-0.5 rounded bg-gh-border/40 text-gh-muted text-[9px]">submitted</span>
-                                @endif
+                                <div class="ml-auto flex items-center gap-1">
+                                    @if(! empty($c['is_draft']))
+                                        <span class="px-1.5 py-0.5 rounded bg-gh-draft/10 text-gh-draft text-[9px]">draft</span>
+                                    @elseif(! empty($c['submitted_at']))
+                                        <span class="px-1.5 py-0.5 rounded bg-gh-border/40 text-gh-muted text-[9px]">submitted</span>
+                                    @endif
+                                    <flux:tooltip content="Copy comment">
+                                        <flux:button
+                                            icon="clipboard-document"
+                                            icon:variant="outline"
+                                            variant="ghost"
+                                            size="xs"
+                                            aria-label="Copy comment"
+                                            x-on:click="
+                                                navigator.clipboard.writeText(@js($c['body'])).then(() => {
+                                                    window.Flux && Flux.toast({ text: 'Copied', variant: 'success' });
+                                                }).catch(() => {});
+                                            "
+                                            class="opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity hover:!text-gh-accent"
+                                        />
+                                    </flux:tooltip>
+                                </div>
                             </div>
                             <div class="text-gh-text whitespace-pre-wrap">{{ $c['body'] }}</div>
                         </div>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -903,7 +903,9 @@ new #[Layout('layouts.app')] class extends Component
     @file-reviewed-changed.window="reviewedFiles[$event.detail.id] = $event.detail.reviewed"
     @reset-reviewed-files.window="reviewedFiles = {}"
     @copy-to-clipboard.window="
-        navigator.clipboard.writeText($event.detail.text).catch(() => {});
+        navigator.clipboard.writeText($event.detail.text).then(() => {
+            if ($event.detail.toast) Flux.toast({ text: $event.detail.toast, variant: 'success' });
+        }).catch(() => {});
     "
     @keydown.window="
         if ($event.target.tagName === 'TEXTAREA' || $event.target.tagName === 'INPUT') {

--- a/tests/Browser/DraftCommentTest.php
+++ b/tests/Browser/DraftCommentTest.php
@@ -95,7 +95,7 @@ test('draft comment exposes an edit button', function () {
     $page->assertSee('Click me');
 
     // Edit button is the explicit affordance (same as finalized comments)
-    $page->page()->getByTestId('edit-comment')->first()->click();
+    $page->page()->getByRole('button', ['name' => 'Edit comment'])->first()->click();
 
     $page->assertSee('Cancel');
 });
@@ -112,7 +112,7 @@ test('clicking edit on a draft re-opens form with pre-filled text', function () 
 
     $page->assertSee('Original draft');
 
-    $page->page()->getByTestId('edit-comment')->first()->click();
+    $page->page()->getByRole('button', ['name' => 'Edit comment'])->first()->click();
 
     $page->assertSee('Cancel');
     expect($page->page()->getByPlaceholder('Write a comment', false)->inputValue())->toBe('Original draft');
@@ -126,7 +126,7 @@ test('saving edited draft promotes to finalized comment', function () {
     $page->page()->getByPlaceholder('Write a comment', false)->press('Escape');
     $page->page()->getByPlaceholder('Write a comment', false)->press('Escape');
 
-    $page->page()->getByTestId('edit-comment')->first()->click();
+    $page->page()->getByRole('button', ['name' => 'Edit comment'])->first()->click();
     $page->page()->getByPlaceholder('Write a comment', false)->fill('Final comment');
     $page->page()->getByPlaceholder('Write a comment', false)->press('Meta+Enter');
 
@@ -145,7 +145,7 @@ test('clearing draft text and pressing esc deletes the draft', function () {
 
     $page->assertSee('Delete me');
 
-    $page->page()->getByTestId('edit-comment')->first()->click();
+    $page->page()->getByRole('button', ['name' => 'Edit comment'])->first()->click();
     $page->page()->getByPlaceholder('Write a comment', false)->fill('');
     $page->page()->getByPlaceholder('Write a comment', false)->press('Escape');
 
@@ -163,7 +163,7 @@ test('double esc on edited draft updates the draft', function () {
 
     $page->assertSee('v1');
 
-    $page->page()->getByTestId('edit-comment')->first()->click();
+    $page->page()->getByRole('button', ['name' => 'Edit comment'])->first()->click();
     $page->page()->getByPlaceholder('Write a comment', false)->fill('v2');
     $page->page()->getByPlaceholder('Write a comment', false)->press('Escape');
     $page->page()->getByPlaceholder('Write a comment', false)->press('Escape');

--- a/tests/Browser/DraftCommentTest.php
+++ b/tests/Browser/DraftCommentTest.php
@@ -84,7 +84,7 @@ test('draft comment shows Draft badge', function () {
     $page->assertSee('Badge test');
 });
 
-test('draft comment has click-to-edit cursor', function () {
+test('draft comment exposes an edit button', function () {
     $page = $this->visit($this->projectUrl());
 
     $page->page()->getByTestId('diff-line-number')->first()->click();
@@ -94,15 +94,15 @@ test('draft comment has click-to-edit cursor', function () {
 
     $page->assertSee('Click me');
 
-    // Click the draft to re-open form
-    $page->page()->getByTestId('draft-comment')->first()->click();
+    // Edit button is the explicit affordance (same as finalized comments)
+    $page->page()->getByTestId('edit-comment')->first()->click();
 
     $page->assertSee('Cancel');
 });
 
 // -- Click-to-edit drafts --
 
-test('clicking draft re-opens edit form with pre-filled text', function () {
+test('clicking edit on a draft re-opens form with pre-filled text', function () {
     $page = $this->visit($this->projectUrl());
 
     $page->page()->getByTestId('diff-line-number')->first()->click();
@@ -112,7 +112,7 @@ test('clicking draft re-opens edit form with pre-filled text', function () {
 
     $page->assertSee('Original draft');
 
-    $page->page()->getByTestId('draft-comment')->first()->click();
+    $page->page()->getByTestId('edit-comment')->first()->click();
 
     $page->assertSee('Cancel');
     expect($page->page()->getByPlaceholder('Write a comment', false)->inputValue())->toBe('Original draft');
@@ -126,7 +126,7 @@ test('saving edited draft promotes to finalized comment', function () {
     $page->page()->getByPlaceholder('Write a comment', false)->press('Escape');
     $page->page()->getByPlaceholder('Write a comment', false)->press('Escape');
 
-    $page->page()->getByTestId('draft-comment')->first()->click();
+    $page->page()->getByTestId('edit-comment')->first()->click();
     $page->page()->getByPlaceholder('Write a comment', false)->fill('Final comment');
     $page->page()->getByPlaceholder('Write a comment', false)->press('Meta+Enter');
 
@@ -145,7 +145,7 @@ test('clearing draft text and pressing esc deletes the draft', function () {
 
     $page->assertSee('Delete me');
 
-    $page->page()->getByTestId('draft-comment')->first()->click();
+    $page->page()->getByTestId('edit-comment')->first()->click();
     $page->page()->getByPlaceholder('Write a comment', false)->fill('');
     $page->page()->getByPlaceholder('Write a comment', false)->press('Escape');
 
@@ -163,7 +163,7 @@ test('double esc on edited draft updates the draft', function () {
 
     $page->assertSee('v1');
 
-    $page->page()->getByTestId('draft-comment')->first()->click();
+    $page->page()->getByTestId('edit-comment')->first()->click();
     $page->page()->getByPlaceholder('Write a comment', false)->fill('v2');
     $page->page()->getByPlaceholder('Write a comment', false)->press('Escape');
     $page->page()->getByPlaceholder('Write a comment', false)->press('Escape');

--- a/tests/Helpers/InteractsWithTestRepositories.php
+++ b/tests/Helpers/InteractsWithTestRepositories.php
@@ -29,7 +29,7 @@ trait InteractsWithTestRepositories
 
     protected function createTempDirectory(string $prefix = 'rfa_test_'): string
     {
-        $path = sys_get_temp_dir().'/'.$prefix.uniqid();
+        $path = sys_get_temp_dir().'/'.$prefix.getmypid().'_'.uniqid('', true);
 
         File::makeDirectory($path, 0755, true);
 

--- a/tests/Unit/Livewire/DiffFileTest.php
+++ b/tests/Unit/Livewire/DiffFileTest.php
@@ -100,6 +100,65 @@ test('file-level saved comments use border-b class', function () {
         ->and($borderPos)->not->toBeFalse();
 });
 
+test('saved comment renders copy, edit, and delete buttons', function () {
+    $comments = [[
+        'id' => 'saved-1',
+        'fileId' => $this->file['id'],
+        'file' => 'src/Test.php',
+        'side' => 'file',
+        'startLine' => null,
+        'endLine' => null,
+        'body' => 'Saved body',
+    ]];
+
+    $html = mountDiffFile($this->file, $comments)->html();
+
+    expect($html)->toContain('data-testid="copy-comment"')
+        ->and($html)->toContain('data-testid="edit-comment"')
+        ->and($html)->toContain('aria-label="Delete comment"');
+});
+
+test('draft comment renders copy, edit, and delete buttons', function () {
+    $comments = [[
+        'id' => 'draft-1',
+        'fileId' => $this->file['id'],
+        'file' => 'src/Test.php',
+        'side' => 'file',
+        'startLine' => null,
+        'endLine' => null,
+        'body' => 'Draft body',
+        'isDraft' => true,
+    ]];
+
+    $html = mountDiffFile($this->file, $comments)->html();
+
+    $draftPos = strpos($html, 'data-testid="draft-comment"');
+    expect($draftPos)->not->toBeFalse();
+
+    // All three buttons must render inside the draft bubble (before the closing wrapper).
+    $slice = substr($html, $draftPos);
+    expect($slice)->toContain('data-testid="copy-comment"')
+        ->and($slice)->toContain('data-testid="edit-comment"')
+        ->and($slice)->toContain('aria-label="Delete comment"');
+});
+
+test('single-line comment displays "Line N" label', function () {
+    $comments = [[
+        'id' => 'c-line',
+        'fileId' => $this->file['id'],
+        'file' => 'src/Test.php',
+        'side' => 'right',
+        'startLine' => 7,
+        'endLine' => 7,
+        'body' => 'Single line',
+    ]];
+
+    $html = mountDiffFile($this->file, $comments)->html();
+
+    expect($html)->toContain('Line 7')
+        ->and($html)->not->toContain('Lines 7-7');
+});
+
 test('comment count badge markup is present', function () {
     $html = mountDiffFile($this->file, loadDiff: false)->html();
 

--- a/tests/Unit/Livewire/DiffFileTest.php
+++ b/tests/Unit/Livewire/DiffFileTest.php
@@ -135,7 +135,6 @@ test('draft comment renders copy, edit, and delete buttons', function () {
     $draftPos = strpos($html, 'data-testid="draft-comment"');
     expect($draftPos)->not->toBeFalse();
 
-    // All three buttons must render inside the draft bubble (before the closing wrapper).
     $slice = substr($html, $draftPos);
     expect($slice)->toContain('data-testid="copy-comment"')
         ->and($slice)->toContain('data-testid="edit-comment"')


### PR DESCRIPTION
## Summary
This PR adds a "Copy comment" button to both saved and draft comments, allowing users to quickly copy comment text to their clipboard with visual feedback via a toast notification.

## Key Changes

- **Comment Display Component** (`comment-display.blade.php`):
  - Added new "Copy comment" button with clipboard icon that dispatches `copy-to-clipboard` event
  - Improved button visibility with hover/focus states using Tailwind's `group` and `opacity` utilities
  - Refactored line number display logic to show "Line N" for single-line comments and "Lines N-M" for multi-line comments
  - Removed click-to-edit behavior from draft comment container (now only via explicit edit button)

- **Comments Drawer** (`comments-drawer.blade.php`):
  - Added copy button to comment list items with same hover/focus visibility pattern
  - Restructured metadata layout to accommodate new button alongside draft/submitted badges

- **Review Page** (`review-page.blade.php`):
  - Enhanced `copy-to-clipboard` event handler to show success toast notification when text is copied
  - Toast only displays if `toast` property is included in event detail

- **Tests**:
  - Added unit tests verifying copy, edit, and delete buttons render for both saved and draft comments
  - Added test for single-line comment label formatting ("Line 7" vs "Lines 7-7")
  - Updated browser tests to use explicit edit button instead of clicking draft comment container

## Implementation Details

- Copy buttons use the existing `copy-to-clipboard` window event pattern
- Buttons are hidden by default and revealed on hover/focus for cleaner UI
- Toast notifications provide immediate user feedback on successful copy
- Line number display now handles edge cases (null values, single vs multi-line)

https://claude.ai/code/session_01WSbmEwu621i5zvoqH5rNND

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Copy comment" button (clipboard icon) to comment displays and drawer; copy event can include an optional toast message.

* **Improvements**
  * Success toast shown when a copy toast payload is provided.
  * Action buttons hidden by default, revealed on hover/focus.
  * Drafts no longer make the entire container clickable; edit remains available.
  * Line number labeling clarified (single vs range).

* **Tests**
  * Updated browser tests to use explicit edit button interactions; added unit tests for comment controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->