### PR TITLE
Add markdown heading folding support for diff regions

### DIFF
--- a/app/Actions/LoadFileDiffAction.php
+++ b/app/Actions/LoadFileDiffAction.php
@@ -9,6 +9,7 @@ use App\DTOs\FileDiff;
 use App\Exceptions\GitCommandException;
 use App\Services\DiffParser;
 use App\Services\GitDiffService;
+use App\Services\MarkdownRegionService;
 use App\Services\MarkdownTableAlignerService;
 use App\Services\SyntaxHighlightService;
 use Illuminate\Support\Facades\Cache;
@@ -21,6 +22,7 @@ final readonly class LoadFileDiffAction
         private DiffParser $diffParser,
         private SyntaxHighlightService $syntaxHighlightService,
         private MarkdownTableAlignerService $markdownTableAligner,
+        private MarkdownRegionService $markdownRegionService,
     ) {}
 
     /** @return array{path: string, status: string, oldPath: ?string, hunks: array<int, array<string, mixed>>, additions: int, deletions: int, isBinary: bool, tooLarge: bool, syntaxStyles: string} */
@@ -35,21 +37,21 @@ final readonly class LoadFileDiffAction
                 Log::warning('Git diff failed', ['path' => $path, 'stderr' => $e->stderr]);
 
                 return FileDiff::emptyArray($path, 'modified', tooLarge: false)
-                    + ['error' => 'Failed to load diff for this file.', 'syntaxStyles' => ''];
+                    + ['error' => 'Failed to load diff for this file.', 'syntaxStyles' => '', 'headingsAnnotated' => true];
             }
 
             if ($rawDiff === null) {
-                return FileDiff::emptyArray($path, 'modified', tooLarge: true) + ['syntaxStyles' => ''];
+                return FileDiff::emptyArray($path, 'modified', tooLarge: true) + ['syntaxStyles' => '', 'headingsAnnotated' => true];
             }
 
             if (trim($rawDiff) === '') {
-                return FileDiff::emptyArray($path, 'modified', tooLarge: false) + ['syntaxStyles' => ''];
+                return FileDiff::emptyArray($path, 'modified', tooLarge: false) + ['syntaxStyles' => '', 'headingsAnnotated' => true];
             }
 
             $fileDiff = $this->diffParser->parseSingle($rawDiff);
 
             if (! $fileDiff) {
-                return FileDiff::emptyArray($path, 'modified', tooLarge: false) + ['syntaxStyles' => ''];
+                return FileDiff::emptyArray($path, 'modified', tooLarge: false) + ['syntaxStyles' => '', 'headingsAnnotated' => true];
             }
 
             $fileDiff = $fileDiff->withHunks(
@@ -57,6 +59,7 @@ final readonly class LoadFileDiffAction
             );
 
             $highlightedHunks = $this->syntaxHighlightService->highlightHunks($fileDiff->hunks, $fileDiff->path);
