### PR TITLE
Add soft refresh capability to review page

### DIFF
--- a/public/js/keymap-store.js
+++ b/public/js/keymap-store.js
@@ -6,7 +6,12 @@
     // hydration overwrite instead of stacking. Components do not need to
     // unregister on teardown for this app — the three overlay panels are
     // always mounted on the review page.
+    // Livewire `wire:navigate` re-executes head scripts, so a module-local
+    // guard would reset to false and attach another listener on each navigation.
+    // Anchor the guard on `window` so it survives across script re-executions.
     function init() {
+        if (window.__keymapAttached) return;
+        window.__keymapAttached = true;
         Alpine.store('keymap', {
             bindings: new Map(),
             /**
@@ -24,9 +29,13 @@
         });
 
         const matches = (combo, e) => {
-            const mod = (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey;
-            if (!mod) return false;
-            const key = combo.replace(/^⌘/, '').toLowerCase();
+            const wantCmd = combo.includes('⌘');
+            const wantShift = combo.includes('⇧');
+            const hasCmd = e.metaKey || e.ctrlKey;
+            if (wantCmd !== hasCmd) return false;
+            if (wantShift !== e.shiftKey) return false;
+            if (e.altKey) return false;
+            const key = combo.replace(/[⌘⇧]/g, '').toLowerCase();
             return e.key.toLowerCase() === key;
         };
 

--- a/public/js/keymap-store.js
+++ b/public/js/keymap-store.js
@@ -3,16 +3,18 @@
     // (⌘K / ⌘B / ⌘J) on init; one window listener dispatches.
     //
     // Registration is keyed by the combo string, so re-registrations during
-    // hydration overwrite instead of stacking. Components do not need to
-    // unregister on teardown for this app — the three overlay panels are
-    // always mounted on the review page.
-    // Livewire `wire:navigate` re-executes head scripts, so a module-local
-    // guard would reset to false and attach another listener on each navigation.
-    // Anchor the guard on `window` so it survives across script re-executions.
+    // hydration overwrite instead of stacking.
+    //
+    // Livewire `wire:navigate` re-executes head scripts, so the attach guard
+    // is anchored on `window` to survive across script re-evaluations. The
+    // store itself persists across SPA navigations — `bindings` is cleared on
+    // `livewire:navigating` so stale shortcuts from the previous page don't
+    // keep firing (and `preventDefault`-ing native keys) on pages that don't
+    // re-register them; the incoming page's `x-init` repopulates after swap.
     function init() {
         if (window.__keymapAttached) return;
         window.__keymapAttached = true;
-        Alpine.store('keymap', {
+        const store = {
             bindings: new Map(),
             /**
              * @param {string} combo       e.g. '⌘K' (also matches Ctrl on non-mac)
@@ -26,6 +28,11 @@
             unregister(combo) {
                 this.bindings.delete(combo);
             },
+        };
+        Alpine.store('keymap', store);
+
+        document.addEventListener('livewire:navigating', () => {
+            store.bindings.clear();
         });
 
         const matches = (combo, e) => {

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -183,6 +183,7 @@ new #[Layout('layouts.app')] class extends Component
 
     private function rehydrateForTarget(): void
     {
+        $this->cachedTarget = null;
         $this->refreshFileList();
         $this->scanReviewFiles();
 
@@ -261,17 +262,10 @@ new #[Layout('layouts.app')] class extends Component
         }
     }
 
-    /**
-     * Re-read the diff from disk and rehydrate session state without a browser
-     * reload. Preserves scroll, activeFileId, collapse state, and open forms —
-     * the renderer process keeps running. Paired with `wire:click.preserve-scroll`
-     * on the refresh button.
-     */
     public function softRefresh(): void
     {
         $before = $this->fileFingerprints($this->files);
 
-        $this->cachedTarget = null;
         $this->rehydrateForTarget();
         $this->checkHeadDivergence();
 
@@ -281,6 +275,10 @@ new #[Layout('layouts.app')] class extends Component
 
         $this->dispatch('fingerprint-reset');
         $this->dispatch('refresh-completed', changedCount: $changedCount);
+
+        if ($changedCount === 0) {
+            $this->skipRender();
+        }
     }
 
     /**
@@ -439,7 +437,6 @@ new #[Layout('layouts.app')] class extends Component
         app(UpdateProjectSettingAction::class)->handle($this->projectId, ['branch' => $newBranch]);
 
         $this->projectBranch = $newBranch;
-        $this->cachedTarget = null;
         $this->dismissedAtHead = null;
         $this->markAligned();
 

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -261,6 +261,48 @@ new #[Layout('layouts.app')] class extends Component
         }
     }
 
+    /**
+     * Re-read the diff from disk and rehydrate session state without a browser
+     * reload. Preserves scroll, activeFileId, collapse state, and open forms —
+     * the renderer process keeps running. Paired with `wire:click.preserve-scroll`
+     * on the refresh button.
+     */
+    public function softRefresh(): void
+    {
+        $before = $this->fileFingerprints($this->files);
+
+        $this->cachedTarget = null;
+        $this->rehydrateForTarget();
+        $this->checkHeadDivergence();
+
+        $after = $this->fileFingerprints($this->files);
+        $changedCount = count(array_diff_assoc($after, $before))
+            + count(array_diff_key($before, $after));
+
+        $this->dispatch('fingerprint-reset');
+        $this->dispatch('refresh-completed', changedCount: $changedCount);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $files
+     * @return array<string, string>
+     */
+    private function fileFingerprints(array $files): array
+    {
+        return collect($files)
+            ->mapWithKeys(fn (array $f) => [
+                (string) $f['id'] => sprintf(
+                    '%s|%s|%s|%s|%s',
+                    $f['status'] ?? '',
+                    $f['additions'] ?? 0,
+                    $f['deletions'] ?? 0,
+                    $f['lastModified'] ?? '',
+                    $f['fileSize'] ?? '',
+                ),
+            ])
+            ->all();
+    }
+
     // endregion: Initialization & Diff Context
 
     // region: Branch Divergence
@@ -1146,12 +1188,25 @@ new #[Layout('layouts.app')] class extends Component
                                 if (!document.hidden) this.check();
                             }, 60000);
                         },
-                        refresh() {
-                            window.location.reload();
-                        }
-                    }" x-init="startPolling(); $store.keymap.register('⌘R', () => refresh(), { allowInEditable: true })" @fingerprint-reset.window="fingerprint = null; hasChanges = false" class="relative flex items-center">
+                        softRefresh() { $wire.softRefresh(); },
+                        hardReload() { window.location.reload(); }
+                    }"
+                    x-init="startPolling();
+                        $store.keymap.register('⌘R', () => softRefresh(), { allowInEditable: true });
+                        $store.keymap.register('⌘⇧R', () => hardReload(), { allowInEditable: true });"
+                    @fingerprint-reset.window="fingerprint = null; hasChanges = false; clearInterval(polling); startPolling();"
+                    @refresh-completed.window="
+                        const n = $event.detail?.changedCount ?? 0;
+                        Flux.toast({
+                            text: n === 0 ? 'Up to date' : (n === 1 ? '1 file updated' : `${n} files updated`),
+                            variant: n === 0 ? 'info' : 'success',
+                        });
+                    "
+                    class="relative flex items-center">
                         <flux:button variant="ghost" size="sm" icon="arrow-path" icon:variant="outline"
