### PR TITLE
Align CSV columns in diffs to match markdown table alignment

### DIFF
--- a/app/Actions/LoadFileDiffAction.php
+++ b/app/Actions/LoadFileDiffAction.php
@@ -7,6 +7,7 @@ namespace App\Actions;
 use App\DTOs\DiffTarget;
 use App\DTOs\FileDiff;
 use App\Exceptions\GitCommandException;
+use App\Services\CsvAlignerService;
 use App\Services\DiffParser;
 use App\Services\GitDiffService;
 use App\Services\MarkdownRegionService;
@@ -22,6 +23,7 @@ final readonly class LoadFileDiffAction
         private DiffParser $diffParser,
         private SyntaxHighlightService $syntaxHighlightService,
         private MarkdownTableAlignerService $markdownTableAligner,
+        private CsvAlignerService $csvAligner,
         private MarkdownRegionService $markdownRegionService,
     ) {}
 
@@ -56,6 +58,10 @@ final readonly class LoadFileDiffAction
 
             $fileDiff = $fileDiff->withHunks(
                 $this->markdownTableAligner->alignTables($fileDiff->hunks, $fileDiff->path)
+            );
+
+            $fileDiff = $fileDiff->withHunks(
+                $this->csvAligner->alignRows($fileDiff->hunks, $fileDiff->path)
             );
 
             $highlightedHunks = $this->syntaxHighlightService->highlightHunks($fileDiff->hunks, $fileDiff->path);

