### PR TITLE
Use modern scrollbar properties globally

### DIFF
--- a/app/Providers/NativeAppServiceProvider.php
+++ b/app/Providers/NativeAppServiceProvider.php
@@ -6,6 +6,7 @@ namespace App\Providers;
 
 use App\Actions\OpenProjectFromPathAction;
 use App\Actions\ResolveStartupRouteAction;
+use App\Console\Benchmark\BenchmarkIsolation;
 use App\Listeners\HandleDeepLink;
 use App\Listeners\HandleMenuItemClicked;
 use App\Support\ZoomRoleMenuItem;
@@ -281,6 +282,14 @@ class NativeAppServiceProvider implements ProvidesPhpIni
     private function clearCompiledViewsForDev(): void
     {
         if (! config('app.debug')) {
+            return;
+        }
+
+        if (app()->environment('testing')) {
+            return;
+        }
+
+        if ((string) getenv(BenchmarkIsolation::ENV_ENABLED) === '1') {
             return;
         }
 

--- a/config/theme.php
+++ b/config/theme.php
@@ -43,9 +43,6 @@ return [
             'hunk-bg' => 'rgba(9,9,11,0.03)',
             'hover-bg' => 'rgba(9,9,11,0.04)',
             'selected-bg' => 'rgba(9,9,11,0.08)',
-            'scrollbar-track' => 'transparent',
-            'scrollbar-thumb' => '#d4d4d8',
-            'scrollbar-hover' => '#a1a1aa',
         ],
         'dark' => [
             'add-bg' => 'rgba(74,222,128,0.10)',
@@ -55,9 +52,6 @@ return [
             'hunk-bg' => 'rgba(250,250,250,0.04)',
             'hover-bg' => 'rgba(250,250,250,0.05)',
             'selected-bg' => 'rgba(250,250,250,0.10)',
-            'scrollbar-track' => 'transparent',
-            'scrollbar-thumb' => '#3f3f46',
-            'scrollbar-hover' => '#52525b',
         ],
     ],
 ];

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -9,3 +9,8 @@
     --font-sans: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
         'Segoe UI Symbol', 'Noto Color Emoji';
 }
+
+* {
+    scrollbar-width: thin;
+    scrollbar-color: gray transparent;
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -131,12 +131,6 @@
             width: 3px;
             background: rgb(var(--gh-muted) / 0.5);
         }
-        /* Scrollbar styling */
-        ::-webkit-scrollbar { width: 6px; height: 6px; }
-        ::-webkit-scrollbar-track { background: transparent; }
-        ::-webkit-scrollbar-thumb { background: var(--gh-scrollbar-thumb); border-radius: 3px; }
-        ::-webkit-scrollbar-thumb:hover { background: var(--gh-scrollbar-hover); }
-
         /* Prevent Flux menu scroll-lock from hiding scrollbar and causing layout shift */
         html { overflow-y: scroll !important; }
 

--- a/tests/Unit/IgnoreServiceTest.php
+++ b/tests/Unit/IgnoreServiceTest.php
@@ -3,6 +3,9 @@
 use App\Services\IgnoreService;
 use Faker\Factory as Faker;
 use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+uses(TestCase::class);
 
 beforeEach(function () {
     $this->faker = Faker::create();

--- a/tests/Unit/Providers/NativeAppServiceProviderTest.php
+++ b/tests/Unit/Providers/NativeAppServiceProviderTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use App\Console\Benchmark\BenchmarkIsolation;
 use App\Providers\NativeAppServiceProvider;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
 use Tests\TestCase;
 
 uses(TestCase::class);
@@ -49,4 +51,47 @@ test('dev compiled view cleanup does not clear persisted updater state', functio
         'status' => 'checking',
         'simulateTerminalState' => true,
     ]);
+});
+
+test('dev compiled view cleanup skips deletion in testing environment', function () {
+    $viewsPath = storage_path('framework/views');
+    File::ensureDirectoryExists($viewsPath);
+    $sentinel = $viewsPath.'/sentinel-'.bin2hex(random_bytes(4)).'.php';
+    File::put($sentinel, '<?php // sentinel');
+
+    $provider = new ReflectionClass(NativeAppServiceProvider::class);
+    $clearCompiledViewsForDev = $provider->getMethod('clearCompiledViewsForDev');
+    $clearCompiledViewsForDev->setAccessible(true);
+
+    $clearCompiledViewsForDev->invoke(new NativeAppServiceProvider);
+
+    expect(File::exists($sentinel))->toBeTrue();
+    expect($provider->getProperty('compiledViewsClearedForDev')->getValue())->toBeFalse();
+
+    File::delete($sentinel);
+});
+
+test('dev compiled view cleanup skips deletion when benchmark isolation is active', function () {
+    $viewsPath = storage_path('framework/views');
+    File::ensureDirectoryExists($viewsPath);
+    $sentinel = $viewsPath.'/sentinel-'.bin2hex(random_bytes(4)).'.php';
+    File::put($sentinel, '<?php // sentinel');
+
+    putenv(BenchmarkIsolation::ENV_ENABLED.'=1');
+    app()->detectEnvironment(fn () => 'local');
+
+    try {
+        $provider = new ReflectionClass(NativeAppServiceProvider::class);
+        $clearCompiledViewsForDev = $provider->getMethod('clearCompiledViewsForDev');
+        $clearCompiledViewsForDev->setAccessible(true);
+
+        $clearCompiledViewsForDev->invoke(new NativeAppServiceProvider);
+
+        expect(File::exists($sentinel))->toBeTrue();
+        expect($provider->getProperty('compiledViewsClearedForDev')->getValue())->toBeFalse();
+    } finally {
+        File::delete($sentinel);
+        putenv(BenchmarkIsolation::ENV_ENABLED);
+        app()->detectEnvironment(fn () => 'testing');
+    }
 });