-                            tooltip="Refresh · ⌘R" aria-label="Refresh · ⌘R" @click="refresh()" />
+                            tooltip="Refresh · ⌘R · ⌘⇧R to hard reload"
+                            aria-label="Refresh · ⌘R · ⌘⇧R to hard reload"
+                            wire:click.preserve-scroll="softRefresh" />
                         <span x-show="hasChanges" x-cloak
                             class="absolute -top-0.5 -right-0.5 flex h-2.5 w-2.5">
                             <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-400 opacity-75"></span>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -2,7 +2,6 @@
 
 use App\Actions\AddCommentAction;
 use App\Actions\BackfillGlobalGitignoreAction;
-use App\Concerns\InteractsWithRemoteLinks;
 use App\Actions\CleanExpiredTrashAction;
 use App\Actions\DeleteCommentAction;
 use App\Actions\DeleteReviewFilesAction;
@@ -12,7 +11,6 @@ use App\Actions\ExportReviewAction;
 use App\Actions\GetCurrentHeadAction;
 use App\Actions\GetFileListAction;
 use App\Actions\GroupReviewFilesAction;
-use App\Actions\ScanReviewFilesAction;
 use App\Actions\LoadCommitMetadataAction;
 use App\Actions\ResolveCommitAction;
 use App\Actions\ResolveProjectAction;
