### PR TITLE
Fix zoom role menu item accelerators on Electron 38

### DIFF
--- a/app/Support/ZoomRoleMenuItem.php
+++ b/app/Support/ZoomRoleMenuItem.php
@@ -7,25 +7,19 @@ namespace App\Support;
 use Native\Desktop\Menu\Items\MenuItem;
 
 /**
- * Role-type menu item for Electron's zoom roles (`zoomIn`, `zoomOut`,
- * `resetZoom`). NativePHP's RolesEnum doesn't expose them, but Electron
- * accepts the role strings directly and ties each one to a default
- * accelerator (⌘+, ⌘-, ⌘0).
+ * Menu item for Electron's zoom roles (`zoomIn`, `zoomOut`, `resetZoom`),
+ * which NativePHP's RolesEnum doesn't expose.
  *
- * Why we emit `type='normal'` instead of `type='role'`:
+ * Emits `type='normal'` (not `type='role'`) so NativePHP's `compileMenu`
+ * helper passes the accelerator through — for role items it strips
+ * everything except `role` and `label`, leaving the keyboard binding to
+ * Electron's role-default lookup, which on Electron 38 silently fails
+ * to register ⌘- for `zoomOut` on macOS (the menu item shows ⌘- and
+ * clicks fire, but the keystroke does nothing).
  *
- * NativePHP's `compileMenu` helper strips everything except `role` and
- * `label` from role items before handing them to Electron, so any
- * `accelerator` we set is dropped. That leaves the menu binding entirely
- * to Electron's role-default lookup — which on Electron 38 silently
- * fails to register ⌘- for `zoomOut` on macOS (the menu item shows the
- * shortcut and clicks fire, but the keystroke does nothing).
- *
- * Per Electron's docs ("when specifying role on macOS, label and
- * accelerator are the only options that will affect the menu item"),
- * emitting `type='normal'` with `role` + `accelerator` lets the helper
- * pass the accelerator through; Electron honors both — the role still
- * drives the zoom action, and our explicit accelerator owns the binding.
+ * Per Electron's docs, when `role` is set on macOS only `label` and
+ * `accelerator` affect the item, so the role still drives the zoom
+ * action while our explicit accelerator owns the binding.
  *
  * @see https://github.com/electron/electron/issues/19559
  * @see https://github.com/electron/electron/issues/15496

--- a/app/Support/ZoomRoleMenuItem.php
+++ b/app/Support/ZoomRoleMenuItem.php
@@ -9,16 +9,38 @@ use Native\Desktop\Menu\Items\MenuItem;
 /**
  * Role-type menu item for Electron's zoom roles (`zoomIn`, `zoomOut`,
  * `resetZoom`). NativePHP's RolesEnum doesn't expose them, but Electron
- * accepts the role strings directly and binds each one to the standard
+ * accepts the role strings directly and ties each one to a default
  * accelerator (⌘+, ⌘-, ⌘0).
+ *
+ * Why we emit `type='normal'` instead of `type='role'`:
+ *
+ * NativePHP's `compileMenu` helper strips everything except `role` and
+ * `label` from role items before handing them to Electron, so any
+ * `accelerator` we set is dropped. That leaves the menu binding entirely
+ * to Electron's role-default lookup — which on Electron 38 silently
+ * fails to register ⌘- for `zoomOut` on macOS (the menu item shows the
+ * shortcut and clicks fire, but the keystroke does nothing).
+ *
+ * Per Electron's docs ("when specifying role on macOS, label and
+ * accelerator are the only options that will affect the menu item"),
+ * emitting `type='normal'` with `role` + `accelerator` lets the helper
+ * pass the accelerator through; Electron honors both — the role still
+ * drives the zoom action, and our explicit accelerator owns the binding.
+ *
+ * @see https://github.com/electron/electron/issues/19559
+ * @see https://github.com/electron/electron/issues/15496
  */
 final class ZoomRoleMenuItem extends MenuItem
 {
-    protected string $type = 'role';
+    protected string $type = 'normal';
 
-    public function __construct(private string $role, ?string $label = null)
-    {
+    public function __construct(
+        private string $role,
+        ?string $label = null,
+        ?string $accelerator = null,
+    ) {
         $this->label = $label;
+        $this->accelerator = $accelerator ?? self::defaultAcceleratorFor($role);
     }
 
     /** @return array<string, mixed> */
@@ -27,5 +49,15 @@ final class ZoomRoleMenuItem extends MenuItem
         return array_merge(parent::toArray(), [
             'role' => $this->role,
         ]);
+    }
+
+    private static function defaultAcceleratorFor(string $role): ?string
+    {
+        return match ($role) {
+            'zoomIn' => 'CommandOrControl+Plus',
+            'zoomOut' => 'CommandOrControl+-',
+            'resetZoom' => 'CommandOrControl+0',
+            default => null,
+        };
     }
 }

--- a/tests/Unit/Support/ZoomRoleMenuItemTest.php
+++ b/tests/Unit/Support/ZoomRoleMenuItemTest.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 use App\Support\ZoomRoleMenuItem;
 