+            $annotatedHunks = $this->markdownRegionService->annotate($highlightedHunks, $fileDiff->path);
 
             $css = '';
             foreach ($this->syntaxHighlightService->getStyleMap() as $cls => $styles) {
@@ -72,12 +75,24 @@ final readonly class LoadFileDiffAction
                 ? null
                 : $this->gitDiffService->getNewFileLineCount($repoPath, $path, $target);
 
-            return $fileDiff->withHunks($highlightedHunks)->toArray() + ['tooLarge' => false, 'syntaxStyles' => $css, 'tableAligned' => true, 'newFileLineCount' => $newFileLineCount];
+            return $fileDiff->withHunks($annotatedHunks)->toArray() + [
+                'tooLarge' => false,
+                'syntaxStyles' => $css,
+                'tableAligned' => true,
+                'newFileLineCount' => $newFileLineCount,
+                'headingsAnnotated' => true,
+            ];
         };
 
         if ($cacheKey) {
             $cached = Cache::get($cacheKey);
-            if ($cached !== null && array_key_exists('syntaxStyles', $cached) && array_key_exists('isSymlink', $cached) && array_key_exists('tableAligned', $cached) && array_key_exists('newFileLineCount', $cached)) {
+            if ($cached !== null
+                && array_key_exists('syntaxStyles', $cached)
+                && array_key_exists('isSymlink', $cached)
+                && array_key_exists('tableAligned', $cached)
+                && array_key_exists('newFileLineCount', $cached)
+                && array_key_exists('headingsAnnotated', $cached)
+            ) {
                 return $cached;
             }
             $result = $compute();

--- a/app/DTOs/DiffLine.php
+++ b/app/DTOs/DiffLine.php
@@ -6,12 +6,18 @@ namespace App\DTOs;
 
 class DiffLine
 {
+    /**
+     * @param  int[]  $headingAncestors
+     */
     public function __construct(
         public readonly string $type, // 'context', 'add', 'remove'
         public readonly string $content,
         public readonly ?int $oldLineNum,
         public readonly ?int $newLineNum,
         public readonly ?string $highlightedContent = null,
+        public readonly ?int $headingLevel = null,
+        public readonly ?int $headingId = null,
+        public readonly array $headingAncestors = [],
     ) {}
 
     /** @return array<string, mixed> */
@@ -26,6 +32,15 @@ class DiffLine
 
         if ($this->highlightedContent !== null) {
             $array['highlightedContent'] = $this->highlightedContent;
+        }
+
+        if ($this->headingLevel !== null) {
+            $array['headingLevel'] = $this->headingLevel;
+            $array['headingId'] = $this->headingId;
+        }
+
+        if ($this->headingAncestors !== []) {
+            $array['headingAncestors'] = $this->headingAncestors;
         }
 
         return $array;

--- a/app/Services/MarkdownRegionService.php
+++ b/app/Services/MarkdownRegionService.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\DTOs\DiffLine;
+use App\DTOs\Hunk;
+
+class MarkdownRegionService
+{
+    private const MARKDOWN_EXTENSIONS = ['md', 'mdx', 'markdown'];
+
+    /**
+     * Annotate diff lines with ATX heading metadata so the UI can fold regions.
+     *
+     * Only lines on the new side (context + add) influence heading state and
+     * fenced-code tracking; remove lines inherit the current ancestor chain so
+     * they fold alongside their surrounding context.
+     *
+     * @param  Hunk[]  $hunks
+     * @return Hunk[]
+     */
+    public function annotate(array $hunks, string $filePath): array
+    {
+        if (! $this->isMarkdown($filePath)) {
+            return $hunks;
+        }
+
+        /** @var array<int, array{id: int, level: int}> $stack */
+        $stack = [];
+        $inFence = false;
+        $nextId = 1;
+
+        $result = [];
+        foreach ($hunks as $hunk) {
+            $newLines = [];
+            foreach ($hunk->lines as $line) {
+                $isNewSide = $line->type !== 'remove';
+                $fenceLine = $isNewSide && $this->isFenceLine($line->content);
+
+                if ($fenceLine) {
+                    $inFence = ! $inFence;
+                    $newLines[] = $this->annotateLine($line, null, null, $this->ancestorIds($stack));
+
+                    continue;
+                }
+
+                $headingLevel = (! $inFence && $isNewSide)
+                    ? $this->headingLevel($line->content)
+                    : null;
+
+                if ($headingLevel !== null) {
+                    while ($stack !== [] && end($stack)['level'] >= $headingLevel) {
+                        array_pop($stack);
+                    }
+                    $ancestors = $this->ancestorIds($stack);
+                    $id = $nextId++;
+                    $stack[] = ['id' => $id, 'level' => $headingLevel];
+                    $newLines[] = $this->annotateLine($line, $headingLevel, $id, $ancestors);
+                } else {
+                    $newLines[] = $this->annotateLine($line, null, null, $this->ancestorIds($stack));
+                }
+            }
+
+            $result[] = new Hunk(
+                header: $hunk->header,
+                oldStart: $hunk->oldStart,
+                oldCount: $hunk->oldCount,
+                newStart: $hunk->newStart,
+                newCount: $hunk->newCount,
+                lines: $newLines,
+            );
+        }
+
+        return $result;
+    }
+
+    private function isMarkdown(string $filePath): bool
+    {
+        $ext = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
+
+        return in_array($ext, self::MARKDOWN_EXTENSIONS, true);
+    }
+
+    /**
+     * ATX heading: 1-6 '#' followed by a space and some text.
+     * Allows up to 3 leading spaces per CommonMark.
+     */
+    private function headingLevel(string $content): ?int
+    {
+        if (! preg_match('/^ {0,3}(#{1,6})\s+\S/', $content, $m)) {
+            return null;
+        }
+
+        return strlen($m[1]);
+    }
+
+    /**
+     * Fenced code block delimiter: ``` or ~~~ (3+ of either), up to 3 leading spaces.
+     */
+    private function isFenceLine(string $content): bool
+    {
+        return (bool) preg_match('/^ {0,3}(`{3,}|~{3,})/', $content);
+    }
+
+    /**
+     * @param  array<int, array{id: int, level: int}>  $stack
+     * @return int[]
+     */
+    private function ancestorIds(array $stack): array
+    {
+        return array_map(fn (array $frame): int => $frame['id'], $stack);
+    }
+
+    /**
+     * @param  int[]  $ancestors
+     */
+    private function annotateLine(DiffLine $line, ?int $headingLevel, ?int $headingId, array $ancestors): DiffLine
+    {
+        return new DiffLine(
+            type: $line->type,
+            content: $line->content,
+            oldLineNum: $line->oldLineNum,
+            newLineNum: $line->newLineNum,
+            highlightedContent: $line->highlightedContent,
+            headingLevel: $headingLevel,
+            headingId: $headingId,
+            headingAncestors: $ancestors,
+        );
+    }
+}

--- a/app/Services/MarkdownRegionService.php
+++ b/app/Services/MarkdownRegionService.php
@@ -17,6 +17,9 @@ class MarkdownRegionService
      * fenced-code tracking; remove lines inherit the current ancestor chain so
      * they fold alongside their surrounding context.
      *
+     * Heading ids are the new-side line number so fold state remains stable
+     * across diff recomputes (e.g. expanding context).
+     *
      * @param  Hunk[]  $hunks
      * @return Hunk[]
      */
@@ -28,33 +31,37 @@ class MarkdownRegionService
 
         /** @var array<int, array{id: int, level: int}> $stack */
         $stack = [];
-        $inFence = false;
-        $nextId = 1;
+        /** @var array{char: string, length: int}|null $openFence */
+        $openFence = null;
 
         $result = [];
         foreach ($hunks as $hunk) {
             $newLines = [];
             foreach ($hunk->lines as $line) {
                 $isNewSide = $line->type !== 'remove';
-                $fenceLine = $isNewSide && $this->isFenceLine($line->content);
+                $fence = $isNewSide ? $this->fenceMarker($line->content) : null;
 
-                if ($fenceLine) {
-                    $inFence = ! $inFence;
+                if ($fence !== null) {
+                    if ($openFence === null) {
+                        $openFence = $fence;
+                    } elseif ($fence['char'] === $openFence['char'] && $fence['length'] >= $openFence['length']) {
+                        $openFence = null;
+                    }
                     $newLines[] = $this->withAncestors($line, $this->ancestorIds($stack));
 
                     continue;
                 }
 
-                $headingLevel = (! $inFence && $isNewSide)
+                $headingLevel = ($openFence === null && $isNewSide)
                     ? $this->headingLevel($line->content)
                     : null;
 
-                if ($headingLevel !== null) {
+                if ($headingLevel !== null && $line->newLineNum !== null) {
                     while ($stack !== [] && end($stack)['level'] >= $headingLevel) {
                         array_pop($stack);
                     }
                     $ancestors = $this->ancestorIds($stack);
-                    $id = $nextId++;
+                    $id = $line->newLineNum;
                     $stack[] = ['id' => $id, 'level' => $headingLevel];
                     $newLines[] = $this->annotateLine($line, $headingLevel, $id, $ancestors);
                 } else {
@@ -89,11 +96,20 @@ class MarkdownRegionService
     }
 
     /**
-     * Fenced code block delimiter: ``` or ~~~ (3+ of either), up to 3 leading spaces.
+     * Detect a fenced code block delimiter (``` or ~~~, 3+ chars, up to 3 leading spaces).
+     *
+     * @return array{char: string, length: int}|null
      */
-    private function isFenceLine(string $content): bool
+    private function fenceMarker(string $content): ?array
     {
-        return (bool) preg_match('/^ {0,3}(`{3,}|~{3,})/', $content);
+        if (! preg_match('/^ {0,3}((`{3,})|(~{3,}))/', $content, $m)) {
+            return null;
+        }
+
+        return [
+            'char' => $m[1][0],
+            'length' => strlen($m[1]),
+        ];
     }
 
     /**

--- a/app/Services/MarkdownRegionService.php
+++ b/app/Services/MarkdownRegionService.php
@@ -6,11 +6,10 @@ namespace App\Services;
 
 use App\DTOs\DiffLine;
 use App\DTOs\Hunk;
+use App\Support\MarkdownPath;
 
 class MarkdownRegionService
 {
-    private const MARKDOWN_EXTENSIONS = ['md', 'mdx', 'markdown'];
-
     /**
      * Annotate diff lines with ATX heading metadata so the UI can fold regions.
      *
@@ -23,7 +22,7 @@ class MarkdownRegionService
      */
     public function annotate(array $hunks, string $filePath): array
     {
-        if (! $this->isMarkdown($filePath)) {
+        if (! MarkdownPath::isMarkdown($filePath)) {
             return $hunks;
         }
 
@@ -41,7 +40,7 @@ class MarkdownRegionService
 
                 if ($fenceLine) {
                     $inFence = ! $inFence;
-                    $newLines[] = $this->annotateLine($line, null, null, $this->ancestorIds($stack));
+                    $newLines[] = $this->withAncestors($line, $this->ancestorIds($stack));
 
                     continue;
                 }
@@ -59,7 +58,7 @@ class MarkdownRegionService
                     $stack[] = ['id' => $id, 'level' => $headingLevel];
                     $newLines[] = $this->annotateLine($line, $headingLevel, $id, $ancestors);
                 } else {
-                    $newLines[] = $this->annotateLine($line, null, null, $this->ancestorIds($stack));
+                    $newLines[] = $this->withAncestors($line, $this->ancestorIds($stack));
                 }
             }
 
@@ -74,13 +73,6 @@ class MarkdownRegionService
         }
 
         return $result;
-    }
-
-    private function isMarkdown(string $filePath): bool
-    {
-        $ext = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
-
-        return in_array($ext, self::MARKDOWN_EXTENSIONS, true);
     }
 
     /**
@@ -111,6 +103,20 @@ class MarkdownRegionService
     private function ancestorIds(array $stack): array
     {
         return array_map(fn (array $frame): int => $frame['id'], $stack);
+    }
+
+    /**
+     * Avoid reconstructing the DiffLine when there is nothing to attach.
+     *
+     * @param  int[]  $ancestors
+     */
+    private function withAncestors(DiffLine $line, array $ancestors): DiffLine
+    {
+        if ($ancestors === []) {
+            return $line;
+        }
+
+        return $this->annotateLine($line, null, null, $ancestors);
     }
 
     /**

--- a/app/Services/MarkdownTableAlignerService.php
+++ b/app/Services/MarkdownTableAlignerService.php
@@ -6,29 +6,21 @@ namespace App\Services;
 
 use App\DTOs\DiffLine;
 use App\DTOs\Hunk;
+use App\Support\MarkdownPath;
 
 class MarkdownTableAlignerService
 {
-    private const MARKDOWN_EXTENSIONS = ['md', 'mdx'];
-
     /**
      * @param  Hunk[]  $hunks
      * @return Hunk[]
      */
     public function alignTables(array $hunks, string $filePath): array
     {
-        if (! $this->isMarkdown($filePath)) {
+        if (! MarkdownPath::isMarkdown($filePath)) {
             return $hunks;
         }
 
         return array_map(fn (Hunk $hunk) => $this->alignHunk($hunk), $hunks);
-    }
-
-    private function isMarkdown(string $filePath): bool
-    {
-        $ext = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
-
-        return in_array($ext, self::MARKDOWN_EXTENSIONS, true);
     }
 
     private function alignHunk(Hunk $hunk): Hunk

--- a/app/Support/MarkdownPath.php
+++ b/app/Support/MarkdownPath.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+final class MarkdownPath
+{
+    private const EXTENSIONS = ['md', 'mdx', 'markdown'];
+
+    public static function isMarkdown(string $path): bool
+    {
+        return in_array(strtolower(pathinfo($path, PATHINFO_EXTENSION)), self::EXTENSIONS, true);
+    }
+}

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -25,6 +25,21 @@
             dragStartLine: null,
             dragSide: null,
 
+            // Markdown heading fold state (id -> true when collapsed)
+            foldedHeadings: {},
+
+            toggleHeadingFold(id) {
+                this.foldedHeadings[id] = !this.foldedHeadings[id];
+            },
+
+            isLineFolded(ancestors) {
+                if (!ancestors || ancestors.length === 0) return false;
+                for (let i = 0; i < ancestors.length; i++) {
+                    if (this.foldedHeadings[ancestors[i]]) return true;
+                }
+                return false;
+            },
+
             onLineContextmenu(event, lineNum, side) {
                 const inSelection = this.formLine !== null
                     && lineNum >= this.formLine

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -536,7 +536,7 @@ new class extends Component {
                             </tr>
                         @endif
 
-                        @foreach($hunk['lines'] as $lineIndex => $line)
+                        @foreach($hunk['lines'] as $line)
                             @php
                                 $lineNum = $line['newLineNum'] ?? $line['oldLineNum'];
                                 [$bgClass, $numBgClass, $prefix] = match($line['type']) {

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -549,6 +549,9 @@ new class extends Component {
                                     'add' => 'right',
                                     default => 'context',
                                 };
+                                $headingId = $line['headingId'] ?? null;
+                                $headingAncestors = $line['headingAncestors'] ?? [];
+                                $ancestorJs = $headingAncestors === [] ? null : json_encode($headingAncestors);
                             @endphp
                             <tr
                                 class="diff-line {{ $bgClass }}"
@@ -557,6 +560,7 @@ new class extends Component {
                                 @if($hasRemote && $lineNum !== null) @contextmenu.prevent="onLineContextmenu($event, {{ $lineNum }}, '{{ $lineSide === 'left' ? 'old' : 'new' }}')" @endif
                                 @if($line['newLineNum']) data-line-new="{{ $line['newLineNum'] }}" @endif
                                 @if($line['oldLineNum']) data-line-old="{{ $line['oldLineNum'] }}" @endif
+                                @if($ancestorJs) x-show="!isLineFolded({{ $ancestorJs }})" @endif
                             >
                                 {{-- Old line number --}}
                                 <td data-testid="diff-line-number" class="diff-line-num w-[1px] px-2 text-right text-gh-muted/50 select-none cursor-pointer {{ $numBgClass }}"
@@ -582,13 +586,21 @@ new class extends Component {
                                 </td>
 
                                 {{-- Content --}}
-                                <td class="px-2 whitespace-pre-wrap break-all">{!! $line['highlightedContent'] ?? e($line['content']) !!}</td>
+                                <td class="px-2 whitespace-pre-wrap break-all">@if($headingId !== null)<button
+                                        type="button"
+                                        data-testid="heading-fold-toggle"
+                                        data-heading-id="{{ $headingId }}"
+                                        @click.stop="toggleHeadingFold({{ $headingId }})"
+                                        :aria-label="foldedHeadings[{{ $headingId }}] ? 'Expand section' : 'Collapse section'"
+                                        :aria-expanded="!foldedHeadings[{{ $headingId }}]"
+                                        class="inline-flex align-middle -my-0.5 mr-1 size-4 items-center justify-center text-gh-muted/60 hover:text-gh-text"
+                                    ><flux:icon icon="chevron-down" variant="outline" class="!size-3" x-show="!foldedHeadings[{{ $headingId }}]" /><flux:icon icon="chevron-right" variant="outline" class="!size-3" x-show="foldedHeadings[{{ $headingId }}]" x-cloak /></button>@endif{!! $line['highlightedContent'] ?? e($line['content']) !!}</td>
                             </tr>
 
                             {{-- Inline comment form (shows after the target line) --}}
                             @if($lineNum !== null)
                                 <template x-if="showForm && formEndLine === {{ $lineNum }} && formSide !== 'file' && (@js($lineSide) === 'context' || formSide === @js($lineSide))">
-                                    <tr>
+                                    <tr @if($ancestorJs) x-show="!isLineFolded({{ $ancestorJs }})" @endif>
                                         <td colspan="4" class="p-0">
                                             <x-comment-form save="submitComment" placeholder="Write a comment..." border-class="border-y" />
                                         </td>
@@ -608,7 +620,7 @@ new class extends Component {
                                 }
                             @endphp
                             @foreach($lineComments as $comment)
-                                <tr x-data x-show="editingCommentId !== '{{ $comment['id'] }}'">
+                                <tr x-data x-show="editingCommentId !== '{{ $comment['id'] }}'@if($ancestorJs) && !isLineFolded({{ $ancestorJs }})@endif">
                                     <td colspan="4" class="p-0">
                                         <x-comment-display :comment="$comment" border-class="border-y" />
                                     </td>

--- a/tests/Unit/Actions/LoadFileDiffActionTest.php
+++ b/tests/Unit/Actions/LoadFileDiffActionTest.php
@@ -6,6 +6,7 @@ use App\Services\DiffParser;
 use App\Services\GitDiffService;
 use App\Services\GitProcessService;
 use App\Services\IgnoreService;
+use App\Services\MarkdownRegionService;
 use App\Services\MarkdownTableAlignerService;
 use App\Services\SyntaxHighlightService;
 use Illuminate\Support\Facades\Cache;
@@ -26,7 +27,7 @@ beforeEach(function () {
 test('returns full DTO array for modified file', function () {
     File::put($this->tmpDir.'/hello.txt', "line1\nline2\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.txt');
 
     expect($result)->toHaveKeys(['path', 'status', 'hunks', 'additions', 'deletions', 'isBinary', 'tooLarge'])
@@ -42,7 +43,7 @@ test('returns tooLarge true when diff exceeds limit', function () {
     // Use a very low maxBytes config
     config(['rfa.diff_max_bytes' => 100]);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.txt');
 
     expect($result)->toHaveKeys(['path', 'status', 'oldPath', 'hunks', 'additions', 'deletions', 'isBinary', 'tooLarge'])
@@ -55,7 +56,7 @@ test('returns tooLarge true when diff exceeds limit', function () {
 });
 
 test('returns empty array for empty diff', function () {
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'nonexistent.txt', isUntracked: true);
 
     expect($result['hunks'])->toBe([])
@@ -65,7 +66,7 @@ test('returns empty array for empty diff', function () {
 test('handles untracked file', function () {
     File::put($this->tmpDir.'/newfile.txt', "hello\nworld\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'newfile.txt', isUntracked: true);
 
     expect($result)->not->toBeNull()
@@ -81,7 +82,7 @@ test('adds highlightedContent for known file types', function () {
     $this->commitTestRepo($this->tmpDir, 'add php');
     File::put($this->tmpDir.'/hello.php', "<?php\necho 'hello';\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.php');
 
     expect($result)->not->toBeNull()
@@ -98,7 +99,7 @@ test('result contains syntaxStyles CSS for known file types', function () {
     $this->commitTestRepo($this->tmpDir, 'add php styles');
     File::put($this->tmpDir.'/hello.php', "<?php\necho 'hello';\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.php');
 
     expect($result)->toHaveKey('syntaxStyles')
@@ -112,7 +113,7 @@ test('no highlightedContent for unknown file types', function () {
     $this->commitTestRepo($this->tmpDir, 'add xyz');
     File::put($this->tmpDir.'/data.xyz', "updated content\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'data.xyz');
 
     expect($result)->not->toBeNull();
@@ -138,6 +139,7 @@ test('contextLines parameter produces single hunk for full context', function ()
         new DiffParser,
         new SyntaxHighlightService,
         new MarkdownTableAlignerService,
+        new MarkdownRegionService,
     );
 
     $default = $action->handle($this->tmpDir, 'many.txt');
@@ -169,7 +171,7 @@ test('stale cache without syntaxStyles triggers re-computation', function () {
         'tooLarge' => false,
     ], 3600);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.php', cacheKey: $cacheKey);
 
     expect($result)->toHaveKey('syntaxStyles')
@@ -182,7 +184,7 @@ test('class names in highlightedContent have matching selectors in syntaxStyles'
     $this->commitTestRepo($this->tmpDir, 'add php selectors');
     File::put($this->tmpDir.'/hello.php', "<?php\necho 'hello';\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.php');
 
     $classNames = [];
@@ -211,7 +213,7 @@ test('result includes newFileLineCount for modified file', function () {
     // hello.txt starts as 1 line, modify to 3 lines
     File::put($this->tmpDir.'/hello.txt', "line1\nline2\nline3\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.txt');
 
     expect($result)->toHaveKey('newFileLineCount')
@@ -227,7 +229,7 @@ test('newFileLineCount reflects actual file length beyond last hunk', function (
     $lines[0] = 'changed1';
     File::put($this->tmpDir.'/many.txt', implode("\n", $lines)."\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'many.txt');
 
     expect($result['newFileLineCount'])->toBe(20);
@@ -257,11 +259,71 @@ test('stale cache without newFileLineCount triggers re-computation', function ()
         'tableAligned' => true,
     ], 3600);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.txt', cacheKey: $cacheKey);
 
     expect($result)->toHaveKey('newFileLineCount')
         ->and($result['newFileLineCount'])->toBe(2);
+});
+
+// -- markdown heading annotation --
+
+test('markdown files get heading metadata on hunk lines', function () {
+    File::put($this->tmpDir.'/doc.md', "# Title\n\nbody\n");
+    $this->commitTestRepo($this->tmpDir, 'add doc');
+    File::put($this->tmpDir.'/doc.md', "# Title\n\nbody updated\n");
+
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $result = $action->handle($this->tmpDir, 'doc.md');
+
+    $hasHeading = collect($result['hunks'][0]['lines'])
+        ->contains(fn ($line) => ($line['headingLevel'] ?? null) === 1);
+
+    expect($hasHeading)->toBeTrue()
+        ->and($result)->toHaveKey('headingsAnnotated');
+});
+
+test('non-markdown files do not get heading metadata', function () {
+    File::put($this->tmpDir.'/hello.php', "<?php\n# this is a PHP comment, not a heading\n");
+    $this->commitTestRepo($this->tmpDir, 'add php with hash');
+    File::put($this->tmpDir.'/hello.php', "<?php\n# updated comment\n");
+
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $result = $action->handle($this->tmpDir, 'hello.php');
+
+    $hasHeading = collect($result['hunks'][0]['lines'])
+        ->contains(fn ($line) => isset($line['headingLevel']));
+
+    expect($hasHeading)->toBeFalse();
+});
+
+test('stale cache without headingsAnnotated triggers re-computation', function () {
+    File::put($this->tmpDir.'/doc.md', "# New\n");
+    $this->commitTestRepo($this->tmpDir, 'add md cache');
+    File::put($this->tmpDir.'/doc.md', "# Changed\n");
+
+    $cacheKey = 'test-stale-headings-key';
+
+    Cache::put($cacheKey, [
+        'path' => 'doc.md',
+        'status' => 'modified',
+        'oldPath' => null,
+        'hunks' => [],
+        'additions' => 0,
+        'deletions' => 0,
+        'isBinary' => false,
+        'isSymlink' => false,
+        'tooLarge' => false,
+        'syntaxStyles' => '',
+        'tableAligned' => true,
+        'newFileLineCount' => 1,
+    ], 3600);
+
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $result = $action->handle($this->tmpDir, 'doc.md', cacheKey: $cacheKey);
+
+    expect($result)->toHaveKey('headingsAnnotated')
+        ->and($result['hunks'])->not->toBeEmpty();
 });
 
 // -- git error propagation --
@@ -271,7 +333,7 @@ test('returns error field when git command fails', function () {
     $gitService->shouldReceive('getFileDiff')
         ->andThrow(new GitCommandException('git diff', 'fatal: bad revision', 128));
 
-    $action = new LoadFileDiffAction($gitService, new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService);
+    $action = new LoadFileDiffAction($gitService, new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.txt');
 
     expect($result['error'])->toBe('Failed to load diff for this file.')

--- a/tests/Unit/Services/MarkdownRegionServiceTest.php
+++ b/tests/Unit/Services/MarkdownRegionServiceTest.php
@@ -8,11 +8,11 @@ beforeEach(function () {
     $this->service = new MarkdownRegionService;
 });
 
-function mdHunk(array $lines): Hunk
+function mdHunk(array $lines, int $startNewLine = 1, int $startOldLine = 1): Hunk
 {
     $diffLines = [];
-    $newLine = 1;
-    $oldLine = 1;
+    $newLine = $startNewLine;
+    $oldLine = $startOldLine;
     foreach ($lines as $spec) {
         [$type, $content] = $spec;
         $diffLines[] = new DiffLine(
@@ -23,7 +23,14 @@ function mdHunk(array $lines): Hunk
         );
     }
 
-    return new Hunk(header: '', oldStart: 1, oldCount: count($lines), newStart: 1, newCount: count($lines), lines: $diffLines);
+    return new Hunk(
+        header: '',
+        oldStart: $startOldLine,
+        oldCount: count($lines),
+        newStart: $startNewLine,
+        newCount: count($lines),
+        lines: $diffLines,
+    );
 }
 
 test('returns hunks unchanged for non-markdown files', function () {
@@ -58,12 +65,12 @@ test('detects a single ATX heading and assigns ancestors to following lines', fu
 
 test('nests headings so deeper levels inherit outer ancestors', function () {
     $hunk = mdHunk([
-        ['context', '# Top'],
-        ['context', 'intro'],
-        ['context', '## Sub'],
-        ['context', 'detail'],
-        ['context', '### Sub-sub'],
-        ['context', 'leaf'],
+        ['context', '# Top'],          // newLine 1
+        ['context', 'intro'],           // newLine 2
+        ['context', '## Sub'],          // newLine 3
+        ['context', 'detail'],          // newLine 4
+        ['context', '### Sub-sub'],     // newLine 5
+        ['context', 'leaf'],            // newLine 6
     ]);
 
     $result = $this->service->annotate([$hunk], 'doc.md');
@@ -72,36 +79,38 @@ test('nests headings so deeper levels inherit outer ancestors', function () {
     expect($lines[0]->headingAncestors)->toBe([])
         ->and($lines[1]->headingAncestors)->toBe([1])
         ->and($lines[2]->headingLevel)->toBe(2)
+        ->and($lines[2]->headingId)->toBe(3)
         ->and($lines[2]->headingAncestors)->toBe([1])
-        ->and($lines[3]->headingAncestors)->toBe([1, 2])
-        ->and($lines[4]->headingAncestors)->toBe([1, 2])
-        ->and($lines[5]->headingAncestors)->toBe([1, 2, 3]);
+        ->and($lines[3]->headingAncestors)->toBe([1, 3])
+        ->and($lines[4]->headingAncestors)->toBe([1, 3])
+        ->and($lines[4]->headingId)->toBe(5)
+        ->and($lines[5]->headingAncestors)->toBe([1, 3, 5]);
 });
 
 test('same-level heading closes the previous section', function () {
     $hunk = mdHunk([
-        ['context', '## A'],
-        ['context', 'a-body'],
-        ['context', '## B'],
-        ['context', 'b-body'],
+        ['context', '## A'],       // newLine 1
+        ['context', 'a-body'],      // newLine 2
+        ['context', '## B'],        // newLine 3
+        ['context', 'b-body'],      // newLine 4
     ]);
 
     $result = $this->service->annotate([$hunk], 'doc.md');
     $lines = $result[0]->lines;
 
     expect($lines[1]->headingAncestors)->toBe([1])
-        ->and($lines[2]->headingId)->toBe(2)
+        ->and($lines[2]->headingId)->toBe(3)
         ->and($lines[2]->headingAncestors)->toBe([])
-        ->and($lines[3]->headingAncestors)->toBe([2]);
+        ->and($lines[3]->headingAncestors)->toBe([3]);
 });
 
 test('higher-level heading closes deeper nested sections', function () {
     $hunk = mdHunk([
-        ['context', '# Top'],
-        ['context', '## Sub'],
-        ['context', '### Deep'],
-        ['context', '## Another Sub'],
-        ['context', 'tail'],
+        ['context', '# Top'],           // newLine 1
+        ['context', '## Sub'],          // newLine 2
+        ['context', '### Deep'],        // newLine 3
+        ['context', '## Another Sub'],  // newLine 4
+        ['context', 'tail'],            // newLine 5
     ]);
 
     $result = $this->service->annotate([$hunk], 'doc.md');
@@ -143,11 +152,55 @@ test('tilde fences also suppress heading detection', function () {
     expect($result[0]->lines[2]->headingLevel)->toBeNull();
 });
 
+test('mismatched fence marker does not close the open fence', function () {
+    $hunk = mdHunk([
+        ['context', '```'],              // opens backtick fence
+        ['context', '~~~'],              // tilde line - should NOT close
+        ['context', '## still inside'],  // must stay inside code block
+        ['context', '```'],              // closes backtick fence
+        ['context', '## now a heading'],
+    ]);
+
+    $result = $this->service->annotate([$hunk], 'doc.md');
+    $lines = $result[0]->lines;
+
+    expect($lines[2]->headingLevel)->toBeNull()
+        ->and($lines[4]->headingLevel)->toBe(2);
+});
+
+test('closing fence must be at least as long as the opening fence', function () {
+    $hunk = mdHunk([
+        ['context', '````'],             // opens with 4 backticks
+        ['context', '```'],              // 3 backticks - too short to close
+        ['context', '## still inside'],
+        ['context', '````'],             // 4 backticks - closes
+        ['context', '## now a heading'],
+    ]);
+
+    $result = $this->service->annotate([$hunk], 'doc.md');
+    $lines = $result[0]->lines;
+
+    expect($lines[2]->headingLevel)->toBeNull()
+        ->and($lines[4]->headingLevel)->toBe(2);
+});
+
+test('closing fence may be longer than the opening fence', function () {
+    $hunk = mdHunk([
+        ['context', '```'],               // opens with 3 backticks
+        ['context', '``````'],            // 6 backticks - valid close
+        ['context', '## now a heading'],
+    ]);
+
+    $result = $this->service->annotate([$hunk], 'doc.md');
+
+    expect($result[0]->lines[2]->headingLevel)->toBe(2);
+});
+
 test('remove lines inherit current ancestors but do not open headings', function () {
     $hunk = mdHunk([
-        ['context', '# Top'],
-        ['remove', '## Was-a-heading'],
-        ['context', 'tail'],
+        ['context', '# Top'],           // newLine 1
+        ['remove', '## Was-a-heading'], // no newLine
+        ['context', 'tail'],            // newLine 2
     ]);
 
     $result = $this->service->annotate([$hunk], 'doc.md');
@@ -174,21 +227,46 @@ test('lines that look heading-like but lack trailing text are ignored', function
 
 test('heading state carries across hunks in the same file', function () {
     $hunkA = mdHunk([
-        ['context', '# Top'],
-        ['context', 'intro'],
+        ['context', '# Top'],      // newLine 1
+        ['context', 'intro'],       // newLine 2
     ]);
     $hunkB = mdHunk([
-        ['context', 'tail'],
-        ['context', '## Sub'],
-        ['context', 'leaf'],
-    ]);
+        ['context', 'tail'],        // newLine 10
+        ['context', '## Sub'],      // newLine 11
+        ['context', 'leaf'],        // newLine 12
+    ], startNewLine: 10);
 
     $result = $this->service->annotate([$hunkA, $hunkB], 'doc.md');
 
     expect($result[1]->lines[0]->headingAncestors)->toBe([1])
         ->and($result[1]->lines[1]->headingLevel)->toBe(2)
+        ->and($result[1]->lines[1]->headingId)->toBe(11)
         ->and($result[1]->lines[1]->headingAncestors)->toBe([1])
-        ->and($result[1]->lines[2]->headingAncestors)->toBe([1, 2]);
+        ->and($result[1]->lines[2]->headingAncestors)->toBe([1, 11]);
+});
+
+test('heading ids are stable across recomputes (driven by new line number)', function () {
+    // Smaller hunk: only the section around '## Sub' is visible.
+    $small = mdHunk([
+        ['context', '## Sub'],     // newLine 5
+        ['context', 'body'],        // newLine 6
+    ], startNewLine: 5);
+
+    // Expanded hunk: the file intro now fits in the diff too.
+    $large = mdHunk([
+        ['context', '# Top'],       // newLine 1
+        ['context', 'intro'],        // newLine 2
+        ['context', ''],             // newLine 3
+        ['context', ''],             // newLine 4
+        ['context', '## Sub'],       // newLine 5
+        ['context', 'body'],         // newLine 6
+    ]);
+
+    $smallResult = $this->service->annotate([$small], 'doc.md');
+    $largeResult = $this->service->annotate([$large], 'doc.md');
+
+    expect($smallResult[0]->lines[0]->headingId)->toBe(5)
+        ->and($largeResult[0]->lines[4]->headingId)->toBe(5);
 });
 
 test('preserves existing line fields when annotating', function () {
@@ -208,7 +286,8 @@ test('preserves existing line fields when annotating', function () {
         ->and($annotated->oldLineNum)->toBe(3)
         ->and($annotated->newLineNum)->toBe(3)
         ->and($annotated->highlightedContent)->toBe('<span>highlighted</span>')
-        ->and($annotated->headingLevel)->toBe(1);
+        ->and($annotated->headingLevel)->toBe(1)
+        ->and($annotated->headingId)->toBe(3);
 });
 
 test('recognises mdx and markdown extensions', function (string $path) {

--- a/tests/Unit/Services/MarkdownRegionServiceTest.php
+++ b/tests/Unit/Services/MarkdownRegionServiceTest.php
@@ -1,0 +1,237 @@
+<?php
+
+use App\DTOs\DiffLine;
+use App\DTOs\Hunk;
+use App\Services\MarkdownRegionService;
+
+beforeEach(function () {
+    $this->service = new MarkdownRegionService;
+});
+
+function mdHunk(array $lines): Hunk
+{
+    $diffLines = [];
+    $newLine = 1;
+    $oldLine = 1;
+    foreach ($lines as $spec) {
+        [$type, $content] = $spec;
+        $diffLines[] = new DiffLine(
+            type: $type,
+            content: $content,
+            oldLineNum: $type === 'add' ? null : $oldLine++,
+            newLineNum: $type === 'remove' ? null : $newLine++,
+        );
+    }
+
+    return new Hunk(header: '', oldStart: 1, oldCount: count($lines), newStart: 1, newCount: count($lines), lines: $diffLines);
+}
+
+test('returns hunks unchanged for non-markdown files', function () {
+    $hunk = mdHunk([
+        ['context', '# Heading'],
+        ['context', 'body'],
+    ]);
+
+    $result = $this->service->annotate([$hunk], 'file.php');
+
+    expect($result[0]->lines[0]->headingLevel)->toBeNull()
+        ->and($result[0]->lines[0]->headingAncestors)->toBe([]);
+});
+
+test('detects a single ATX heading and assigns ancestors to following lines', function () {
+    $hunk = mdHunk([
+        ['context', '# Title'],
+        ['context', 'paragraph text'],
+        ['add', 'new paragraph'],
+    ]);
+
+    $result = $this->service->annotate([$hunk], 'README.md');
+    $lines = $result[0]->lines;
+
+    expect($lines[0]->headingLevel)->toBe(1)
+        ->and($lines[0]->headingId)->toBe(1)
+        ->and($lines[0]->headingAncestors)->toBe([])
+        ->and($lines[1]->headingLevel)->toBeNull()
+        ->and($lines[1]->headingAncestors)->toBe([1])
+        ->and($lines[2]->headingAncestors)->toBe([1]);
+});
+
+test('nests headings so deeper levels inherit outer ancestors', function () {
+    $hunk = mdHunk([
+        ['context', '# Top'],
+        ['context', 'intro'],
+        ['context', '## Sub'],
+        ['context', 'detail'],
+        ['context', '### Sub-sub'],
+        ['context', 'leaf'],
+    ]);
+
+    $result = $this->service->annotate([$hunk], 'doc.md');
+    $lines = $result[0]->lines;
+
+    expect($lines[0]->headingAncestors)->toBe([])
+        ->and($lines[1]->headingAncestors)->toBe([1])
+        ->and($lines[2]->headingLevel)->toBe(2)
+        ->and($lines[2]->headingAncestors)->toBe([1])
+        ->and($lines[3]->headingAncestors)->toBe([1, 2])
+        ->and($lines[4]->headingAncestors)->toBe([1, 2])
+        ->and($lines[5]->headingAncestors)->toBe([1, 2, 3]);
+});
+
+test('same-level heading closes the previous section', function () {
+    $hunk = mdHunk([
+        ['context', '## A'],
+        ['context', 'a-body'],
+        ['context', '## B'],
+        ['context', 'b-body'],
+    ]);
+
+    $result = $this->service->annotate([$hunk], 'doc.md');
+    $lines = $result[0]->lines;
+
+    expect($lines[1]->headingAncestors)->toBe([1])
+        ->and($lines[2]->headingId)->toBe(2)
+        ->and($lines[2]->headingAncestors)->toBe([])
+        ->and($lines[3]->headingAncestors)->toBe([2]);
+});
+
+test('higher-level heading closes deeper nested sections', function () {
+    $hunk = mdHunk([
+        ['context', '# Top'],
+        ['context', '## Sub'],
+        ['context', '### Deep'],
+        ['context', '## Another Sub'],
+        ['context', 'tail'],
+    ]);
+
+    $result = $this->service->annotate([$hunk], 'doc.md');
+    $lines = $result[0]->lines;
+
+    expect($lines[3]->headingLevel)->toBe(2)
+        ->and($lines[3]->headingAncestors)->toBe([1])
+        ->and($lines[4]->headingAncestors)->toBe([1, 4]);
+});
+
+test('lines inside a fenced code block are not treated as headings', function () {
+    $hunk = mdHunk([
+        ['context', '# Real'],
+        ['context', '```'],
+        ['context', '# not a heading'],
+        ['context', '## also not'],
+        ['context', '```'],
+        ['context', 'after fence'],
+    ]);
+
+    $result = $this->service->annotate([$hunk], 'doc.md');
+    $lines = $result[0]->lines;
+
+    expect($lines[2]->headingLevel)->toBeNull()
+        ->and($lines[3]->headingLevel)->toBeNull()
+        ->and($lines[5]->headingAncestors)->toBe([1]);
+});
+
+test('tilde fences also suppress heading detection', function () {
+    $hunk = mdHunk([
+        ['context', '# Real'],
+        ['context', '~~~'],
+        ['context', '## inside'],
+        ['context', '~~~'],
+    ]);
+
+    $result = $this->service->annotate([$hunk], 'doc.md');
+
+    expect($result[0]->lines[2]->headingLevel)->toBeNull();
+});
+
+test('remove lines inherit current ancestors but do not open headings', function () {
+    $hunk = mdHunk([
+        ['context', '# Top'],
+        ['remove', '## Was-a-heading'],
+        ['context', 'tail'],
+    ]);
+
+    $result = $this->service->annotate([$hunk], 'doc.md');
+    $lines = $result[0]->lines;
+
+    expect($lines[1]->headingLevel)->toBeNull()
+        ->and($lines[1]->headingAncestors)->toBe([1])
+        ->and($lines[2]->headingAncestors)->toBe([1]);
+});
+
+test('lines that look heading-like but lack trailing text are ignored', function () {
+    $hunk = mdHunk([
+        ['context', '#no-space'],
+        ['context', '#'],
+        ['context', '#   '],
+    ]);
+
+    $result = $this->service->annotate([$hunk], 'doc.md');
+
+    foreach ($result[0]->lines as $line) {
+        expect($line->headingLevel)->toBeNull();
+    }
+});
+
+test('heading state carries across hunks in the same file', function () {
+    $hunkA = mdHunk([
+        ['context', '# Top'],
+        ['context', 'intro'],
+    ]);
+    $hunkB = mdHunk([
+        ['context', 'tail'],
+        ['context', '## Sub'],
+        ['context', 'leaf'],
+    ]);
+
+    $result = $this->service->annotate([$hunkA, $hunkB], 'doc.md');
+
+    expect($result[1]->lines[0]->headingAncestors)->toBe([1])
+        ->and($result[1]->lines[1]->headingLevel)->toBe(2)
+        ->and($result[1]->lines[1]->headingAncestors)->toBe([1])
+        ->and($result[1]->lines[2]->headingAncestors)->toBe([1, 2]);
+});
+
+test('preserves existing line fields when annotating', function () {
+    $line = new DiffLine(
+        type: 'context',
+        content: '# Title',
+        oldLineNum: 3,
+        newLineNum: 3,
+        highlightedContent: '<span>highlighted</span>',
+    );
+    $hunk = new Hunk('', 1, 1, 1, 1, [$line]);
+
+    $result = $this->service->annotate([$hunk], 'doc.md');
+    $annotated = $result[0]->lines[0];
+
+    expect($annotated->content)->toBe('# Title')
+        ->and($annotated->oldLineNum)->toBe(3)
+        ->and($annotated->newLineNum)->toBe(3)
+        ->and($annotated->highlightedContent)->toBe('<span>highlighted</span>')
+        ->and($annotated->headingLevel)->toBe(1);
+});
+
+test('recognises mdx and markdown extensions', function (string $path) {
+    $hunk = mdHunk([['context', '# H']]);
+
+    $result = $this->service->annotate([$hunk], $path);
+
+    expect($result[0]->lines[0]->headingLevel)->toBe(1);
+})->with(['doc.md', 'doc.mdx', 'doc.markdown', 'README.MD']);
+
+test('toArray emits heading fields only when set', function () {
+    $hunk = mdHunk([
+        ['context', '# Top'],
+        ['context', 'body'],
+    ]);
+
+    $result = $this->service->annotate([$hunk], 'doc.md');
+    $headingArr = $result[0]->lines[0]->toArray();
+    $bodyArr = $result[0]->lines[1]->toArray();
+
+    expect($headingArr)->toHaveKeys(['headingLevel', 'headingId'])
+        ->and($headingArr)->not->toHaveKey('headingAncestors')
+        ->and($headingArr['headingLevel'])->toBe(1)
+        ->and($bodyArr)->not->toHaveKey('headingLevel')
+        ->and($bodyArr['headingAncestors'])->toBe([1]);
+});


### PR DESCRIPTION
## Summary
This PR adds the ability to fold/collapse markdown sections in diff views based on heading hierarchy. Users can now click on headings to collapse all content under that heading, improving navigation in large markdown diffs.

## Key Changes

- **New `MarkdownRegionService`**: Analyzes markdown diffs to detect ATX headings (# through ######) and build a hierarchical structure of heading regions
  - Tracks heading nesting and ancestor chains
  - Respects fenced code blocks (``` and ~~~) to avoid treating code as headings
  - Handles removed lines by inheriting current heading context without opening new sections
  - Maintains state across multiple hunks in the same file

- **New `MarkdownPath` utility**: Extracted markdown file detection logic into a reusable helper that recognizes `.md`, `.mdx`, and `.markdown` extensions (case-insensitive)

- **Enhanced `DiffLine` DTO**: Added three new optional fields to track heading metadata:
  - `headingLevel`: The heading level (1-6) if this line is a heading
  - `headingId`: Unique identifier for the heading
  - `headingAncestors`: Array of ancestor heading IDs for hierarchical folding

- **Updated `LoadFileDiffAction`**: Integrated `MarkdownRegionService` into the diff processing pipeline to annotate hunks with heading metadata

- **Frontend folding logic**: Added JavaScript state management in `diff-file.js` to track which headings are collapsed and determine line visibility based on ancestor fold state

- **UI updates**: Modified the diff view template to:
  - Render fold toggle buttons on heading lines
  - Conditionally hide lines based on ancestor fold state
  - Pass heading metadata to the frontend

- **Refactored `MarkdownTableAlignerService`**: Now uses the shared `MarkdownPath` utility instead of duplicating file extension logic

## Implementation Details

- Heading detection follows CommonMark spec: 1-6 `#` characters, followed by a space, with up to 3 leading spaces allowed
- Fenced code block detection supports both backtick and tilde delimiters (3+ characters)
- Heading state is maintained across hunks to properly handle multi-hunk diffs
- The `toArray()` method on `DiffLine` only includes heading fields when they're actually set, keeping serialized output minimal
- Removed lines inherit the current heading context but don't open new sections, ensuring proper visual grouping

https://claude.ai/code/session_01YYEmMiMSgtXnn8yuqgLUXi