### PR TITLE
Add remote link integration for GitHub/GitLab repositories

### DIFF
--- a/app/Actions/BuildRemoteUrlAction.php
+++ b/app/Actions/BuildRemoteUrlAction.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\DTOs\RemoteTarget;
+use App\Models\Project;
+use App\Services\GitMetadataService;
+use App\Services\GitRemoteParser;
+use App\Services\RemoteUrlBuilderService;
+
+/**
+ * Resolves a project slug + target description into a GitHub / GitLab URL.
+ *
+ * Self-heals: if the project was registered before we captured `remote_url`,
+ * or if the user added an `origin` after registration, the first call fills
+ * it in from `git config` and persists it.
+ */
+final readonly class BuildRemoteUrlAction
+{
+    public function __construct(
+        private GitMetadataService $git,
+        private GitRemoteParser $parser,
+        private RemoteUrlBuilderService $builder,
+    ) {}
+
+    /** @param array<string, mixed> $params */
+    public function handle(string $projectSlug, string $type, array $params = []): ?string
+    {
+        $project = Project::where('slug', $projectSlug)->first();
+        if ($project === null) {
+            return null;
+        }
+
+        $remoteUrl = $project->remote_url;
+        if ($remoteUrl === null || $remoteUrl === '') {
+            $remoteUrl = $this->git->getRemoteUrl($project->path);
+            if ($remoteUrl === null) {
+                return null;
+            }
+            $project->forceFill(['remote_url' => $remoteUrl])->save();
+        }
+
+        $parsed = $this->parser->parse($remoteUrl);
+        if ($parsed === null) {
+            return null;
+        }
+
+        $target = RemoteTarget::fromWire($type, $params);
+
+        return $this->builder->build($parsed, $target);
+    }
+}

--- a/app/Actions/BuildRemoteUrlAction.php
+++ b/app/Actions/BuildRemoteUrlAction.php
@@ -11,11 +11,9 @@ use App\Services\GitRemoteParser;
 use App\Services\RemoteUrlBuilderService;
 
 /**
- * Resolves a project slug + target description into a GitHub / GitLab URL.
- *
- * Self-heals: if the project was registered before we captured `remote_url`,
- * or if the user added an `origin` after registration, the first call fills
- * it in from `git config` and persists it.
+ * Resolves a project slug + target into a GitHub / GitLab URL. Self-heals the
+ * project's stored `remote_url` on first use for repos registered before we
+ * captured it, or where `origin` was added after registration.
  */
 final readonly class BuildRemoteUrlAction
 {
@@ -33,13 +31,9 @@ final readonly class BuildRemoteUrlAction
             return null;
         }
 
-        $remoteUrl = $project->remote_url;
-        if ($remoteUrl === null || $remoteUrl === '') {
-            $remoteUrl = $this->git->getRemoteUrl($project->path);
-            if ($remoteUrl === null) {
-                return null;
-            }
-            $project->forceFill(['remote_url' => $remoteUrl])->save();
+        $remoteUrl = $project->remote_url ?: $this->resolveAndPersistRemoteUrl($project);
+        if ($remoteUrl === null) {
+            return null;
         }
 
         $parsed = $this->parser->parse($remoteUrl);
@@ -47,8 +41,17 @@ final readonly class BuildRemoteUrlAction
             return null;
         }
 
-        $target = RemoteTarget::fromWire($type, $params);
+        return $this->builder->build($parsed, RemoteTarget::fromWire($type, $params));
+    }
 
-        return $this->builder->build($parsed, $target);
+    private function resolveAndPersistRemoteUrl(Project $project): ?string
+    {
+        $remoteUrl = $this->git->getRemoteUrl($project->path);
+        if ($remoteUrl === null) {
+            return null;
+        }
+        $project->forceFill(['remote_url' => $remoteUrl])->save();
+
+        return $remoteUrl;
     }
 }

--- a/app/Actions/RegisterProjectAction.php
+++ b/app/Actions/RegisterProjectAction.php
@@ -56,6 +56,7 @@ final readonly class RegisterProjectAction
             'git_common_dir' => $gitCommonDir,
             'is_worktree' => $isWorktree,
             'branch' => $branch,
+            'remote_url' => $this->git->getRemoteUrl($path),
             'global_gitignore_path' => $this->git->resolveGlobalExcludesFile($path),
         ]);
     }