@@ -20,10 +18,12 @@ use App\Actions\ResolveRangeAction;
 use App\Actions\ResolveRangeToWorkingAction;
 use App\Actions\ResolveStartupRouteAction;
 use App\Actions\RestoreDiscardedFileAction;
+use App\Actions\ScanReviewFilesAction;
 use App\Actions\SessionStateAction;
 use App\Actions\ToggleReviewedAction;
 use App\Actions\UpdateCommentAction;
 use App\Actions\UpdateProjectSettingAction;
+use App\Concerns\InteractsWithRemoteLinks;
 use App\DTOs\CurrentHeadResult;
 use App\DTOs\DiffTarget;
 use App\DTOs\FileListEntry;
@@ -267,7 +267,7 @@ new #[Layout('layouts.app')] class extends Component
         $before = $this->fileFingerprints($this->files);
 
         $this->rehydrateForTarget();
-        $this->checkHeadDivergence();
+        $divergenceChanged = $this->refreshDivergenceState();
 
         $after = $this->fileFingerprints($this->files);
         $changedCount = count(array_diff_assoc($after, $before))
@@ -276,7 +276,7 @@ new #[Layout('layouts.app')] class extends Component
         $this->dispatch('fingerprint-reset');
         $this->dispatch('refresh-completed', changedCount: $changedCount);
 
-        if ($changedCount === 0) {
+        if ($changedCount === 0 && ! $divergenceChanged) {
             $this->skipRender();
         }
     }
@@ -308,13 +308,25 @@ new #[Layout('layouts.app')] class extends Component
     #[On('head-divergence-transitioned')]
     public function checkHeadDivergence(): void
     {
+        if (! $this->refreshDivergenceState()) {
+            $this->skipRender();
+        }
+    }
+
+    /**
+     * Recompute divergence state. Returns true if state changed since the last
+     * check (i.e. the caller should render), false when the caller can skip.
+     * Kept separate from `checkHeadDivergence()` so callers like `softRefresh`
+     * can update divergence without latching `skipRender()` onto a response
+     * that still needs to morph because files did change.
+     */
+    private function refreshDivergenceState(): bool
+    {
         if ($this->isCommitMode()) {
-            if ($this->divergenceChecked) {
-                $this->skipRender();
-            }
+            $changed = ! $this->divergenceChecked;
             $this->divergenceChecked = true;
 
-            return;
+            return $changed;
         }
 
         $before = [$this->divergenceState, $this->divergenceContext, $this->dismissedAtHead, $this->projectBranch];
@@ -324,11 +336,10 @@ new #[Layout('layouts.app')] class extends Component
 
         $after = [$this->divergenceState, $this->divergenceContext, $this->dismissedAtHead, $this->projectBranch];
 
-        if ($this->divergenceChecked && $before === $after) {
-            $this->skipRender();
-        }
-
+        $changed = ! $this->divergenceChecked || $before !== $after;
         $this->divergenceChecked = true;
+
+        return $changed;
     }
 
     private function resolveDivergenceState(CurrentHeadResult $head): void

--- a/tests/Browser/Csrf419RecoveryTest.php
+++ b/tests/Browser/Csrf419RecoveryTest.php
@@ -46,6 +46,31 @@ function waitForSessionValue($page, string $key, string $expected, float $timeou
     return $latest;
 }
 
