### PR TITLE
Fix update banner positioning to stay at top while scrolling

### DIFF
--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -973,9 +973,11 @@ new #[Layout('layouts.app')] class extends Component
         @endif
     "
 >
-    @native
-        <livewire:update-banner />
-    @endnative
+    {{-- Sticky top region: update banner + header pin together so the banner stays at the top while scrolling --}}
+    <div class="sticky top-0 z-50">
+        @native
+            <livewire:update-banner />
+        @endnative
 
     @if($hasRemote)
         {{-- Shared remote-link context menu (one instance per review-page) --}}
@@ -1013,7 +1015,7 @@ new #[Layout('layouts.app')] class extends Component
     @endif
 
     {{-- Header --}}
-    <header class="sticky top-0 z-50 bg-gh-bg/80 backdrop-blur-sm border-b border-gh-border px-5 py-3.5 flex items-center justify-between">
+    <header class="bg-gh-bg/80 backdrop-blur-sm border-b border-gh-border px-5 py-3.5 flex items-center justify-between">
         <div class="flex items-center gap-2">
             <div @if($hasRemote) x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" @endif class="inline-flex">
                 @native
@@ -1170,6 +1172,7 @@ new #[Layout('layouts.app')] class extends Component
             <livewire:theme-switcher />
         </div>
     </header>
+    </div>
 
     {{-- Branch divergence banner + polling island (working-tree mode only) --}}
     @if(! $this->isCommitMode())

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -973,12 +973,6 @@ new #[Layout('layouts.app')] class extends Component
         @endif
     "
 >
-    {{-- Sticky top region: update banner + header pin together so the banner stays at the top while scrolling --}}
-    <div class="sticky top-0 z-50">
-        @native
-            <livewire:update-banner />
-        @endnative
-
     @if($hasRemote)
         {{-- Shared remote-link context menu (one instance per review-page) --}}
         <template x-teleport="body">
@@ -1014,164 +1008,168 @@ new #[Layout('layouts.app')] class extends Component
         </template>
     @endif
 
-    {{-- Header --}}
-    <header class="bg-gh-bg/80 backdrop-blur-sm border-b border-gh-border px-5 py-3.5 flex items-center justify-between">
-        <div class="flex items-center gap-2">
-            <div @if($hasRemote) x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" @endif class="inline-flex">
-                @native
-                    <livewire:project-picker :current-slug="$projectSlug" :project-name="$projectName" />
-                @else
-                    <span class="font-display font-bold tracking-brutal-tight text-base">{{ $projectName }}</span>
-                @endnative
-                @if($hasRemote)
-                    <x-remote-link-menu
+    <div class="sticky top-0 z-50">
+        @native
+            <livewire:update-banner />
+        @endnative
+
+        <header class="bg-gh-bg/80 backdrop-blur-sm border-b border-gh-border px-5 py-3.5 flex items-center justify-between">
+            <div class="flex items-center gap-2">
+                <div @if($hasRemote) x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" @endif class="inline-flex">
+                    @native
+                        <livewire:project-picker :current-slug="$projectSlug" :project-name="$projectName" />
+                    @else
+                        <span class="font-display font-bold tracking-brutal-tight text-base">{{ $projectName }}</span>
+                    @endnative
+                    @if($hasRemote)
+                        <x-remote-link-menu
+                            :project-slug="$projectSlug"
+                            type="repo"
+                            label="repository"
+                        />
+                    @endif
+                </div>
+                @php
+                    $shortFrom = $diffFrom === 'HEAD' ? 'HEAD' : substr($diffFrom, 0, 7);
+                    $shortTo = $diffTo ? substr($diffTo, 0, 7) : null;
+                    if ($diffTo === null && $diffFrom === 'HEAD') {
+                        $selectionLabel = 'Working tree';
+                        $selectionTitle = 'Working tree changes';
+                    } elseif ($diffTo === null) {
+                        $selectionLabel = 'WT · '.$shortFrom;
+                        $selectionTitle = 'Working tree + commits through '.$diffFrom;
+                    } elseif ($diffFrom === $diffTo.'^') {
+                        $selectionLabel = $shortTo;
+                        $selectionTitle = $commitInfo['message'] ?? $diffTo;
+                    } else {
+                        $selectionLabel = $shortFrom.'..'.$shortTo;
+                        $selectionTitle = 'Range '.$diffFrom.'..'.$diffTo;
+                    }
+                @endphp
+                @if($projectBranch)
+                    <x-header-separator />
+                    <livewire:branch-explorer
+                        :repo-path="$repoPath"
+                        :current-branch="$projectBranch"
                         :project-slug="$projectSlug"