--- a/app/Services/CsvAlignerService.php
+++ b/app/Services/CsvAlignerService.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\DTOs\DiffLine;
+use App\DTOs\Hunk;
+use App\Support\CsvPath;
+
+class CsvAlignerService
+{
+    /**
+     * @param  Hunk[]  $hunks
+     * @return Hunk[]
+     */
+    public function alignRows(array $hunks, string $filePath): array
+    {
+        if (! CsvPath::isCsv($filePath)) {
+            return $hunks;
+        }
+
+        return array_map(fn (Hunk $hunk) => $this->alignHunk($hunk), $hunks);
+    }
+
+    private function alignHunk(Hunk $hunk): Hunk
+    {
+        $lines = $hunk->lines;
+        $count = count($lines);
+
+        if ($count === 0) {
+            return $hunk;
+        }
+
+        $modified = false;
+        $newLines = $lines;
+        $i = 0;
+
+        while ($i < $count) {
+            if ($this->isCsvLine($lines[$i]->content)) {
+                $groupStart = $i;
+                while ($i < $count && $this->isCsvLine($lines[$i]->content)) {
+                    $i++;
+                }
+
+                $aligned = $this->alignGroup(array_slice($lines, $groupStart, $i - $groupStart));
+
+                foreach ($aligned as $offset => $line) {
+                    if ($line !== $lines[$groupStart + $offset]) {
+                        $modified = true;
+                    }
+                    $newLines[$groupStart + $offset] = $line;
+                }
+            } else {
+                $i++;
+            }
+        }
+
+        if (! $modified) {
+            return $hunk;
+        }
+
+        return new Hunk(
+            header: $hunk->header,
+            oldStart: $hunk->oldStart,
+            oldCount: $hunk->oldCount,
+            newStart: $hunk->newStart,
+            newCount: $hunk->newCount,
+            lines: $newLines,
+        );
+    }
+
+    private function isCsvLine(string $content): bool
+    {
+        return trim($content) !== '';
+    }
+
+    /**
+     * @param  DiffLine[]  $group
+     * @return DiffLine[]
+     */
+    private function alignGroup(array $group): array
+    {
+        $parsed = [];
+        $maxCols = 0;
+
+        foreach ($group as $line) {
+            $row = $this->parseCells($line->content);
+
+            if ($row['unterminatedQuote']) {
+                return $group;
+            }
+
+            $parsed[] = $row;
+            $maxCols = max($maxCols, count($row['cells']));
+        }
+
+        if ($maxCols <= 1) {
+            return $group;
+        }
+
+        $colWidths = array_fill(0, $maxCols, 0);
+        foreach ($parsed as $row) {
+            foreach ($row['cells'] as $colIndex => $cell) {
+                $colWidths[$colIndex] = max($colWidths[$colIndex], mb_strwidth($cell));
+            }
+        }
+
+        $result = [];
+        foreach ($group as $i => $line) {
+            $row = $parsed[$i];
+            $cellCount = count($row['cells']);
+            $paddedCells = [];
+
+            foreach ($row['cells'] as $colIndex => $cell) {
+                $isLast = $colIndex === $cellCount - 1;
+                $paddedCells[] = $isLast ? $cell : $this->padCell($cell, $colWidths[$colIndex]);
+            }
+
+            $newContent = implode(',', $paddedCells);
+
+            if ($newContent === $line->content) {
+                $result[] = $line;
+            } else {
+                $result[] = new DiffLine(
+                    type: $line->type,
+                    content: $newContent,
+                    oldLineNum: $line->oldLineNum,
+                    newLineNum: $line->newLineNum,
+                );
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Parse a CSV line into its source-preserving cells (quotes kept intact).
+     *
+     * @return array{cells: string[], unterminatedQuote: bool}
+     */
+    private function parseCells(string $content): array
+    {
+        $cells = [];
+        $current = '';
+        $inQuotes = false;
+        $length = strlen($content);
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = $content[$i];
+
+            if ($char === '"') {
+                if ($inQuotes && $i + 1 < $length && $content[$i + 1] === '"') {
+                    $current .= '""';
+                    $i++;
+
+                    continue;
+                }
+
+                $inQuotes = ! $inQuotes;
+                $current .= '"';
+
+                continue;
+            }
+
+            if ($char === ',' && ! $inQuotes) {
+                $cells[] = $current;
+                $current = '';
+
+                continue;
+            }
+
+            $current .= $char;
+        }
+
+        $cells[] = $current;
+
+        return [
+            'cells' => $cells,
+            'unterminatedQuote' => $inQuotes,
+        ];
+    }
+
+    private function padCell(string $cell, int $width): string
+    {
+        $currentWidth = mb_strwidth($cell);
+        $padding = max(0, $width - $currentWidth);
+
+        return $cell.str_repeat(' ', $padding);
+    }
+}

--- a/app/Services/CsvAlignerService.php
+++ b/app/Services/CsvAlignerService.php
@@ -135,8 +135,6 @@ class CsvAlignerService
     }
 
     /**
-     * Parse a CSV line into its source-preserving cells (quotes kept intact).
-     *
      * @return array{cells: string[], unterminatedQuote: bool}
      */
     private function parseCells(string $content): array

--- a/app/Support/CsvPath.php
+++ b/app/Support/CsvPath.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+final class CsvPath
+{
+    private const EXTENSIONS = ['csv'];
+
+    public static function isCsv(string $path): bool
+    {
+        return in_array(strtolower(pathinfo($path, PATHINFO_EXTENSION)), self::EXTENSIONS, true);
+    }
+}

--- a/tests/Unit/Actions/LoadFileDiffActionTest.php
+++ b/tests/Unit/Actions/LoadFileDiffActionTest.php
@@ -2,6 +2,7 @@
 
 use App\Actions\LoadFileDiffAction;
 use App\Exceptions\GitCommandException;
+use App\Services\CsvAlignerService;
 use App\Services\DiffParser;
 use App\Services\GitDiffService;
 use App\Services\GitProcessService;
@@ -27,7 +28,7 @@ beforeEach(function () {
 test('returns full DTO array for modified file', function () {
     File::put($this->tmpDir.'/hello.txt', "line1\nline2\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.txt');
 
     expect($result)->toHaveKeys(['path', 'status', 'hunks', 'additions', 'deletions', 'isBinary', 'tooLarge'])
@@ -43,7 +44,7 @@ test('returns tooLarge true when diff exceeds limit', function () {
     // Use a very low maxBytes config
     config(['rfa.diff_max_bytes' => 100]);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.txt');
 
     expect($result)->toHaveKeys(['path', 'status', 'oldPath', 'hunks', 'additions', 'deletions', 'isBinary', 'tooLarge'])
@@ -56,7 +57,7 @@ test('returns tooLarge true when diff exceeds limit', function () {
 });
 
 test('returns empty array for empty diff', function () {
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'nonexistent.txt', isUntracked: true);
 
     expect($result['hunks'])->toBe([])
@@ -66,7 +67,7 @@ test('returns empty array for empty diff', function () {
 test('handles untracked file', function () {
     File::put($this->tmpDir.'/newfile.txt', "hello\nworld\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'newfile.txt', isUntracked: true);
 
     expect($result)->not->toBeNull()
@@ -82,7 +83,7 @@ test('adds highlightedContent for known file types', function () {
     $this->commitTestRepo($this->tmpDir, 'add php');
     File::put($this->tmpDir.'/hello.php', "<?php\necho 'hello';\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.php');
 
     expect($result)->not->toBeNull()
@@ -99,7 +100,7 @@ test('result contains syntaxStyles CSS for known file types', function () {
     $this->commitTestRepo($this->tmpDir, 'add php styles');
     File::put($this->tmpDir.'/hello.php', "<?php\necho 'hello';\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.php');
 
     expect($result)->toHaveKey('syntaxStyles')
@@ -113,7 +114,7 @@ test('no highlightedContent for unknown file types', function () {
     $this->commitTestRepo($this->tmpDir, 'add xyz');
     File::put($this->tmpDir.'/data.xyz', "updated content\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'data.xyz');
 
     expect($result)->not->toBeNull();
@@ -139,6 +140,7 @@ test('contextLines parameter produces single hunk for full context', function ()
         new DiffParser,
         new SyntaxHighlightService,
         new MarkdownTableAlignerService,
+        new CsvAlignerService,
         new MarkdownRegionService,
     );
 
@@ -171,7 +173,7 @@ test('stale cache without syntaxStyles triggers re-computation', function () {
         'tooLarge' => false,
     ], 3600);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.php', cacheKey: $cacheKey);
 
     expect($result)->toHaveKey('syntaxStyles')
@@ -184,7 +186,7 @@ test('class names in highlightedContent have matching selectors in syntaxStyles'
     $this->commitTestRepo($this->tmpDir, 'add php selectors');
     File::put($this->tmpDir.'/hello.php', "<?php\necho 'hello';\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.php');
 
     $classNames = [];
@@ -213,7 +215,7 @@ test('result includes newFileLineCount for modified file', function () {
     // hello.txt starts as 1 line, modify to 3 lines
     File::put($this->tmpDir.'/hello.txt', "line1\nline2\nline3\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.txt');
 
     expect($result)->toHaveKey('newFileLineCount')
@@ -229,7 +231,7 @@ test('newFileLineCount reflects actual file length beyond last hunk', function (
     $lines[0] = 'changed1';
     File::put($this->tmpDir.'/many.txt', implode("\n", $lines)."\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'many.txt');
 
     expect($result['newFileLineCount'])->toBe(20);
@@ -259,7 +261,7 @@ test('stale cache without newFileLineCount triggers re-computation', function ()
         'tableAligned' => true,
     ], 3600);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.txt', cacheKey: $cacheKey);
 
     expect($result)->toHaveKey('newFileLineCount')
@@ -273,7 +275,7 @@ test('markdown files get heading metadata on hunk lines', function () {
     $this->commitTestRepo($this->tmpDir, 'add doc');
     File::put($this->tmpDir.'/doc.md', "# Title\n\nbody updated\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'doc.md');
 
     $hasHeading = collect($result['hunks'][0]['lines'])
@@ -288,7 +290,7 @@ test('non-markdown files do not get heading metadata', function () {
     $this->commitTestRepo($this->tmpDir, 'add php with hash');
     File::put($this->tmpDir.'/hello.php', "<?php\n# updated comment\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.php');
 
     $hasHeading = collect($result['hunks'][0]['lines'])
@@ -319,7 +321,7 @@ test('stale cache without headingsAnnotated triggers re-computation', function (
         'newFileLineCount' => 1,
     ], 3600);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'doc.md', cacheKey: $cacheKey);
 
     expect($result)->toHaveKey('headingsAnnotated')
@@ -333,7 +335,7 @@ test('returns error field when git command fails', function () {
     $gitService->shouldReceive('getFileDiff')
         ->andThrow(new GitCommandException('git diff', 'fatal: bad revision', 128));
 
-    $action = new LoadFileDiffAction($gitService, new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction($gitService, new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
     $result = $action->handle($this->tmpDir, 'hello.txt');
 
     expect($result['error'])->toBe('Failed to load diff for this file.')

--- a/tests/Unit/CsvAlignerServiceTest.php
+++ b/tests/Unit/CsvAlignerServiceTest.php
@@ -1,0 +1,209 @@
+<?php
+
+use App\DTOs\DiffLine;
+use App\DTOs\Hunk;
+use App\Services\CsvAlignerService;
+
+beforeEach(function () {
+    $this->aligner = new CsvAlignerService;
+});
+
+test('returns hunks unchanged for non-csv files', function () {
+    $hunks = [
+        new Hunk('', 1, 1, 1, 1, [
+            new DiffLine('context', 'a,b,c', 1, 1),
+        ]),
+    ];
+
+    $result = $this->aligner->alignRows($hunks, 'file.php');
+
+    expect($result)->toBe($hunks);
+});
+
+test('aligns simple csv columns', function () {
+    $hunks = [
+        new Hunk('', 1, 3, 1, 3, [
+            new DiffLine('context', 'name,age,city', 1, 1),
+            new DiffLine('context', 'Alice,30,NYC', 2, 2),
+            new DiffLine('context', 'Bob,25,Los Angeles', 3, 3),
+        ]),
+    ];
+
+    $result = $this->aligner->alignRows($hunks, 'data.csv');
+
+    expect($result[0]->lines[0]->content)->toBe('name ,age,city');
+    expect($result[0]->lines[1]->content)->toBe('Alice,30 ,NYC');
+    expect($result[0]->lines[2]->content)->toBe('Bob  ,25 ,Los Angeles');
+});
+
+test('handles mixed diff types in group', function () {
+    $hunks = [
+        new Hunk('', 1, 3, 1, 3, [
+            new DiffLine('context', 'col,value', 1, 1),
+            new DiffLine('remove', 'short,x', 2, null),
+            new DiffLine('add', 'a much longer cell,updated', null, 2),
+        ]),
+    ];
+
+    $result = $this->aligner->alignRows($hunks, 'docs.csv');
+
+    $lines = $result[0]->lines;
+    expect($lines[0]->content)->toBe('col               ,value');
+    expect($lines[1]->content)->toBe('short             ,x');
+    expect($lines[1]->type)->toBe('remove');
+    expect($lines[2]->content)->toBe('a much longer cell,updated');
+    expect($lines[2]->type)->toBe('add');
+});
+
+test('does not pad the last column', function () {
+    $hunks = [
+        new Hunk('', 1, 2, 1, 2, [
+            new DiffLine('context', 'a,b', 1, 1),
+            new DiffLine('context', 'longer,c', 2, 2),
+        ]),
+    ];
+
+    $result = $this->aligner->alignRows($hunks, 'x.csv');
+
+    expect($result[0]->lines[0]->content)->toBe('a     ,b');
+    expect($result[0]->lines[1]->content)->toBe('longer,c');
+});
+
+test('preserves quoted fields containing commas', function () {
+    $hunks = [
+        new Hunk('', 1, 2, 1, 2, [
+            new DiffLine('context', '"Smith, John",30,NYC', 1, 1),
+            new DiffLine('context', 'Alice,25,LA', 2, 2),
+        ]),
+    ];
+
+    $result = $this->aligner->alignRows($hunks, 'people.csv');
+
+    expect($result[0]->lines[0]->content)->toBe('"Smith, John",30,NYC');
+    expect($result[0]->lines[1]->content)->toBe('Alice        ,25,LA');
+});
+
+test('preserves escaped double quotes inside quoted fields', function () {
+    $hunks = [
+        new Hunk('', 1, 2, 1, 2, [
+            new DiffLine('context', '"he said ""hi""",x', 1, 1),
+            new DiffLine('context', 'short,y', 2, 2),
+        ]),
+    ];
+
+    $result = $this->aligner->alignRows($hunks, 'quotes.csv');
+
+    expect($result[0]->lines[0]->content)->toBe('"he said ""hi""",x');
+    expect($result[0]->lines[1]->content)->toBe('short           ,y');
+});
+
+test('skips alignment when a line has an unterminated quote', function () {
+    $hunks = [
+        new Hunk('', 1, 2, 1, 2, [
+            new DiffLine('context', '"starts here', 1, 1),
+            new DiffLine('context', 'continues",x', 2, 2),
+        ]),
+    ];
+
+    $result = $this->aligner->alignRows($hunks, 'multiline.csv');
+
+    expect($result)->toBe($hunks);
+});
+
+test('skips alignment for single-column csv', function () {
+    $hunks = [
+        new Hunk('', 1, 2, 1, 2, [
+            new DiffLine('context', 'apple', 1, 1),
+            new DiffLine('context', 'banana', 2, 2),
+        ]),
+    ];
+
+    $result = $this->aligner->alignRows($hunks, 'one.csv');
+
+    expect($result)->toBe($hunks);
+});
+
+test('handles rows with different column counts', function () {
+    $hunks = [
+        new Hunk('', 1, 2, 1, 2, [
+            new DiffLine('context', 'a,b,c', 1, 1),
+            new DiffLine('add', 'x,y', null, 2),
+        ]),
+    ];
+
+    $result = $this->aligner->alignRows($hunks, 'r.csv');
+
+    $lines = $result[0]->lines;
+    expect($lines[0]->content)->toBe('a,b,c');
+    expect($lines[1]->content)->toBe('x,y');
+});
+
+test('handles multiple groups separated by blank lines', function () {
+    $hunks = [
+        new Hunk('', 1, 5, 1, 5, [
+            new DiffLine('context', 'a,b', 1, 1),
+            new DiffLine('context', 'longer,x', 2, 2),
+            new DiffLine('context', '', 3, 3),
+            new DiffLine('context', 'c,d', 4, 4),
+            new DiffLine('context', 'y,much longer', 5, 5),
+        ]),
+    ];
+
+    $result = $this->aligner->alignRows($hunks, 'two.csv');
+
+    expect($result[0]->lines[0]->content)->toBe('a     ,b');
+    expect($result[0]->lines[1]->content)->toBe('longer,x');
+    expect($result[0]->lines[2]->content)->toBe('');
+    expect($result[0]->lines[3]->content)->toBe('c,d');
+    expect($result[0]->lines[4]->content)->toBe('y,much longer');
+});
+
+test('handles empty hunks', function () {
+    $result = $this->aligner->alignRows([], 'data.csv');
+
+    expect($result)->toBe([]);
+});
+
+test('preserves line numbers and types', function () {
+    $hunks = [
+        new Hunk('', 10, 2, 10, 2, [
+            new DiffLine('context', 'a,b', 10, 10),
+            new DiffLine('add', 'longer,x', null, 11),
+        ]),
+    ];
+
+    $result = $this->aligner->alignRows($hunks, 'data.csv');
+
+    expect($result[0]->lines[0]->oldLineNum)->toBe(10)
+        ->and($result[0]->lines[0]->newLineNum)->toBe(10)
+        ->and($result[0]->lines[1]->type)->toBe('add')
+        ->and($result[0]->lines[1]->oldLineNum)->toBeNull()
+        ->and($result[0]->lines[1]->newLineNum)->toBe(11);
+});
+
+test('returns hunks unchanged when all columns already aligned', function () {
+    $hunks = [
+        new Hunk('', 1, 2, 1, 2, [
+            new DiffLine('context', 'aaa,bbb', 1, 1),
+            new DiffLine('context', 'xxx,yyy', 2, 2),
+        ]),
+    ];
+
+    $result = $this->aligner->alignRows($hunks, 'aligned.csv');
+
+    expect($result)->toBe($hunks);
+});
+
+test('handles multi-byte characters using display width', function () {
+    $hunks = [
+        new Hunk('', 1, 2, 1, 2, [
+            new DiffLine('context', 'name,city', 1, 1),
+            new DiffLine('context', '日本,Tokyo', 2, 2),
+        ]),
+    ];
+
+    $result = $this->aligner->alignRows($hunks, 'mb.csv');
+
+    expect($result[0]->lines[0]->content)->toBe('name,city');
+    expect($result[0]->lines[1]->content)->toBe('日本,Tokyo');
+});


### PR DESCRIPTION
Mirrors MarkdownTableAlignerService for .csv files so diff rows line up
visually. Parses cells preserving source text (quotes intact), pads all
columns except the last to the group's max width, and skips groups with
unterminated quotes to avoid garbling multi-line records.

https://claude.ai/code/session_01MMkd6WviP9SEX4Z9WnJ6MT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV files now display with automatically aligned columns in diff views for improved readability when comparing data rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->