### PR TITLE
Add zoom controls to View menu with custom role menu item

### DIFF
--- a/app/Providers/NativeAppServiceProvider.php
+++ b/app/Providers/NativeAppServiceProvider.php
@@ -8,6 +8,7 @@ use App\Actions\OpenProjectFromPathAction;
 use App\Actions\ResolveStartupRouteAction;
 use App\Listeners\HandleDeepLink;
 use App\Listeners\HandleMenuItemClicked;
+use App\Support\ZoomRoleMenuItem;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
@@ -170,11 +171,17 @@ class NativeAppServiceProvider implements ProvidesPhpIni
             // accelerators from role items, so the binding can't be retargeted
             // and the keydown never reaches the renderer. Keeping the View
             // menu lean here lets the ⌘R registration in the review page's
-            // keymap store fire as intended.
+            // keymap store fire as intended. The zoom role items are added
+            // explicitly because NativePHP's RolesEnum doesn't expose them,
+            // and dropping viewMenu also drops their default ⌘+/⌘-/⌘0 bindings.
             Menu::make(
-                Menu::devTools(),
+                new ZoomRoleMenuItem('resetZoom', 'Actual Size'),
+                new ZoomRoleMenuItem('zoomIn', 'Zoom In'),
+                new ZoomRoleMenuItem('zoomOut', 'Zoom Out'),
                 Menu::separator(),
                 Menu::fullscreen(),
+                Menu::separator(),
+                Menu::devTools(),
             )->label('View'),
             Menu::window(),
         );

--- a/app/Support/ZoomRoleMenuItem.php
+++ b/app/Support/ZoomRoleMenuItem.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Native\Desktop\Menu\Items\MenuItem;
+
+/**
+ * Role-type menu item for Electron's zoom roles (`zoomIn`, `zoomOut`,
+ * `resetZoom`). NativePHP's RolesEnum doesn't expose them, but Electron
+ * accepts the role strings directly and binds each one to the standard
+ * accelerator (⌘+, ⌘-, ⌘0).
+ */
+final class ZoomRoleMenuItem extends MenuItem
+{
+    protected string $type = 'role';
+
+    public function __construct(private string $role, ?string $label = null)
+    {
+        $this->label = $label;
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return array_merge(parent::toArray(), [
+            'role' => $this->role,
+        ]);
+    }
+}

--- a/tests/Unit/Support/ZoomRoleMenuItemTest.php
+++ b/tests/Unit/Support/ZoomRoleMenuItemTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\ZoomRoleMenuItem;
+
+test('serializes zoom role with label', function () {
+    $array = (new ZoomRoleMenuItem('zoomIn', 'Zoom In'))->toArray();
+
+    expect($array)->toMatchArray([
+        'type' => 'role',
+        'role' => 'zoomIn',
+        'label' => 'Zoom In',
+    ]);
+});
+
+test('omits label when none is provided', function () {
+    $array = (new ZoomRoleMenuItem('resetZoom'))->toArray();
+
+    expect($array['type'])->toBe('role');
+    expect($array['role'])->toBe('resetZoom');
+    expect($array)->not->toHaveKey('label');
+});

--- a/tests/Unit/Support/ZoomRoleMenuItemTest.php
+++ b/tests/Unit/Support/ZoomRoleMenuItemTest.php
@@ -17,7 +17,8 @@ test('serializes zoom role with label', function () {
 test('omits label when none is provided', function () {
     $array = (new ZoomRoleMenuItem('resetZoom'))->toArray();
 
-    expect($array['type'])->toBe('role');
-    expect($array['role'])->toBe('resetZoom');
-    expect($array)->not->toHaveKey('label');
+    expect($array)
+        ->type->toBe('role')
+        ->role->toBe('resetZoom')
+        ->not->toHaveKey('label');
 });


### PR DESCRIPTION
## Summary
This PR adds zoom in, zoom out, and reset zoom controls to the application's View menu. Since NativePHP's `RolesEnum` doesn't expose Electron's zoom roles, a new `ZoomRoleMenuItem` class was created to support these role-type menu items directly.

## Key Changes
- **New `ZoomRoleMenuItem` class**: A custom menu item that extends NativePHP's `MenuItem` to support Electron's zoom roles (`zoomIn`, `zoomOut`, `resetZoom`) with proper serialization
- **Updated View menu**: Added three zoom control menu items ("Actual Size", "Zoom In", "Zoom Out") with their standard keyboard accelerators (⌘0, ⌘+, ⌘-)
- **Menu reorganization**: Restructured the View menu to include zoom controls while maintaining the existing dev tools and fullscreen options
- **Comprehensive tests**: Added unit tests verifying the `ZoomRoleMenuItem` correctly serializes with and without labels

## Implementation Details
The `ZoomRoleMenuItem` class bypasses NativePHP's limitations by directly setting the `type` to `'role'` and including the role string in the serialized output. This allows Electron to bind the standard zoom accelerators automatically. The zoom items are positioned at the top of the View menu for better UX, with separators organizing the menu logically.

https://claude.ai/code/session_01XDyuWuYkRBcRS8MtLv7oQM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added zoom controls (Zoom In, Zoom Out, Actual Size) to the View menu in the desktop application interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->