-                        type="repo"
-                        label="repository"
+                        :active-commit-hash="$diffTo"
+                        :active-diff-from="$diffFrom"
+                        :has-remote="$hasRemote"
+                        :selection-label="$selectionLabel"
+                        :selection-title="$selectionTitle"
                     />
                 @endif
+                <livewire:comments-drawer :repo-path="$repoPath" :project-id="$projectId ?: null" />
             </div>
-            @php
-                $shortFrom = $diffFrom === 'HEAD' ? 'HEAD' : substr($diffFrom, 0, 7);
-                $shortTo = $diffTo ? substr($diffTo, 0, 7) : null;
-                if ($diffTo === null && $diffFrom === 'HEAD') {
-                    $selectionLabel = 'Working tree';
-                    $selectionTitle = 'Working tree changes';
-                } elseif ($diffTo === null) {
-                    $selectionLabel = 'WT · '.$shortFrom;
-                    $selectionTitle = 'Working tree + commits through '.$diffFrom;
-                } elseif ($diffFrom === $diffTo.'^') {
-                    $selectionLabel = $shortTo;
-                    $selectionTitle = $commitInfo['message'] ?? $diffTo;
-                } else {
-                    $selectionLabel = $shortFrom.'..'.$shortTo;
-                    $selectionTitle = 'Range '.$diffFrom.'..'.$diffTo;
-                }
-            @endphp
-            @if($projectBranch)
-                <x-header-separator />
-                <livewire:branch-explorer
-                    :repo-path="$repoPath"
-                    :current-branch="$projectBranch"
-                    :project-slug="$projectSlug"
-                    :active-commit-hash="$diffTo"
-                    :active-diff-from="$diffFrom"
-                    :has-remote="$hasRemote"
-                    :selection-label="$selectionLabel"
-                    :selection-title="$selectionTitle"
-                />
-            @endif
-            <livewire:comments-drawer :repo-path="$repoPath" :project-id="$projectId ?: null" />
-        </div>
-        <div class="flex items-center gap-2.5 text-xs">
-            {{-- Stats --}}
-            <span class="font-mono text-gh-muted"
-                x-text="fileFilter === '' && !hideReviewed
-                    ? '{{ count($sourceFiles) }} {{ Str::plural('file', count($sourceFiles)) }}'
-                    : sourceFileEntries.filter(f => fileMatchesFilter(f.path, f.id)).length + '/{{ count($sourceFiles) }} files'"
-            >{{ count($sourceFiles) }} {{ Str::plural('file', count($sourceFiles)) }}</span>
-            <span class="font-mono text-gh-green">+{{ collect($sourceFiles)->sum('additions') }}</span>
-            <span class="font-mono text-gh-red">-{{ collect($sourceFiles)->sum('deletions') }}</span>
+            <div class="flex items-center gap-2.5 text-xs">
+                {{-- Stats --}}
+                <span class="font-mono text-gh-muted"
+                    x-text="fileFilter === '' && !hideReviewed
+                        ? '{{ count($sourceFiles) }} {{ Str::plural('file', count($sourceFiles)) }}'
+                        : sourceFileEntries.filter(f => fileMatchesFilter(f.path, f.id)).length + '/{{ count($sourceFiles) }} files'"
+                >{{ count($sourceFiles) }} {{ Str::plural('file', count($sourceFiles)) }}</span>
+                <span class="font-mono text-gh-green">+{{ collect($sourceFiles)->sum('additions') }}</span>
+                <span class="font-mono text-gh-red">-{{ collect($sourceFiles)->sum('deletions') }}</span>
 
