### PR TITLE
Customize View menu to prevent ⌘R reload conflict

### DIFF
--- a/app/Providers/NativeAppServiceProvider.php
+++ b/app/Providers/NativeAppServiceProvider.php
@@ -164,7 +164,18 @@ class NativeAppServiceProvider implements ProvidesPhpIni
                     ->icon(resource_path('icons/scan-folderTemplate.png')),
             )->label('File'),
             Menu::edit(),
-            Menu::view(),
+            // Custom View submenu that intentionally omits `reload`. The
+            // viewMenu role would otherwise bind ⌘R to Electron's built-in
+            // reload accelerator — NativePHP's menu helper strips custom
+            // accelerators from role items, so the binding can't be retargeted
+            // and the keydown never reaches the renderer. Keeping the View
+            // menu lean here lets the ⌘R registration in the review page's
+            // keymap store fire as intended.
+            Menu::make(
+                Menu::devTools(),
+                Menu::separator(),
+                Menu::fullscreen(),
+            )->label('View'),
             Menu::window(),
         );
     }


### PR DESCRIPTION
## Summary
Modified the View menu in the native app service provider to use a custom menu configuration instead of the default `Menu::view()`. This prevents NativePHP's menu helper from binding the ⌘R keyboard shortcut to Electron's built-in reload accelerator, allowing the review page's custom ⌘R keymap binding to work as intended.

## Key Changes
- Replaced `Menu::view()` with a custom menu containing only `devTools()` and `fullscreen()` options
- Removed the default View menu items that would trigger the problematic ⌘R binding
- Added detailed inline comments explaining the rationale for this customization

## Implementation Details
The issue stems from NativePHP's menu helper stripping custom accelerators from role-based menu items. When using the standard `Menu::view()`, the ⌘R shortcut gets bound to Electron's reload function, and this binding cannot be retargeted. By creating a lean custom View menu without the reload option, the ⌘R keydown event now properly reaches the renderer and fires the review page's keymap store binding as intended.

https://claude.ai/code/session_01N3ELsW72567K3uMRTz46Nt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the application reload keyboard shortcut to respond correctly as intended.
  * Customized the application menu with updated View menu options for developer tools and fullscreen controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->