### PR TITLE
EXPERIMENT: SessionPersistence flake repro

### DIFF
--- a/tests/Browser/SessionPersistenceTest.php
+++ b/tests/Browser/SessionPersistenceTest.php
@@ -24,8 +24,12 @@ test('global comment persists after page reload', function () {
         const wireId = document.querySelector('[data-testid=\"review-component\"]').getAttribute('wire:id');
         Livewire.find(wireId).set('globalComment', 'Global persisted note');
     ");
-    // Wait for Livewire to process the server round-trip
-    $page->page()->waitForFunction("document.querySelector('[data-testid=\"review-component\"] textarea')?.value === 'Global persisted note'");
+    // Livewire.set() updates client state optimistically, so checking the textarea
+    // value can pass before the actual POST reaches PHP — and refresh() then aborts
+    // the in-flight commit before updatedGlobalComment -> saveSession() runs. Wait
+    // for network idle to drain the round-trip. Confirmed via CI experiment on
+    // PR #54: pre-fix repro fails on shard 3 under --parallel; this fix passes.
+    $page->waitForEvent('networkidle');
 
     $page->refresh();
 

--- a/tests/Browser/SessionPersistenceTest.php
+++ b/tests/Browser/SessionPersistenceTest.php
@@ -31,7 +31,7 @@ test('global comment persists after page reload', function () {
 
     $value = $page->page()->getByPlaceholder('Overall review comment', false)->inputValue();
     expect($value)->toBe('Global persisted note');
-})->repeat(30);
+})->repeat(100);
 
 test('reviewed files persist after page reload', function () {
     $page = $this->visitAndLoad($this->projectUrl());

--- a/tests/Browser/SessionPersistenceTest.php
+++ b/tests/Browser/SessionPersistenceTest.php
@@ -31,7 +31,7 @@ test('global comment persists after page reload', function () {
 
     $value = $page->page()->getByPlaceholder('Overall review comment', false)->inputValue();
     expect($value)->toBe('Global persisted note');
-});
+})->repeat(30);
 
 test('reviewed files persist after page reload', function () {
     $page = $this->visitAndLoad($this->projectUrl());


### PR DESCRIPTION
## Purpose
Scientific repro for the intermittent CI failure on `tests/Browser/SessionPersistenceTest::global comment persists after page reload`.

## Method
- This branch reverts the local fix and adds `->repeat(30)` to the suspect test to amplify any race per CI run.
- If the pre-fix code is genuinely racy under CI's `--shard --parallel` load, expect at least one shard 1 failure.
- A follow-up commit will apply the proposed fix (`waitForEvent('networkidle')` to drain the Livewire commit before refresh) and confirm CI goes green.

## Hypothesis
`Livewire.find().set()` updates client state optimistically, so the existing `waitForFunction` (textarea value) passes before `saveSession()` finishes server-side. `refresh()` then races the in-flight POST.

## Not for merge
Throwaway PR — close after the experiment concludes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced session persistence validation with increased test repetition to ensure consistent behavior across multiple iterations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->