+/**
+ * Read a sessionStorage value once, retrying on the "execution context was
+ * destroyed" errors that naturally fire while a reload navigation is in
+ * flight. `waitForLoadState('load')` only guarantees the current page is
+ * loaded — browser-internal navigations or late beforeunload→load cycles can
+ * still destroy the context between two statements. Raises the last caught
+ * error if every attempt within $timeoutSec fails.
+ */
+function readSessionValue($page, string $key, float $timeoutSec = 3.0): ?string
+{
+    $deadline = microtime(true) + $timeoutSec;
+    $lastError = null;
+
+    while (microtime(true) < $deadline) {
+        try {
+            return $page->page()->evaluate("sessionStorage.getItem('{$key}')");
+        } catch (Throwable $e) {
+            $lastError = $e;
+            usleep(100_000);
+        }
+    }
+
+    throw $lastError ?? new RuntimeException("readSessionValue('{$key}') timed out");
+}
+
 test('interceptor silently reloads on 419 instead of showing Livewire confirm dialog', function () {
     $page = $this->visit($this->projectUrl());
 
@@ -81,9 +106,9 @@ test('interceptor silently reloads on 419 instead of showing Livewire confirm di
     expect(waitForSessionValue($page, '__csrf419ReloadRan', '1'))->toBe('1');
 
     // beforeunload fired, but the reload navigation may still be in flight.
-    // Wait for it to settle before reading sessionStorage again — otherwise
-    // the evaluate races the destroyed execution context.
+    // Wait for it to settle before reading sessionStorage again, and retry
+    // the read because late nav cycles can still destroy the context.
     $page->page()->waitForLoadState('load');
 
-    expect($page->page()->evaluate("sessionStorage.getItem('__csrf419Dialog')"))->toBeNull();
+    expect(readSessionValue($page, '__csrf419Dialog'))->toBeNull();
 });

--- a/tests/Browser/RefreshShortcutTest.php
+++ b/tests/Browser/RefreshShortcutTest.php
@@ -6,55 +6,74 @@ beforeEach(function () {
     $this->setUpTestRepo();
 });
 
+const REFRESH_LABEL = 'Refresh · ⌘R · ⌘⇧R to hard reload';
+
 /**
- * Replace the Alpine refresh() with a counter so Meta+R doesn't actually
- * reload the document mid-test. window.location.reload itself is read-only
- * and can't be stubbed, so we swap the caller instead.
+ * Replace the registered keymap handlers for ⌘R / ⌘⇧R with counters so the
+ * keyboard shortcuts don't actually round-trip through Livewire or reload the
+ * document mid-test. Stubbing at the keymap layer (not via `Alpine.$data` set)
+ * avoids triggering Alpine's reactive setter side-effects.
  */
-function stubRefreshCounter(PendingAwaitablePage $page): void
+function stubRefreshCounters(PendingAwaitablePage $page): void
 {
     $page->page()->evaluate(<<<'JS'
-        window.__refreshCalls = 0;
-        const el = document.querySelector('[data-testid="change-polling"]');
-        Alpine.$data(el).refresh = () => { window.__refreshCalls += 1; };
+        window.__softRefreshCalls = 0;
+        window.__hardReloadCalls = 0;
+        const bindings = Alpine.store('keymap').bindings;
+        bindings.set('⌘R', { handler: () => { window.__softRefreshCalls += 1; }, allowInEditable: true });
+        bindings.set('⌘⇧R', { handler: () => { window.__hardReloadCalls += 1; }, allowInEditable: true });
     JS);
 }
 
-test('the header shows a refresh button labelled with the ⌘R shortcut', function () {
+test('the header shows a refresh button with ⌘R shortcut hint', function () {
     $page = $this->visit($this->projectUrl());
 
-    $page->page()->getByLabel('Refresh · ⌘R')->first()->waitFor();
-    expect($page->page()->getByLabel('Refresh · ⌘R')->count())->toBeGreaterThan(0);
+    $page->page()->getByLabel(REFRESH_LABEL)->first()->waitFor();
+    expect($page->page()->getByLabel(REFRESH_LABEL)->count())->toBeGreaterThan(0);
 });
 
-test('pressing ⌘R triggers the refresh handler', function () {
+test('pressing ⌘R triggers the soft-refresh handler', function () {
     $page = $this->visitAndLoad($this->projectUrl());
 
-    // Waiting for the button confirms the x-init keymap registration ran.
-    $page->page()->getByLabel('Refresh · ⌘R')->first()->waitFor();
+    $page->page()->getByLabel(REFRESH_LABEL)->first()->waitFor();
 
-    stubRefreshCounter($page);
+    stubRefreshCounters($page);
 
     $page->page()->locator('body')->press('Meta+r');
 
-    $page->page()->waitForFunction('window.__refreshCalls >= 1');
-    expect($page->page()->evaluate('window.__refreshCalls'))->toBeGreaterThan(0);
+    $page->page()->waitForFunction('window.__softRefreshCalls >= 1');
+    expect($page->page()->evaluate('window.__softRefreshCalls'))->toBeGreaterThan(0);
+    expect($page->page()->evaluate('window.__hardReloadCalls'))->toBe(0);
+});
+
+test('pressing ⌘⇧R triggers the hard-reload handler', function () {
+    $page = $this->visitAndLoad($this->projectUrl());
+
+    $page->page()->getByLabel(REFRESH_LABEL)->first()->waitFor();
+
+    stubRefreshCounters($page);
+
+    $page->page()->locator('body')->press('Meta+Shift+r');
+
+    $page->page()->waitForFunction('window.__hardReloadCalls >= 1');
+    expect($page->page()->evaluate('window.__hardReloadCalls'))->toBeGreaterThan(0);
+    expect($page->page()->evaluate('window.__softRefreshCalls'))->toBe(0);
 });
 
 test('⌘R fires even while a comment input is focused', function () {
     $page = $this->visitAndLoad($this->projectUrl());
 
-    $page->page()->getByLabel('Refresh · ⌘R')->first()->waitFor();
+    $page->page()->getByLabel(REFRESH_LABEL)->first()->waitFor();
 
     $page->page()->getByTestId('diff-line-number')->first()->click();
     $input = $page->page()->getByPlaceholder('Write a comment', false);
     $input->waitFor();
     $input->focus();
 
-    stubRefreshCounter($page);
+    stubRefreshCounters($page);
 
     $input->press('Meta+r');
 
-    $page->page()->waitForFunction('window.__refreshCalls >= 1');
-    expect($page->page()->evaluate('window.__refreshCalls'))->toBeGreaterThan(0);
+    $page->page()->waitForFunction('window.__softRefreshCalls >= 1');
+    expect($page->page()->evaluate('window.__softRefreshCalls'))->toBeGreaterThan(0);
 });

--- a/tests/Unit/Livewire/ReviewPageSoftRefreshTest.php
+++ b/tests/Unit/Livewire/ReviewPageSoftRefreshTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use App\Actions\BackfillGlobalGitignoreAction;
+use App\Actions\GetCurrentHeadAction;
+use App\Actions\GetFileListAction;
+use App\Actions\ResolveProjectAction;
+use App\Actions\SessionStateAction;
+use App\DTOs\CurrentHeadResult;
+use App\DTOs\DiffTarget;
+use App\Models\Project;
+use App\Services\GitFileContentService;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+beforeEach(function () {
+    $this->project = Project::create([
+        'slug' => 'soft-refresh-test',
+        'name' => 'Soft Refresh Test',
+        'path' => '/tmp/repo',
+        'git_common_dir' => '/tmp/repo/.git',
+        'branch' => 'main',
+        'global_gitignore_path' => null,
+        'respect_global_gitignore' => true,
+    ]);
+
+    $project = $this->project;
+
+    app()->bind(ResolveProjectAction::class, fn () => new class($project)
+    {
+        public function __construct(private Project $project) {}
+
+        public function handle(string $slug, bool $touch = false): ?array
+        {
+            return $this->project->fresh()->toArray();
+        }
+    });
+
+    // Mutable file list so tests can simulate disk changes across softRefresh calls.
+    $this->fileListFake = new class
+    {
+        /** @var array<int, array<string, mixed>> */
+        public array $files = [
+            ['id' => 'abc123', 'path' => 'src/Foo.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 5, 'deletions' => 2, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T00:00:00Z', 'fileSize' => '100'],
+        ];
+
+        public int $callCount = 0;
+
+        public function handle(string $repoPath, bool $clearCache = true, ?int $projectId = null, ?string $globalGitignorePath = null, ?DiffTarget $target = null): array
+        {
+            $this->callCount++;
+
+            return $this->files;
+        }
+    };
+
+    app()->instance(GetFileListAction::class, $this->fileListFake);
+
+    app()->bind(SessionStateAction::class, fn () => new class
+    {
+        public function handle(string $repoPath, array $currentFiles, ?int $projectId = null, ?DiffTarget $target = null): array
+        {
+            return ['comments' => [], 'reviewedFiles' => [], 'globalComment' => '', 'orphanedPaths' => []];
+        }
+
+        public function saveGlobalNote(string $repoPath, string $globalComment, ?int $projectId = null): void {}
+    });
+
+    $gitFileContentMock = Mockery::mock(GitFileContentService::class);
+    $gitFileContentMock->shouldReceive('hashAt')->andReturn('mock-hash');
+    app()->instance(GitFileContentService::class, $gitFileContentMock);
+
+    app()->bind(BackfillGlobalGitignoreAction::class, fn () => new class
+    {
+        public function handle(int $projectId, string $repoPath): ?string
+        {
+            return null;
+        }
+    });
+
+    app()->instance(GetCurrentHeadAction::class, new class
+    {
+        public function handle(string $repoPath, ?string $targetBranch = null): CurrentHeadResult
+        {
+            return new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true);
+        }
+    });
+});
+
+test('softRefresh re-reads file list and dispatches refresh-completed with zero changes when nothing changed', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'soft-refresh-test']);
+
+    $callsAfterMount = $this->fileListFake->callCount;
+
+    $component->call('softRefresh')
+        ->assertDispatched('fingerprint-reset')
+        ->assertDispatched('refresh-completed', changedCount: 0);
+
+    expect($this->fileListFake->callCount)->toBeGreaterThan($callsAfterMount);
+});
+
+test('softRefresh reports changedCount when files differ', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'soft-refresh-test']);
+
+    // Simulate: one file's line counts changed on disk, plus a brand new file appeared.
+    $this->fileListFake->files = [
+        ['id' => 'abc123', 'path' => 'src/Foo.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 7, 'deletions' => 2, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T01:00:00Z', 'fileSize' => '120'],
+        ['id' => 'def456', 'path' => 'src/Bar.php', 'status' => 'added', 'oldPath' => null, 'additions' => 10, 'deletions' => 0, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T01:00:00Z', 'fileSize' => '200'],
+    ];
+
+    $component->call('softRefresh')
+        ->assertDispatched('fingerprint-reset')
+        ->assertDispatched('refresh-completed', changedCount: 2);
+});
+
+test('softRefresh preserves activeFileId across the call', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'soft-refresh-test'])
+        ->set('activeFileId', 'abc123');
+
+    $component->call('softRefresh');
+
+    expect($component->get('activeFileId'))->toBe('abc123');
+});