-            {{-- Reviewed progress --}}
-            <div x-show="reviewedCount > 0" x-cloak class="flex items-center gap-1.5">
-                <span class="w-px h-3.5 bg-gh-border"></span>
-                <div class="flex flex-col items-center min-w-[2.5rem]">
-                    <span data-testid="reviewed-counter" class="font-mono text-gh-muted" x-text="reviewedCount + '/{{ count($sourceFiles) }} reviewed'"></span>
-                    <div class="w-full h-0.5 bg-gh-border/50 rounded-full overflow-hidden mt-0.5">
-                        <div class="h-full bg-gh-green/70 rounded-full transition-all duration-300" :style="'width:' + Math.round(reviewedCount / {{ count($sourceFiles) }} * 100) + '%'"></div>
+                {{-- Reviewed progress --}}
+                <div x-show="reviewedCount > 0" x-cloak class="flex items-center gap-1.5">
+                    <span class="w-px h-3.5 bg-gh-border"></span>
+                    <div class="flex flex-col items-center min-w-[2.5rem]">
+                        <span data-testid="reviewed-counter" class="font-mono text-gh-muted" x-text="reviewedCount + '/{{ count($sourceFiles) }} reviewed'"></span>
+                        <div class="w-full h-0.5 bg-gh-border/50 rounded-full overflow-hidden mt-0.5">
+                            <div class="h-full bg-gh-green/70 rounded-full transition-all duration-300" :style="'width:' + Math.round(reviewedCount / {{ count($sourceFiles) }} * 100) + '%'"></div>
+                        </div>
                     </div>
                 </div>
-            </div>
 
-            @if(count($reviewPairs) > 0)
-                <span class="font-mono text-xs text-gh-muted px-1.5 py-0.5 rounded border border-gh-border">{{ count($reviewPairs) }} {{ Str::plural('review', count($reviewPairs)) }}</span>
-            @endif
+                @if(count($reviewPairs) > 0)
+                    <span class="font-mono text-xs text-gh-muted px-1.5 py-0.5 rounded border border-gh-border">{{ count($reviewPairs) }} {{ Str::plural('review', count($reviewPairs)) }}</span>
+                @endif
 
-            <span class="w-px h-4 bg-gh-border"></span>
+                <span class="w-px h-4 bg-gh-border"></span>
 
-            {{-- Hide reviewed toggle --}}
-            <div x-show="reviewedCount > 0" x-cloak class="grid place-items-center">
-                <flux:button variant="ghost" size="sm" icon="eye-slash" icon:variant="outline"
-                    tooltip="Hide reviewed"
-                    class="col-start-1 row-start-1"
-                    @click="hideReviewed = true"
-                    x-show="!hideReviewed" />
-                <flux:button variant="ghost" size="sm" icon="eye" icon:variant="outline"
-                    tooltip="Show all files"
-                    class="col-start-1 row-start-1"
-                    @click="hideReviewed = false"
-                    x-show="hideReviewed" x-cloak />
-            </div>
-
-            {{-- Expand/Collapse toggle --}}
-            <div class="grid place-items-center">
-                <flux:button variant="ghost" size="sm" icon="expand-all" icon:variant="outline"
-                    tooltip="Expand all · ⇧E" aria-label="Expand all (⇧E)"
-                    class="col-start-1 row-start-1"
-                    @click="$store.settings.collapseAll = false; $dispatch('expand-all-files')"
-                    x-show="$store.settings.collapseAll" x-cloak />
-                <flux:button variant="ghost" size="sm" icon="collapse-all" icon:variant="outline"
-                    tooltip="Collapse all · ⇧C" aria-label="Collapse all (⇧C)"
-                    class="col-start-1 row-start-1"
-                    @click="$store.settings.collapseAll = true; $dispatch('collapse-all-files')"
-                    x-show="!$store.settings.collapseAll" />
-            </div>
-
-            @if(! $this->isCommitMode())
-                <div data-testid="change-polling" x-data="{
-                    hasChanges: false,
-                    fingerprint: null,
-                    polling: null,
-                    async check() {
-                        try {
-                            const res = await fetch('/api/changes/{{ $projectId }}');
-                            const data = await res.json();
-                            if (this.fingerprint === null) {
-                                this.fingerprint = data.fingerprint;
-                            } else if (data.fingerprint !== this.fingerprint) {
-                                this.hasChanges = true;
-                            }
-                        } catch {}
-                    },
-                    startPolling() {
-                        this.check();
-                        this.polling = setInterval(() => {
-                            if (!document.hidden) this.check();
-                        }, 60000);
-                    },
-                    refresh() {
-                        window.location.reload();
-                    }
-                }" x-init="startPolling(); $store.keymap.register('⌘R', () => refresh(), { allowInEditable: true })" @fingerprint-reset.window="fingerprint = null; hasChanges = false" class="relative flex items-center">
-                    <flux:button variant="ghost" size="sm" icon="arrow-path" icon:variant="outline"
-                        tooltip="Refresh · ⌘R" aria-label="Refresh · ⌘R" @click="refresh()" />
-                    <span x-show="hasChanges" x-cloak
-                        class="absolute -top-0.5 -right-0.5 flex h-2.5 w-2.5">
-                        <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-400 opacity-75"></span>
-                        <span class="relative inline-flex rounded-full h-2.5 w-2.5 bg-amber-500"></span>
-                    </span>
+                {{-- Hide reviewed toggle --}}
+                <div x-show="reviewedCount > 0" x-cloak class="grid place-items-center">
+                    <flux:button variant="ghost" size="sm" icon="eye-slash" icon:variant="outline"
+                        tooltip="Hide reviewed"
+                        class="col-start-1 row-start-1"
+                        @click="hideReviewed = true"
+                        x-show="!hideReviewed" />
+                    <flux:button variant="ghost" size="sm" icon="eye" icon:variant="outline"
+                        tooltip="Show all files"
+                        class="col-start-1 row-start-1"
+                        @click="hideReviewed = false"
+                        x-show="hideReviewed" x-cloak />
                 </div>
