### PR TITLE
Allow selecting working tree alongside commits in branch explorer

### DIFF
--- a/app/Actions/ResolveRangeToWorkingAction.php
+++ b/app/Actions/ResolveRangeToWorkingAction.php
@@ -13,11 +13,6 @@ final readonly class ResolveRangeToWorkingAction
         private GitMetadataService $gitMetadataService,
     ) {}
 
-    /**
-     * Resolve a "from-commit through the working tree" target. Typically the
-     * caller passes `<oldest-selected>^` so the diff spans every committed
-     * change plus uncommitted/untracked edits.
-     */
     public function handle(string $repoPath, string $from): DiffTarget
     {
         $effectiveFrom = $from;

--- a/app/Actions/ResolveRangeToWorkingAction.php
+++ b/app/Actions/ResolveRangeToWorkingAction.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\DTOs\DiffTarget;
+use App\Services\GitMetadataService;
+
+final readonly class ResolveRangeToWorkingAction
+{
+    public function __construct(
+        private GitMetadataService $gitMetadataService,
+    ) {}
+
+    /**
+     * Resolve a "from-commit through the working tree" target. Typically the
+     * caller passes `<oldest-selected>^` so the diff spans every committed
+     * change plus uncommitted/untracked edits.
+     */
+    public function handle(string $repoPath, string $from): DiffTarget
+    {
+        $effectiveFrom = $from;
+
+        // Root commits have no parent, so `<root>^` is not a valid revision.
+        // Match ResolveRangeAction and diff against git's empty tree so the
+        // earliest included commit renders as pure additions.
+        if (str_ends_with($effectiveFrom, '^')
+            && $this->gitMetadataService->isRootCommit($repoPath, substr($effectiveFrom, 0, -1))) {
+            $effectiveFrom = DiffTarget::EMPTY_TREE_HASH;
+        }
+
+        return DiffTarget::rangeToWorking($effectiveFrom);
+    }
+}

--- a/app/DTOs/DiffTarget.php
+++ b/app/DTOs/DiffTarget.php
@@ -30,7 +30,6 @@ final readonly class DiffTarget
         return new self(from: $from, to: $to);
     }
 
-    /** Range from a commit through the working tree (committed + uncommitted + untracked). */
     public static function rangeToWorking(string $from): self
     {
         return new self(from: $from, to: null);

--- a/app/DTOs/DiffTarget.php
+++ b/app/DTOs/DiffTarget.php
@@ -30,6 +30,12 @@ final readonly class DiffTarget
         return new self(from: $from, to: $to);
     }
 
