### PR TITLE
Extract head-divergence polling into a dedicated Livewire component

### DIFF
--- a/resources/views/livewire/head-divergence-poller.blade.php
+++ b/resources/views/livewire/head-divergence-poller.blade.php
@@ -14,6 +14,7 @@ new class extends Component
     #[Locked]
     public string $target = '';
 
+    #[Locked]
     public string $fingerprint = '';
 
     public function mount(): void

--- a/resources/views/livewire/head-divergence-poller.blade.php
+++ b/resources/views/livewire/head-divergence-poller.blade.php
@@ -1,0 +1,66 @@
+<?php
+
+use App\Actions\GetCurrentHeadAction;
+use App\DTOs\CurrentHeadResult;
+use Livewire\Attributes\Locked;
+use Livewire\Attributes\Renderless;
+use Livewire\Component;
+
+new class extends Component
+{
+    #[Locked]
+    public string $repoPath = '';
+
+    #[Locked]
+    public string $target = '';
+
+    public string $fingerprint = '';
+
+    public function mount(): void
+    {
+        // Prime the fingerprint so the first poll after mount does not dispatch
+        // unless HEAD actually moves. The parent's own mount() already ran
+        // checkHeadDivergence once; we don't need to force a second round-trip.
+        $head = app(GetCurrentHeadAction::class)->handle($this->repoPath, $this->target !== '' ? $this->target : null);
+
+        if ($head->sha !== '') {
+            $this->fingerprint = $this->fingerprintOf($head);
+        }
+    }
+
+    #[Renderless]
+    public function poll(): void
+    {
+        $head = app(GetCurrentHeadAction::class)->handle($this->repoPath, $this->target !== '' ? $this->target : null);
+
+        // Sentinel: GetCurrentHeadAction returns sha='' when git fails transiently
+        // (mid-rebase, lock contention). Skip this tick so we don't mask a real
+        // state with a spurious transition — retry on the next poll.
+        if ($head->sha === '') {
+            return;
+        }
+
+        $next = $this->fingerprintOf($head);
+
+        if ($next === $this->fingerprint) {
+            return;
+        }
+
+        $this->fingerprint = $next;
+        $this->dispatch('head-divergence-transitioned');
+    }
+
+    private function fingerprintOf(CurrentHeadResult $head): string
+    {
+        $targetExists = match ($head->targetExists) {
+            true => '1',
+            false => '0',
+            null => 'n',
+        };
+
+        return ($head->branch ?? '').'|'.$head->sha.'|'.($head->detached ? '1' : '0').'|'.$targetExists;
+    }
+};
+?>
+
+<div wire:poll.2s="poll" class="hidden"></div>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -265,6 +265,7 @@ new #[Layout('layouts.app')] class extends Component
 
     // region: Branch Divergence
 
+    #[On('head-divergence-transitioned')]
     public function checkHeadDivergence(): void
     {
         if ($this->isCommitMode()) {
@@ -454,7 +455,7 @@ new #[Layout('layouts.app')] class extends Component
 
         $this->comments[] = $comment;
         $this->dispatchFileComments($fileId);
-        $this->skipRender();
+        $this->checkHeadDivergence();
     }
 
     #[On('update-comment')]
@@ -500,7 +501,7 @@ new #[Layout('layouts.app')] class extends Component
             $this->dispatch('undo-available', type: 'delete', payload: [$deletedComment], message: 'Comment deleted');
         }
 
-        $this->skipRender();
+        $this->checkHeadDivergence();
     }
 
     public function clearAllComments(): void
@@ -523,7 +524,7 @@ new #[Layout('layouts.app')] class extends Component
         $count = count($deletedComments);
         $this->dispatch('undo-available', type: 'clear-all', payload: $deletedComments,
             message: "Cleared {$count} comment".($count === 1 ? '' : 's'));
-        $this->skipRender();
+        $this->checkHeadDivergence();
     }
 
     /** @param  array<int, array<string, mixed>>  $comments */
@@ -560,7 +561,7 @@ new #[Layout('layouts.app')] class extends Component
             ->unique()
             ->each(fn (string $fileId) => $this->dispatchFileComments($fileId));
 