--- a/app/Actions/RegisterProjectAction.php
+++ b/app/Actions/RegisterProjectAction.php
@@ -29,8 +29,10 @@ final readonly class RegisterProjectAction
 
         if ($existing) {
             // Branch is owned by the review page's divergence logic once a project
-            // exists; only refresh gitignore on re-registration.
+            // exists; refresh gitignore + remote URL so `git remote set-url` and
+            // global-gitignore edits are picked up on re-registration.
             $existing->update([
+                'remote_url' => $this->git->getRemoteUrl($path),
                 'global_gitignore_path' => $this->git->resolveGlobalExcludesFile($path),
             ]);
 

--- a/app/Concerns/InteractsWithRemoteLinks.php
+++ b/app/Concerns/InteractsWithRemoteLinks.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Concerns;
+
+use App\Actions\BuildRemoteUrlAction;
+use Native\Desktop\Facades\Shell;
+
+/**
+ * Shared Livewire methods for "Open on remote" and "Copy remote link" context
+ * menu actions. Consumers call `openRemote($slug, $type, $params)` or
+ * `copyRemoteLink(...)` from Blade; the URL is always rebuilt server-side from
+ * the project's stored `remote_url`, so we never trust a URL from the DOM.
+ */
+trait InteractsWithRemoteLinks
+{
+    /** @param array<string, mixed> $params */
+    public function openRemote(string $projectSlug, string $type, array $params = []): void
+    {
+        $url = app(BuildRemoteUrlAction::class)->handle($projectSlug, $type, $params);
+
+        if ($url !== null) {
+            Shell::openExternal($url);
+        }
+    }
+
+    /** @param array<string, mixed> $params */
+    public function copyRemoteLink(string $projectSlug, string $type, array $params = []): void
+    {
+        $url = app(BuildRemoteUrlAction::class)->handle($projectSlug, $type, $params);
+
+        if ($url !== null) {
+            $this->dispatch('copy-to-clipboard', text: $url);
+        }
+    }
+}

--- a/app/Concerns/InteractsWithRemoteLinks.php
+++ b/app/Concerns/InteractsWithRemoteLinks.php
@@ -8,10 +8,8 @@ use App\Actions\BuildRemoteUrlAction;
 use Native\Desktop\Facades\Shell;
 
 /**
- * Shared Livewire methods for "Open on remote" and "Copy remote link" context
- * menu actions. Consumers call `openRemote($slug, $type, $params)` or
- * `copyRemoteLink(...)` from Blade; the URL is always rebuilt server-side from
- * the project's stored `remote_url`, so we never trust a URL from the DOM.
+ * The URL is always rebuilt server-side from the project's stored `remote_url`
+ * so the trait never trusts a URL passed from the DOM.
  */
 trait InteractsWithRemoteLinks
 {

--- a/app/DTOs/RemoteTarget.php
+++ b/app/DTOs/RemoteTarget.php
@@ -7,10 +7,8 @@ namespace App\DTOs;
 use InvalidArgumentException;
 
 /**
- * Describes what part of a repo a "open on remote" / "copy link" action targets.
- *
- * Constructed only via the static factories. The `$params` shape is validated on
- * construction so the builder can rely on the keys it reads.
+ * Construct only via the static factories — the builder relies on the shape
+ * of `$params` they produce.
  */
 final readonly class RemoteTarget
 {
@@ -71,11 +69,10 @@ final readonly class RemoteTarget
             throw new InvalidArgumentException('Line start must be >= 1');
         }
 
-        // Normalise: end >= start, drop `end` when equal to start.
         if ($end !== null && $end < $start) {
             [$start, $end] = [$end, $start];
         }
-        if ($end !== null && $end === $start) {
+        if ($end === $start) {
             $end = null;
         }
 
@@ -93,11 +90,7 @@ final readonly class RemoteTarget
         return ['type' => $this->type, 'params' => $this->params];
     }
 
-    /**
-     * Reconstruct from a primitive payload sent by the frontend.
-     *
-     * @param  array<string, mixed>  $params
-     */
+    /** @param array<string, mixed> $params */
     public static function fromWire(string $type, array $params): self
     {
         return match ($type) {

--- a/app/DTOs/RemoteTarget.php
+++ b/app/DTOs/RemoteTarget.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+use InvalidArgumentException;
+
+/**
+ * Describes what part of a repo a "open on remote" / "copy link" action targets.
+ *
+ * Constructed only via the static factories. The `$params` shape is validated on
+ * construction so the builder can rely on the keys it reads.
+ */
+final readonly class RemoteTarget
+{
+    public const TYPE_REPO = 'repo';
+
+    public const TYPE_BRANCH = 'branch';
+
+    public const TYPE_COMMIT = 'commit';
+
+    public const TYPE_FILE = 'file';
+
+    public const TYPE_LINE = 'line';
+
+    /** @param array<string, mixed> $params */
+    private function __construct(
+        public string $type,
+        public array $params,
+    ) {}
+
+    public static function repo(): self
+    {
+        return new self(self::TYPE_REPO, []);
+    }
+
+    public static function branch(string $name): self
+    {
+        if ($name === '') {
+            throw new InvalidArgumentException('Branch name cannot be empty');
+        }
+
+        return new self(self::TYPE_BRANCH, ['name' => $name]);
+    }
+
+    public static function commit(string $sha): self
+    {
+        if ($sha === '') {
+            throw new InvalidArgumentException('Commit sha cannot be empty');
+        }
+
+        return new self(self::TYPE_COMMIT, ['sha' => $sha]);
+    }
+
+    public static function file(string $ref, string $path): self
+    {
+        if ($ref === '' || $path === '') {
+            throw new InvalidArgumentException('File target requires a non-empty ref and path');
+        }
+
+        return new self(self::TYPE_FILE, ['ref' => $ref, 'path' => $path]);
+    }
+
+    public static function line(string $ref, string $path, int $start, ?int $end = null): self
+    {
+        if ($ref === '' || $path === '') {
+            throw new InvalidArgumentException('Line target requires a non-empty ref and path');
+        }
+        if ($start < 1) {
+            throw new InvalidArgumentException('Line start must be >= 1');
+        }
+
+        // Normalise: end >= start, drop `end` when equal to start.
+        if ($end !== null && $end < $start) {
+            [$start, $end] = [$end, $start];
+        }
+        if ($end !== null && $end === $start) {
+            $end = null;
+        }
+
+        return new self(self::TYPE_LINE, [
+            'ref' => $ref,
+            'path' => $path,
+            'start' => $start,
+            'end' => $end,
+        ]);
+    }
+
+    /** @return array{type: string, params: array<string, mixed>} */
+    public function toArray(): array
+    {
+        return ['type' => $this->type, 'params' => $this->params];
+    }
+
+    /**
+     * Reconstruct from a primitive payload sent by the frontend.
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public static function fromWire(string $type, array $params): self
+    {
+        return match ($type) {
+            self::TYPE_REPO => self::repo(),
+            self::TYPE_BRANCH => self::branch((string) ($params['name'] ?? '')),
+            self::TYPE_COMMIT => self::commit((string) ($params['sha'] ?? '')),
+            self::TYPE_FILE => self::file((string) ($params['ref'] ?? ''), (string) ($params['path'] ?? '')),
+            self::TYPE_LINE => self::line(
+                (string) ($params['ref'] ?? ''),
+                (string) ($params['path'] ?? ''),
+                (int) ($params['start'] ?? 0),
+                isset($params['end']) ? (int) $params['end'] : null,
+            ),
+            default => throw new InvalidArgumentException("Unknown remote target type: {$type}"),
+        };
+    }
+}

--- a/app/DTOs/RemoteTarget.php
+++ b/app/DTOs/RemoteTarget.php
@@ -65,15 +65,16 @@ final readonly class RemoteTarget
         if ($ref === '' || $path === '') {
             throw new InvalidArgumentException('Line target requires a non-empty ref and path');
         }
-        if ($start < 1) {
-            throw new InvalidArgumentException('Line start must be >= 1');
-        }
 
         if ($end !== null && $end < $start) {
             [$start, $end] = [$end, $start];
         }
         if ($end === $start) {
             $end = null;
+        }
+
+        if ($start < 1 || ($end !== null && $end < 1)) {
+            throw new InvalidArgumentException('Line numbers must be >= 1');
         }
 
         return new self(self::TYPE_LINE, [

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -24,6 +24,7 @@ class Project extends Model
         'git_common_dir',
         'is_worktree',
         'branch',
+        'remote_url',
         'global_gitignore_path',
         'respect_global_gitignore',
     ];

--- a/app/Services/GitMetadataService.php
+++ b/app/Services/GitMetadataService.php
@@ -86,6 +86,21 @@ class GitMetadataService
         return trim($this->git->run($directory, ['rev-parse', '--abbrev-ref', 'HEAD']));
     }
 
+    /**
+     * Read the URL configured for `origin`. Returns null when no origin is set
+     * (e.g. repos with no remote, or remotes under a different name).
+     */
+    public function getRemoteUrl(string $directory, string $remoteName = 'origin'): ?string
+    {
+        try {
+            $url = trim($this->git->run($directory, ['config', '--get', 'remote.'.$remoteName.'.url']));
+        } catch (GitCommandException) {
+            return null;
+        }
+
+        return $url === '' ? null : $url;
+    }
+
     public function getHeadSha(string $directory): string
     {
         return trim($this->git->run($directory, ['rev-parse', 'HEAD']));

--- a/app/Services/GitRemoteParser.php
+++ b/app/Services/GitRemoteParser.php
@@ -5,17 +5,9 @@ declare(strict_types=1);
 namespace App\Services;
 
 /**
- * Parses `git remote` URLs into a provider, host, owner, and repo name so we
- * can build web URLs for GitHub / GitLab (and recognise self-hosted instances
- * of either by hostname substring).
- *
- * Accepts:
- *   - SSH:          git@github.com:owner/repo(.git)
- *   - SSH URL:      ssh://git@host[:port]/owner/repo(.git)
- *   - HTTPS / HTTP: https://host/owner/repo(.git)
- *   - git protocol: git://host/owner/repo(.git)
- *
- * Returns null if the URL cannot be parsed or the provider is not recognised.
+ * Parses git remote URLs (scp-style SSH, ssh://, https://, git://) and
+ * recognises GitHub / GitLab (including self-hosted) by hostname substring.
+ * Returns null for unrecognised providers or malformed input.
  */
 final class GitRemoteParser
 {
@@ -34,7 +26,6 @@ final class GitRemoteParser
             return null;
         }
 
-        // Strip trailing `.git` and trailing slash.
         $ownerRepo = preg_replace('/\.git$/i', '', $ownerRepo) ?? $ownerRepo;
         $ownerRepo = rtrim($ownerRepo, '/');
 
@@ -69,16 +60,15 @@ final class GitRemoteParser
      */
     private function extractHostAndPath(string $remoteUrl): ?array
     {
-        // SCP-style SSH: git@host:owner/repo.git
-        if (preg_match('#^(?:[^@\s]+@)?([^:\s/]+):([^\s]+)$#', $remoteUrl, $m) === 1 && ! str_contains($m[1], '/')) {
-            // Reject matches that are really URLs (contain "://") via the parts already,
-            // but be defensive: if the "path" begins with "//", drop through to url parsing.
-            if (! str_starts_with($m[2], '/')) {
-                return [strtolower($m[1]), ltrim($m[2], '/')];
-            }
+        // SCP-style: `git@host:owner/repo.git`. Defer to parse_url() if the path starts
+        // with `/`, otherwise this regex would mis-claim true URLs.
+        if (preg_match('#^(?:[^@\s]+@)?([^:\s/]+):([^\s]+)$#', $remoteUrl, $m) === 1
+            && ! str_contains($m[1], '/')
+            && ! str_starts_with($m[2], '/')
+        ) {
+            return [strtolower($m[1]), ltrim($m[2], '/')];
         }
 
-        // URL-style: ssh://, https://, http://, git://
         $parts = parse_url($remoteUrl);
         if (! is_array($parts) || ! isset($parts['host'], $parts['path'])) {
             return null;

--- a/app/Services/GitRemoteParser.php
+++ b/app/Services/GitRemoteParser.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+/**
+ * Parses `git remote` URLs into a provider, host, owner, and repo name so we
+ * can build web URLs for GitHub / GitLab (and recognise self-hosted instances
+ * of either by hostname substring).
+ *
+ * Accepts:
+ *   - SSH:          git@github.com:owner/repo(.git)
+ *   - SSH URL:      ssh://git@host[:port]/owner/repo(.git)
+ *   - HTTPS / HTTP: https://host/owner/repo(.git)
+ *   - git protocol: git://host/owner/repo(.git)
+ *
+ * Returns null if the URL cannot be parsed or the provider is not recognised.
+ */
+final class GitRemoteParser
+{
+    /**
+     * @return array{provider: string, host: string, owner: string, repo: string, webBaseUrl: string}|null
+     */
+    public function parse(string $remoteUrl): ?array
+    {
+        $remoteUrl = trim($remoteUrl);
+        if ($remoteUrl === '') {
+            return null;
+        }
+
+        [$host, $ownerRepo] = $this->extractHostAndPath($remoteUrl) ?? [null, null];
+        if ($host === null || $ownerRepo === null || $ownerRepo === '') {
+            return null;
+        }
+
+        // Strip trailing `.git` and trailing slash.
+        $ownerRepo = preg_replace('/\.git$/i', '', $ownerRepo) ?? $ownerRepo;
+        $ownerRepo = rtrim($ownerRepo, '/');
+
+        $lastSlash = strrpos($ownerRepo, '/');
+        if ($lastSlash === false) {
+            return null;
+        }
+
+        $owner = substr($ownerRepo, 0, $lastSlash);
+        $repo = substr($ownerRepo, $lastSlash + 1);
+
+        if ($owner === '' || $repo === '') {
+            return null;
+        }
+
+        $provider = $this->detectProvider($host);
+        if ($provider === null) {
+            return null;
+        }
+
+        return [
+            'provider' => $provider,
+            'host' => $host,
+            'owner' => $owner,
+            'repo' => $repo,
+            'webBaseUrl' => "https://{$host}/{$owner}/{$repo}",
+        ];
+    }
+
+    /**
+     * @return array{0: string, 1: string}|null [host, ownerAndRepoPath]
+     */
+    private function extractHostAndPath(string $remoteUrl): ?array
+    {
+        // SCP-style SSH: git@host:owner/repo.git
+        if (preg_match('#^(?:[^@\s]+@)?([^:\s/]+):([^\s]+)$#', $remoteUrl, $m) === 1 && ! str_contains($m[1], '/')) {
+            // Reject matches that are really URLs (contain "://") via the parts already,
+            // but be defensive: if the "path" begins with "//", drop through to url parsing.
+            if (! str_starts_with($m[2], '/')) {
+                return [strtolower($m[1]), ltrim($m[2], '/')];
+            }
+        }
+
+        // URL-style: ssh://, https://, http://, git://
+        $parts = parse_url($remoteUrl);
+        if (! is_array($parts) || ! isset($parts['host'], $parts['path'])) {
+            return null;
+        }
+
+        return [strtolower((string) $parts['host']), ltrim((string) $parts['path'], '/')];
+    }
+
+    private function detectProvider(string $host): ?string
+    {
+        if (str_contains($host, 'github')) {
+            return 'github';
+        }
+        if (str_contains($host, 'gitlab')) {
+            return 'gitlab';
+        }
+
+        return null;
+    }
+}

--- a/app/Services/GitRemoteParser.php
+++ b/app/Services/GitRemoteParser.php
@@ -12,7 +12,7 @@ namespace App\Services;
 final class GitRemoteParser
 {
     /**
-     * @return array{provider: string, host: string, owner: string, repo: string, webBaseUrl: string}|null
+     * @return array{provider: string, scheme: string, host: string, owner: string, repo: string, webBaseUrl: string}|null
      */
     public function parse(string $remoteUrl): ?array
     {
@@ -21,8 +21,8 @@ final class GitRemoteParser
             return null;
         }
 
-        [$host, $ownerRepo] = $this->extractHostAndPath($remoteUrl) ?? [null, null];
-        if ($host === null || $ownerRepo === null || $ownerRepo === '') {
+        [$host, $ownerRepo, $scheme] = $this->extractHostAndPath($remoteUrl) ?? [null, null, null];
+        if ($host === null || $ownerRepo === null || $ownerRepo === '' || $scheme === null) {
             return null;
         }
 
@@ -48,15 +48,16 @@ final class GitRemoteParser
 
         return [
             'provider' => $provider,
+            'scheme' => $scheme,
             'host' => $host,
             'owner' => $owner,
             'repo' => $repo,
-            'webBaseUrl' => "https://{$host}/{$owner}/{$repo}",
+            'webBaseUrl' => "{$scheme}://{$host}/{$owner}/{$repo}",
         ];
     }
 
     /**
-     * @return array{0: string, 1: string}|null [host, ownerAndRepoPath]
+     * @return array{0: string, 1: string, 2: string}|null [host, ownerAndRepoPath, webScheme]
      */
     private function extractHostAndPath(string $remoteUrl): ?array
     {
@@ -66,7 +67,7 @@ final class GitRemoteParser
             && ! str_contains($m[1], '/')
             && ! str_starts_with($m[2], '/')
         ) {
-            return [strtolower($m[1]), ltrim($m[2], '/')];
+            return [strtolower($m[1]), ltrim($m[2], '/'), 'https'];
         }
 
         $parts = parse_url($remoteUrl);
@@ -74,7 +75,13 @@ final class GitRemoteParser
             return null;
         }
 
-        return [strtolower((string) $parts['host']), ltrim((string) $parts['path'], '/')];
+        // Preserve http:// for explicitly-insecure remotes (e.g. self-hosted on an
+        // internal network); every other scheme — ssh://, git://, or missing — maps
+        // to https for the web URL since those don't have a browser-facing variant.
+        $rawScheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $webScheme = $rawScheme === 'http' ? 'http' : 'https';
+
+        return [strtolower((string) $parts['host']), ltrim((string) $parts['path'], '/'), $webScheme];
     }
 
     private function detectProvider(string $host): ?string

--- a/app/Services/RemoteUrlBuilderService.php
+++ b/app/Services/RemoteUrlBuilderService.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\DTOs\RemoteTarget;
+
+/**
+ * Builds an https URL for a parsed remote + RemoteTarget, honouring each
+ * provider's URL conventions (GitLab prefixes with `/-/`, GitHub does not;
+ * both use the same `#L10` / `#L10-L20` line-anchor format).
+ */
+final class RemoteUrlBuilderService
+{
+    /**
+     * @param  array{provider: string, host: string, owner: string, repo: string, webBaseUrl: string}  $remote
+     */
+    public function build(array $remote, RemoteTarget $target): ?string
+    {
+        $base = $remote['webBaseUrl'];
+        $prefix = $remote['provider'] === 'gitlab' ? '/-' : '';
+
+        return match ($target->type) {
+            RemoteTarget::TYPE_REPO => $base,
+            RemoteTarget::TYPE_BRANCH => $base.$prefix.'/tree/'.$this->encodeRef((string) $target->params['name']),
+            RemoteTarget::TYPE_COMMIT => $base.$prefix.'/commit/'.rawurlencode((string) $target->params['sha']),
+            RemoteTarget::TYPE_FILE => $base.$prefix.'/blob/'
+                .$this->encodeRef((string) $target->params['ref']).'/'
+                .$this->encodePath((string) $target->params['path']),
+            RemoteTarget::TYPE_LINE => $base.$prefix.'/blob/'
+                .$this->encodeRef((string) $target->params['ref']).'/'
+                .$this->encodePath((string) $target->params['path'])
+                .$this->lineAnchor($remote['provider'], (int) $target->params['start'], $target->params['end'] ?? null),
+            default => null,
+        };
+    }
+
+    /** Preserve `/` in nested paths; encode every other segment component. */
+    private function encodePath(string $path): string
+    {
+        return implode('/', array_map('rawurlencode', explode('/', $path)));
+    }
+
+    /**
+     * Encode branch / tag / sha refs. GitLab allows `/` in branch names
+     * (e.g. `release/1.0`); both providers resolve these as path segments.
+     */
+    private function encodeRef(string $ref): string
+    {
+        return implode('/', array_map('rawurlencode', explode('/', $ref)));
+    }
+
+    private function lineAnchor(string $provider, int $start, ?int $end): string
+    {
+        if ($end === null || $end === $start) {
+            return '#L'.$start;
+        }
+
+        // GitHub: #L10-L20. GitLab: #L10-20.
+        return $provider === 'gitlab'
+            ? '#L'.$start.'-'.$end
+            : '#L'.$start.'-L'.$end;
+    }
+}

--- a/app/Services/RemoteUrlBuilderService.php
+++ b/app/Services/RemoteUrlBuilderService.php
@@ -7,9 +7,9 @@ namespace App\Services;
 use App\DTOs\RemoteTarget;
 
 /**
- * Builds an https URL for a parsed remote + RemoteTarget, honouring each
- * provider's URL conventions (GitLab prefixes with `/-/`, GitHub does not;
- * both use the same `#L10` / `#L10-L20` line-anchor format).
+ * Composes web URLs from a parsed remote + RemoteTarget. GitLab prefixes
+ * tree/commit/blob with `/-/`; line-range anchors are `#L10-L20` on GitHub
+ * and `#L10-20` on GitLab.
  */
 final class RemoteUrlBuilderService
 {
@@ -36,19 +36,18 @@ final class RemoteUrlBuilderService
         };
     }
 
-    /** Preserve `/` in nested paths; encode every other segment component. */
+    /**
+     * GitLab supports `/` inside branch names (e.g. `release/1.0`); both providers
+     * resolve those as path segments, so we encode each segment and re-join with `/`.
+     */
     private function encodePath(string $path): string
     {
         return implode('/', array_map('rawurlencode', explode('/', $path)));
     }
 
-    /**
-     * Encode branch / tag / sha refs. GitLab allows `/` in branch names
-     * (e.g. `release/1.0`); both providers resolve these as path segments.
-     */
     private function encodeRef(string $ref): string
     {
-        return implode('/', array_map('rawurlencode', explode('/', $ref)));
+        return $this->encodePath($ref);
     }
 
     private function lineAnchor(string $provider, int $start, ?int $end): string
@@ -57,7 +56,6 @@ final class RemoteUrlBuilderService
             return '#L'.$start;
         }
 
-        // GitHub: #L10-L20. GitLab: #L10-20.
         return $provider === 'gitlab'
             ? '#L'.$start.'-'.$end
             : '#L'.$start.'-L'.$end;

--- a/database/migrations/2026_04_23_154033_add_remote_url_to_projects.php
+++ b/database/migrations/2026_04_23_154033_add_remote_url_to_projects.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->string('remote_url')->nullable()->after('branch');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dropColumn('remote_url');
+        });
+    }
+};

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,3 +7,9 @@ parameters:
         - app/
     scanDirectories:
         - database/factories/
+    ignoreErrors:
+        # Traits in app/Concerns are consumed by Livewire SFC anonymous classes in
+        # resources/views, which PHPStan doesn't analyse — so `trait.unused` false-positives.
+        -
+            identifier: trait.unused
+            path: app/Concerns/*.php

--- a/public/js/context-menu.js
+++ b/public/js/context-menu.js
@@ -1,0 +1,35 @@
+// Right-click context menu state for Alpine.
+//
+// Two usage modes:
+//   1. Standalone:   <div x-data="contextMenu()" @contextmenu.prevent="openAt($event)">
+//   2. Composed:     <div x-data="{ ...contextMenuState(), foo: 1 }" @contextmenu.prevent="openAt($event)">
+//
+// Paired with <x-remote-link-menu> which reads `open`, `x`, `y`, `close()`.
+(function () {
+    window.contextMenuState = function () {
+        return {
+            open: false,
+            x: 0,
+            y: 0,
+
+            openAt(event) {
+                const margin = 8;
+                const menuW = 200;
+                const menuH = 80;
+                this.x = Math.min(event.clientX, window.innerWidth - menuW - margin);
+                this.y = Math.min(event.clientY, window.innerHeight - menuH - margin);
+                this.open = true;
+            },
+
+            close() {
+                this.open = false;
+            },
+        };
+    };
+
+    function init() {
+        Alpine.data('contextMenu', window.contextMenuState);
+    }
+
+    window.Alpine ? init() : document.addEventListener('alpine:init', init);
+})();

--- a/public/js/context-menu.js
+++ b/public/js/context-menu.js
@@ -1,25 +1,28 @@
 // Alpine state factory for right-click context menus. Exposed both as an
 // Alpine.data('contextMenu') component and as a window-level factory so the
-// fields (`open`, `x`, `y`, `openAt`, `close`) can be spread into another
-// component's x-data, e.g. `{ ...contextMenuState(), status: null }`.
+// fields (`ctxOpen`, `ctxX`, `ctxY`, `openCtx`, `closeCtx`) can be spread into
+// another component's x-data.
+//
+// Field names are deliberately scoped (`ctx*`) so they don't collide with
+// panels / drawers that also use names like `open`, `x`, or `y`.
 (function () {
     window.contextMenuState = function () {
         return {
-            open: false,
-            x: 0,
-            y: 0,
+            ctxOpen: false,
+            ctxX: 0,
+            ctxY: 0,
 
-            openAt(event) {
+            openCtx(event) {
                 const margin = 8;
                 const menuW = 200;
                 const menuH = 80;
-                this.x = Math.min(event.clientX, window.innerWidth - menuW - margin);
-                this.y = Math.min(event.clientY, window.innerHeight - menuH - margin);
-                this.open = true;
+                this.ctxX = Math.min(event.clientX, window.innerWidth - menuW - margin);
+                this.ctxY = Math.min(event.clientY, window.innerHeight - menuH - margin);
+                this.ctxOpen = true;
             },
 
-            close() {
-                this.open = false;
+            closeCtx() {
+                this.ctxOpen = false;
             },
         };
     };

--- a/public/js/context-menu.js
+++ b/public/js/context-menu.js
@@ -1,10 +1,7 @@
-// Right-click context menu state for Alpine.
-//
-// Two usage modes:
-//   1. Standalone:   <div x-data="contextMenu()" @contextmenu.prevent="openAt($event)">
-//   2. Composed:     <div x-data="{ ...contextMenuState(), foo: 1 }" @contextmenu.prevent="openAt($event)">
-//
-// Paired with <x-remote-link-menu> which reads `open`, `x`, `y`, `close()`.
+// Alpine state factory for right-click context menus. Exposed both as an
+// Alpine.data('contextMenu') component and as a window-level factory so the
+// fields (`open`, `x`, `y`, `openAt`, `close`) can be spread into another
+// component's x-data, e.g. `{ ...contextMenuState(), status: null }`.
 (function () {
     window.contextMenuState = function () {
         return {

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -25,9 +25,9 @@
             dragSide: null,
 
             // Shared line context-menu state (one instance per file, not per line).
-            lineMenu: { open: false, x: 0, y: 0, start: null, end: null },
+            lineMenu: { open: false, x: 0, y: 0, start: null, end: null, side: 'new' },
 
-            openLineMenu(event, lineNum) {
+            openLineMenu(event, lineNum, side = 'new') {
                 event.preventDefault();
                 const inSelection = this.formLine !== null
                     && lineNum >= this.formLine
@@ -41,6 +41,7 @@
                     y: Math.min(event.clientY, window.innerHeight - menuH - margin),
                     start: inSelection ? this.formLine : lineNum,
                     end: inSelection ? (this.formEndLine ?? this.formLine) : null,
+                    side,
                 };
             },
 

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -23,6 +23,43 @@
             isDragging: false,
             dragStartLine: null,
             dragSide: null,
+
+            // Shared line context-menu state (one instance per file, not per line).
+            lineMenuOpen: false,
+            lineMenuX: 0,
+            lineMenuY: 0,
+            lineMenuStart: null,
+            lineMenuEnd: null,
+
+            openLineMenu(event, lineNum) {
+                event.preventDefault();
+                // If the right-clicked line falls inside an active selection, link the range;
+                // otherwise just link this single line.
+                const inSelection = this.formLine !== null
+                    && lineNum >= this.formLine
+                    && lineNum <= (this.formEndLine ?? this.formLine);
+                this.lineMenuStart = inSelection ? this.formLine : lineNum;
+                this.lineMenuEnd = inSelection ? (this.formEndLine ?? this.formLine) : null;
+
+                const margin = 8;
+                const menuW = 220;
+                const menuH = 80;
+                this.lineMenuX = Math.min(event.clientX, window.innerWidth - menuW - margin);
+                this.lineMenuY = Math.min(event.clientY, window.innerHeight - menuH - margin);
+                this.lineMenuOpen = true;
+            },
+
+            closeLineMenu() {
+                this.lineMenuOpen = false;
+            },
+
+            get lineMenuLabel() {
+                if (this.lineMenuStart === null) return 'line';
+                if (this.lineMenuEnd === null || this.lineMenuEnd === this.lineMenuStart) {
+                    return 'line ' + this.lineMenuStart;
+                }
+                return 'lines ' + this.lineMenuStart + '-' + this.lineMenuEnd;
+            },
             _dragMouseX: 0,
             _dragMouseY: 0,
             _scrollRafId: null,

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -1,9 +1,10 @@
 // Alpine component for livewire/⚡diff-file.blade.php
 (function () {
     function init() {
-        Alpine.data('diffFile', ({ fileId, filePath, isReviewed, singleFile = false }) => ({
+        Alpine.data('diffFile', ({ fileId, filePath, oldPath = null, isReviewed, singleFile = false }) => ({
             fileId,
             filePath,
+            oldPath,
             collapsed: singleFile ? false : (Alpine.store('settings')?.collapseAll || isReviewed),
             reviewed: isReviewed,
 
@@ -24,36 +25,21 @@
             dragStartLine: null,
             dragSide: null,
 
-            // Shared line context-menu state (one instance per file, not per line).
-            lineMenu: { open: false, x: 0, y: 0, start: null, end: null, side: 'new' },
-
-            openLineMenu(event, lineNum, side = 'new') {
-                event.preventDefault();
+            onLineContextmenu(event, lineNum, side) {
                 const inSelection = this.formLine !== null
                     && lineNum >= this.formLine
                     && lineNum <= (this.formEndLine ?? this.formLine);
-                const margin = 8;
-                const menuW = 220;
-                const menuH = 80;
-                this.lineMenu = {
-                    open: true,
-                    x: Math.min(event.clientX, window.innerWidth - menuW - margin),
-                    y: Math.min(event.clientY, window.innerHeight - menuH - margin),
+                this.$dispatch('show-remote-menu', {
+                    target: 'line',
+                    fileId: this.fileId,
+                    filePath: this.filePath,
+                    oldPath: this.oldPath,
+                    side,
                     start: inSelection ? this.formLine : lineNum,
                     end: inSelection ? (this.formEndLine ?? this.formLine) : null,
-                    side,
-                };
-            },
-
-            closeLineMenu() {
-                this.lineMenu.open = false;
-            },
-
-            get lineMenuLabel() {
-                const { start, end } = this.lineMenu;
-                if (start === null) return 'line';
-                if (end === null || end === start) return 'line ' + start;
-                return 'lines ' + start + '-' + end;
+                    clientX: event.clientX,
+                    clientY: event.clientY,
+                });
             },
             _dragMouseX: 0,
             _dragMouseY: 0,

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -25,40 +25,34 @@
             dragSide: null,
 
             // Shared line context-menu state (one instance per file, not per line).
-            lineMenuOpen: false,
-            lineMenuX: 0,
-            lineMenuY: 0,
-            lineMenuStart: null,
-            lineMenuEnd: null,
+            lineMenu: { open: false, x: 0, y: 0, start: null, end: null },
 
             openLineMenu(event, lineNum) {
                 event.preventDefault();
-                // If the right-clicked line falls inside an active selection, link the range;
-                // otherwise just link this single line.
                 const inSelection = this.formLine !== null
                     && lineNum >= this.formLine
                     && lineNum <= (this.formEndLine ?? this.formLine);
-                this.lineMenuStart = inSelection ? this.formLine : lineNum;
-                this.lineMenuEnd = inSelection ? (this.formEndLine ?? this.formLine) : null;
-
                 const margin = 8;
                 const menuW = 220;
                 const menuH = 80;
-                this.lineMenuX = Math.min(event.clientX, window.innerWidth - menuW - margin);
-                this.lineMenuY = Math.min(event.clientY, window.innerHeight - menuH - margin);
-                this.lineMenuOpen = true;
+                this.lineMenu = {
+                    open: true,
+                    x: Math.min(event.clientX, window.innerWidth - menuW - margin),
+                    y: Math.min(event.clientY, window.innerHeight - menuH - margin),
+                    start: inSelection ? this.formLine : lineNum,
+                    end: inSelection ? (this.formEndLine ?? this.formLine) : null,
+                };
             },
 
             closeLineMenu() {
-                this.lineMenuOpen = false;
+                this.lineMenu.open = false;
             },
 
             get lineMenuLabel() {
-                if (this.lineMenuStart === null) return 'line';
-                if (this.lineMenuEnd === null || this.lineMenuEnd === this.lineMenuStart) {
-                    return 'line ' + this.lineMenuStart;
-                }
-                return 'lines ' + this.lineMenuStart + '-' + this.lineMenuEnd;
+                const { start, end } = this.lineMenu;
+                if (start === null) return 'line';
+                if (end === null || end === start) return 'line ' + start;
+                return 'lines ' + start + '-' + end;
             },
             _dragMouseX: 0,
             _dragMouseY: 0,

--- a/resources/CLAUDE.md
+++ b/resources/CLAUDE.md
@@ -103,6 +103,7 @@ ReviewPage (`resources/views/pages/⚡review-page.blade.php`) renders N DiffFile
 | `undo-available` | ReviewPage PHP dispatch | undo-toast Alpine `@window` | `{type: 'delete'\|'clear-all'\|'discard', payload: comment[]\|int, message: string}` |
 | `discard-file` | DiffFile Alpine `$dispatch` | ReviewPage `#[On]` | `{fileId}` |
 | `fingerprint-reset` | ReviewPage PHP dispatch | change-polling Alpine `@window` | none |
+| `show-remote-menu` | DiffFile Alpine `$dispatch` | ReviewPage Alpine `@window` | `{target: 'file'\|'line', fileId, filePath, oldPath, side?, start?, end?, clientX, clientY}` |
 
 ### Known Debt
 

--- a/resources/views/components/project-list.blade.php
+++ b/resources/views/components/project-list.blade.php
@@ -63,13 +63,14 @@
                     data-project-picker-row
                     data-slug="{{ $project['slug'] }}"
                 @endif
-                x-data="{ status: null, loaded: false }"
+                x-data="{ ...contextMenuState(), status: null, loaded: false }"
                 x-intersect.once="setTimeout(() => {
                     fetch('{{ route('api.status', $project['id']) }}')
                         .then(r => r.json())
                         .then(d => { status = d; loaded = true; })
                         .catch(() => { loaded = true; });
                 }, {{ $rowIndex * 40 }})"
+                @contextmenu.prevent="openAt($event)"
                 @class([
                     'group px-3 py-2.5 border-b border-gh-border/50 last:border-b-0 cursor-pointer transition-colors',
                     'bg-gh-link/5 border-l-2 border-l-gh-link' => $isCurrent,
@@ -134,6 +135,11 @@
                     </div>
                 </div>
                 <p class="mt-1 font-mono text-[11px] text-gh-muted/70 truncate pl-6">{{ $project['path'] }}</p>
+                <x-remote-link-menu
+                    :project-slug="$project['slug']"
+                    type="repo"
+                    label="repository"
+                />
             </div>
             @php $rowIndex++; @endphp
         @endforeach

--- a/resources/views/components/project-list.blade.php
+++ b/resources/views/components/project-list.blade.php
@@ -70,7 +70,7 @@
                         .then(d => { status = d; loaded = true; })
                         .catch(() => { loaded = true; });
                 }, {{ $rowIndex * 40 }})"
-                @contextmenu.prevent="openAt($event)"
+                @contextmenu.prevent="openCtx($event)"
                 @class([
                     'group px-3 py-2.5 border-b border-gh-border/50 last:border-b-0 cursor-pointer transition-colors',
                     'bg-gh-link/5 border-l-2 border-l-gh-link' => $isCurrent,

--- a/resources/views/components/remote-link-menu.blade.php
+++ b/resources/views/components/remote-link-menu.blade.php
@@ -1,0 +1,84 @@
+{{--
+    Right-click menu for "Open on remote" + "Copy remote link" actions.
+
+    Must be rendered inside an `x-data="contextMenu()"` scope that dispatches
+    `openAt($event)` from the trigger's `@contextmenu.prevent` handler. The
+    enclosing Livewire component must `use App\Concerns\InteractsWithRemoteLinks`.
+
+    Static use (known target at render time):
+      <x-remote-link-menu project-slug="..." type="repo" label="repository" />
+      <x-remote-link-menu project-slug="..." type="commit" :params="['sha' => $hash]" label="commit" />
+
+    Dynamic use (target comes from Alpine state, e.g. an x-for loop):
+      <x-remote-link-menu
+          project-slug="..."
+          type-js="'branch'"
+          params-js="{ name: branch.name.replace(/^origin\//, '') }"
+          label-js="'branch ' + branch.name"
+      />
+
+    The menu teleports to the document body so fixed positioning isn't clipped
+    by sticky / overflow-hidden ancestors (e.g. the diff-file header).
+--}}
+
+@props([
+    'projectSlug',
+    'type' => null,
+    'typeJs' => null,
+    'params' => [],
+    'paramsJs' => null,
+    'label' => 'on remote',
+    'labelJs' => null,
+])
+
+@php
+    // Encoding flags ensure the resulting JS literal is safe to paste into an
+    // HTML attribute (`@click="..."`) — no raw quotes, tags, or ampersands.
+    $attrJsonFlags = JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT;
+    $typeExpr = $typeJs ?? json_encode((string) $type, $attrJsonFlags);
+    $paramsExpr = $paramsJs ?? json_encode($params, $attrJsonFlags);
+@endphp
+
+@assets
+<script src="/js/context-menu.js"></script>
+@endassets
+
+<template x-teleport="body">
+    <div
+        x-show="open"
+        x-cloak
+        x-transition.opacity.duration.75ms
+        @click.outside="close()"
+        @keydown.escape.window="close()"
+        @click="close()"
+        class="fixed z-[100] min-w-[180px] py-1 rounded-md border border-gh-border bg-gh-surface shadow-lg"
+        :style="`left:${x}px; top:${y}px`"
+    >
+        @native
+            <button
+                type="button"
+                @click.stop="$wire.openRemote(@js($projectSlug), {{ $typeExpr }}, {{ $paramsExpr }}); close()"
+                class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
+            >
+                <flux:icon icon="arrow-top-right-on-square" variant="outline" class="!size-3.5 text-gh-muted" />
+                @if($labelJs !== null)
+                    <span>Open </span><span x-text="{{ $labelJs }}"></span>
+                @else
+                    <span>Open {{ $label }}</span>
+                @endif
+            </button>
+        @endnative
+        <button
+            type="button"
+            @click.stop="$wire.copyRemoteLink(@js($projectSlug), {{ $typeExpr }}, {{ $paramsExpr }}); close()"
+            class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
+        >
+            <flux:icon icon="link" variant="outline" class="!size-3.5 text-gh-muted" />
+            @if($labelJs !== null)
+                <span>Copy </span><span x-text="{{ $labelJs }}"></span><span> link</span>
+            @else
+                <span>Copy {{ $label }} link</span>
+            @endif
+        </button>
+    </div>
+</template>

--- a/resources/views/components/remote-link-menu.blade.php
+++ b/resources/views/components/remote-link-menu.blade.php
@@ -1,15 +1,14 @@
 {{--
     Right-click menu for "Open on remote" + "Copy remote link" actions.
 
-    Must be rendered inside an `x-data="contextMenu()"` scope that dispatches
-    `openAt($event)` from the trigger's `@contextmenu.prevent` handler. The
+    Must be rendered inside an `x-data="contextMenu()"` scope whose trigger
+    element dispatches `openAt($event)` from `@contextmenu.prevent`. The
     enclosing Livewire component must `use App\Concerns\InteractsWithRemoteLinks`.
 
-    Static use (known target at render time):
+    Static use (target known at render time):
       <x-remote-link-menu project-slug="..." type="repo" label="repository" />
-      <x-remote-link-menu project-slug="..." type="commit" :params="['sha' => $hash]" label="commit" />
 
-    Dynamic use (target comes from Alpine state, e.g. an x-for loop):
+    Dynamic use (target from Alpine state, e.g. in an x-for loop):
       <x-remote-link-menu
           project-slug="..."
           type-js="'branch'"
@@ -17,8 +16,8 @@
           label-js="'branch ' + branch.name"
       />
 
-    The menu teleports to the document body so fixed positioning isn't clipped
-    by sticky / overflow-hidden ancestors (e.g. the diff-file header).
+    Teleports to <body> so fixed positioning isn't clipped by sticky /
+    overflow-hidden ancestors (e.g. the diff-file header).
 --}}
 
 @props([
@@ -32,11 +31,15 @@
 ])
 
 @php
-    // Encoding flags ensure the resulting JS literal is safe to paste into an
-    // HTML attribute (`@click="..."`) — no raw quotes, tags, or ampersands.
+    // Flags ensure the JS literal is safe to paste into an HTML attribute
+    // (`@click="..."`) — no raw quotes, tags, or ampersands.
     $attrJsonFlags = JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT;
     $typeExpr = $typeJs ?? json_encode((string) $type, $attrJsonFlags);
     $paramsExpr = $paramsJs ?? json_encode($params, $attrJsonFlags);
+    $actions = [
+        ['method' => 'openRemote', 'icon' => 'arrow-top-right-on-square', 'verb' => 'Open', 'suffix' => '', 'nativeOnly' => true],
+        ['method' => 'copyRemoteLink', 'icon' => 'link', 'verb' => 'Copy', 'suffix' => ' link', 'nativeOnly' => false],
+    ];
 @endphp
 
 @assets
@@ -54,31 +57,21 @@
         class="fixed z-[100] min-w-[180px] py-1 rounded-md border border-gh-border bg-gh-surface shadow-lg"
         :style="`left:${x}px; top:${y}px`"
     >
-        @native
-            <button
-                type="button"
-                @click.stop="$wire.openRemote(@js($projectSlug), {{ $typeExpr }}, {{ $paramsExpr }}); close()"
-                class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
-            >
-                <flux:icon icon="arrow-top-right-on-square" variant="outline" class="!size-3.5 text-gh-muted" />
-                @if($labelJs !== null)
-                    <span>Open </span><span x-text="{{ $labelJs }}"></span>
-                @else
-                    <span>Open {{ $label }}</span>
-                @endif
-            </button>
-        @endnative
-        <button
-            type="button"
-            @click.stop="$wire.copyRemoteLink(@js($projectSlug), {{ $typeExpr }}, {{ $paramsExpr }}); close()"
-            class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
-        >
-            <flux:icon icon="link" variant="outline" class="!size-3.5 text-gh-muted" />
-            @if($labelJs !== null)
-                <span>Copy </span><span x-text="{{ $labelJs }}"></span><span> link</span>
-            @else
-                <span>Copy {{ $label }} link</span>
-            @endif
-        </button>
+        @foreach($actions as $action)
+            @if($action['nativeOnly'])@native @endif
+                <button
+                    type="button"
+                    @click.stop="$wire.{{ $action['method'] }}(@js($projectSlug), {{ $typeExpr }}, {{ $paramsExpr }}); close()"
+                    class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
+                >
+                    <flux:icon icon="{{ $action['icon'] }}" variant="outline" class="!size-3.5 text-gh-muted" />
+                    @if($labelJs !== null)
+                        <span>{{ $action['verb'] }} </span><span x-text="{{ $labelJs }}"></span>@if($action['suffix'])<span>{{ $action['suffix'] }}</span>@endif
+                    @else
+                        <span>{{ $action['verb'] }} {{ $label }}{{ $action['suffix'] }}</span>
+                    @endif
+                </button>
+            @if($action['nativeOnly'])@endnative @endif
+        @endforeach
     </div>
 </template>

--- a/resources/views/components/remote-link-menu.blade.php
+++ b/resources/views/components/remote-link-menu.blade.php
@@ -2,7 +2,7 @@
     Right-click menu for "Open on remote" + "Copy remote link" actions.
 
     Must be rendered inside an `x-data="contextMenu()"` scope whose trigger
-    element dispatches `openAt($event)` from `@contextmenu.prevent`. The
+    element dispatches `openCtx($event)` from `@contextmenu.prevent`. The
     enclosing Livewire component must `use App\Concerns\InteractsWithRemoteLinks`.
 
     Static use (target known at render time):
@@ -48,20 +48,20 @@
 
 <template x-teleport="body">
     <div
-        x-show="open"
+        x-show="ctxOpen"
         x-cloak
         x-transition.opacity.duration.75ms
-        @click.outside="close()"
-        @keydown.escape.window="close()"
-        @click="close()"
+        @click.outside="closeCtx()"
+        @keydown.escape.window="closeCtx()"
+        @click="closeCtx()"
         class="fixed z-[100] min-w-[180px] py-1 rounded-md border border-gh-border bg-gh-surface shadow-lg"
-        :style="`left:${x}px; top:${y}px`"
+        :style="`left:${ctxX}px; top:${ctxY}px`"
     >
         @foreach($actions as $action)
             @if($action['nativeOnly'])@native @endif
                 <button
                     type="button"
-                    @click.stop="$wire.{{ $action['method'] }}(@js($projectSlug), {{ $typeExpr }}, {{ $paramsExpr }}); close()"
+                    @click.stop="$wire.{{ $action['method'] }}(@js($projectSlug), {{ $typeExpr }}, {{ $paramsExpr }}); closeCtx()"
                     class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
                 >
                     <flux:icon icon="{{ $action['icon'] }}" variant="outline" class="!size-3.5 text-gh-muted" />

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -2,10 +2,13 @@
 
 use App\Actions\GetBranchListAction;
 use App\Actions\GetCommitHistoryAction;
+use App\Concerns\InteractsWithRemoteLinks;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
 
 new class extends Component {
+    use InteractsWithRemoteLinks;
+
     #[Locked]
     public string $repoPath = '';
 
@@ -76,36 +79,61 @@ new class extends Component {
     x-effect="if (open && !$store.overlays.is('branch-explorer')) closePanel()"
 >
     <div class="inline-flex items-stretch rounded-md border border-gh-border/70 bg-gh-surface/30 hover:border-gh-text/30 transition-colors">
-        <flux:tooltip content="Switch branch · ⌘B">
-            <button
-                type="button"
-                class="group inline-flex items-center gap-1.5 px-2 py-1 text-xs font-mono text-gh-muted hover:text-gh-text hover:bg-gh-border/25 rounded-l-md transition-colors cursor-pointer"
-                aria-label="Switch branch (⌘B)"
-                aria-haspopup="dialog"
-                x-on:click="openPanel()"
-                x-bind:aria-expanded="open"
-            >
-                <flux:icon icon="share" variant="outline" class="!size-3 text-gh-muted/70 group-hover:text-gh-text transition-colors" />
-                <span class="tracking-tight">{{ $currentBranch }}</span>
-            </button>
-        </flux:tooltip>
+        <div x-data="contextMenu()" @contextmenu.prevent="openAt($event)" class="inline-flex">
+            <flux:tooltip content="Switch branch · ⌘B">
+                <button
+                    type="button"
+                    class="group inline-flex items-center gap-1.5 px-2 py-1 text-xs font-mono text-gh-muted hover:text-gh-text hover:bg-gh-border/25 rounded-l-md transition-colors cursor-pointer"
+                    aria-label="Switch branch (⌘B)"
+                    aria-haspopup="dialog"
+                    x-on:click="openPanel()"
+                    x-bind:aria-expanded="open"
+                >
+                    <flux:icon icon="share" variant="outline" class="!size-3 text-gh-muted/70 group-hover:text-gh-text transition-colors" />
+                    <span class="tracking-tight">{{ $currentBranch }}</span>
+                </button>
+            </flux:tooltip>
+            <x-remote-link-menu
+                :project-slug="$projectSlug"
+                type="branch"
+                :params="['name' => $currentBranch]"
+                label="branch"
+            />
+        </div>
 
         <span class="w-px self-stretch bg-gh-border/70" aria-hidden="true"></span>
 
-        <flux:tooltip content="{{ $selectionTitle }} · ⌘B">
-            <button
-                type="button"
-                class="group inline-flex items-center gap-1.5 px-2 py-1 text-xs font-mono text-gh-text hover:bg-gh-border/25 rounded-r-md transition-colors cursor-pointer"
-                aria-label="Open selection drawer"
-                aria-haspopup="dialog"
-                x-on:click="openPanel()"
-                x-bind:aria-expanded="open"
-            >
-                <flux:icon icon="square-3-stack-3d" variant="outline" class="!size-3 text-gh-muted/70 group-hover:text-gh-text transition-colors" />
-                <span>{{ $selectionLabel }}</span>
-                <x-chevron-icon variant="mono" />
-            </button>
-        </flux:tooltip>
+        <div x-data="contextMenu()" @contextmenu.prevent="openAt($event)" class="inline-flex">
+            <flux:tooltip content="{{ $selectionTitle }} · ⌘B">
+                <button
+                    type="button"
+                    class="group inline-flex items-center gap-1.5 px-2 py-1 text-xs font-mono text-gh-text hover:bg-gh-border/25 rounded-r-md transition-colors cursor-pointer"
+                    aria-label="Open selection drawer"
+                    aria-haspopup="dialog"
+                    x-on:click="openPanel()"
+                    x-bind:aria-expanded="open"
+                >
+                    <flux:icon icon="square-3-stack-3d" variant="outline" class="!size-3 text-gh-muted/70 group-hover:text-gh-text transition-colors" />
+                    <span>{{ $selectionLabel }}</span>
+                    <x-chevron-icon variant="mono" />
+                </button>
+            </flux:tooltip>
+            @if($activeCommitHash !== null)
+                <x-remote-link-menu
+                    :project-slug="$projectSlug"
+                    type="commit"
+                    :params="['sha' => $activeCommitHash]"
+                    label="commit"
+                />
+            @else
+                <x-remote-link-menu
+                    :project-slug="$projectSlug"
+                    type="branch"
+                    :params="['name' => $currentBranch]"
+                    label="branch"
+                />
+            @endif
+        </div>
     </div>
 
     <x-overlay-panel name="branch-explorer" aria-label="Switch branch" size="lg" on-close="closePanel()">
@@ -136,16 +164,24 @@ new class extends Component {
                                     <span class="section-label text-gh-muted">Local</span>
                                 </div>
                                 <template x-for="(branch, i) in filteredLocal" :key="branch.name">
-                                    <button
-                                        @click="selectBranchAt(i)"
-                                        class="w-full text-left px-3 py-2 text-xs font-mono flex items-center gap-2 transition-colors"
-                                        :class="selectedIndex === i ? 'bg-gh-text/10 text-gh-text font-medium' : 'text-gh-muted hover:bg-gh-border/30 hover:text-gh-text'"
-                                        :data-selected="selectedIndex === i"
-                                    >
-                                        <flux:icon icon="check" variant="outline" class="shrink-0" x-show="branch.isCurrent" x-cloak />
-                                        <span class="shrink-0 w-3" x-show="!branch.isCurrent"></span>
-                                        <span class="truncate" x-text="branch.name"></span>
-                                    </button>
+                                    <div x-data="contextMenu()" @contextmenu.prevent="openAt($event)">
+                                        <button
+                                            @click="selectBranchAt(i)"
+                                            class="w-full text-left px-3 py-2 text-xs font-mono flex items-center gap-2 transition-colors cursor-pointer"
+                                            :class="selectedIndex === i ? 'bg-gh-text/10 text-gh-text font-medium' : 'text-gh-muted hover:bg-gh-border/30 hover:text-gh-text'"
+                                            :data-selected="selectedIndex === i"
+                                        >
+                                            <flux:icon icon="check" variant="outline" class="shrink-0" x-show="branch.isCurrent" x-cloak />
+                                            <span class="shrink-0 w-3" x-show="!branch.isCurrent"></span>
+                                            <span class="truncate" x-text="branch.name"></span>
+                                        </button>
+                                        <x-remote-link-menu
+                                            :project-slug="$projectSlug"
+                                            type-js="'branch'"
+                                            params-js="{ name: branch.name }"
+                                            label-js="'branch ' + branch.name"
+                                        />
+                                    </div>
                                 </template>
                             </div>
                         </template>
@@ -157,15 +193,23 @@ new class extends Component {
                                     <span class="section-label text-gh-muted">Remote</span>
                                 </div>
                                 <template x-for="(branch, j) in filteredRemote" :key="branch.name">
-                                    <button
-                                        @click="selectBranchAt(filteredLocal.length + j)"
-                                        class="w-full text-left px-3 py-2 text-xs font-mono flex items-center gap-2 transition-colors"
-                                        :class="selectedIndex === (filteredLocal.length + j) ? 'bg-gh-text/10 text-gh-text font-medium' : 'text-gh-muted hover:bg-gh-border/30 hover:text-gh-text'"
-                                        :data-selected="selectedIndex === (filteredLocal.length + j)"
-                                    >
-                                        <span class="shrink-0 w-3"></span>
-                                        <span class="truncate" x-text="branch.name"></span>
-                                    </button>
+                                    <div x-data="contextMenu()" @contextmenu.prevent="openAt($event)">
+                                        <button
+                                            @click="selectBranchAt(filteredLocal.length + j)"
+                                            class="w-full text-left px-3 py-2 text-xs font-mono flex items-center gap-2 transition-colors cursor-pointer"
+                                            :class="selectedIndex === (filteredLocal.length + j) ? 'bg-gh-text/10 text-gh-text font-medium' : 'text-gh-muted hover:bg-gh-border/30 hover:text-gh-text'"
+                                            :data-selected="selectedIndex === (filteredLocal.length + j)"
+                                        >
+                                            <span class="shrink-0 w-3"></span>
+                                            <span class="truncate" x-text="branch.name"></span>
+                                        </button>
+                                        <x-remote-link-menu
+                                            :project-slug="$projectSlug"
+                                            type-js="'branch'"
+                                            params-js="{ name: branch.remote && branch.name.startsWith(branch.remote + '/') ? branch.name.slice(branch.remote.length + 1) : branch.name }"
+                                            label-js="'branch ' + branch.name"
+                                        />
+                                    </div>
                                 </template>
                             </div>
                         </template>
@@ -254,6 +298,8 @@ new class extends Component {
                             <div
                                 data-testid="commit-row"
                                 :data-commit-hash="commit.hash"
+                                x-data="contextMenu()"
+                                @contextmenu.prevent="openAt($event)"
                                 class="px-4 py-2.5 border-b border-gh-border/50 hover:bg-gh-border/20 transition-colors group cursor-pointer"
                                 @click="viewCommit(commit.hash)"
                                 :class="{
@@ -295,6 +341,12 @@ new class extends Component {
                                         ></button>
                                     </div>
                                 </div>
+                                <x-remote-link-menu
+                                    :project-slug="$projectSlug"
+                                    type-js="'commit'"
+                                    params-js="{ sha: commit.hash }"
+                                    label-js="'commit ' + commit.shortHash"
+                                />
                             </div>
                         </template>
 

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -108,7 +108,7 @@ new class extends Component {
                 <button
                     type="button"
                     class="group inline-flex items-center gap-1.5 px-2 py-1 text-xs font-mono text-gh-text hover:bg-gh-border/25 rounded-r-md transition-colors cursor-pointer"
-                    aria-label="Open selection drawer"
+                    aria-label="{{ $selectionTitle }} (⌘B)"
                     aria-haspopup="dialog"
                     x-on:click="openPanel()"
                     x-bind:aria-expanded="open"

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -79,7 +79,7 @@ new class extends Component {
     x-effect="if (open && !$store.overlays.is('branch-explorer')) closePanel()"
 >
     <div class="inline-flex items-stretch rounded-md border border-gh-border/70 bg-gh-surface/30 hover:border-gh-text/30 transition-colors">
-        <div x-data="contextMenu()" @contextmenu.prevent="openAt($event)" class="inline-flex">
+        <div x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" class="inline-flex">
             <flux:tooltip content="Switch branch · ⌘B">
                 <button
                     type="button"
@@ -103,7 +103,7 @@ new class extends Component {
 
         <span class="w-px self-stretch bg-gh-border/70" aria-hidden="true"></span>
 
-        <div x-data="contextMenu()" @contextmenu.prevent="openAt($event)" class="inline-flex">
+        <div x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" class="inline-flex">
             <flux:tooltip content="{{ $selectionTitle }} · ⌘B">
                 <button
                     type="button"
@@ -164,7 +164,7 @@ new class extends Component {
                                     <span class="section-label text-gh-muted">Local</span>
                                 </div>
                                 <template x-for="(branch, i) in filteredLocal" :key="branch.name">
-                                    <div x-data="contextMenu()" @contextmenu.prevent="openAt($event)">
+                                    <div x-data="contextMenu()" @contextmenu.prevent="openCtx($event)">
                                         <button
                                             @click="selectBranchAt(i)"
                                             class="w-full text-left px-3 py-2 text-xs font-mono flex items-center gap-2 transition-colors cursor-pointer"
@@ -193,7 +193,7 @@ new class extends Component {
                                     <span class="section-label text-gh-muted">Remote</span>
                                 </div>
                                 <template x-for="(branch, j) in filteredRemote" :key="branch.name">
-                                    <div x-data="contextMenu()" @contextmenu.prevent="openAt($event)">
+                                    <div x-data="contextMenu()" @contextmenu.prevent="openCtx($event)">
                                         <button
                                             @click="selectBranchAt(filteredLocal.length + j)"
                                             class="w-full text-left px-3 py-2 text-xs font-mono flex items-center gap-2 transition-colors cursor-pointer"
@@ -299,7 +299,7 @@ new class extends Component {
                                 data-testid="commit-row"
                                 :data-commit-hash="commit.hash"
                                 x-data="contextMenu()"
-                                @contextmenu.prevent="openAt($event)"
+                                @contextmenu.prevent="openCtx($event)"
                                 class="px-4 py-2.5 border-b border-gh-border/50 hover:bg-gh-border/20 transition-colors group cursor-pointer"
                                 @click="viewCommit(commit.hash)"
                                 :class="{

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -22,6 +22,9 @@ new class extends Component {
     public ?string $activeCommitHash = null;
 
     #[Locked]
+    public bool $hasRemote = false;
+
+    #[Locked]
     public string $selectionLabel = 'Working tree';
 
     #[Locked]
@@ -79,7 +82,7 @@ new class extends Component {
     x-effect="if (open && !$store.overlays.is('branch-explorer')) closePanel()"
 >
     <div class="inline-flex items-stretch rounded-md border border-gh-border/70 bg-gh-surface/30 hover:border-gh-text/30 transition-colors">
-        <div x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" class="inline-flex">
+        <div @if($hasRemote) x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" @endif class="inline-flex">
             <flux:tooltip content="Switch branch · ⌘B">
                 <button
                     type="button"
@@ -93,17 +96,19 @@ new class extends Component {
                     <span class="tracking-tight">{{ $currentBranch }}</span>
                 </button>
             </flux:tooltip>
-            <x-remote-link-menu
-                :project-slug="$projectSlug"
-                type="branch"
-                :params="['name' => $currentBranch]"
-                label="branch"
-            />
+            @if($hasRemote)
+                <x-remote-link-menu
+                    :project-slug="$projectSlug"
+                    type="branch"
+                    :params="['name' => $currentBranch]"
+                    label="branch"
+                />
+            @endif
         </div>
 
         <span class="w-px self-stretch bg-gh-border/70" aria-hidden="true"></span>
 
-        <div x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" class="inline-flex">
+        <div @if($hasRemote) x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" @endif class="inline-flex">
             <flux:tooltip content="{{ $selectionTitle }} · ⌘B">
                 <button
                     type="button"
@@ -118,20 +123,22 @@ new class extends Component {
                     <x-chevron-icon variant="mono" />
                 </button>
             </flux:tooltip>
-            @if($activeCommitHash !== null)
-                <x-remote-link-menu
-                    :project-slug="$projectSlug"
-                    type="commit"
-                    :params="['sha' => $activeCommitHash]"
-                    label="commit"
-                />
-            @else
-                <x-remote-link-menu
-                    :project-slug="$projectSlug"
-                    type="branch"
-                    :params="['name' => $currentBranch]"
-                    label="branch"
-                />
+            @if($hasRemote)
+                @if($activeCommitHash !== null)
+                    <x-remote-link-menu
+                        :project-slug="$projectSlug"
+                        type="commit"
+                        :params="['sha' => $activeCommitHash]"
+                        label="commit"
+                    />
+                @else
+                    <x-remote-link-menu
+                        :project-slug="$projectSlug"
+                        type="branch"
+                        :params="['name' => $currentBranch]"
+                        label="branch"
+                    />
+                @endif
             @endif
         </div>
     </div>
@@ -164,7 +171,7 @@ new class extends Component {
                                     <span class="section-label text-gh-muted">Local</span>
                                 </div>
                                 <template x-for="(branch, i) in filteredLocal" :key="branch.name">
-                                    <div x-data="contextMenu()" @contextmenu.prevent="openCtx($event)">
+                                    <div @if($hasRemote) x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" @endif>
                                         <button
                                             @click="selectBranchAt(i)"
                                             class="w-full text-left px-3 py-2 text-xs font-mono flex items-center gap-2 transition-colors cursor-pointer"
@@ -175,12 +182,14 @@ new class extends Component {
                                             <span class="shrink-0 w-3" x-show="!branch.isCurrent"></span>
                                             <span class="truncate" x-text="branch.name"></span>
                                         </button>
-                                        <x-remote-link-menu
-                                            :project-slug="$projectSlug"
-                                            type-js="'branch'"
-                                            params-js="{ name: branch.name }"
-                                            label-js="'branch ' + branch.name"
-                                        />
+                                        @if($hasRemote)
+                                            <x-remote-link-menu
+                                                :project-slug="$projectSlug"
+                                                type-js="'branch'"
+                                                params-js="{ name: branch.name }"
+                                                label-js="'branch ' + branch.name"
+                                            />
+                                        @endif
                                     </div>
                                 </template>
                             </div>
@@ -193,7 +202,7 @@ new class extends Component {
                                     <span class="section-label text-gh-muted">Remote</span>
                                 </div>
                                 <template x-for="(branch, j) in filteredRemote" :key="branch.name">
-                                    <div x-data="contextMenu()" @contextmenu.prevent="openCtx($event)">
+                                    <div @if($hasRemote) x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" @endif>
                                         <button
                                             @click="selectBranchAt(filteredLocal.length + j)"
                                             class="w-full text-left px-3 py-2 text-xs font-mono flex items-center gap-2 transition-colors cursor-pointer"
@@ -203,12 +212,14 @@ new class extends Component {
                                             <span class="shrink-0 w-3"></span>
                                             <span class="truncate" x-text="branch.name"></span>
                                         </button>
-                                        <x-remote-link-menu
-                                            :project-slug="$projectSlug"
-                                            type-js="'branch'"
-                                            params-js="{ name: branch.remote && branch.name.startsWith(branch.remote + '/') ? branch.name.slice(branch.remote.length + 1) : branch.name }"
-                                            label-js="'branch ' + branch.name"
-                                        />
+                                        @if($hasRemote)
+                                            <x-remote-link-menu
+                                                :project-slug="$projectSlug"
+                                                type-js="'branch'"
+                                                params-js="{ name: branch.remote && branch.name.startsWith(branch.remote + '/') ? branch.name.slice(branch.remote.length + 1) : branch.name }"
+                                                label-js="'branch ' + branch.name"
+                                            />
+                                        @endif
                                     </div>
                                 </template>
                             </div>
@@ -298,8 +309,7 @@ new class extends Component {
                             <div
                                 data-testid="commit-row"
                                 :data-commit-hash="commit.hash"
-                                x-data="contextMenu()"
-                                @contextmenu.prevent="openCtx($event)"
+                                @if($hasRemote) x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" @endif
                                 class="px-4 py-2.5 border-b border-gh-border/50 hover:bg-gh-border/20 transition-colors group cursor-pointer"
                                 @click="viewCommit(commit.hash)"
                                 :class="{
@@ -341,12 +351,14 @@ new class extends Component {
                                         ></button>
                                     </div>
                                 </div>
-                                <x-remote-link-menu
-                                    :project-slug="$projectSlug"
-                                    type-js="'commit'"
-                                    params-js="{ sha: commit.hash }"
-                                    label-js="'commit ' + commit.shortHash"
-                                />
+                                @if($hasRemote)
+                                    <x-remote-link-menu
+                                        :project-slug="$projectSlug"
+                                        type-js="'commit'"
+                                        params-js="{ sha: commit.hash }"
+                                        label-js="'commit ' + commit.shortHash"
+                                    />
+                                @endif
                             </div>
                         </template>
 

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -108,7 +108,7 @@ new class extends Component {
                 <button
                     type="button"
                     class="group inline-flex items-center gap-1.5 px-2 py-1 text-xs font-mono text-gh-text hover:bg-gh-border/25 rounded-r-md transition-colors cursor-pointer"
-                    aria-label="{{ $selectionTitle }} (⌘B)"
+                    aria-label="Open selection drawer (⌘B)"
                     aria-haspopup="dialog"
                     x-on:click="openPanel()"
                     x-bind:aria-expanded="open"

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -10,7 +10,6 @@ use Livewire\Attributes\Locked;
 use Livewire\Component;
 
 new class extends Component {
-
     /** @var array<string, mixed> */
     #[Locked]
     public array $file = [];
@@ -20,12 +19,6 @@ new class extends Component {
 
     #[Locked]
     public int $projectId = 0;
-
-    #[Locked]
-    public string $projectSlug = '';
-
-    #[Locked]
-    public string $projectBranch = '';
 
     #[Locked]
     public bool $hasRemote = false;
@@ -225,6 +218,7 @@ new class extends Component {
     x-data="diffFile({
         fileId: @js($file['id']),
         filePath: @js($file['path']),
+        oldPath: @js($file['oldPath'] ?? null),
         isReviewed: @js($isReviewed ?? false),
         singleFile: @js($singleFile ?? false),
     })"
@@ -236,65 +230,10 @@ new class extends Component {
     @expand-file.window="if ($event.detail.id === fileId) { autoExpandedForComment = false; collapsed = false }"
     class="group"
 >
-    @if($hasRemote)
-        @php
-            // File-level / new-side links target the current ref and new path. Old-side
-            // links (removed lines, old path on renames) target the parent ref so the
-            // line exists at that revision. In working-tree mode both sides resolve to
-            // the current branch since there's no pushed commit to anchor to.
-            $remoteRefNew = $diffTo ?: ($projectBranch ?: 'HEAD');
-            $remoteRefOld = $diffTo !== null ? $diffFrom : ($projectBranch ?: 'HEAD');
-            $remoteFilePathNew = $file['path'];
-            $remoteFilePathOld = $file['oldPath'] ?? $file['path'];
-        @endphp
-
-        {{-- Shared line-level context menu (teleported, one per file) --}}
-        <template x-teleport="body">
-            <div
-                x-show="lineMenu.open"
-                x-cloak
-                x-transition.opacity.duration.75ms
-                @click.outside="closeLineMenu()"
-                @keydown.escape.window="closeLineMenu()"
-                @click="closeLineMenu()"
-                class="fixed z-[100] min-w-[200px] py-1 rounded-md border border-gh-border bg-gh-surface shadow-lg"
-                :style="`left:${lineMenu.x}px; top:${lineMenu.y}px`"
-            >
-                @native
-                    <button
-                        type="button"
-                        @click.stop="$wire.openRemote(@js($projectSlug), 'line', { ref: lineMenu.side === 'old' ? @js($remoteRefOld) : @js($remoteRefNew), path: lineMenu.side === 'old' ? @js($remoteFilePathOld) : @js($remoteFilePathNew), start: lineMenu.start, end: lineMenu.end }); closeLineMenu()"
-                        class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
-                    >
-                        <flux:icon icon="arrow-top-right-on-square" variant="outline" class="!size-3.5 text-gh-muted" />
-                        <span>Open </span><span x-text="lineMenuLabel"></span>
-                    </button>
-                @endnative
-                <button
-                    type="button"
-                    @click.stop="$wire.copyRemoteLink(@js($projectSlug), 'line', { ref: lineMenu.side === 'old' ? @js($remoteRefOld) : @js($remoteRefNew), path: lineMenu.side === 'old' ? @js($remoteFilePathOld) : @js($remoteFilePathNew), start: lineMenu.start, end: lineMenu.end }); closeLineMenu()"
-                    class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
-                >
-                    <flux:icon icon="link" variant="outline" class="!size-3.5 text-gh-muted" />
-                    <span>Copy </span><span x-text="lineMenuLabel"></span><span> link</span>
-                </button>
-            </div>
-        </template>
-    @endif
-
     {{-- File header --}}
     <div data-testid="file-header"
-         @if($hasRemote) x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" @endif
+         @if($hasRemote) @contextmenu.prevent="$dispatch('show-remote-menu', {target: 'file', fileId, filePath, oldPath, clientX: $event.clientX, clientY: $event.clientY})" @endif
          class="sticky top-[var(--header-h)] z-10 bg-gh-surface/80 backdrop-blur-sm border-b border-gh-border px-5 py-2.5 flex items-center gap-2.5">
-
-        @if($hasRemote)
-            <x-remote-link-menu
-                :project-slug="$projectSlug"
-                type="file"
-                :params="['ref' => $remoteRefNew, 'path' => $remoteFilePathNew]"
-                label="file"
-            />
-        @endif
 
         {{-- Toggle zone: click anywhere here to expand/collapse --}}
         <div data-testid="toggle-zone"
@@ -615,7 +554,7 @@ new class extends Component {
                                 class="diff-line {{ $bgClass }}"
                                 :class="isLineInSelection({{ $lineNum ?? 'null' }}) ? 'line-selected' : ''"
                                 @mouseenter="onDragOver({{ $line['newLineNum'] ?? 'null' }}, {{ $line['oldLineNum'] ?? 'null' }})"
-                                @if($hasRemote && $lineNum !== null) @contextmenu.prevent="openLineMenu($event, {{ $lineNum }}, '{{ $lineSide === 'left' ? 'old' : 'new' }}')" @endif
+                                @if($hasRemote && $lineNum !== null) @contextmenu.prevent="onLineContextmenu($event, {{ $lineNum }}, '{{ $lineSide === 'left' ? 'old' : 'new' }}')" @endif
                                 @if($line['newLineNum']) data-line-new="{{ $line['newLineNum'] }}" @endif
                                 @if($line['oldLineNum']) data-line-old="{{ $line['oldLineNum'] }}" @endif
                             >

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -236,26 +236,26 @@ new class extends Component {
     class="group"
 >
     @php
-        $remoteRef = $diffTo ?: ($projectBranch !== '' ? $projectBranch : 'HEAD');
+        $remoteRef = $diffTo ?: ($projectBranch ?: 'HEAD');
         $remoteFilePath = $file['path'];
     @endphp
 
     {{-- Shared line-level context menu (teleported, one per file) --}}
     <template x-teleport="body">
         <div
-            x-show="lineMenuOpen"
+            x-show="lineMenu.open"
             x-cloak
             x-transition.opacity.duration.75ms
             @click.outside="closeLineMenu()"
             @keydown.escape.window="closeLineMenu()"
             @click="closeLineMenu()"
             class="fixed z-[100] min-w-[200px] py-1 rounded-md border border-gh-border bg-gh-surface shadow-lg"
-            :style="`left:${lineMenuX}px; top:${lineMenuY}px`"
+            :style="`left:${lineMenu.x}px; top:${lineMenu.y}px`"
         >
             @native
                 <button
                     type="button"
-                    @click.stop="$wire.openRemote(@js($projectSlug), 'line', { ref: @js($remoteRef), path: @js($remoteFilePath), start: lineMenuStart, end: lineMenuEnd }); closeLineMenu()"
+                    @click.stop="$wire.openRemote(@js($projectSlug), 'line', { ref: @js($remoteRef), path: @js($remoteFilePath), start: lineMenu.start, end: lineMenu.end }); closeLineMenu()"
                     class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
                 >
                     <flux:icon icon="arrow-top-right-on-square" variant="outline" class="!size-3.5 text-gh-muted" />
@@ -264,7 +264,7 @@ new class extends Component {
             @endnative
             <button
                 type="button"
-                @click.stop="$wire.copyRemoteLink(@js($projectSlug), 'line', { ref: @js($remoteRef), path: @js($remoteFilePath), start: lineMenuStart, end: lineMenuEnd }); closeLineMenu()"
+                @click.stop="$wire.copyRemoteLink(@js($projectSlug), 'line', { ref: @js($remoteRef), path: @js($remoteFilePath), start: lineMenu.start, end: lineMenu.end }); closeLineMenu()"
                 class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
             >
                 <flux:icon icon="link" variant="outline" class="!size-3.5 text-gh-muted" />

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -236,8 +236,17 @@ new class extends Component {
     class="group"
 >
     @php
-        $remoteRef = $diffTo ?: ($projectBranch ?: 'HEAD');
-        $remoteFilePath = $file['path'];
+        // File-level / new-side links target the current ref and new path. Old-side
+        // links (removed lines, old path on renames) target the parent ref so the
+        // line exists at that revision. In working-tree mode both sides resolve to
+        // the current branch since there's no pushed commit to anchor to.
+        $remoteRefNew = $diffTo ?: ($projectBranch ?: 'HEAD');
+        $remoteRefOld = $diffTo !== null ? $diffFrom : ($projectBranch ?: 'HEAD');
+        $remoteFilePathNew = $file['path'];
+        $remoteFilePathOld = $file['oldPath'] ?? $file['path'];
+        // Back-compat alias for the file-header menu (always uses new side).
+        $remoteRef = $remoteRefNew;
+        $remoteFilePath = $remoteFilePathNew;
     @endphp
 
     {{-- Shared line-level context menu (teleported, one per file) --}}
@@ -255,7 +264,7 @@ new class extends Component {
             @native
                 <button
                     type="button"
-                    @click.stop="$wire.openRemote(@js($projectSlug), 'line', { ref: @js($remoteRef), path: @js($remoteFilePath), start: lineMenu.start, end: lineMenu.end }); closeLineMenu()"
+                    @click.stop="$wire.openRemote(@js($projectSlug), 'line', { ref: lineMenu.side === 'old' ? @js($remoteRefOld) : @js($remoteRefNew), path: lineMenu.side === 'old' ? @js($remoteFilePathOld) : @js($remoteFilePathNew), start: lineMenu.start, end: lineMenu.end }); closeLineMenu()"
                     class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
                 >
                     <flux:icon icon="arrow-top-right-on-square" variant="outline" class="!size-3.5 text-gh-muted" />
@@ -264,7 +273,7 @@ new class extends Component {
             @endnative
             <button
                 type="button"
-                @click.stop="$wire.copyRemoteLink(@js($projectSlug), 'line', { ref: @js($remoteRef), path: @js($remoteFilePath), start: lineMenu.start, end: lineMenu.end }); closeLineMenu()"
+                @click.stop="$wire.copyRemoteLink(@js($projectSlug), 'line', { ref: lineMenu.side === 'old' ? @js($remoteRefOld) : @js($remoteRefNew), path: lineMenu.side === 'old' ? @js($remoteFilePathOld) : @js($remoteFilePathNew), start: lineMenu.start, end: lineMenu.end }); closeLineMenu()"
                 class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
             >
                 <flux:icon icon="link" variant="outline" class="!size-3.5 text-gh-muted" />
@@ -605,7 +614,7 @@ new class extends Component {
                                 class="diff-line {{ $bgClass }}"
                                 :class="isLineInSelection({{ $lineNum ?? 'null' }}) ? 'line-selected' : ''"
                                 @mouseenter="onDragOver({{ $line['newLineNum'] ?? 'null' }}, {{ $line['oldLineNum'] ?? 'null' }})"
-                                @if($lineNum !== null) @contextmenu.prevent="openLineMenu($event, {{ $lineNum }})" @endif
+                                @if($lineNum !== null) @contextmenu.prevent="openLineMenu($event, {{ $lineNum }}, '{{ $lineSide === 'left' ? 'old' : 'new' }}')" @endif
                                 @if($line['newLineNum']) data-line-new="{{ $line['newLineNum'] }}" @endif
                                 @if($line['oldLineNum']) data-line-old="{{ $line['oldLineNum'] }}" @endif
                             >

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -3,7 +3,6 @@
 use App\Actions\ExpandDiffGapAction;
 use App\Actions\GetFileCopyContentAction;
 use App\Actions\LoadFileDiffAction;
-use App\Concerns\InteractsWithRemoteLinks;
 use App\DTOs\DiffTarget;
 use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
@@ -11,7 +10,6 @@ use Livewire\Attributes\Locked;
 use Livewire\Component;
 
 new class extends Component {
-    use InteractsWithRemoteLinks;
 
     /** @var array<string, mixed> */
     #[Locked]
@@ -28,6 +26,9 @@ new class extends Component {
 
     #[Locked]
     public string $projectBranch = '';
+
+    #[Locked]
+    public bool $hasRemote = false;
 
     #[Locked]
     public int $loadDelay = 0;
@@ -235,65 +236,65 @@ new class extends Component {
     @expand-file.window="if ($event.detail.id === fileId) { autoExpandedForComment = false; collapsed = false }"
     class="group"
 >
-    @php
-        // File-level / new-side links target the current ref and new path. Old-side
-        // links (removed lines, old path on renames) target the parent ref so the
-        // line exists at that revision. In working-tree mode both sides resolve to
-        // the current branch since there's no pushed commit to anchor to.
-        $remoteRefNew = $diffTo ?: ($projectBranch ?: 'HEAD');
-        $remoteRefOld = $diffTo !== null ? $diffFrom : ($projectBranch ?: 'HEAD');
-        $remoteFilePathNew = $file['path'];
-        $remoteFilePathOld = $file['oldPath'] ?? $file['path'];
-        // Back-compat alias for the file-header menu (always uses new side).
-        $remoteRef = $remoteRefNew;
-        $remoteFilePath = $remoteFilePathNew;
-    @endphp
+    @if($hasRemote)
+        @php
+            // File-level / new-side links target the current ref and new path. Old-side
+            // links (removed lines, old path on renames) target the parent ref so the
+            // line exists at that revision. In working-tree mode both sides resolve to
+            // the current branch since there's no pushed commit to anchor to.
+            $remoteRefNew = $diffTo ?: ($projectBranch ?: 'HEAD');
+            $remoteRefOld = $diffTo !== null ? $diffFrom : ($projectBranch ?: 'HEAD');
+            $remoteFilePathNew = $file['path'];
+            $remoteFilePathOld = $file['oldPath'] ?? $file['path'];
+        @endphp
 
-    {{-- Shared line-level context menu (teleported, one per file) --}}
-    <template x-teleport="body">
-        <div
-            x-show="lineMenu.open"
-            x-cloak
-            x-transition.opacity.duration.75ms
-            @click.outside="closeLineMenu()"
-            @keydown.escape.window="closeLineMenu()"
-            @click="closeLineMenu()"
-            class="fixed z-[100] min-w-[200px] py-1 rounded-md border border-gh-border bg-gh-surface shadow-lg"
-            :style="`left:${lineMenu.x}px; top:${lineMenu.y}px`"
-        >
-            @native
+        {{-- Shared line-level context menu (teleported, one per file) --}}
+        <template x-teleport="body">
+            <div
+                x-show="lineMenu.open"
+                x-cloak
+                x-transition.opacity.duration.75ms
+                @click.outside="closeLineMenu()"
+                @keydown.escape.window="closeLineMenu()"
+                @click="closeLineMenu()"
+                class="fixed z-[100] min-w-[200px] py-1 rounded-md border border-gh-border bg-gh-surface shadow-lg"
+                :style="`left:${lineMenu.x}px; top:${lineMenu.y}px`"
+            >
+                @native
+                    <button
+                        type="button"
+                        @click.stop="$wire.openRemote(@js($projectSlug), 'line', { ref: lineMenu.side === 'old' ? @js($remoteRefOld) : @js($remoteRefNew), path: lineMenu.side === 'old' ? @js($remoteFilePathOld) : @js($remoteFilePathNew), start: lineMenu.start, end: lineMenu.end }); closeLineMenu()"
+                        class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
+                    >
+                        <flux:icon icon="arrow-top-right-on-square" variant="outline" class="!size-3.5 text-gh-muted" />
+                        <span>Open </span><span x-text="lineMenuLabel"></span>
+                    </button>
+                @endnative
                 <button
                     type="button"
-                    @click.stop="$wire.openRemote(@js($projectSlug), 'line', { ref: lineMenu.side === 'old' ? @js($remoteRefOld) : @js($remoteRefNew), path: lineMenu.side === 'old' ? @js($remoteFilePathOld) : @js($remoteFilePathNew), start: lineMenu.start, end: lineMenu.end }); closeLineMenu()"
+                    @click.stop="$wire.copyRemoteLink(@js($projectSlug), 'line', { ref: lineMenu.side === 'old' ? @js($remoteRefOld) : @js($remoteRefNew), path: lineMenu.side === 'old' ? @js($remoteFilePathOld) : @js($remoteFilePathNew), start: lineMenu.start, end: lineMenu.end }); closeLineMenu()"
                     class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
                 >
-                    <flux:icon icon="arrow-top-right-on-square" variant="outline" class="!size-3.5 text-gh-muted" />
-                    <span>Open </span><span x-text="lineMenuLabel"></span>
+                    <flux:icon icon="link" variant="outline" class="!size-3.5 text-gh-muted" />
+                    <span>Copy </span><span x-text="lineMenuLabel"></span><span> link</span>
                 </button>
-            @endnative
-            <button
-                type="button"
-                @click.stop="$wire.copyRemoteLink(@js($projectSlug), 'line', { ref: lineMenu.side === 'old' ? @js($remoteRefOld) : @js($remoteRefNew), path: lineMenu.side === 'old' ? @js($remoteFilePathOld) : @js($remoteFilePathNew), start: lineMenu.start, end: lineMenu.end }); closeLineMenu()"
-                class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
-            >
-                <flux:icon icon="link" variant="outline" class="!size-3.5 text-gh-muted" />
-                <span>Copy </span><span x-text="lineMenuLabel"></span><span> link</span>
-            </button>
-        </div>
-    </template>
+            </div>
+        </template>
+    @endif
 
     {{-- File header --}}
     <div data-testid="file-header"
-         x-data="contextMenu()"
-         @contextmenu.prevent="openCtx($event)"
+         @if($hasRemote) x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" @endif
          class="sticky top-[var(--header-h)] z-10 bg-gh-surface/80 backdrop-blur-sm border-b border-gh-border px-5 py-2.5 flex items-center gap-2.5">
 
-        <x-remote-link-menu
-            :project-slug="$projectSlug"
-            type="file"
-            :params="['ref' => $remoteRef, 'path' => $remoteFilePath]"
-            label="file"
-        />
+        @if($hasRemote)
+            <x-remote-link-menu
+                :project-slug="$projectSlug"
+                type="file"
+                :params="['ref' => $remoteRefNew, 'path' => $remoteFilePathNew]"
+                label="file"
+            />
+        @endif
 
         {{-- Toggle zone: click anywhere here to expand/collapse --}}
         <div data-testid="toggle-zone"
@@ -614,7 +615,7 @@ new class extends Component {
                                 class="diff-line {{ $bgClass }}"
                                 :class="isLineInSelection({{ $lineNum ?? 'null' }}) ? 'line-selected' : ''"
                                 @mouseenter="onDragOver({{ $line['newLineNum'] ?? 'null' }}, {{ $line['oldLineNum'] ?? 'null' }})"
-                                @if($lineNum !== null) @contextmenu.prevent="openLineMenu($event, {{ $lineNum }}, '{{ $lineSide === 'left' ? 'old' : 'new' }}')" @endif
+                                @if($hasRemote && $lineNum !== null) @contextmenu.prevent="openLineMenu($event, {{ $lineNum }}, '{{ $lineSide === 'left' ? 'old' : 'new' }}')" @endif
                                 @if($line['newLineNum']) data-line-new="{{ $line['newLineNum'] }}" @endif
                                 @if($line['oldLineNum']) data-line-old="{{ $line['oldLineNum'] }}" @endif
                             >

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -285,7 +285,7 @@ new class extends Component {
     {{-- File header --}}
     <div data-testid="file-header"
          x-data="contextMenu()"
-         @contextmenu.prevent="openAt($event)"
+         @contextmenu.prevent="openCtx($event)"
          class="sticky top-[var(--header-h)] z-10 bg-gh-surface/80 backdrop-blur-sm border-b border-gh-border px-5 py-2.5 flex items-center gap-2.5">
 
         <x-remote-link-menu

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -3,6 +3,7 @@
 use App\Actions\ExpandDiffGapAction;
 use App\Actions\GetFileCopyContentAction;
 use App\Actions\LoadFileDiffAction;
+use App\Concerns\InteractsWithRemoteLinks;
 use App\DTOs\DiffTarget;
 use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
@@ -10,6 +11,8 @@ use Livewire\Attributes\Locked;
 use Livewire\Component;
 
 new class extends Component {
+    use InteractsWithRemoteLinks;
+
     /** @var array<string, mixed> */
     #[Locked]
     public array $file = [];
@@ -19,6 +22,12 @@ new class extends Component {
 
     #[Locked]
     public int $projectId = 0;
+
+    #[Locked]
+    public string $projectSlug = '';
+
+    #[Locked]
+    public string $projectBranch = '';
 
     #[Locked]
     public int $loadDelay = 0;
@@ -226,8 +235,56 @@ new class extends Component {
     @expand-file.window="if ($event.detail.id === fileId) { autoExpandedForComment = false; collapsed = false }"
     class="group"
 >
+    @php
+        $remoteRef = $diffTo ?: ($projectBranch !== '' ? $projectBranch : 'HEAD');
+        $remoteFilePath = $file['path'];
+    @endphp
+
+    {{-- Shared line-level context menu (teleported, one per file) --}}
+    <template x-teleport="body">
+        <div
+            x-show="lineMenuOpen"
+            x-cloak
+            x-transition.opacity.duration.75ms
+            @click.outside="closeLineMenu()"
+            @keydown.escape.window="closeLineMenu()"
+            @click="closeLineMenu()"
+            class="fixed z-[100] min-w-[200px] py-1 rounded-md border border-gh-border bg-gh-surface shadow-lg"
+            :style="`left:${lineMenuX}px; top:${lineMenuY}px`"
+        >
+            @native
+                <button
+                    type="button"
+                    @click.stop="$wire.openRemote(@js($projectSlug), 'line', { ref: @js($remoteRef), path: @js($remoteFilePath), start: lineMenuStart, end: lineMenuEnd }); closeLineMenu()"
+                    class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
+                >
+                    <flux:icon icon="arrow-top-right-on-square" variant="outline" class="!size-3.5 text-gh-muted" />
+                    <span>Open </span><span x-text="lineMenuLabel"></span>
+                </button>
+            @endnative
+            <button
+                type="button"
+                @click.stop="$wire.copyRemoteLink(@js($projectSlug), 'line', { ref: @js($remoteRef), path: @js($remoteFilePath), start: lineMenuStart, end: lineMenuEnd }); closeLineMenu()"
+                class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
+            >
+                <flux:icon icon="link" variant="outline" class="!size-3.5 text-gh-muted" />
+                <span>Copy </span><span x-text="lineMenuLabel"></span><span> link</span>
+            </button>
+        </div>
+    </template>
+
     {{-- File header --}}
-    <div data-testid="file-header" class="sticky top-[var(--header-h)] z-10 bg-gh-surface/80 backdrop-blur-sm border-b border-gh-border px-5 py-2.5 flex items-center gap-2.5">
+    <div data-testid="file-header"
+         x-data="contextMenu()"
+         @contextmenu.prevent="openAt($event)"
+         class="sticky top-[var(--header-h)] z-10 bg-gh-surface/80 backdrop-blur-sm border-b border-gh-border px-5 py-2.5 flex items-center gap-2.5">
+
+        <x-remote-link-menu
+            :project-slug="$projectSlug"
+            type="file"
+            :params="['ref' => $remoteRef, 'path' => $remoteFilePath]"
+            label="file"
+        />
 
         {{-- Toggle zone: click anywhere here to expand/collapse --}}
         <div data-testid="toggle-zone"
@@ -548,6 +605,7 @@ new class extends Component {
                                 class="diff-line {{ $bgClass }}"
                                 :class="isLineInSelection({{ $lineNum ?? 'null' }}) ? 'line-selected' : ''"
                                 @mouseenter="onDragOver({{ $line['newLineNum'] ?? 'null' }}, {{ $line['oldLineNum'] ?? 'null' }})"
+                                @if($lineNum !== null) @contextmenu.prevent="openLineMenu($event, {{ $lineNum }})" @endif
                                 @if($line['newLineNum']) data-line-new="{{ $line['newLineNum'] }}" @endif
                                 @if($line['oldLineNum']) data-line-old="{{ $line['oldLineNum'] }}" @endif
                             >

--- a/resources/views/livewire/⚡project-picker.blade.php
+++ b/resources/views/livewire/⚡project-picker.blade.php
@@ -2,6 +2,7 @@
 
 use App\Actions\ListProjectsAction;
 use App\Actions\RemoveProjectAction;
+use App\Concerns\InteractsWithRemoteLinks;
 use Livewire\Attributes\Lazy;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
@@ -12,6 +13,8 @@ new
 #[Lazy]
 class extends Component
 {
+    use InteractsWithRemoteLinks;
+
     #[Locked]
     public string $currentSlug = '';
 

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -849,6 +849,42 @@ new #[Layout('layouts.app')] class extends Component
         sourceFileEntries: @js(collect($sourceFiles)->map(fn($f) => ['id' => $f['id'], 'path' => $f['path']])->values()->all()),
         sidebarWidth: $store.settings.sidebarWidth,
         resizing: false,
+        remoteMenu: { open: false, x: 0, y: 0, projectSlug: '', type: '', params: {}, label: '' },
+        showRemoteMenu($event) {
+            const d = $event.detail;
+            const projectBranch = @js($projectBranch);
+            const diffFrom = @js($diffFrom);
+            const diffTo = @js($diffTo);
+            const refNew = diffTo || projectBranch || 'HEAD';
+            const refOld = diffTo !== null ? diffFrom : (projectBranch || 'HEAD');
+            const pathOld = d.oldPath || d.filePath;
+            let type, params, label;
+            if (d.target === 'file') {
+                type = 'file';
+                params = { ref: refNew, path: d.filePath };
+                label = 'file';
+            } else {
+                type = 'line';
+                params = {
+                    ref: d.side === 'old' ? refOld : refNew,
+                    path: d.side === 'old' ? pathOld : d.filePath,
+                    start: d.start,
+                    end: d.end,
+                };
+                label = (d.end === null || d.end === d.start) ? 'line ' + d.start : 'lines ' + d.start + '-' + d.end;
+            }
+            const margin = 8;
+            const menuW = 220;
+            const menuH = 80;
+            this.remoteMenu = {
+                open: true,
+                x: Math.min(d.clientX, window.innerWidth - menuW - margin),
+                y: Math.min(d.clientY, window.innerHeight - menuH - margin),
+                projectSlug: @js($projectSlug),
+                type, params, label,
+            };
+        },
+        closeRemoteMenu() { this.remoteMenu.open = false; },
         get reviewedCount() {
             return Object.values(this.reviewedFiles).filter(Boolean).length;
         },
@@ -908,6 +944,7 @@ new #[Layout('layouts.app')] class extends Component
     }"
     @file-reviewed-changed.window="reviewedFiles[$event.detail.id] = $event.detail.reviewed"
     @reset-reviewed-files.window="reviewedFiles = {}"
+    @show-remote-menu.window="showRemoteMenu($event)"
     @copy-to-clipboard.window="
         navigator.clipboard.writeText($event.detail.text).catch(() => {});
     "
@@ -928,6 +965,41 @@ new #[Layout('layouts.app')] class extends Component
     @native
         <livewire:update-banner />
     @endnative
+
+    @if($hasRemote)
+        {{-- Shared remote-link context menu (one instance per review-page) --}}
+        <template x-teleport="body">
+            <div
+                x-show="remoteMenu.open"
+                x-cloak
+                x-transition.opacity.duration.75ms
+                @click.outside="closeRemoteMenu()"
+                @keydown.escape.window="closeRemoteMenu()"
+                @click="closeRemoteMenu()"
+                class="fixed z-[100] min-w-[200px] py-1 rounded-md border border-gh-border bg-gh-surface shadow-lg"
+                :style="`left:${remoteMenu.x}px; top:${remoteMenu.y}px`"
+            >
+                @native
+                    <button
+                        type="button"
+                        @click.stop="$wire.openRemote(remoteMenu.projectSlug, remoteMenu.type, remoteMenu.params); closeRemoteMenu()"
+                        class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
+                    >
+                        <flux:icon icon="arrow-top-right-on-square" variant="outline" class="!size-3.5 text-gh-muted" />
+                        <span>Open </span><span x-text="remoteMenu.label"></span>
+                    </button>
+                @endnative
+                <button
+                    type="button"
+                    @click.stop="$wire.copyRemoteLink(remoteMenu.projectSlug, remoteMenu.type, remoteMenu.params); closeRemoteMenu()"
+                    class="w-full text-left px-3 py-1.5 text-xs font-mono text-gh-text hover:bg-gh-border/40 flex items-center gap-2 cursor-pointer"
+                >
+                    <flux:icon icon="link" variant="outline" class="!size-3.5 text-gh-muted" />
+                    <span>Copy </span><span x-text="remoteMenu.label"></span><span> link</span>
+                </button>
+            </div>
+        </template>
+    @endif
 
     {{-- Header --}}
     <header class="sticky top-0 z-50 bg-gh-bg/80 backdrop-blur-sm border-b border-gh-border px-5 py-3.5 flex items-center justify-between">
@@ -1354,8 +1426,6 @@ new #[Layout('layouts.app')] class extends Component
                                         :is-reviewed="array_key_exists($pair['jsonFile']['path'], $reviewedFiles)"
                                         :repo-path="$repoPath"
                                         :project-id="$projectId"
-                                        :project-slug="$projectSlug"
-                                        :project-branch="$projectBranch"
                                         :has-remote="$hasRemote"
                                         :diff-from="$diffFrom"
                                         :diff-to="$diffTo"
@@ -1370,8 +1440,6 @@ new #[Layout('layouts.app')] class extends Component
                                         :is-reviewed="array_key_exists($pair['mdFile']['path'], $reviewedFiles)"
                                         :repo-path="$repoPath"
                                         :project-id="$projectId"
-                                        :project-slug="$projectSlug"
-                                        :project-branch="$projectBranch"
                                         :has-remote="$hasRemote"
                                         :diff-from="$diffFrom"
                                         :diff-to="$diffTo"
@@ -1395,8 +1463,6 @@ new #[Layout('layouts.app')] class extends Component
                             :single-file="$singleFile"
                             :repo-path="$repoPath"
                             :project-id="$projectId"
-                            :project-slug="$projectSlug"
-                            :project-branch="$projectBranch"
                             :has-remote="$hasRemote"
                             :diff-from="$diffFrom"
                             :diff-to="$diffTo"

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -64,6 +64,8 @@ new #[Layout('layouts.app')] class extends Component
 
     public string $projectSlug = '';
 
+    public bool $hasRemote = false;
+
     public ?string $exportResult = null;
 
     public bool $submitted = false;
@@ -128,6 +130,7 @@ new #[Layout('layouts.app')] class extends Component
         $this->projectName = $project['name'];
         $this->projectBranch = $project['branch'] ?? '';
         $this->projectSlug = $project['slug'];
+        $this->hasRemote = ! empty($project['remote_url']);
 
         app(ResolveStartupRouteAction::class)->rememberLastOpened($slug);
 
@@ -929,17 +932,19 @@ new #[Layout('layouts.app')] class extends Component
     {{-- Header --}}
     <header class="sticky top-0 z-50 bg-gh-bg/80 backdrop-blur-sm border-b border-gh-border px-5 py-3.5 flex items-center justify-between">
         <div class="flex items-center gap-2">
-            <div x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" class="inline-flex">
+            <div @if($hasRemote) x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" @endif class="inline-flex">
                 @native
                     <livewire:project-picker :current-slug="$projectSlug" :project-name="$projectName" />
                 @else
                     <span class="font-display font-bold tracking-brutal-tight text-base">{{ $projectName }}</span>
                 @endnative
-                <x-remote-link-menu
-                    :project-slug="$projectSlug"
-                    type="repo"
-                    label="repository"
-                />
+                @if($hasRemote)
+                    <x-remote-link-menu
+                        :project-slug="$projectSlug"
+                        type="repo"
+                        label="repository"
+                    />
+                @endif
             </div>
             @php
                 $shortFrom = $diffFrom === 'HEAD' ? 'HEAD' : substr($diffFrom, 0, 7);
@@ -962,6 +967,7 @@ new #[Layout('layouts.app')] class extends Component
                     :current-branch="$projectBranch"
                     :project-slug="$projectSlug"
                     :active-commit-hash="$diffTo"
+                    :has-remote="$hasRemote"
                     :selection-label="$selectionLabel"
                     :selection-title="$selectionTitle"
                 />
@@ -1350,6 +1356,7 @@ new #[Layout('layouts.app')] class extends Component
                                         :project-id="$projectId"
                                         :project-slug="$projectSlug"
                                         :project-branch="$projectBranch"
+                                        :has-remote="$hasRemote"
                                         :diff-from="$diffFrom"
                                         :diff-to="$diffTo"
                                     />
@@ -1365,6 +1372,7 @@ new #[Layout('layouts.app')] class extends Component
                                         :project-id="$projectId"
                                         :project-slug="$projectSlug"
                                         :project-branch="$projectBranch"
+                                        :has-remote="$hasRemote"
                                         :diff-from="$diffFrom"
                                         :diff-to="$diffTo"
                                     />
@@ -1389,6 +1397,7 @@ new #[Layout('layouts.app')] class extends Component
                             :project-id="$projectId"
                             :project-slug="$projectSlug"
                             :project-branch="$projectBranch"
+                            :has-remote="$hasRemote"
                             :diff-from="$diffFrom"
                             :diff-to="$diffTo"
                         />

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -929,7 +929,7 @@ new #[Layout('layouts.app')] class extends Component
     {{-- Header --}}
     <header class="sticky top-0 z-50 bg-gh-bg/80 backdrop-blur-sm border-b border-gh-border px-5 py-3.5 flex items-center justify-between">
         <div class="flex items-center gap-2">
-            <div x-data="contextMenu()" @contextmenu.prevent="openAt($event)" class="inline-flex">
+            <div x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" class="inline-flex">
                 @native
                     <livewire:project-picker :current-slug="$projectSlug" :project-name="$projectName" />
                 @else

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -2,6 +2,7 @@
 
 use App\Actions\AddCommentAction;
 use App\Actions\BackfillGlobalGitignoreAction;
+use App\Concerns\InteractsWithRemoteLinks;
 use App\Actions\CleanExpiredTrashAction;
 use App\Actions\DeleteCommentAction;
 use App\Actions\DeleteReviewFilesAction;
@@ -37,6 +38,8 @@ use Livewire\Component;
 
 new #[Layout('layouts.app')] class extends Component
 {
+    use InteractsWithRemoteLinks;
+
     /** @var array<int, array<string, mixed>> */
     public array $files = [];
 
@@ -926,11 +929,18 @@ new #[Layout('layouts.app')] class extends Component
     {{-- Header --}}
     <header class="sticky top-0 z-50 bg-gh-bg/80 backdrop-blur-sm border-b border-gh-border px-5 py-3.5 flex items-center justify-between">
         <div class="flex items-center gap-2">
-            @native
-                <livewire:project-picker :current-slug="$projectSlug" :project-name="$projectName" />
-            @else
-                <span class="font-display font-bold tracking-brutal-tight text-base">{{ $projectName }}</span>
-            @endnative
+            <div x-data="contextMenu()" @contextmenu.prevent="openAt($event)" class="inline-flex">
+                @native
+                    <livewire:project-picker :current-slug="$projectSlug" :project-name="$projectName" />
+                @else
+                    <span class="font-display font-bold tracking-brutal-tight text-base">{{ $projectName }}</span>
+                @endnative
+                <x-remote-link-menu
+                    :project-slug="$projectSlug"
+                    type="repo"
+                    label="repository"
+                />
+            </div>
             @php
                 $shortFrom = $diffFrom === 'HEAD' ? 'HEAD' : substr($diffFrom, 0, 7);
                 $shortTo = $diffTo ? substr($diffTo, 0, 7) : null;
@@ -1338,6 +1348,8 @@ new #[Layout('layouts.app')] class extends Component
                                         :is-reviewed="array_key_exists($pair['jsonFile']['path'], $reviewedFiles)"
                                         :repo-path="$repoPath"
                                         :project-id="$projectId"
+                                        :project-slug="$projectSlug"
+                                        :project-branch="$projectBranch"
                                         :diff-from="$diffFrom"
                                         :diff-to="$diffTo"
                                     />
@@ -1351,6 +1363,8 @@ new #[Layout('layouts.app')] class extends Component
                                         :is-reviewed="array_key_exists($pair['mdFile']['path'], $reviewedFiles)"
                                         :repo-path="$repoPath"
                                         :project-id="$projectId"
+                                        :project-slug="$projectSlug"
+                                        :project-branch="$projectBranch"
                                         :diff-from="$diffFrom"
                                         :diff-to="$diffTo"
                                     />
@@ -1373,6 +1387,8 @@ new #[Layout('layouts.app')] class extends Component
                             :single-file="$singleFile"
                             :repo-path="$repoPath"
                             :project-id="$projectId"
+                            :project-slug="$projectSlug"
+                            :project-branch="$projectBranch"
                             :diff-from="$diffFrom"
                             :diff-to="$diffTo"
                         />

--- a/resources/views/pages/⚡select-repo-page.blade.php
+++ b/resources/views/pages/⚡select-repo-page.blade.php
@@ -3,6 +3,7 @@
 use App\Actions\ListProjectsAction;
 use App\Actions\RemoveProjectAction;
 use App\Actions\ResolveStartupRouteAction;
+use App\Concerns\InteractsWithRemoteLinks;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\On;
 use Livewire\Attributes\Session;
@@ -11,6 +12,8 @@ use Native\Desktop\Facades\Shell;
 
 new #[Layout('layouts.app')] class extends Component
 {
+    use InteractsWithRemoteLinks;
+
     public string $search = '';
 
     #[Session('select-repo-page.sort-by')]

--- a/tests/Unit/Actions/BuildRemoteUrlActionTest.php
+++ b/tests/Unit/Actions/BuildRemoteUrlActionTest.php
@@ -88,7 +88,6 @@ test('builds a line url with a range anchor', function () {
 });
 
 test('self-heals a missing remote_url by reading git config and persisting it', function () {
-    // Add a real origin to the test repo so GitMetadataService can find it.
     $this->runTestRepoCommand($this->testRepoPath, 'git remote add origin git@github.com:fgilio/rfa.git');
 
     $project = Project::create([

--- a/tests/Unit/Actions/BuildRemoteUrlActionTest.php
+++ b/tests/Unit/Actions/BuildRemoteUrlActionTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use App\Actions\BuildRemoteUrlAction;
+use App\Models\Project;
+use App\Services\GitMetadataService;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+beforeEach(function () {
+    $this->testRepoPath = $this->createTempDirectory('rfa_build_remote_url_');
+    $this->initTestRepo($this->testRepoPath);
+    File::put($this->testRepoPath.'/file.txt', 'hello');
+    $this->commitTestRepo($this->testRepoPath, 'init');
+});
+
+test('returns null for unknown slug', function () {
+    expect(app(BuildRemoteUrlAction::class)->handle('does-not-exist', 'repo'))
+        ->toBeNull();
+});
+
+test('returns null when project has no remote and none can be resolved', function () {
+    $project = Project::create([
+        'slug' => 'no-remote',
+        'name' => 'no-remote',
+        'path' => $this->testRepoPath,
+        'git_common_dir' => $this->testRepoPath.'/.git',
+        'is_worktree' => false,
+        'branch' => 'main',
+    ]);
+
+    expect(app(BuildRemoteUrlAction::class)->handle($project->slug, 'repo'))
+        ->toBeNull();
+});
+
+test('returns null for a recognised-but-unsupported provider (e.g. bitbucket)', function () {
+    $project = Project::create([
+        'slug' => 'bitbucket-repo',
+        'name' => 'bitbucket-repo',
+        'path' => $this->testRepoPath,
+        'git_common_dir' => $this->testRepoPath.'/.git',
+        'is_worktree' => false,
+        'branch' => 'main',
+        'remote_url' => 'git@bitbucket.org:team/project.git',
+    ]);
+
+    expect(app(BuildRemoteUrlAction::class)->handle($project->slug, 'repo'))
+        ->toBeNull();
+});
+
+test('builds a github repo url from a stored remote', function () {
+    $project = Project::create([
+        'slug' => 'rfa',
+        'name' => 'rfa',
+        'path' => $this->testRepoPath,
+        'git_common_dir' => $this->testRepoPath.'/.git',
+        'is_worktree' => false,
+        'branch' => 'main',
+        'remote_url' => 'git@github.com:fgilio/rfa.git',
+    ]);
+
+    $url = app(BuildRemoteUrlAction::class)->handle($project->slug, 'repo');
+
+    expect($url)->toBe('https://github.com/fgilio/rfa');
+});
+
+test('builds a line url with a range anchor', function () {
+    $project = Project::create([
+        'slug' => 'rfa',
+        'name' => 'rfa',
+        'path' => $this->testRepoPath,
+        'git_common_dir' => $this->testRepoPath.'/.git',
+        'is_worktree' => false,
+        'branch' => 'main',
+        'remote_url' => 'https://github.com/fgilio/rfa.git',
+    ]);
+
+    $url = app(BuildRemoteUrlAction::class)->handle($project->slug, 'line', [
+        'ref' => 'main',
+        'path' => 'README.md',
+        'start' => 10,
+        'end' => 20,
+    ]);
+
+    expect($url)->toBe('https://github.com/fgilio/rfa/blob/main/README.md#L10-L20');
+});
+
+test('self-heals a missing remote_url by reading git config and persisting it', function () {
+    // Add a real origin to the test repo so GitMetadataService can find it.
+    $this->runTestRepoCommand($this->testRepoPath, 'git remote add origin git@github.com:fgilio/rfa.git');
+
+    $project = Project::create([
+        'slug' => 'rfa',
+        'name' => 'rfa',
+        'path' => $this->testRepoPath,
+        'git_common_dir' => $this->testRepoPath.'/.git',
+        'is_worktree' => false,
+        'branch' => 'main',
+        'remote_url' => null,
+    ]);
+
+    $url = app(BuildRemoteUrlAction::class)->handle($project->slug, 'repo');
+
+    expect($url)->toBe('https://github.com/fgilio/rfa');
+    expect($project->fresh()->remote_url)->toBe('git@github.com:fgilio/rfa.git');
+});
+
+test('getRemoteUrl returns null when no origin is configured', function () {
+    $service = app(GitMetadataService::class);
+
+    expect($service->getRemoteUrl($this->testRepoPath))->toBeNull();
+});
+
+test('getRemoteUrl returns the configured origin url', function () {
+    $this->runTestRepoCommand($this->testRepoPath, 'git remote add origin https://github.com/fgilio/rfa.git');
+
+    $service = app(GitMetadataService::class);
+
+    expect($service->getRemoteUrl($this->testRepoPath))->toBe('https://github.com/fgilio/rfa.git');
+});

--- a/tests/Unit/DTOs/RemoteTargetTest.php
+++ b/tests/Unit/DTOs/RemoteTargetTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\DTOs\RemoteTarget;
+
+test('repo factory has no params', function () {
+    $t = RemoteTarget::repo();
+
+    expect($t->type)->toBe(RemoteTarget::TYPE_REPO);
+    expect($t->params)->toBe([]);
+});
+
+test('branch factory rejects empty name', function () {
+    expect(fn () => RemoteTarget::branch(''))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+test('commit factory rejects empty sha', function () {
+    expect(fn () => RemoteTarget::commit(''))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+test('file factory rejects empty ref or path', function () {
+    expect(fn () => RemoteTarget::file('', 'foo.php'))->toThrow(InvalidArgumentException::class);
+    expect(fn () => RemoteTarget::file('main', ''))->toThrow(InvalidArgumentException::class);
+});
+
+test('line factory rejects invalid line numbers', function () {
+    expect(fn () => RemoteTarget::line('main', 'foo.php', 0))->toThrow(InvalidArgumentException::class);
+    expect(fn () => RemoteTarget::line('main', 'foo.php', -1))->toThrow(InvalidArgumentException::class);
+});
+
+test('line factory collapses end-equals-start to single-line', function () {
+    $t = RemoteTarget::line('main', 'foo.php', 5, 5);
+
+    expect($t->params['start'])->toBe(5);
+    expect($t->params['end'])->toBeNull();
+});
+
+test('line factory normalises reversed start/end', function () {
+    $t = RemoteTarget::line('main', 'foo.php', 20, 10);
+
+    expect($t->params['start'])->toBe(10);
+    expect($t->params['end'])->toBe(20);
+});
+
+test('fromWire reconstructs each target type', function () {
+    expect(RemoteTarget::fromWire('repo', [])->type)->toBe(RemoteTarget::TYPE_REPO);
+    expect(RemoteTarget::fromWire('branch', ['name' => 'main'])->params['name'])->toBe('main');
+    expect(RemoteTarget::fromWire('commit', ['sha' => 'abc'])->params['sha'])->toBe('abc');
+
+    $file = RemoteTarget::fromWire('file', ['ref' => 'main', 'path' => 'a.php']);
+    expect($file->params)->toBe(['ref' => 'main', 'path' => 'a.php']);
+
+    $line = RemoteTarget::fromWire('line', ['ref' => 'main', 'path' => 'a.php', 'start' => 10, 'end' => 20]);
+    expect($line->params['start'])->toBe(10);
+    expect($line->params['end'])->toBe(20);
+});
+
+test('fromWire rejects unknown type', function () {
+    expect(fn () => RemoteTarget::fromWire('unknown', []))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+test('fromWire rejects missing required params via the factory', function () {
+    expect(fn () => RemoteTarget::fromWire('branch', []))->toThrow(InvalidArgumentException::class);
+    expect(fn () => RemoteTarget::fromWire('commit', []))->toThrow(InvalidArgumentException::class);
+});

--- a/tests/Unit/DTOs/RemoteTargetTest.php
+++ b/tests/Unit/DTOs/RemoteTargetTest.php
@@ -66,4 +66,7 @@ test('fromWire rejects unknown type', function () {
 test('fromWire rejects missing required params via the factory', function () {
     expect(fn () => RemoteTarget::fromWire('branch', []))->toThrow(InvalidArgumentException::class);
     expect(fn () => RemoteTarget::fromWire('commit', []))->toThrow(InvalidArgumentException::class);
+    expect(fn () => RemoteTarget::fromWire('file', ['ref' => 'main']))->toThrow(InvalidArgumentException::class);
+    expect(fn () => RemoteTarget::fromWire('file', ['path' => 'a.php']))->toThrow(InvalidArgumentException::class);
+    expect(fn () => RemoteTarget::fromWire('line', ['ref' => 'main', 'path' => 'a.php', 'start' => 0]))->toThrow(InvalidArgumentException::class);
 });

--- a/tests/Unit/DTOs/RemoteTargetTest.php
+++ b/tests/Unit/DTOs/RemoteTargetTest.php
@@ -27,6 +27,8 @@ test('file factory rejects empty ref or path', function () {
 test('line factory rejects invalid line numbers', function () {
     expect(fn () => RemoteTarget::line('main', 'foo.php', 0))->toThrow(InvalidArgumentException::class);
     expect(fn () => RemoteTarget::line('main', 'foo.php', -1))->toThrow(InvalidArgumentException::class);
+    expect(fn () => RemoteTarget::line('main', 'foo.php', 1, -5))->toThrow(InvalidArgumentException::class);
+    expect(fn () => RemoteTarget::line('main', 'foo.php', 5, 0))->toThrow(InvalidArgumentException::class);
 });
 
 test('line factory collapses end-equals-start to single-line', function () {

--- a/tests/Unit/Services/GitRemoteParserTest.php
+++ b/tests/Unit/Services/GitRemoteParserTest.php
@@ -102,3 +102,27 @@ test('lowercases the host for stable comparisons', function () {
     expect($result['host'])->toBe('github.com');
     expect($result['provider'])->toBe('github');
 });
+
+test('preserves http scheme for explicitly-insecure self-hosted remotes', function () {
+    $result = $this->parser->parse('http://gitlab.internal.corp/team/project.git');
+
+    expect($result['scheme'])->toBe('http');
+    expect($result['webBaseUrl'])->toBe('http://gitlab.internal.corp/team/project');
+});
+
+test('upgrades ssh:// and git:// remotes to https for the web url', function () {
+    $ssh = $this->parser->parse('ssh://git@github.com/fgilio/rfa.git');
+    $git = $this->parser->parse('git://github.com/fgilio/rfa.git');
+
+    expect($ssh['scheme'])->toBe('https');
+    expect($ssh['webBaseUrl'])->toBe('https://github.com/fgilio/rfa');
+    expect($git['scheme'])->toBe('https');
+    expect($git['webBaseUrl'])->toBe('https://github.com/fgilio/rfa');
+});
+
+test('defaults scp-style remotes to https', function () {
+    $result = $this->parser->parse('git@github.com:fgilio/rfa.git');
+
+    expect($result['scheme'])->toBe('https');
+    expect($result['webBaseUrl'])->toBe('https://github.com/fgilio/rfa');
+});

--- a/tests/Unit/Services/GitRemoteParserTest.php
+++ b/tests/Unit/Services/GitRemoteParserTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use App\Services\GitRemoteParser;
+
+beforeEach(function () {
+    $this->parser = new GitRemoteParser;
+});
+
+test('parses github https url', function () {
+    $result = $this->parser->parse('https://github.com/fgilio/rfa.git');
+
+    expect($result)->not->toBeNull();
+    expect($result['provider'])->toBe('github');
+    expect($result['host'])->toBe('github.com');
+    expect($result['owner'])->toBe('fgilio');
+    expect($result['repo'])->toBe('rfa');
+    expect($result['webBaseUrl'])->toBe('https://github.com/fgilio/rfa');
+});
+
+test('parses github https url without .git suffix', function () {
+    $result = $this->parser->parse('https://github.com/fgilio/rfa');
+
+    expect($result['repo'])->toBe('rfa');
+    expect($result['webBaseUrl'])->toBe('https://github.com/fgilio/rfa');
+});
+
+test('parses github ssh scp-style url', function () {
+    $result = $this->parser->parse('git@github.com:fgilio/rfa.git');
+
+    expect($result['provider'])->toBe('github');
+    expect($result['host'])->toBe('github.com');
+    expect($result['owner'])->toBe('fgilio');
+    expect($result['repo'])->toBe('rfa');
+});
+
+test('parses ssh:// url form', function () {
+    $result = $this->parser->parse('ssh://git@github.com/fgilio/rfa.git');
+
+    expect($result['provider'])->toBe('github');
+    expect($result['owner'])->toBe('fgilio');
+    expect($result['repo'])->toBe('rfa');
+});
+
+test('parses gitlab https url with nested group', function () {
+    $result = $this->parser->parse('https://gitlab.com/acme/team/backend.git');
+
+    expect($result['provider'])->toBe('gitlab');
+    expect($result['host'])->toBe('gitlab.com');
+    expect($result['owner'])->toBe('acme/team');
+    expect($result['repo'])->toBe('backend');
+    expect($result['webBaseUrl'])->toBe('https://gitlab.com/acme/team/backend');
+});
+
+test('parses gitlab ssh scp-style url with nested group', function () {
+    $result = $this->parser->parse('git@gitlab.com:acme/team/backend.git');
+
+    expect($result['provider'])->toBe('gitlab');
+    expect($result['owner'])->toBe('acme/team');
+    expect($result['repo'])->toBe('backend');
+});
+
+test('recognises self-hosted github enterprise by hostname', function () {
+    $result = $this->parser->parse('git@github.acme.com:internal/repo.git');
+
+    expect($result['provider'])->toBe('github');
+    expect($result['host'])->toBe('github.acme.com');
+    expect($result['webBaseUrl'])->toBe('https://github.acme.com/internal/repo');
+});
+
+test('recognises self-hosted gitlab by hostname', function () {
+    $result = $this->parser->parse('https://gitlab.mycorp.local/team/project.git');
+
+    expect($result['provider'])->toBe('gitlab');
+    expect($result['host'])->toBe('gitlab.mycorp.local');
+});
+
+test('returns null for unknown provider', function () {
+    $result = $this->parser->parse('https://bitbucket.org/team/project.git');
+
+    expect($result)->toBeNull();
+});
+
+test('returns null for empty input', function () {
+    expect($this->parser->parse(''))->toBeNull();
+    expect($this->parser->parse('   '))->toBeNull();
+});
+
+test('returns null for malformed url', function () {
+    expect($this->parser->parse('not-a-url'))->toBeNull();
+    expect($this->parser->parse('git@github.com'))->toBeNull();
+});
+
+test('handles trailing slash', function () {
+    $result = $this->parser->parse('https://github.com/fgilio/rfa/');
+
+    expect($result['repo'])->toBe('rfa');
+});
+
+test('lowercases the host for stable comparisons', function () {
+    $result = $this->parser->parse('https://GitHub.com/fgilio/rfa.git');
+
+    expect($result['host'])->toBe('github.com');
+    expect($result['provider'])->toBe('github');
+});

--- a/tests/Unit/Services/RemoteUrlBuilderServiceTest.php
+++ b/tests/Unit/Services/RemoteUrlBuilderServiceTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use App\DTOs\RemoteTarget;
+use App\Services\RemoteUrlBuilderService;
+
+beforeEach(function () {
+    $this->builder = new RemoteUrlBuilderService;
+    $this->github = [
+        'provider' => 'github',
+        'host' => 'github.com',
+        'owner' => 'fgilio',
+        'repo' => 'rfa',
+        'webBaseUrl' => 'https://github.com/fgilio/rfa',
+    ];
+    $this->gitlab = [
+        'provider' => 'gitlab',
+        'host' => 'gitlab.com',
+        'owner' => 'acme/team',
+        'repo' => 'backend',
+        'webBaseUrl' => 'https://gitlab.com/acme/team/backend',
+    ];
+});
+
+test('builds repo url for github', function () {
+    expect($this->builder->build($this->github, RemoteTarget::repo()))
+        ->toBe('https://github.com/fgilio/rfa');
+});
+
+test('builds branch url for github', function () {
+    expect($this->builder->build($this->github, RemoteTarget::branch('main')))
+        ->toBe('https://github.com/fgilio/rfa/tree/main');
+});
+
+test('builds branch url for gitlab uses dash prefix', function () {
+    expect($this->builder->build($this->gitlab, RemoteTarget::branch('main')))
+        ->toBe('https://gitlab.com/acme/team/backend/-/tree/main');
+});
+
+test('preserves slashes in branch names with path segments', function () {
+    expect($this->builder->build($this->github, RemoteTarget::branch('release/1.0')))
+        ->toBe('https://github.com/fgilio/rfa/tree/release/1.0');
+});
+
+test('builds commit url for github', function () {
+    expect($this->builder->build($this->github, RemoteTarget::commit('abc123')))
+        ->toBe('https://github.com/fgilio/rfa/commit/abc123');
+});
+
+test('builds commit url for gitlab with dash prefix', function () {
+    expect($this->builder->build($this->gitlab, RemoteTarget::commit('abc123')))
+        ->toBe('https://gitlab.com/acme/team/backend/-/commit/abc123');
+});
+
+test('builds file url for github with nested path', function () {
+    expect($this->builder->build($this->github, RemoteTarget::file('main', 'src/app/Models/Project.php')))
+        ->toBe('https://github.com/fgilio/rfa/blob/main/src/app/Models/Project.php');
+});
+
+test('builds file url for gitlab with dash prefix', function () {
+    expect($this->builder->build($this->gitlab, RemoteTarget::file('main', 'app/Http/Controller.php')))
+        ->toBe('https://gitlab.com/acme/team/backend/-/blob/main/app/Http/Controller.php');
+});
+
+test('builds single-line url for github', function () {
+    expect($this->builder->build($this->github, RemoteTarget::line('main', 'README.md', 42)))
+        ->toBe('https://github.com/fgilio/rfa/blob/main/README.md#L42');
+});
+
+test('builds line range url for github with L<start>-L<end>', function () {
+    expect($this->builder->build($this->github, RemoteTarget::line('main', 'README.md', 10, 20)))
+        ->toBe('https://github.com/fgilio/rfa/blob/main/README.md#L10-L20');
+});
+
+test('builds line range url for gitlab with L<start>-<end> (no L on end)', function () {
+    expect($this->builder->build($this->gitlab, RemoteTarget::line('main', 'README.md', 10, 20)))
+        ->toBe('https://gitlab.com/acme/team/backend/-/blob/main/README.md#L10-20');
+});
+
+test('normalises line range when end equals start to a single-line anchor', function () {
+    expect($this->builder->build($this->github, RemoteTarget::line('main', 'foo.php', 5, 5)))
+        ->toBe('https://github.com/fgilio/rfa/blob/main/foo.php#L5');
+});
+
+test('swaps line start/end when end precedes start', function () {
+    expect($this->builder->build($this->github, RemoteTarget::line('main', 'foo.php', 20, 10)))
+        ->toBe('https://github.com/fgilio/rfa/blob/main/foo.php#L10-L20');
+});
+
+test('url-encodes branch names with unsafe characters', function () {
+    $result = $this->builder->build($this->github, RemoteTarget::branch('feature/my branch'));
+
+    expect($result)->toBe('https://github.com/fgilio/rfa/tree/feature/my%20branch');
+});
+
+test('url-encodes path segments but keeps slashes', function () {
+    $result = $this->builder->build($this->github, RemoteTarget::file('main', 'a b/c d.php'));
+
+    expect($result)->toBe('https://github.com/fgilio/rfa/blob/main/a%20b/c%20d.php');
+});


### PR DESCRIPTION
## Summary
This PR adds the ability to open and copy links to remote repositories (GitHub/GitLab) directly from the application. Users can right-click on branches, commits, files, and lines to open them on the remote or copy the link to clipboard.

## Key Changes

- **Remote URL parsing and building**: Added `GitRemoteParser` service to parse git remote URLs (SSH, HTTPS, git://) and detect GitHub/GitLab providers (including self-hosted instances). Added `RemoteUrlBuilderService` to compose web URLs for different target types (repo, branch, commit, file, line).

- **Remote target DTO**: Created `RemoteTarget` DTO with factory methods for type-safe construction of different remote targets (repo, branch, commit, file, line) with validation and normalization (e.g., swapping reversed line ranges).

- **Livewire trait**: Added `InteractsWithRemoteLinks` trait providing `openRemote()` and `copyRemoteLink()` methods that rebuild URLs server-side from stored project metadata, ensuring security by never trusting client-provided URLs.

- **UI components**: 
  - Added `remote-link-menu.blade.php` component for right-click context menus with "Open on remote" and "Copy link" actions
  - Integrated context menus into branch explorer, diff file viewer, and project picker
  - Added Alpine.js `context-menu.js` utility for positioning and managing context menu state

- **Database**: Added `remote_url` column to projects table to cache the git remote URL, with self-healing logic to populate it from git config on first use.

- **Integration points**:
  - Branch explorer: Right-click on branch name or commit selection
  - Diff file viewer: Right-click on individual lines or line ranges
  - Project picker: Right-click on project rows
  - All components use the shared `InteractsWithRemoteLinks` trait

- **Comprehensive tests**: Added unit tests for `RemoteTarget`, `GitRemoteParser`, `RemoteUrlBuilderService`, and `BuildRemoteUrlAction` covering various URL formats, edge cases, and provider-specific behavior.

## Implementation Details

- Remote URL resolution is lazy: projects without a stored `remote_url` will read from git config on first use and persist it
- Line range anchors differ by provider: GitHub uses `#L10-L20`, GitLab uses `#L10-20`
- GitLab URLs use `/-/` prefix for tree/commit/blob paths
- Branch names with slashes (e.g., `release/1.0`) are preserved as path segments
- Context menus teleport to `<body>` to avoid clipping by overflow-hidden ancestors
- All remote link generation happens server-side via `BuildRemoteUrlAction` for security

https://claude.ai/code/session_01NPb8qLV3EJDfj3USsohZFN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Right-click context menus on projects, branches, commits, files and lines to open or copy GitHub/GitLab links
  * Support for repository, branch, commit, file and line-range link types; correctly constructs provider-specific URLs and anchors

* **Chores**
  * Projects now store a nullable remote URL with a migration; missing remotes are auto-detected and persisted

* **Tests**
  * Comprehensive unit tests for remote detection, parsing, target validation, and URL building
<!-- end of auto-generated comment: release notes by coderabbit.ai -->