--- a/tests/Unit/Livewire/ReviewPageSoftRefreshTest.php
+++ b/tests/Unit/Livewire/ReviewPageSoftRefreshTest.php
@@ -122,3 +122,33 @@ test('softRefresh preserves activeFileId across the call', function () {
 
     expect($component->get('activeFileId'))->toBe('abc123');
 });
+
+/**
+ * Regression: after mount, `divergenceChecked` is true, so an unchanged
+ * divergence poll inside softRefresh would latch `skipRender()` onto the
+ * response. If files also changed, the toast fires but the Blade never
+ * morphs and the UI stays stale until a hard reload. softRefresh must
+ * still render when `changedCount > 0`, even with stable divergence.
+ */
+test('softRefresh with file changes renders the new file list despite stable divergence', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'soft-refresh-test']);
+
+    expect($component->get('divergenceChecked'))->toBeTrue();
+
+    $this->fileListFake->files = [
+        ['id' => 'abc123', 'path' => 'src/Foo.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 5, 'deletions' => 2, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T00:00:00Z', 'fileSize' => '100'],
+        ['id' => 'def456', 'path' => 'src/NewlyAdded.php', 'status' => 'added', 'oldPath' => null, 'additions' => 10, 'deletions' => 0, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T01:00:00Z', 'fileSize' => '200'],
+    ];
+
+    $component->call('softRefresh')
+        ->assertDispatched('refresh-completed', changedCount: 1)
+        ->assertSee('src/NewlyAdded.php');
+});
+
+test('softRefresh with no file changes and stable divergence skips the render', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'soft-refresh-test']);
+
+    $component->call('softRefresh');
+
+    expect($component->effects['html'] ?? null)->toBeNull();
+});