-        $this->skipRender();
+        $this->checkHeadDivergence();
     }
 
     // endregion: Comment Management
@@ -1172,14 +1173,11 @@ new #[Layout('layouts.app')] class extends Component
 
     {{-- Branch divergence banner + polling island (working-tree mode only) --}}
     @if(! $this->isCommitMode())
-        <div wire:key="head-divergence-polling" data-testid="head-divergence-polling" x-data="{
-            interval: null,
-            start() {
-                this.interval = setInterval(() => {
-                    if (!document.hidden) $wire.checkHeadDivergence();
-                }, 2000);
-            }
-        }" x-init="start()" x-destroy="clearInterval(interval)" class="hidden"></div>
+        <livewire:head-divergence-poller
+            wire:key="head-divergence-poller-{{ $projectId }}-{{ $diffFrom }}-{{ $projectBranch }}"
+            :repo-path="$repoPath"
+            :target="$projectBranch"
+        />
 
         @if($divergenceState === DivergenceState::Diverged)
             <div class="px-5 py-3 border-b border-gh-border" data-testid="divergence-banner-diverged">

--- a/tests/Unit/Livewire/HeadDivergencePollerTest.php
+++ b/tests/Unit/Livewire/HeadDivergencePollerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use App\Actions\GetCurrentHeadAction;
+use App\DTOs\CurrentHeadResult;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+function bindFakeHeadAction(CurrentHeadResult $initial): object
+{
+    $fake = new class($initial)
+    {
+        public function __construct(public CurrentHeadResult $result) {}
+
+        public function handle(string $repoPath, ?string $targetBranch = null): CurrentHeadResult
+        {
+            return $this->result;
+        }
+    };
+
+    app()->instance(GetCurrentHeadAction::class, $fake);
+
+    return $fake;
+}
+
+test('mount primes the fingerprint without dispatching', function () {
+    bindFakeHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
+
+    $poller = Livewire::test('head-divergence-poller', ['repoPath' => '/tmp/repo', 'target' => 'main']);
+
+    $poller->assertNotDispatched('head-divergence-transitioned');
+    expect($poller->get('fingerprint'))->not->toBe('');
+});
+
+test('poll after mount on an unchanged HEAD does not dispatch', function () {
+    bindFakeHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
+
+    $poller = Livewire::test('head-divergence-poller', ['repoPath' => '/tmp/repo', 'target' => 'main']);
+
+    $poller->call('poll')->assertNotDispatched('head-divergence-transitioned');
+});
+
+test('mount does not prime when git is transiently failing', function () {
+    bindFakeHeadAction(new CurrentHeadResult(branch: null, sha: '', detached: false));
+
+    $poller = Livewire::test('head-divergence-poller', ['repoPath' => '/tmp/repo', 'target' => 'main']);
+
+    expect($poller->get('fingerprint'))->toBe('');
+});
+
+test('poll dispatches again when SHA changes', function () {
+    $fake = bindFakeHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
+
+    $poller = Livewire::test('head-divergence-poller', ['repoPath' => '/tmp/repo', 'target' => 'main']);
+    $poller->call('poll');
+
+    $fake->result = new CurrentHeadResult(branch: 'main', sha: 'b'.str_repeat('0', 39), detached: false, targetExists: true);
+
+    $poller->call('poll')->assertDispatched('head-divergence-transitioned');
+});
+
+test('poll dispatches again when branch changes', function () {
+    $fake = bindFakeHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
+
+    $poller = Livewire::test('head-divergence-poller', ['repoPath' => '/tmp/repo', 'target' => 'main']);
+    $poller->call('poll');
+
+    $fake->result = new CurrentHeadResult(branch: 'feature-x', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true);
+
+    $poller->call('poll')->assertDispatched('head-divergence-transitioned');
+});
+
+test('poll dispatches again when detached flag flips', function () {
+    $fake = bindFakeHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
+
+    $poller = Livewire::test('head-divergence-poller', ['repoPath' => '/tmp/repo', 'target' => 'main']);
+    $poller->call('poll');
+
+    $fake->result = new CurrentHeadResult(branch: null, sha: 'a'.str_repeat('0', 39), detached: true, targetExists: true);
+
+    $poller->call('poll')->assertDispatched('head-divergence-transitioned');
+});
+
+test('poll dispatches again when targetExists flips', function () {
+    $fake = bindFakeHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
+
+    $poller = Livewire::test('head-divergence-poller', ['repoPath' => '/tmp/repo', 'target' => 'main']);
+    $poller->call('poll');
+
+    $fake->result = new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: false);
+
+    $poller->call('poll')->assertDispatched('head-divergence-transitioned');
+});
+
+test('sentinel result (empty sha) does not dispatch and does not advance fingerprint', function () {
+    $fake = bindFakeHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
+
+    $poller = Livewire::test('head-divergence-poller', ['repoPath' => '/tmp/repo', 'target' => 'main']);
+    $poller->call('poll');
+
+    $established = $poller->get('fingerprint');
+
+    // Simulate transient git failure (mid-rebase, lock contention).
+    $fake->result = new CurrentHeadResult(branch: null, sha: '', detached: false);
+    $poller->call('poll')->assertNotDispatched('head-divergence-transitioned');
+
+    expect($poller->get('fingerprint'))->toBe($established);
+});

