### PR TITLE
Speed up CI by caching vendor, skipping dead steps, and rebalancing browser shards

### DIFF
--- a/.github/actions/setup-php-composer/action.yml
+++ b/.github/actions/setup-php-composer/action.yml
@@ -1,5 +1,7 @@
 name: Setup PHP + Composer
-description: Installs PHP, restores the Composer cache, and runs composer install.
+description: >
+  Installs PHP, restores vendor/ + the Composer download cache, and runs
+  `composer install` only when the vendor cache misses.
 
 inputs:
   php-version:
@@ -19,12 +21,30 @@ runs:
       id: composer-cache-dir
       shell: bash
       run: echo "dir=$(composer config --global cache-files-dir)" >> "$GITHUB_OUTPUT"
-    - name: Cache Composer packages
+    # Always restore the Composer download cache. Even when vendor/ is a hit
+    # and we skip `composer install` here, downstream jobs (benchmark-perf
+    # checks out an older SHA and runs `composer install` against a
+    # potentially different lockfile) reuse this cache.
+    - name: Cache Composer downloads
       uses: actions/cache@v5
       with:
         path: ${{ steps.composer-cache-dir.outputs.dir }}
         key: composer-${{ runner.os }}-php${{ inputs.php-version }}-${{ hashFiles('composer.lock') }}
         restore-keys: composer-${{ runner.os }}-php${{ inputs.php-version }}-
+    # Restoring vendor/ + the post-autoload-dump artefacts (packages.php /
+    # services.php) lets us skip `composer install` entirely on a cache hit.
+    # Key includes patch-native-preload.php because that script runs as a
+    # post-autoload-dump hook and mutates files inside vendor/.
+    - name: Cache vendor + bootstrap/cache
+      id: vendor-cache
+      uses: actions/cache@v5
+      with:
+        path: |
+          vendor
+          bootstrap/cache/packages.php
+          bootstrap/cache/services.php
+        key: vendor-${{ runner.os }}-php${{ inputs.php-version }}-${{ hashFiles('composer.lock', 'composer.json', 'scripts/patch-native-preload.php') }}
     - name: Install Composer dependencies
+      if: steps.vendor-cache.outputs.cache-hit != 'true'
       shell: bash
       run: composer install --no-interaction --prefer-dist --no-progress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,17 @@ jobs:
       - uses: ./.github/actions/setup-php-composer
         with:
           php-version: ${{ env.PHP_VERSION }}
+      # PHPStan stores per-file analysis results so unchanged code is skipped
+      # on subsequent runs. Cache key only needs to flip when the analysed
+      # source or PHPStan config changes; restore-keys lets us reuse a partial
+      # cache when only a few files changed.
+      - name: Cache PHPStan result cache
+        uses: actions/cache@v5
+        with:
+          path: /tmp/phpstan
+          key: phpstan-${{ runner.os }}-php${{ env.PHP_VERSION }}-${{ hashFiles('phpstan.neon.dist', 'app/**/*.php', 'database/factories/**/*.php') }}
+          restore-keys: |
+            phpstan-${{ runner.os }}-php${{ env.PHP_VERSION }}-
       - run: composer test:types
 
   test-core:
@@ -46,20 +57,19 @@ jobs:
           php-version: ${{ env.PHP_VERSION }}
       - run: cp .env.example .env
       - run: php artisan key:generate
-      - run: touch database/database.sqlite
-      - run: php artisan migrate --force
+      # No `migrate` step: tests use DB_DATABASE=:memory: from phpunit.xml.
       - run: composer test
 
-  # Browser tests are split into 3 parallel runners via Pest's native
+  # Browser tests are split into 4 parallel runners via Pest's native
   # `--shard=X/Y` (4.6+). Each shard also runs `--parallel` internally, so total
   # concurrency is (shards × per-runner workers).
   test-browser-shard:
