### PR TITLE
Add press-and-hold drag to extend commit selection

### DIFF
--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -12,9 +12,6 @@
             selectedHashes: [],
             lastSelectionIndex: -1,
             _loadId: 0, // Stale-response guard: incremented before each async load, checked after
-            _dragActive: false,
-            _dragAnchorIdx: -1,
-            _dragMoved: false,
 
             _filterBranches(key) {
                 const list = this.allBranches[key] || [];
@@ -138,12 +135,6 @@
             toggleSelection(hash, idx, event) {
                 event.stopPropagation();
 
-                if (this._dragMoved) {
-                    // Drag already committed a range; the trailing click is vestigial.
-                    this._dragMoved = false;
-                    return;
-                }
-
                 if (event.shiftKey && this.lastSelectionIndex >= 0) {
                     const start = Math.min(this.lastSelectionIndex, idx);
                     const end = Math.max(this.lastSelectionIndex, idx);
@@ -173,13 +164,13 @@
             // so the app has one "mouse path selects a range" pattern, not two.
             startDrag(idx, event) {
                 if (event.button !== 0) return;
-                if (event.shiftKey) return; // shift+click keeps the additive-range behaviour
-                this._dragActive = true;
-                this._dragAnchorIdx = idx;
-                this._dragMoved = false;
+                if (event.shiftKey) return;
+                let moved = false;
+                let active = true;
+                let lastHoveredIdx = idx;
 
                 const onPointerOver = (e) => {
-                    if (!this._dragActive) return;
+                    if (!active) return;
                     if (e.buttons === 0) {
                         // Mouse released outside the window — recover on first re-entry.
                         endDrag();
@@ -189,20 +180,20 @@
                     if (!row) return;
                     const hovered = parseInt(row.dataset.commitIdx, 10);
                     if (Number.isNaN(hovered)) return;
-                    if (hovered === this._dragAnchorIdx && !this._dragMoved) return;
-                    this._dragMoved = true;
-                    const start = Math.min(this._dragAnchorIdx, hovered);
-                    const end = Math.max(this._dragAnchorIdx, hovered);
+                    if (hovered === lastHoveredIdx) return;
+                    lastHoveredIdx = hovered;
+                    moved = true;
+                    const start = Math.min(idx, hovered);
+                    const end = Math.max(idx, hovered);
                     this.selectedHashes = this.$wire.commits.slice(start, end + 1).map(c => c.hash);
                 };
 
                 const endDrag = () => {
-                    if (!this._dragActive) return;
+                    if (!active) return;
+                    active = false;
                     window.removeEventListener('pointerover', onPointerOver);
                     window.removeEventListener('pointerup', endDrag);
                     window.removeEventListener('blur', endDrag);
-                    const moved = this._dragMoved;
-                    this._dragActive = false;
                     if (moved) {
                         // Whichever element mouseup landed on, its click fires next.
                         // Swallow it so we don't navigate into a commit or re-toggle.
@@ -212,7 +203,7 @@
                             window.removeEventListener('click', swallow, true);
                         };
                         window.addEventListener('click', swallow, true);
-                        this.lastSelectionIndex = this._dragAnchorIdx;
+                        this.lastSelectionIndex = idx;
                     }
                 };
 

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -12,6 +12,9 @@
             selectedHashes: [],
             lastSelectionIndex: -1,
             _loadId: 0, // Stale-response guard: incremented before each async load, checked after
+            _dragActive: false,
+            _dragAnchorIdx: -1,
+            _dragMoved: false,
 
             _filterBranches(key) {
                 const list = this.allBranches[key] || [];
@@ -135,6 +138,12 @@
             toggleSelection(hash, idx, event) {
                 event.stopPropagation();
 
+                if (this._dragMoved) {
+                    // Drag already committed a range; the trailing click is vestigial.
+                    this._dragMoved = false;
+                    return;
+                }
+
                 if (event.shiftKey && this.lastSelectionIndex >= 0) {
                     const start = Math.min(this.lastSelectionIndex, idx);
                     const end = Math.max(this.lastSelectionIndex, idx);
@@ -157,6 +166,59 @@
             clearSelection() {
                 this.selectedHashes = [];
                 this.lastSelectionIndex = -1;
+            },
+
+            // Press-and-hold on a commit's checkbox, then drag across rows to extend
+            // the selection from the anchor. Mirrors the diff-file line-range gesture
+            // so the app has one "mouse path selects a range" pattern, not two.
+            startDrag(idx, event) {
+                if (event.button !== 0) return;
+                if (event.shiftKey) return; // shift+click keeps the additive-range behaviour
+                this._dragActive = true;
+                this._dragAnchorIdx = idx;
+                this._dragMoved = false;
+
+                const onPointerOver = (e) => {
+                    if (!this._dragActive) return;
+                    if (e.buttons === 0) {
+                        // Mouse released outside the window — recover on first re-entry.
+                        endDrag();
+                        return;
+                    }
+                    const row = e.target?.closest?.('[data-commit-idx]');
+                    if (!row) return;
+                    const hovered = parseInt(row.dataset.commitIdx, 10);
+                    if (Number.isNaN(hovered)) return;
+                    if (hovered === this._dragAnchorIdx && !this._dragMoved) return;
+                    this._dragMoved = true;
+                    const start = Math.min(this._dragAnchorIdx, hovered);
+                    const end = Math.max(this._dragAnchorIdx, hovered);
+                    this.selectedHashes = this.$wire.commits.slice(start, end + 1).map(c => c.hash);
+                };
+
+                const endDrag = () => {
+                    if (!this._dragActive) return;
+                    window.removeEventListener('pointerover', onPointerOver);
+                    window.removeEventListener('pointerup', endDrag);
+                    window.removeEventListener('blur', endDrag);
+                    const moved = this._dragMoved;
+                    this._dragActive = false;
+                    if (moved) {
+                        // Whichever element mouseup landed on, its click fires next.
+                        // Swallow it so we don't navigate into a commit or re-toggle.
+                        const swallow = (ev) => {
+                            ev.stopPropagation();
+                            ev.preventDefault();
+                            window.removeEventListener('click', swallow, true);
+                        };
+                        window.addEventListener('click', swallow, true);
+                        this.lastSelectionIndex = this._dragAnchorIdx;
+                    }
+                };
+
+                window.addEventListener('pointerover', onPointerOver);
+                window.addEventListener('pointerup', endDrag);
+                window.addEventListener('blur', endDrag);
             },
 
             applySelection() {

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -173,7 +173,8 @@
                     if (!active) return;
                     if (e.buttons === 0) {
                         // Mouse released outside the window — recover on first re-entry.
-                        endDrag();
+                        // Release wasn't in-window, so there's no trailing click to swallow.
+                        endDrag(false);
                         return;
                     }
                     const row = e.target?.closest?.('[data-commit-idx]');
@@ -188,28 +189,31 @@
                     this.selectedHashes = this.$wire.commits.slice(start, end + 1).map(c => c.hash);
                 };
 
-                const endDrag = () => {
+                const endDrag = (swallowClick) => {
                     if (!active) return;
                     active = false;
                     window.removeEventListener('pointerover', onPointerOver);
-                    window.removeEventListener('pointerup', endDrag);
-                    window.removeEventListener('blur', endDrag);
-                    if (moved) {
-                        // Whichever element mouseup landed on, its click fires next.
-                        // Swallow it so we don't navigate into a commit or re-toggle.
-                        const swallow = (ev) => {
-                            ev.stopPropagation();
-                            ev.preventDefault();
-                            window.removeEventListener('click', swallow, true);
-                        };
-                        window.addEventListener('click', swallow, true);
-                        this.lastSelectionIndex = idx;
-                    }
+                    window.removeEventListener('pointerup', onPointerUp);
+                    window.removeEventListener('blur', onBlur);
+                    if (!moved) return;
+                    this.lastSelectionIndex = idx;
+                    if (!swallowClick) return;
+                    // Whichever element mouseup landed on, its click fires next.
+                    // Swallow it so we don't navigate into a commit or re-toggle.
+                    const swallow = (ev) => {
+                        ev.stopPropagation();
+                        ev.preventDefault();
+                        window.removeEventListener('click', swallow, true);
+                    };
+                    window.addEventListener('click', swallow, true);
                 };
 
+                const onPointerUp = () => endDrag(true);
+                const onBlur = () => endDrag(false);
+
                 window.addEventListener('pointerover', onPointerOver);
-                window.addEventListener('pointerup', endDrag);
-                window.addEventListener('blur', endDrag);
+                window.addEventListener('pointerup', onPointerUp);
+                window.addEventListener('blur', onBlur);
             },
 
             applySelection() {

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -309,6 +309,7 @@ new class extends Component {
                             <div
                                 data-testid="commit-row"
                                 :data-commit-hash="commit.hash"
+                                :data-commit-idx="commitIdx"
                                 @if($hasRemote) x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" @endif
                                 class="px-4 py-2.5 border-b border-gh-border/50 hover:bg-gh-border/20 transition-colors group cursor-pointer"
                                 @click="viewCommit(commit.hash)"
@@ -322,12 +323,12 @@ new class extends Component {
                                         type="button"
                                         data-testid="commit-select-toggle"
                                         @click.stop="toggleSelection(commit.hash, commitIdx, $event)"
-                                        @mousedown.stop
+                                        @mousedown.stop="startDrag(commitIdx, $event)"
                                         class="mt-0.5 size-4 shrink-0 grid place-items-center rounded border transition-colors cursor-pointer"
                                         :class="isSelected(commit.hash)
                                             ? 'border-gh-link bg-gh-link/20 text-gh-link'
                                             : 'border-gh-border opacity-0 group-hover:opacity-100 hover:border-gh-text/40'"
-                                        :title="isSelected(commit.hash) ? 'Remove from selection' : 'Add to selection (shift+click for range)'"
+                                        :title="isSelected(commit.hash) ? 'Remove from selection' : 'Click to add, drag to extend range'"
                                     >
                                         <template x-if="isSelected(commit.hash)">
                                             <flux:icon icon="check" variant="outline" class="!size-3" />

--- a/tests/Browser/SelectionDragRangeTest.php
+++ b/tests/Browser/SelectionDragRangeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+beforeEach(function () {
+    $this->setUpCommitHistoryRepo();
+});
+
+test('press-and-hold on a checkbox, drag across rows, release: range from anchor is selected', function () {
+    $page = $this->visitAndLoad($this->projectUrl());
+    $page->page()->getByLabel('Open selection drawer')->click();
+    $page->page()->getByText('Add greet function')->waitFor();
+
+    // Press on the newest commit's checkbox (idx 0), drag to the oldest row (idx 2),
+    // release. Dispatch synthetic events so the test doesn't depend on pointer
+    // geometry or the overlay popover's viewport layout.
+    $page->script(<<<'JS'
+        (() => {
+            const anchor = document.querySelector('[data-commit-idx="0"]');
+            const target = document.querySelector('[data-commit-idx="2"]');
+            const checkbox = anchor.querySelector('[data-testid="commit-select-toggle"]');
+
+            checkbox.dispatchEvent(new MouseEvent('mousedown', { button: 0, bubbles: true }));
+            target.dispatchEvent(new PointerEvent('pointerover', { bubbles: true, buttons: 1 }));
+            window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+        })()
+    JS);
+
+    $page->page()->getByText('3 selected')->waitFor();
+});
+
+test('dragging back toward the anchor shrinks the range', function () {
+    $page = $this->visitAndLoad($this->projectUrl());
+    $page->page()->getByLabel('Open selection drawer')->click();
+    $page->page()->getByText('Add greet function')->waitFor();
+
+    $page->script(<<<'JS'
+        (() => {
+            const anchor = document.querySelector('[data-commit-idx="0"]');
+            const far = document.querySelector('[data-commit-idx="2"]');
+            const mid = document.querySelector('[data-commit-idx="1"]');
+            const checkbox = anchor.querySelector('[data-testid="commit-select-toggle"]');
+
+            checkbox.dispatchEvent(new MouseEvent('mousedown', { button: 0, bubbles: true }));
+            // Extend to the oldest row, then walk back toward anchor.
+            far.dispatchEvent(new PointerEvent('pointerover', { bubbles: true, buttons: 1 }));
+            mid.dispatchEvent(new PointerEvent('pointerover', { bubbles: true, buttons: 1 }));
+            window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+        })()
+    JS);
+
+    $page->page()->getByText('2 selected')->waitFor();
+});
+
+test('pressing without drag falls back to the single-toggle click', function () {
+    $page = $this->visitAndLoad($this->projectUrl());
+    $page->page()->getByLabel('Open selection drawer')->click();
+    $page->page()->getByText('Add greet function')->waitFor();
+
+    // No pointerover between mousedown and pointerup → regular click, regular toggle.
+    $row = $page->page()->locator('[data-testid="commit-row"]')->filter(['hasText' => 'Add greet function']);
+    $row->hover();
+    $row->getByTestId('commit-select-toggle')->click();
+
+    $page->page()->getByText('1 selected')->waitFor();
+});

--- a/tests/Browser/SelectionDragRangeTest.php
+++ b/tests/Browser/SelectionDragRangeTest.php
@@ -62,3 +62,38 @@ test('pressing without drag falls back to the single-toggle click', function () 
 
     $page->page()->getByText('1 selected')->waitFor();
 });
+
+test('drag ended by out-of-window release does not eat the next intentional click', function () {
+    $page = $this->visitAndLoad($this->projectUrl());
+    $page->page()->getByLabel('Open selection drawer')->click();
+    $page->page()->getByText('Add greet function')->waitFor();
+
+    // Simulate: press on anchor, drag to another row, then release outside the
+    // window. Re-entering the window fires a pointerover with buttons===0 —
+    // that's the recovery path. After it, a real user click must still fire.
+    $clickFired = $page->script(<<<'JS'
+        (() => {
+            const anchor = document.querySelector('[data-commit-idx="0"]');
+            const far = document.querySelector('[data-commit-idx="2"]');
+            const checkbox = anchor.querySelector('[data-testid="commit-select-toggle"]');
+
+            checkbox.dispatchEvent(new MouseEvent('mousedown', { button: 0, bubbles: true }));
+            far.dispatchEvent(new PointerEvent('pointerover', { bubbles: true, buttons: 1 }));
+            // No pointerup — simulates release outside the window. Cursor
+            // re-enters; buttons===0 drives the recovery branch.
+            anchor.dispatchEvent(new PointerEvent('pointerover', { bubbles: true, buttons: 0 }));
+
+            let fired = false;
+            const probe = document.createElement('button');
+            probe.addEventListener('click', () => { fired = true; });
+            document.body.appendChild(probe);
+            probe.click();
+            probe.remove();
+            return fired;
+        })()
+    JS);
+
+    expect($clickFired)->toBeTrue();
+    // The drag itself still selected the range.
+    $page->page()->getByText('3 selected')->waitFor();
+});


### PR DESCRIPTION
Mirrors the diff-file line-range gesture so the picker has one
"mouse path selects a range" pattern, not two. Pressing a commit's
checkbox arms the anchor; dragging across other rows replaces the
selection with the contiguous range from the anchor to the hovered
row. Plain click still toggles a single commit and shift+click still
builds an additive range.

https://claude.ai/code/session_011Er8YHkUm24Jmr5JxZ8u95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added press-and-hold drag to select a contiguous range of commits by dragging across commit rows; tooltips updated to describe the new interaction.
* **Bug Fixes**
  * Prevented accidental navigation or re-toggling after completing a drag to avoid unintended clicks.
* **Tests**
  * Added browser end-to-end tests validating drag selection, range expansion/collapse, out-of-window release, and normal single-toggle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->