-            @endif
 
-            <span class="w-px h-4 bg-gh-border"></span>
+                {{-- Expand/Collapse toggle --}}
+                <div class="grid place-items-center">
+                    <flux:button variant="ghost" size="sm" icon="expand-all" icon:variant="outline"
+                        tooltip="Expand all · ⇧E" aria-label="Expand all (⇧E)"
+                        class="col-start-1 row-start-1"
+                        @click="$store.settings.collapseAll = false; $dispatch('expand-all-files')"
+                        x-show="$store.settings.collapseAll" x-cloak />
+                    <flux:button variant="ghost" size="sm" icon="collapse-all" icon:variant="outline"
+                        tooltip="Collapse all · ⇧C" aria-label="Collapse all (⇧C)"
+                        class="col-start-1 row-start-1"
+                        @click="$store.settings.collapseAll = true; $dispatch('collapse-all-files')"
+                        x-show="!$store.settings.collapseAll" />
+                </div>
 
-            {{-- Settings --}}
-            @if(! $this->isCommitMode())
-                <flux:dropdown position="bottom" align="end">
-                    <flux:button variant="ghost" size="sm" icon="cog-6-tooth" icon:variant="outline"
-                        aria-label="Settings" />
-                    <flux:menu>
-                        <flux:menu.item keep-open>
-                            <flux:checkbox wire:model.live="respectGlobalGitignore" label="Global .gitignore" class="text-xs whitespace-nowrap" />
-                        </flux:menu.item>
-                    </flux:menu>
-                </flux:dropdown>
-            @endif
+                @if(! $this->isCommitMode())
+                    <div data-testid="change-polling" x-data="{
+                        hasChanges: false,
+                        fingerprint: null,
+                        polling: null,
+                        async check() {
+                            try {
+                                const res = await fetch('/api/changes/{{ $projectId }}');
+                                const data = await res.json();
+                                if (this.fingerprint === null) {
+                                    this.fingerprint = data.fingerprint;
+                                } else if (data.fingerprint !== this.fingerprint) {
+                                    this.hasChanges = true;
+                                }
+                            } catch {}
+                        },
+                        startPolling() {
+                            this.check();
+                            this.polling = setInterval(() => {
+                                if (!document.hidden) this.check();
+                            }, 60000);
+                        },
+                        refresh() {
+                            window.location.reload();
+                        }
+                    }" x-init="startPolling(); $store.keymap.register('⌘R', () => refresh(), { allowInEditable: true })" @fingerprint-reset.window="fingerprint = null; hasChanges = false" class="relative flex items-center">
+                        <flux:button variant="ghost" size="sm" icon="arrow-path" icon:variant="outline"
+                            tooltip="Refresh · ⌘R" aria-label="Refresh · ⌘R" @click="refresh()" />
+                        <span x-show="hasChanges" x-cloak
+                            class="absolute -top-0.5 -right-0.5 flex h-2.5 w-2.5">
+                            <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-400 opacity-75"></span>
+                            <span class="relative inline-flex rounded-full h-2.5 w-2.5 bg-amber-500"></span>
+                        </span>
+                    </div>
+                @endif
 
-            <livewire:theme-switcher />
-        </div>
-    </header>
+                <span class="w-px h-4 bg-gh-border"></span>
+
+                {{-- Settings --}}
+                @if(! $this->isCommitMode())
+                    <flux:dropdown position="bottom" align="end">
+                        <flux:button variant="ghost" size="sm" icon="cog-6-tooth" icon:variant="outline"
+                            aria-label="Settings" />
+                        <flux:menu>
+                            <flux:menu.item keep-open>
+                                <flux:checkbox wire:model.live="respectGlobalGitignore" label="Global .gitignore" class="text-xs whitespace-nowrap" />
+                            </flux:menu.item>
+                        </flux:menu>
+                    </flux:dropdown>
+                @endif
+
+                <livewire:theme-switcher />
+            </div>
+        </header>
     </div>
 
     {{-- Branch divergence banner + polling island (working-tree mode only) --}}

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1008,7 +1008,15 @@ new #[Layout('layouts.app')] class extends Component
         </template>
     @endif
 