+    /** Range from a commit through the working tree (committed + uncommitted + untracked). */
+    public static function rangeToWorking(string $from): self
+    {
+        return new self(from: $from, to: null);
+    }
+
     /** Build from raw ref strings - null $to means working directory */
     public static function fromRefs(string $from, ?string $to): self
     {
@@ -60,7 +66,7 @@ final readonly class DiffTarget
 
     public function contextKey(): string
     {
-        return $this->to === null ? GitRef::Working->value : $this->from.'..'.$this->to;
+        return $this->from.'..'.($this->to ?? GitRef::Working->value);
     }
 
     /** @return list<string> Git diff command prefix args */

--- a/app/Support/DiffCacheKey.php
+++ b/app/Support/DiffCacheKey.php
@@ -8,8 +8,11 @@ use App\Enums\GitRef;
 
 final class DiffCacheKey
 {
-    public static function for(int|string $projectIdOrRepoPath, string $fileId, string $contextKey = GitRef::Working->value): string
+    /** Default for the implicit working-tree context ("HEAD..working"). Matches DiffTarget::workingDirectory()->contextKey(). */
+    private const WORKING_TREE_CONTEXT = 'HEAD..'.GitRef::Working->value;
+
+    public static function for(int|string $projectIdOrRepoPath, string $fileId, string $contextKey = self::WORKING_TREE_CONTEXT): string
     {
-        return 'rfa_diff_v6_'.hash('xxh128', $projectIdOrRepoPath.':'.$contextKey.':'.$fileId);
+        return 'rfa_diff_v7_'.hash('xxh128', $projectIdOrRepoPath.':'.$contextKey.':'.$fileId);
     }
 }

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -1,17 +1,43 @@
 // Alpine component for livewire/⚡branch-explorer.blade.php
 (function () {
     function init() {
-        Alpine.data('branchExplorer', ({ currentBranch, activeCommitHash, projectSlug, branches }) => ({
+        Alpine.data('branchExplorer', ({ currentBranch, activeCommitHash, activeDiffFrom, projectSlug, branches }) => ({
             open: false,
             search: '',
             selectedIndex: 0,
             selectedBranch: currentBranch,
             allBranches: branches,
             activeCommitHash,
+            activeDiffFrom: activeDiffFrom || 'HEAD',
             projectSlug,
             selectedHashes: [],
+            workingTreeSelected: false,
             lastSelectionIndex: -1,
             _loadId: 0, // Stale-response guard: incremented before each async load, checked after
+
+            get isWorkingTreeActive() {
+                return this.activeCommitHash === null;
+            },
+
+            get hasAnySelection() {
+                return this.workingTreeSelected || this.selectedHashes.length > 0;
+            },
+
+            get selectionBadge() {
+                const n = this.selectedHashes.length;
+                if (this.workingTreeSelected && n > 0) return `WT+${n}`;
+                if (this.workingTreeSelected) return 'WT';
+                return String(n);
+            },
+
+            get selectionDescription() {
+                const parts = [];
+                if (this.workingTreeSelected) parts.push('working tree');
+                if (this.selectedHashes.length > 0) {
+                    parts.push(`${this.selectedHashes.length} commit${this.selectedHashes.length === 1 ? '' : 's'}`);
+                }
+                return parts.join(' + ') || 'nothing';
+            },
 
             _filterBranches(key) {
                 const list = this.allBranches[key] || [];
@@ -154,13 +180,31 @@
                 this.lastSelectionIndex = idx;
             },
 
+            toggleWorkingTreeSelection(event) {
+                event.stopPropagation();
+
+                // Shift-click with a prior commit selection extends the range from the
+                // working tree down through commit index [0..lastSelectionIndex].
+                if (event.shiftKey && this.lastSelectionIndex >= 0) {
+                    const rangeHashes = this.$wire.commits.slice(0, this.lastSelectionIndex + 1).map(c => c.hash);
+                    const merged = new Set(this.selectedHashes);
+                    rangeHashes.forEach(h => merged.add(h));
+                    this.selectedHashes = [...merged];
+                    this.workingTreeSelected = true;
+                    return;
+                }
+
+                this.workingTreeSelected = !this.workingTreeSelected;
+            },
+
             clearSelection() {
                 this.selectedHashes = [];
+                this.workingTreeSelected = false;
                 this.lastSelectionIndex = -1;
             },
 
             applySelection() {
-                if (this.selectedHashes.length === 0) return;
+                if (!this.hasAnySelection) return;
 
                 const indices = [...new Set(
                     this.selectedHashes
@@ -168,7 +212,36 @@
                         .filter(i => i >= 0)
                 )].sort((a, b) => a - b);
 
-                if (indices.length === 0) return;
+                // Working tree alone → plain working-tree view.
+                if (this.workingTreeSelected && indices.length === 0) {
+                    Livewire.navigate(`/p/${this.projectSlug}`);
+                    this.closePanel();
+                    return;
+                }
+
+                // A non-contiguous commit pick (e.g. A and C without B) would silently pull B
+                // into the diff if we just used min/max. Reject it so users have to
+                // explicitly include every commit in their range.
+                if (indices.length > 0 && indices[indices.length - 1] - indices[0] + 1 !== indices.length) {
+                    window.alert('Selection is not contiguous — pick every commit between the oldest and newest you want to review.');
+                    return;
+                }
+
+                // Commits are listed newest-first; lowest index = tip, highest = oldest.
+                // Working tree is conceptually at index -1 (one step newer than the tip).
+                // When WT is selected alongside commits, the commits must start at index 0.
+                if (this.workingTreeSelected && indices.length > 0 && indices[0] !== 0) {
+                    window.alert('Selection is not contiguous — working tree must be paired with the newest commits.');
+                    return;
+                }
+
+                if (this.workingTreeSelected) {
+                    const oldest = this.$wire.commits[indices[indices.length - 1]];
+                    const fromRef = encodeURIComponent(oldest.hash + '^');
+                    Livewire.navigate(`/p/${this.projectSlug}/rw/${fromRef}`);
+                    this.closePanel();
+                    return;
+                }
 
                 if (indices.length === 1) {
                     Livewire.navigate(`/p/${this.projectSlug}/c/${this.$wire.commits[indices[0]].hash}`);
@@ -176,15 +249,6 @@
                     return;
                 }
 
-                // A non-contiguous pick (e.g. A and C without B) would silently pull B
-                // into the diff if we just used min/max. Reject it so users have to
-                // explicitly include every commit in their range.
-                if (indices[indices.length - 1] - indices[0] + 1 !== indices.length) {
-                    window.alert('Selection is not contiguous — pick every commit between the oldest and newest you want to review.');
-                    return;
-                }
-
-                // Commits are listed newest-first; lowest index = tip, highest = oldest.
                 const newest = this.$wire.commits[indices[0]];
                 const oldest = this.$wire.commits[indices[indices.length - 1]];
                 const baseRef = encodeURIComponent(oldest.hash + '^');

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -18,6 +18,10 @@ new class extends Component {
     #[Locked]
     public ?string $activeCommitHash = null;
 
+    /** Left-endpoint of the active diff. 'HEAD' for plain working-tree view; a commit sha for range views. */
+    #[Locked]
+    public string $activeDiffFrom = 'HEAD';
+
     #[Locked]
     public string $selectionLabel = 'Working tree';
 
@@ -67,6 +71,7 @@ new class extends Component {
     x-data="branchExplorer({
         currentBranch: @js($currentBranch),
         activeCommitHash: @js($activeCommitHash),
+        activeDiffFrom: @js($activeDiffFrom),
         projectSlug: @js($projectSlug),
         branches: @js($branches),
     })"
@@ -187,18 +192,18 @@ new class extends Component {
                         <span class="text-xs font-semibold tracking-brutal text-gh-text truncate" x-text="selectedBranch || 'Select a branch'"></span>
                         <span class="text-xs font-mono text-gh-muted" x-show="$wire.commits.length > 0" x-text="'(' + $wire.commits.length + ($wire.hasMore ? '+' : '') + ')'"></span>
 
-                        <template x-if="selectedHashes.length > 0">
+                        <template x-if="hasAnySelection">
                             <div class="ml-auto flex items-center gap-1">
                                 {{-- Segmented apply button: count + label + apply act as one unit --}}
                                 <button
                                     type="button"
                                     @click="applySelection()"
                                     class="group flex items-stretch h-6 rounded-md overflow-hidden ring-1 ring-inset ring-gh-link/30 bg-gh-link/10 hover:bg-gh-link/20 hover:ring-gh-link/50 transition-colors cursor-pointer"
-                                    :aria-label="'Apply ' + selectedHashes.length + ' selected commits'"
+                                    :aria-label="'Apply ' + selectionDescription"
                                 >
                                     <span
                                         class="grid place-items-center min-w-[18px] h-full px-1 bg-gh-link text-[10px] font-mono font-bold text-gh-bg tabular-nums leading-none"
-                                        x-text="selectedHashes.length"
+                                        x-text="selectionBadge"
                                     ></span>
                                     <span class="flex items-center px-2 text-[9px] font-display font-semibold uppercase tracking-brutal text-gh-link/80 border-r border-gh-link/25">
                                         selected
@@ -225,24 +230,38 @@ new class extends Component {
 
                     {{-- Commits list --}}
                     <div class="overflow-y-auto flex-1">
-                        <button
-                            type="button"
+                        <div
                             data-testid="working-tree-row"
-                            class="w-full text-left px-4 py-2.5 border-b border-gh-border/50 hover:bg-gh-border/20 transition-colors cursor-pointer"
+                            class="px-4 py-2.5 border-b border-gh-border/50 hover:bg-gh-border/20 transition-colors group cursor-pointer"
                             @click="viewWorkingTree()"
-                            :class="{ 'bg-gh-text/5 border-l-2 border-l-gh-text': activeCommitHash === null }"
-                            :aria-current="activeCommitHash === null ? 'true' : null"
+                            :class="{
+                                'bg-gh-text/5 border-l-2 border-l-gh-text': isWorkingTreeActive,
+                                'bg-gh-link/5 border-l-2 border-l-gh-link': workingTreeSelected,
+                            }"
+                            :aria-current="isWorkingTreeActive ? 'true' : null"
                         >
                             <div class="flex items-start gap-2">
-                                <div class="mt-0.5 size-4 shrink-0 grid place-items-center">
-                                    <flux:icon icon="pencil-square" variant="outline" class="!size-3.5 text-gh-muted" />
-                                </div>
+                                <button
+                                    type="button"
+                                    data-testid="working-tree-select-toggle"
+                                    @click.stop="toggleWorkingTreeSelection($event)"
+                                    @mousedown.stop
+                                    class="mt-0.5 size-4 shrink-0 grid place-items-center rounded border transition-colors cursor-pointer"
+                                    :class="workingTreeSelected
+                                        ? 'border-gh-link bg-gh-link/20 text-gh-link'
+                                        : 'border-gh-border opacity-0 group-hover:opacity-100 hover:border-gh-text/40'"
+                                    :title="workingTreeSelected ? 'Remove working tree from selection' : 'Add working tree to selection (shift+click for range)'"
+                                >
+                                    <template x-if="workingTreeSelected">
+                                        <flux:icon icon="check" variant="outline" class="!size-3" />
+                                    </template>
+                                </button>
                                 <div class="min-w-0 flex-1">
                                     <div class="text-xs text-gh-text truncate font-medium tracking-tight">Working tree</div>
                                     <span class="block mt-0.5 text-[10px] font-mono text-gh-muted">uncommitted changes</span>
                                 </div>
                             </div>
-                        </button>
+                        </div>
 
                         <template x-if="$wire.commits.length === 0">
                             <div class="flex items-center justify-center h-32">

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -16,6 +16,7 @@ use App\Actions\LoadCommitMetadataAction;
 use App\Actions\ResolveCommitAction;
 use App\Actions\ResolveProjectAction;
 use App\Actions\ResolveRangeAction;
+use App\Actions\ResolveRangeToWorkingAction;
 use App\Actions\ResolveStartupRouteAction;
 use App\Actions\RestoreDiscardedFileAction;
 use App\Actions\SessionStateAction;
@@ -117,7 +118,7 @@ new #[Layout('layouts.app')] class extends Component
 
     // region: Initialization & Diff Context
 
-    public function mount(string $slug, ?string $hash = null, ?string $ref = null, ?string $baseRef = null, ?string $from = null, ?string $to = null): void
+    public function mount(string $slug, ?string $hash = null, ?string $ref = null, ?string $baseRef = null, ?string $from = null, ?string $to = null, ?string $rangeFromWorking = null): void
     {
         $project = app(ResolveProjectAction::class)->handle($slug, touch: true) ?? abort(404);
         $this->repoPath = $project['path'];
@@ -152,6 +153,11 @@ new #[Layout('layouts.app')] class extends Component
             $this->diffFrom = $target->from();
             $this->diffTo = $target->to();
             $this->loadCommitInfo();
+        } elseif ($rangeFromWorking !== null) {
+            // Range-to-working mode: /p/{slug}/rw/{from} — commits from $from through the working tree.
+            $target = app(ResolveRangeToWorkingAction::class)->handle($this->repoPath, $rangeFromWorking);
+            $this->diffFrom = $target->from();
+            $this->diffTo = $target->to();
         } elseif ($ref !== null) {
             // Range mode from URL params
             $target = app(ResolveRangeAction::class)->handle($this->repoPath, $baseRef, $ref);
@@ -934,9 +940,12 @@ new #[Layout('layouts.app')] class extends Component
             @php
                 $shortFrom = $diffFrom === 'HEAD' ? 'HEAD' : substr($diffFrom, 0, 7);
                 $shortTo = $diffTo ? substr($diffTo, 0, 7) : null;
-                if ($diffTo === null) {
+                if ($diffTo === null && $diffFrom === 'HEAD') {
                     $selectionLabel = 'Working tree';
                     $selectionTitle = 'Working tree changes';
+                } elseif ($diffTo === null) {
+                    $selectionLabel = 'WT · '.$shortFrom;
+                    $selectionTitle = 'Working tree + commits through '.$diffFrom;
                 } elseif ($diffFrom === $diffTo.'^') {
                     $selectionLabel = $shortTo;
                     $selectionTitle = $commitInfo['message'] ?? $diffTo;
@@ -952,6 +961,7 @@ new #[Layout('layouts.app')] class extends Component
                     :current-branch="$projectBranch"
                     :project-slug="$projectSlug"
                     :active-commit-hash="$diffTo"
+                    :active-diff-from="$diffFrom"
                     :selection-label="$selectionLabel"
                     :selection-title="$selectionTitle"
                 />

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -202,7 +202,9 @@ new #[Layout('layouts.app')] class extends Component
 
     private function buildDiffTarget(): DiffTarget
     {
-        return $this->cachedTarget ??= DiffTarget::fromRefs($this->diffFrom, $this->diffTo);
+        return $this->cachedTarget ??= $this->diffTo !== null
+            ? DiffTarget::range($this->diffFrom, $this->diffTo)
+            : DiffTarget::rangeToWorking($this->diffFrom);
     }
 
     private function loadCommitInfo(): void

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,9 @@ Route::livewire('/p/{slug}/r/{from}..{to}', 'pages::review-page')
     ->where('from', '[0-9a-fA-F]{4,40}')
     ->where('to', '[0-9a-fA-F]{4,40}')
     ->name('review-page.range');
+Route::livewire('/p/{slug}/rw/{rangeFromWorking}', 'pages::review-page')
+    ->where('rangeFromWorking', '[0-9a-fA-F]{4,40}\^?')
+    ->name('review-page.range-to-working');
 Route::livewire('/p/{slug}/{ref?}/{baseRef?}', 'pages::review-page')->name('review-page');
 
 Route::get('/api/status/{project}', function (Project $project) {

--- a/tests/Browser/SessionPersistenceTest.php
+++ b/tests/Browser/SessionPersistenceTest.php
@@ -39,6 +39,11 @@ test('reviewed files persist after page reload', function () {
     $page->page()->getByRole('checkbox', ['name' => 'Reviewed'])->first()->click();
     // Alpine updates the counter on the next microtask; poll until it renders.
     $page->page()->waitForFunction("document.querySelector('[data-testid=\"reviewed-counter\"]')?.textContent?.includes('1/3 reviewed')");
+    // Counter above is driven by Alpine's local mirror, which fires before the
+    // toggleReviewed Livewire POST reaches the DB. Refreshing mid-POST aborts
+    // the request (net::ERR_ABORTED) and the toggle is lost on reload — flake
+    // amplified under --parallel. Wait for network idle to drain the round-trip.
+    $page->waitForEvent('networkidle');
 
     $page->refresh();
     $page->page()->waitForFunction("document.querySelector('[data-testid=\"reviewed-counter\"]')?.textContent?.includes('1/3 reviewed')");

--- a/tests/Feature/ReviewPageRoutesTest.php
+++ b/tests/Feature/ReviewPageRoutesTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+test('review-page named routes cover the four addressable shapes', function () {
+    expect(route('review-page', ['slug' => 'demo']))->toEndWith('/p/demo')
+        ->and(route('review-page.commit', ['slug' => 'demo', 'hash' => 'abc1234']))->toEndWith('/p/demo/c/abc1234')
+        ->and(route('review-page.range', ['slug' => 'demo', 'from' => 'abc1234', 'to' => 'def5678']))->toEndWith('/p/demo/r/abc1234..def5678')
+        ->and(route('review-page.range-to-working', ['slug' => 'demo', 'rangeFromWorking' => 'abc1234^']))->toEndWith('/p/demo/rw/abc1234%5E');
+});
+
+test('rw path dispatches to the review-page component', function () {
+    $routes = app('router')->getRoutes();
+    $match = $routes->getByName('review-page.range-to-working');
+
+    expect($match)->not->toBeNull()
+        ->and($match->uri())->toBe('p/{slug}/rw/{rangeFromWorking}');
+});

--- a/tests/Feature/ReviewPageRoutesTest.php
+++ b/tests/Feature/ReviewPageRoutesTest.php
@@ -4,12 +4,10 @@ use Tests\TestCase;
 
 uses(TestCase::class);
 
-test('review-page named routes cover the four addressable shapes', function () {
-    expect(route('review-page', ['slug' => 'demo']))->toEndWith('/p/demo')
-        ->and(route('review-page.commit', ['slug' => 'demo', 'hash' => 'abc1234']))->toEndWith('/p/demo/c/abc1234')
-        ->and(route('review-page.range', ['slug' => 'demo', 'from' => 'abc1234', 'to' => 'def5678']))->toEndWith('/p/demo/r/abc1234..def5678')
-        ->and(route('review-page.range-to-working', ['slug' => 'demo', 'rangeFromWorking' => 'abc1234^']))->toEndWith('/p/demo/rw/abc1234%5E');
-});
+test('review-page named routes cover the four addressable shapes', fn () => expect(route('review-page', ['slug' => 'demo']))->toEndWith('/p/demo')
+    ->and(route('review-page.commit', ['slug' => 'demo', 'hash' => 'abc1234']))->toEndWith('/p/demo/c/abc1234')
+    ->and(route('review-page.range', ['slug' => 'demo', 'from' => 'abc1234', 'to' => 'def5678']))->toEndWith('/p/demo/r/abc1234..def5678')
+    ->and(route('review-page.range-to-working', ['slug' => 'demo', 'rangeFromWorking' => 'abc1234^']))->toEndWith('/p/demo/rw/abc1234%5E'));
 
 test('rw path dispatches to the review-page component', function () {
     $routes = app('router')->getRoutes();

--- a/tests/Unit/Actions/ResolveRangeToWorkingActionTest.php
+++ b/tests/Unit/Actions/ResolveRangeToWorkingActionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Actions\ResolveRangeToWorkingAction;
+use App\DTOs\DiffTarget;
+use App\Services\GitMetadataService;
+use App\Services\GitProcessService;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    $this->tmpDir = $this->createTempDirectory('rfa_resolve_range_to_working_test_');
+    $this->initTestRepo($this->tmpDir);
+
+    File::put($this->tmpDir.'/a.txt', "root\n");
+    $this->commitTestRepo($this->tmpDir, 'root commit');
+    $this->rootSha = trim($this->runTestRepoCommand($this->tmpDir, 'git rev-parse HEAD'));
+
+    File::put($this->tmpDir.'/b.txt', "child\n");
+    $this->commitTestRepo($this->tmpDir, 'child commit');
+    $this->childSha = trim($this->runTestRepoCommand($this->tmpDir, 'git rev-parse HEAD'));
+
+    $this->action = new ResolveRangeToWorkingAction(new GitMetadataService(new GitProcessService));
+});
+
+test('falls back to empty tree when from is parent of the root commit', function () {
+    $target = $this->action->handle($this->tmpDir, $this->rootSha.'^');
+
+    expect($target->from())->toBe(DiffTarget::EMPTY_TREE_HASH)
+        ->and($target->to())->toBeNull();
+});
+
+test('passes through a normal <hash>^ from when the hash has a parent', function () {
+    $target = $this->action->handle($this->tmpDir, $this->childSha.'^');
+
+    expect($target->from())->toBe($this->childSha.'^')
+        ->and($target->to())->toBeNull();
+});
+
+test('passes through a plain sha from unchanged', function () {
+    $target = $this->action->handle($this->tmpDir, $this->rootSha);
+
+    expect($target->from())->toBe($this->rootSha)
+        ->and($target->to())->toBeNull()
+        ->and($target->isWorkingDirectory())->toBeTrue();
+});

--- a/tests/Unit/DTOs/DiffTargetTest.php
+++ b/tests/Unit/DTOs/DiffTargetTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use App\DTOs\DiffTarget;
+use App\Support\DiffCacheKey;
+
+test('workingDirectory builds a HEAD → working-tree target', function () {
+    $target = DiffTarget::workingDirectory();
+
+    expect($target->from())->toBe('HEAD')
+        ->and($target->to())->toBeNull()
+        ->and($target->isWorkingDirectory())->toBeTrue()
+        ->and($target->isImmutable())->toBeFalse();
+});
+
+test('commit derives from empty-tree when no parent is provided', function () {
+    $target = DiffTarget::commit('abc123');
+
+    expect($target->from())->toBe(DiffTarget::EMPTY_TREE_HASH)
+        ->and($target->to())->toBe('abc123');
+});
+
+test('range keeps both endpoints verbatim', function () {
+    $target = DiffTarget::range('from-sha', 'to-sha');
+
+    expect($target->from())->toBe('from-sha')
+        ->and($target->to())->toBe('to-sha')
+        ->and($target->isImmutable())->toBeTrue();
+});
+
+test('rangeToWorking preserves the from commit with a null to', function () {
+    $target = DiffTarget::rangeToWorking('abc123');
+
+    expect($target->from())->toBe('abc123')
+        ->and($target->to())->toBeNull()
+        ->and($target->isWorkingDirectory())->toBeTrue()
+        ->and($target->isImmutable())->toBeFalse();
+});
+
+test('toDiffArgs emits single-arg diff for range-to-working', function () {
+    expect(DiffTarget::rangeToWorking('abc123')->toDiffArgs())->toBe(['diff', 'abc123'])
+        ->and(DiffTarget::workingDirectory()->toDiffArgs())->toBe(['diff', 'HEAD'])
+        ->and(DiffTarget::range('from', 'to')->toDiffArgs())->toBe(['diff', 'from', 'to']);
+});
+
+test('contextKey disambiguates working-tree targets by their from ref', function () {
+    $workingFromHead = DiffTarget::workingDirectory()->contextKey();
+    $workingFromCommit = DiffTarget::rangeToWorking('abc123')->contextKey();
+
+    expect($workingFromHead)->toBe('HEAD..working')
+        ->and($workingFromCommit)->toBe('abc123..working')
+        ->and($workingFromHead)->not->toBe($workingFromCommit);
+});
+
+test('DiffCacheKey produces distinct keys for HEAD→WT vs commit→WT', function () {
+    $keyHead = DiffCacheKey::for('repo', 'file-1', DiffTarget::workingDirectory()->contextKey());
+    $keyCommit = DiffCacheKey::for('repo', 'file-1', DiffTarget::rangeToWorking('abc123')->contextKey());
+
+    expect($keyHead)->not->toBe($keyCommit);
+});
+
+test('DiffCacheKey default matches workingDirectory contextKey', function () {
+    $defaultKey = DiffCacheKey::for('repo', 'file-1');
+    $explicitKey = DiffCacheKey::for('repo', 'file-1', DiffTarget::workingDirectory()->contextKey());
+
+    expect($defaultKey)->toBe($explicitKey);
+});

--- a/tests/Unit/Livewire/ReviewPageRangeAndSelectionTest.php
+++ b/tests/Unit/Livewire/ReviewPageRangeAndSelectionTest.php
@@ -6,6 +6,7 @@ use App\Actions\LoadCommitMetadataAction;
 use App\Actions\ResolveCommitAction;
 use App\Actions\ResolveProjectAction;
 use App\Actions\ResolveRangeAction;
+use App\Actions\ResolveRangeToWorkingAction;
 use App\Actions\SessionStateAction;
 use App\DTOs\DiffTarget;
 use App\Models\Project;
@@ -100,6 +101,14 @@ beforeEach(function () {
         }
     });
 
+    app()->bind(ResolveRangeToWorkingAction::class, fn () => new class
+    {
+        public function handle(string $repoPath, string $from): DiffTarget
+        {
+            return DiffTarget::rangeToWorking($from);
+        }
+    });
+
     $gitFileContentMock = Mockery::mock(GitFileContentService::class);
     $gitFileContentMock->shouldReceive('hashAt')->andReturn('mock-hash');
     app()->instance(GitFileContentService::class, $gitFileContentMock);
@@ -171,4 +180,34 @@ test('selection badge shows from..to when an explicit range is set', function ()
     ]);
 
     $component->assertSee('aaaa111..cccc222');
+});
+
+// -- Range-to-working route mount --
+
+test('mounting with /rw/{from} sets diffFrom to the commit and diffTo to null', function () {
+    $component = Livewire::test('pages::review-page', [
+        'slug' => 'test-project',
+        'rangeFromWorking' => 'abc1234',
+    ]);
+
+    expect($component->get('diffFrom'))->toBe('abc1234');
+    expect($component->get('diffTo'))->toBeNull();
+});
+
+test('buildDiffTarget preserves the base commit for range-to-working mounts', function () {
+    // Regression: fromRefs($from, null) silently collapses to workingDirectory(),
+    // which would reset diffFrom to HEAD and make every downstream consumer
+    // (cache keys, file list, comments) key off the wrong diff context.
+    $component = Livewire::test('pages::review-page', [
+        'slug' => 'test-project',
+        'rangeFromWorking' => 'abc1234',
+    ]);
+
+    $instance = $component->instance();
+    $method = new ReflectionMethod($instance, 'buildDiffTarget');
+    $target = $method->invoke($instance);
+
+    expect($target->from())->toBe('abc1234')
+        ->and($target->to())->toBeNull()
+        ->and($target->contextKey())->toBe('abc1234..working');
 });


### PR DESCRIPTION
Working tree was mutually exclusive with commit selection: users
preparing to push a branch had to switch modes to review committed +
uncommitted changes together. The WT row now sits above the newest
commit with the same checkbox affordance; checking it alongside the N
newest commits navigates to /p/{slug}/rw/{oldest}^ (git diff
<from-commit>..working-tree, which already includes staged, unstaged,
and untracked files).

Also fixes a latent cache-key collision: DiffTarget::contextKey()
returned the literal 'working' whenever \$to was null, so the new
commit→working-tree targets would have silently shared cache entries
with plain HEAD→working-tree. contextKey now always encodes both
endpoints ('HEAD..working' vs 'abc123..working'); DiffCacheKey
version bumped v6 → v7 to flush any ambiguous entries.

https://claude.ai/code/session_01DDjskNm7kgYcamF9AiEB7Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compare historical commits against the current working directory ("range-to-working" diffs).
  * Branch explorer: toggle/select working-tree, shift‑click range selection, updated selection badges/labels and improved apply/button accessibility.
  * New route to directly open range-to-working diff views and refined header labels for working-tree modes.

* **Tests**
  * Added unit, feature, and browser tests covering range-to-working resolution, diff target behavior, route generation, branch-explorer selection, and session persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->