-    name: test-browser-shard (${{ matrix.shard }}/3)
+    name: test-browser-shard (${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-php-composer
@@ -79,18 +89,21 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-chromium
+      # On cache hit we do *nothing*: ubuntu-latest already ships Google Chrome
+      # and the shared libraries Chromium needs, so the cached browser binary
+      # launches without `playwright install-deps`. Skipping this step saves
+      # ~18s per shard on every PR (apt update + apt install). On cache miss
+      # (Playwright version bump) we still pay `--with-deps` once so a future
+      # runner image change can't silently break us.
       - if: steps.playwright-cache.outputs.cache-hit != 'true'
         name: Install Chromium + OS deps
         run: npx playwright install chromium --with-deps
-      - if: steps.playwright-cache.outputs.cache-hit == 'true'
-        name: Install Chromium OS deps only
-        run: npx playwright install-deps chromium
       - run: cp .env.example .env
       - run: php artisan key:generate
-      - run: touch database/database.sqlite
-      - run: php artisan migrate --force
-      - name: Run browser tests (shard ${{ matrix.shard }}/3)
-        run: ./vendor/bin/pest --testsuite=Browser --shard=${{ matrix.shard }}/3 --parallel --compact
+      # No `migrate` step: browser tests use DB_DATABASE=:memory: from phpunit.xml,
+      # and Pest spins the test server up in-process so it inherits that env.
+      - name: Run browser tests (shard ${{ matrix.shard }}/4)
+        run: ./vendor/bin/pest --testsuite=Browser --shard=${{ matrix.shard }}/4 --parallel --compact
       - name: Upload browser screenshots on failure
         if: failure()
         uses: actions/upload-artifact@v4
@@ -126,8 +139,10 @@ jobs:
           php-version: ${{ env.PHP_VERSION }}
       - run: cp .env.example .env
       - run: php artisan key:generate
-      - run: touch database/database.sqlite
-      - run: php artisan migrate --force
+      # No upfront `migrate`: BenchmarkPerformanceCommand provisions its own
+      # isolated sqlite via BenchmarkIsolation::activate() and runs migrate
+      # against that. The baseline / head sections below also run
+      # `migrate:fresh` themselves.
       - name: Capture baseline benchmark on main
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,8 @@ jobs:
       - run: composer test
 
   # Browser tests are split into 4 parallel runners via Pest's native
-  # `--shard=X/Y` (4.6+). Each shard also runs `--parallel` internally, so total
-  # concurrency is (shards × per-runner workers).
+  # `--shard=X/Y` (4.6+). Each shard also runs `--parallel` internally, so
+  # total concurrency is (shards × per-runner workers).
   test-browser-shard:
     name: test-browser-shard (${{ matrix.shard }}/4)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,13 +88,18 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-chromium
+          # Include env.ImageVersion (runner image build id, bumped every
+          # ~1-2 weeks). Without it the cache key only reflected OS +
+          # Playwright version, so a runner-image bump that dropped a shared
+          # lib could leave us with a cached Chromium that fails to launch
+          # because install-deps was never re-run.
+          key: playwright-${{ runner.os }}-${{ env.ImageVersion }}-${{ steps.playwright-version.outputs.version }}-chromium
       # On cache hit we do *nothing*: ubuntu-latest already ships Google Chrome
       # and the shared libraries Chromium needs, so the cached browser binary
       # launches without `playwright install-deps`. Skipping this step saves
-      # ~18s per shard on every PR (apt update + apt install). On cache miss
-      # (Playwright version bump) we still pay `--with-deps` once so a future
-      # runner image change can't silently break us.
+      # ~18s per shard on every PR (apt update + apt install). The cache key
+      # above bakes in env.ImageVersion, so a Playwright bump *or* a runner
+      # image roll forces a miss → `--with-deps` re-runs.
       - if: steps.playwright-cache.outputs.cache-hit != 'true'
         name: Install Chromium + OS deps
         run: npx playwright install chromium --with-deps

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,11 @@ includes:
 
 parameters:
     level: 6
+    # Pin the result-cache dir so CI can persist it between runs (see
+    # `Cache PHPStan result cache` in .github/workflows/ci.yml). PHPStan
+    # writes %tmpDir%/cache/PHPStan/resultCache.php and reuses per-file
+    # analysis when source/dependency hashes are unchanged.
+    tmpDir: /tmp/phpstan
     paths:
         - app/
     scanDirectories:


### PR DESCRIPTION
Wall-time bottleneck was test-browser-shard at ~1m 50s. Combined wins:

- Composite action caches vendor/ + bootstrap/cache/{packages,services}.php
  keyed on composer.lock+composer.json+patch-native-preload.php; on hit we
  skip composer install (and its post-autoload-dump scripts) entirely.
  Composer download cache stays unconditionally restored so benchmark-perf's
  base-SHA install still benefits.
- Drop `touch database/database.sqlite` + `php artisan migrate --force` from
  test-core, test-browser-shard, and benchmark-perf's preamble. Tests use
  DB_DATABASE=:memory: from phpunit.xml; benchmark-perf's command builds its
  own isolated sqlite via BenchmarkIsolation and the baseline/head sections
  already run their own migrate:fresh.
- Skip `playwright install-deps chromium` on cache hit. ubuntu-latest ships
  Google Chrome and the shared libs Chromium needs, so the cached browser
  launches without re-running apt update + install (~18s saved per shard
  per run). Cache miss still pays --with-deps so a future runner image
  change can't silently break us.
- Bump browser shards 3 -> 4 to flatten the slowest-shard tail.
- Persist PHPStan's result cache across runs (pinned tmpDir: /tmp/phpstan,
  cache key keyed on app sources + neon config). Re-runs analyse only
  changed files (~1s warm vs ~5-8s cold).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline with improved caching mechanisms for faster builds and deployments.
  * Enhanced testing infrastructure through streamlined database and browser testing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->