-    <div class="sticky top-0 z-50">
+    <div
+        class="sticky top-0 z-50"
+        x-data
+        x-init="
+            const update = () => document.documentElement.style.setProperty('--header-h', $el.offsetHeight + 'px');
+            update();
+            new ResizeObserver(update).observe($el);
+        "
+    >
         @native
             <livewire:update-banner />
         @endnative

--- a/resources/views/pages/⚡select-repo-page.blade.php
+++ b/resources/views/pages/⚡select-repo-page.blade.php
@@ -90,21 +90,24 @@ new #[Layout('layouts.app')] class extends Component
 ?>
 
 <div class="min-h-screen flex flex-col">
-    @native
-        <livewire:update-banner />
-    @endnative
+    {{-- Sticky top region: update banner + header pin together so the banner stays at the top while scrolling --}}
+    <div class="sticky top-0 z-50">
+        @native
+            <livewire:update-banner />
+        @endnative
 
-    <header class="sticky top-0 z-50 bg-gh-bg/80 backdrop-blur-sm border-b border-gh-border px-6 py-4 flex items-center justify-between">
-        <div class="flex items-baseline gap-2">
-            <span class="rfa-logo text-2xl">rfa</span>
-            @native
-                <span class="font-mono text-xs text-gh-muted">v{{ config('nativephp.version') }}</span>
-            @endnative
-        </div>
-        <div class="flex items-center gap-3">
-            <livewire:theme-switcher />
-        </div>
-    </header>
+        <header class="bg-gh-bg/80 backdrop-blur-sm border-b border-gh-border px-6 py-4 flex items-center justify-between">
+            <div class="flex items-baseline gap-2">
+                <span class="rfa-logo text-2xl">rfa</span>
+                @native
+                    <span class="font-mono text-xs text-gh-muted">v{{ config('nativephp.version') }}</span>
+                @endnative
+            </div>
+            <div class="flex items-center gap-3">
+                <livewire:theme-switcher />
+            </div>
+        </header>
+    </div>
 
     <main class="flex-1 flex items-center justify-center px-6 py-10">
         @if($totalProjects === 0)

--- a/resources/views/pages/⚡select-repo-page.blade.php
+++ b/resources/views/pages/⚡select-repo-page.blade.php
@@ -90,8 +90,15 @@ new #[Layout('layouts.app')] class extends Component
 ?>
 
 <div class="min-h-screen flex flex-col">
-    {{-- Sticky top region: update banner + header pin together so the banner stays at the top while scrolling --}}
-    <div class="sticky top-0 z-50">
+    <div
+        class="sticky top-0 z-50"
+        x-data
+        x-init="
+            const update = () => document.documentElement.style.setProperty('--header-h', $el.offsetHeight + 'px');
+            update();
+            new ResizeObserver(update).observe($el);
+        "
+    >
         @native
             <livewire:update-banner />
         @endnative


### PR DESCRIPTION
## Summary
Restructured the layout of the update banner and header elements to ensure the update banner remains fixed at the top of the viewport while the header scrolls beneath it. Previously, the banner and header were siblings, causing the banner to scroll out of view.

## Changes
- **Review page**: Wrapped the update banner and header in a new sticky container (`<div class="sticky top-0 z-50">`) that keeps both elements pinned to the top while allowing the page content to scroll independently
- **Select repo page**: Applied the same sticky container pattern to maintain consistent behavior across pages
- Removed `sticky top-0 z-50` classes from the header element itself since the container now provides the sticky positioning
- Updated header styling to remove duplicate sticky positioning (changed from `sticky top-0 z-50` to just the background/border styles)

## Implementation Details
- The update banner is now a child of the sticky container, ensuring it stays visible at the top
- The header remains directly below the banner within the same sticky context
- Both elements scroll together as a unit, but remain pinned to the top of the viewport
- Z-index management is handled at the container level for proper layering

https://claude.ai/code/session_01HgEAcoZwSTiMTtrwE5QZjr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted sticky positioning behavior on review and repository selection pages for improved layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->