--- a/tests/Unit/Providers/NativeAppServiceProviderTest.php
+++ b/tests/Unit/Providers/NativeAppServiceProviderTest.php
@@ -77,10 +77,13 @@ test('dev compiled view cleanup skips deletion when benchmark isolation is activ
     $sentinel = $viewsPath.'/sentinel-'.bin2hex(random_bytes(4)).'.php';
     File::put($sentinel, '<?php // sentinel');
 
-    putenv(BenchmarkIsolation::ENV_ENABLED.'=1');
-    app()->detectEnvironment(fn () => 'local');
+    $originalEnvVar = getenv(BenchmarkIsolation::ENV_ENABLED);
+    $originalEnvironment = app()->environment();
 
     try {
+        putenv(BenchmarkIsolation::ENV_ENABLED.'=1');
+        app()->detectEnvironment(fn () => 'local');
+
         $provider = new ReflectionClass(NativeAppServiceProvider::class);
         $clearCompiledViewsForDev = $provider->getMethod('clearCompiledViewsForDev');
         $clearCompiledViewsForDev->setAccessible(true);
@@ -91,7 +94,13 @@ test('dev compiled view cleanup skips deletion when benchmark isolation is activ
         expect($provider->getProperty('compiledViewsClearedForDev')->getValue())->toBeFalse();
     } finally {
         File::delete($sentinel);
-        putenv(BenchmarkIsolation::ENV_ENABLED);
-        app()->detectEnvironment(fn () => 'testing');
+
+        if ($originalEnvVar === false) {
+            putenv(BenchmarkIsolation::ENV_ENABLED);
+        } else {
+            putenv(BenchmarkIsolation::ENV_ENABLED.'='.$originalEnvVar);
+        }
+
+        app()->detectEnvironment(fn () => $originalEnvironment);
     }
 });

--- a/tests/Unit/Scripts/PatchNativePreloadTest.php
+++ b/tests/Unit/Scripts/PatchNativePreloadTest.php
@@ -30,7 +30,7 @@ JS;
 
 function tempPreload(?string $content = null): string
 {
-    $dir = sys_get_temp_dir().'/rfa_test_preload_'.uniqid();
+    $dir = sys_get_temp_dir().'/rfa_test_preload_'.getmypid().'_'.uniqid('', true);
     mkdir($dir, 0755, true);
     $path = $dir.'/index.mjs';
 
@@ -42,8 +42,7 @@ function tempPreload(?string $content = null): string
 }
 
 afterEach(function () {
-    // Clean up any temp files created during the test
-    foreach (glob(sys_get_temp_dir().'/rfa_test_preload_*', GLOB_ONLYDIR) as $dir) {
+    foreach (glob(sys_get_temp_dir().'/rfa_test_preload_'.getmypid().'_*', GLOB_ONLYDIR) as $dir) {
         array_map('unlink', glob($dir.'/*'));
         rmdir($dir);
     }


### PR DESCRIPTION
Replace ::-webkit-scrollbar custom styling with the standard
scrollbar-width / scrollbar-color properties applied to all elements,
and drop the now-unused scrollbar-track/thumb/hover theme tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated scrollbar styling for a thinner, cleaner appearance (gray thumb, transparent track); removed some inline custom scrollbar rules so native/browser defaults apply where appropriate.

* **Bug Fixes**
  * Prevents compiled view cleanup during testing and benchmark-isolation modes to avoid accidental view removal.

* **Tests**
  * Added unit tests to verify the preserved view-cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->