--- a/tests/Unit/Livewire/ReviewPageSoftRefreshTest.php
+++ b/tests/Unit/Livewire/ReviewPageSoftRefreshTest.php
@@ -104,7 +104,6 @@ test('softRefresh re-reads file list and dispatches refresh-completed with zero 
 test('softRefresh reports changedCount when files differ', function () {
     $component = Livewire::test('pages::review-page', ['slug' => 'soft-refresh-test']);
 
-    // Simulate: one file's line counts changed on disk, plus a brand new file appeared.
     $this->fileListFake->files = [
         ['id' => 'abc123', 'path' => 'src/Foo.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 7, 'deletions' => 2, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T01:00:00Z', 'fileSize' => '120'],
         ['id' => 'def456', 'path' => 'src/Bar.php', 'status' => 'added', 'oldPath' => null, 'additions' => 10, 'deletions' => 0, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T01:00:00Z', 'fileSize' => '200'],


### PR DESCRIPTION
## Summary
Implements a soft refresh feature for the review page that re-reads the file list and detects changes without a full page reload, while preserving the hard refresh option via ⌘⇧R.

## Key Changes

- **New `softRefresh()` method** in ReviewPage component that:
  - Re-reads the file list via `rehydrateForTarget()`
  - Compares file fingerprints (status, additions, deletions, lastModified, fileSize) before and after
  - Dispatches `fingerprint-reset` and `refresh-completed` events with change count
  - Skips rendering if no changes detected for performance

- **File fingerprinting system** via `fileFingerprints()` helper that creates a stable hash of file metadata to detect meaningful changes

- **Updated keyboard shortcuts**:
  - ⌘R now triggers soft refresh (via `$wire.softRefresh()`)
  - ⌘⇧R triggers hard reload (full page reload)
  - Both shortcuts work even when editing comments

- **Enhanced keymap store** (`keymap-store.js`):
  - Added support for modifier key combinations (⌘ and ⇧)
  - Fixed module initialization guard to survive `wire:navigate` re-executions
  - Improved key matching logic to handle shift modifier

- **UI improvements**:
  - Refresh button tooltip now shows both shortcuts
  - Toast notifications display change count ("Up to date", "1 file updated", "N files updated")
  - Polling interval resets on fingerprint-reset to avoid stale checks

- **Bug fix**: Moved `$this->cachedTarget = null` from `autoFollowToHead()` to `rehydrateForTarget()` to ensure cache is cleared on all refresh paths

## Testing
Added comprehensive test suite (`ReviewPageSoftRefreshTest.php`) covering:
- Zero changes detection
- Multiple file changes detection
- Active file ID preservation across refresh

Updated browser tests to verify both soft and hard refresh shortcuts work correctly, including while editing comments.

https://claude.ai/code/session_01GniKRueVSGK54W1FixHQkR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added soft refresh (⌘R) that smartly updates only changed content without full page reload
  * Added hard reload shortcut (⌘⇧R) for full page refresh when needed
  * Improved keyboard shortcut handling to prevent duplicate handlers across page navigation
  * Enhanced refresh notifications with toast messages indicating "Up to date" or file change counts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->