-test('serializes zoom role with label', function () {
+test('serializes zoom role with label and default accelerator', function () {
     $array = (new ZoomRoleMenuItem('zoomIn', 'Zoom In'))->toArray();
 
     expect($array)->toMatchArray([
-        'type' => 'role',
+        'type' => 'normal',
         'role' => 'zoomIn',
         'label' => 'Zoom In',
+        'accelerator' => 'CommandOrControl+Plus',
     ]);
 });
 
@@ -18,7 +19,36 @@ test('omits label when none is provided', function () {
     $array = (new ZoomRoleMenuItem('resetZoom'))->toArray();
 
     expect($array)
-        ->type->toBe('role')
+        ->type->toBe('normal')
         ->role->toBe('resetZoom')
+        ->accelerator->toBe('CommandOrControl+0')
         ->not->toHaveKey('label');
+});
+
+test('uses default accelerator for zoomOut so ⌘- is bound explicitly', function () {
+    // Regression: with type='role' the NativePHP helper strips the
+    // accelerator and Electron's role-default ⌘- binding silently fails
+    // on macOS for zoomOut. Emitting type='normal' with an explicit
+    // accelerator lets the binding survive the compileMenu helper.
+    $array = (new ZoomRoleMenuItem('zoomOut', 'Zoom Out'))->toArray();
+
+    expect($array)
+        ->type->toBe('normal')
+        ->role->toBe('zoomOut')
+        ->accelerator->toBe('CommandOrControl+-');
+});
+
+test('accepts an explicit accelerator override', function () {
+    $array = (new ZoomRoleMenuItem('zoomIn', 'Zoom In', 'CommandOrControl+='))->toArray();
+
+    expect($array)->accelerator->toBe('CommandOrControl+=');
+});
+
+test('omits accelerator for unknown role when none is provided', function () {
+    $array = (new ZoomRoleMenuItem('unknown', 'Unknown'))->toArray();
+
+    expect($array)
+        ->type->toBe('normal')
+        ->role->toBe('unknown')
+        ->not->toHaveKey('accelerator');
 });

--- a/tests/Unit/Support/ZoomRoleMenuItemTest.php
+++ b/tests/Unit/Support/ZoomRoleMenuItemTest.php
@@ -4,38 +4,26 @@ declare(strict_types=1);
 
 use App\Support\ZoomRoleMenuItem;
 
-test('serializes zoom role with label and default accelerator', function () {
-    $array = (new ZoomRoleMenuItem('zoomIn', 'Zoom In'))->toArray();
+test('uses default accelerator for known zoom roles', function (string $role, string $accelerator) {
+    $array = (new ZoomRoleMenuItem($role, 'Some Label'))->toArray();
 
-    expect($array)->toMatchArray([
-        'type' => 'normal',
-        'role' => 'zoomIn',
-        'label' => 'Zoom In',
-        'accelerator' => 'CommandOrControl+Plus',
-    ]);
-});
+    expect($array)
+        ->type->toBe('normal')
+        ->role->toBe($role)
+        ->accelerator->toBe($accelerator)
+        ->label->toBe('Some Label');
+})->with([
+    'zoomIn' => ['zoomIn', 'CommandOrControl+Plus'],
+    'zoomOut' => ['zoomOut', 'CommandOrControl+-'],
+    'resetZoom' => ['resetZoom', 'CommandOrControl+0'],
+]);
 
 test('omits label when none is provided', function () {
     $array = (new ZoomRoleMenuItem('resetZoom'))->toArray();
 
     expect($array)
-        ->type->toBe('normal')
         ->role->toBe('resetZoom')
-        ->accelerator->toBe('CommandOrControl+0')
         ->not->toHaveKey('label');
-});
-
-test('uses default accelerator for zoomOut so ⌘- is bound explicitly', function () {
-    // Regression: with type='role' the NativePHP helper strips the
-    // accelerator and Electron's role-default ⌘- binding silently fails
-    // on macOS for zoomOut. Emitting type='normal' with an explicit
-    // accelerator lets the binding survive the compileMenu helper.
-    $array = (new ZoomRoleMenuItem('zoomOut', 'Zoom Out'))->toArray();
-
-    expect($array)
-        ->type->toBe('normal')
-        ->role->toBe('zoomOut')
-        ->accelerator->toBe('CommandOrControl+-');
 });
 
 test('accepts an explicit accelerator override', function () {
@@ -48,7 +36,6 @@ test('omits accelerator for unknown role when none is provided', function () {
     $array = (new ZoomRoleMenuItem('unknown', 'Unknown'))->toArray();
 
     expect($array)
-        ->type->toBe('normal')
         ->role->toBe('unknown')
         ->not->toHaveKey('accelerator');
 });


### PR DESCRIPTION
## Summary
Changes the zoom role menu item implementation to use `type='normal'` instead of `type='role'` and explicitly define accelerators, working around an Electron 38 bug where the `zoomOut` role's default keyboard binding (⌘-) fails to register on macOS.

## Key Changes
- Changed `ZoomRoleMenuItem` from `type='role'` to `type='normal'` to allow NativePHP's menu compiler to pass through explicit accelerators
- Added `accelerator` parameter to constructor with sensible defaults for zoom roles:
  - `zoomIn`: `CommandOrControl+Plus`
  - `zoomOut`: `CommandOrControl+-`
  - `resetZoom`: `CommandOrControl+0`
- Implemented `defaultAcceleratorFor()` private method to map roles to their standard accelerators
- Added support for custom accelerator overrides via constructor parameter
- Updated tests to verify correct accelerator assignment and support for custom overrides

## Implementation Details
The root cause is that Electron 38's role-default lookup silently fails to register the ⌘- binding for `zoomOut` on macOS when using `type='role'`. By switching to `type='normal'` with explicit accelerators, we let the role still drive the zoom action while our accelerator owns the keyboard binding. Per Electron's documentation, on macOS only `label` and `accelerator` affect role items, so this approach maintains the intended behavior while working around the bug.

References:
- https://github.com/electron/electron/issues/19559
- https://github.com/electron/electron/issues/15496

https://claude.ai/code/session_01As5PTPurAai3o2654Aza2U