--- a/tests/Unit/Livewire/ReviewPageBranchDivergenceTest.php
+++ b/tests/Unit/Livewire/ReviewPageBranchDivergenceTest.php
@@ -230,6 +230,73 @@ test('switchReviewToHead persists the new branch and clears the banner', functio
     expect($this->project->fresh()->branch)->toBe('feature-x');
 });
 
+test('head-divergence-transitioned event triggers checkHeadDivergence on review-page', function () {
+    Comment::create([
+        'id' => 'c1',
+        'project_id' => $this->project->id,
+        'repo_path' => $this->project->path,
+        'origin_ref' => 'main',
+        'file_path' => 'src/Foo.php',
+        'side' => 'new',
+        'start_line' => 1,
+        'end_line' => 1,
+        'file_content_hash' => 'mock-hash',
+        'body' => 'hello',
+        'is_draft' => false,
+        'submitted_at' => now(),
+    ]);
+
+    $fake = bindFakeCurrentHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
+
+    $component = Livewire::test('pages::review-page', ['slug' => 'divergence-test']);
+    expect($component->get('divergenceState'))->toBe(DivergenceState::Aligned);
+
+    // Simulate the child poller detecting a change and dispatching to the parent.
+    $fake->result = new CurrentHeadResult(branch: 'feature-x', sha: 'b'.str_repeat('0', 39), detached: false, targetExists: true);
+    $component->dispatch('head-divergence-transitioned');
+
+    expect($component->get('divergenceState'))->toBe(DivergenceState::Diverged);
+    expect($component->get('divergenceContext.currentBranch'))->toBe('feature-x');
+});
+
+test('clearing the last persisted comment while HEAD is diverged auto-follows to HEAD', function () {
+    Comment::create([
+        'id' => 'c1',
+        'project_id' => $this->project->id,
+        'repo_path' => $this->project->path,
+        'origin_ref' => 'main',
+        'file_path' => 'src/Foo.php',
+        'side' => 'new',
+        'start_line' => 1,
+        'end_line' => 1,
+        'file_content_hash' => 'mock-hash',
+        'body' => 'hello',
+        'is_draft' => false,
+        'submitted_at' => now(),
+    ]);
+
+    bindFakeCurrentHeadAction(new CurrentHeadResult(branch: 'feature-x', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
+
+    $component = Livewire::test('pages::review-page', ['slug' => 'divergence-test']);
+
+    expect($component->get('divergenceState'))->toBe(DivergenceState::Diverged);
+
+    $component->set('comments', [[
+        'id' => 'c1',
+        'fileId' => 'abc123',
+        'file' => 'src/Foo.php',
+        'side' => 'new',
+        'startLine' => 1,
+        'endLine' => 1,
+        'body' => 'hello',
+        'isDraft' => false,
+    ]]);
+    $component->call('clearAllComments');
+
+    expect($component->get('divergenceState'))->toBe(DivergenceState::Aligned);
+    expect($component->get('projectBranch'))->toBe('feature-x');
+});
+
 test('sentinel HEAD result leaves state untouched', function () {
     $fake = bindFakeCurrentHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
 


### PR DESCRIPTION
## Summary
Stop the review-page's 2-second head-divergence poll from POSTing the full component snapshot on every tick.

## Why
`$wire.checkHeadDivergence()` on the review-page posted the whole component snapshot (~28 KB on a real project) to `/livewire/update` every 2 seconds. That pinned V8 in shape-churn deopt loops, piled up aborted-commit promise rejections, and — most visibly — made the renderer's main thread too busy to process `before-quit`, so the Electron app refused to close after long sessions.

Diagnostic capture from one 19-hour session:

- 68 requests in 58 s to `/livewire/update`, **100% status 0** (Livewire cancelled each commit when the next 2 s tick fired before the previous one returned).
- Avg payload 12 KB, max 28 KB.
- 2,906 identical `Uncaught (in promise) Object` rejections from `livewire.min.js`.
- Renderer sample stuck in `v8::internal::compiler::CompilationDependencies::FieldConstnessDependencyOffTheRecord` — classic shape-churn hot path from re-hydrating a large snapshot on every tick.
- Squirrel `ShipIt` stuck because the app couldn't exit.

## Solution

- **New SFC `resources/views/livewire/head-divergence-poller.blade.php`**
  - Snapshot is three scalars (`repoPath`, `target`, `fingerprint`), not the review-page's files array
  - `#[Renderless]` `poll()` fingerprints `CurrentHeadResult` and only `$this->dispatch('head-divergence-transitioned')` on change
  - `mount()` pre-computes the fingerprint so the first poll is silent
  - Sentinel (`sha === ''`) short-circuits on transient git failure
- **Review-page now listens via `#[On('head-divergence-transitioned')]`** on its existing `checkHeadDivergence()` method
  - Old Alpine `setInterval` island replaced with `<livewire:head-divergence-poller …>`
  - `wire:key` composes `projectId` + `diffFrom` + `projectBranch` as the remount boundary (avoids `#[Reactive]` per the project's 1+N re-render rule)
- **Comment CRUD triggers the same re-check**
  - `createComment`, `deleteComment`, `clearAllComments`, `restoreComments` now call `$this->checkHeadDivergence()` instead of `$this->skipRender()`
  - `hasPersistedComments()` is a second input to `resolveDivergenceState` that the poller can't observe — without this, clearing the last persisted comment while diverged would leave the banner stuck until HEAD moved again
  - Idle case is unchanged because `checkHeadDivergence` itself skips render when state doesn't transition

## Changes

- **`resources/views/livewire/head-divergence-poller.blade.php`** — new SFC
- **`resources/views/pages/⚡review-page.blade.php`**
  - `#[On('head-divergence-transitioned')]` on `checkHeadDivergence()`
  - Alpine `setInterval` polling island replaced with the Livewire child
  - 4 comment-mutation methods swap `skipRender()` → `checkHeadDivergence()`
- **Tests**
  - New `tests/Unit/Livewire/HeadDivergencePollerTest.php` (8 cases)
  - New assertions in `tests/Unit/Livewire/ReviewPageBranchDivergenceTest.php` — event → listener wiring, clearing last comment auto-follows HEAD

## Test plan
- [x] `composer test:lint`
- [x] `composer test:types`
- [x] `composer test` — 754/754 pass
- [ ] Manual: `composer native:dev`, open a project, DevTools → Network filtered on `livewire/update`. Idle steady-state should be only the poller's ~200 B ticks every 2 s; no 28 KB `checkHeadDivergence` storms.
- [ ] Manual: `git checkout <other-branch>` in the repo under review; within ~2 s the banner should update. Dismiss it and it should stay aligned until HEAD moves again.
- [ ] Manual: leave the app idle on a review page for 15+ min, then ⌘Q — should quit promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced automatic head divergence monitoring that detects repository branch and commit changes in real-time.
  * Review page state now synchronizes with branch changes automatically.
  * Comment operations trigger immediate branch state updates.

* **Tests**
  * Added comprehensive unit tests for head divergence monitoring and review page synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->