### PR TITLE
Document parallel-test flakiness traps in tests/CLAUDE.md

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -23,6 +23,14 @@ target the same isolated blade dir.
 If you need shared mutable state in a test, switch to `composer test:serial`
 or scope the test to its own file so it gets its own worker.
 
+Boot-time code (service providers, registered macros, etc.) that mutates
+shared paths like `storage/framework/views` must bail when
+`app()->environment('testing')` **and** when
+`getenv(BenchmarkIsolation::ENV_ENABLED) === '1'`. Otherwise it races
+against other workers' isolated compile dirs and produces flakes that only
+reproduce under `--parallel`. See `NativeAppServiceProvider::clearCompiledViewsForDev`
+for the pattern.
+
 ## Suite Model
 
 - `Core` = `Unit` + `Arch`
@@ -45,6 +53,12 @@ or scope the test to its own file so it gets its own worker.
 - Prefer `InteractsWithTestRepositories::createTempDirectory()` for tracked temp dirs
 - If a test needs git repo setup, use `InteractsWithTestRepositories::initTestRepo()` and `commitTestRepo()`
 - Global cleanup in `tests/Pest.php` removes tracked temp dirs after each test
+- If you must build an ad-hoc path under `sys_get_temp_dir()`, scope it by
+  **both** `getmypid()` and `uniqid('', true)` (e.g.
+  `sys_get_temp_dir().'/rfa_test_foo_'.getmypid().'_'.uniqid('', true)`).
+  `afterEach` cleanup must glob the same PID-scoped prefix — a bare
+  `rfa_test_foo_*` glob wipes other parallel workers' files mid-run and
+  produces flakes that only surface under `--parallel`.
 - `initTestRepo()` copies a per-process `.git` template (single `cp -R`) instead
   of running `git init` + 3 `git config` calls. Author/committer/`commit.gpgsign`
   come from `GIT_AUTHOR_*` / `GIT_CONFIG_*` env vars in `phpunit.xml`, so

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -24,12 +24,13 @@ If you need shared mutable state in a test, switch to `composer test:serial`
 or scope the test to its own file so it gets its own worker.
 
 Boot-time code (service providers, registered macros, etc.) that mutates
-shared paths like `storage/framework/views` must bail when
-`app()->environment('testing')` **and** when
-`getenv(BenchmarkIsolation::ENV_ENABLED) === '1'`. Otherwise it races
-against other workers' isolated compile dirs and produces flakes that only
-reproduce under `--parallel`. See `NativeAppServiceProvider::clearCompiledViewsForDev`
-for the pattern.
+shared paths like `storage/framework/views` must short-circuit if **either**
+of the following is true: `app()->environment('testing')`, or
+`getenv(BenchmarkIsolation::ENV_ENABLED) === '1'`. Either flag alone is
+enough to trigger the guard. Otherwise it races against other workers'
+isolated compile dirs and produces flakes that only reproduce under
+`--parallel`. See `NativeAppServiceProvider::clearCompiledViewsForDev` for
+the pattern.
 
 ## Suite Model
 


### PR DESCRIPTION
## Summary
Captures the two patterns that surfaced in #60 so we don't repeat them:

- **Temp Directories**: ad-hoc `sys_get_temp_dir()` paths must be scoped by `getmypid()` *and* `uniqid('', true)`, and the matching `afterEach` cleanup must glob the same PID-scoped prefix. A bare `rfa_test_foo_*` glob wipes other parallel workers' files mid-run.
- **Parallel test isolation**: boot-time code (service providers, registered macros) that mutates shared paths like `storage/framework/views` must bail in the `testing` env *and* under `BenchmarkIsolation::ENV_ENABLED=1`. References `NativeAppServiceProvider::clearCompiledViewsForDev` as the canonical example.

Both edits land in the existing sections of `tests/CLAUDE.md` rather than introducing a new file. Considered enforcing this with a custom PHPStan rule or arch test, but the patterns are too semantic (closure context, per-call-site intent) for static checks to catch without high false-positive noise.

## Test plan
- [ ] Docs-only change; no code paths affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J72wKTAqTf567J131eBN2P)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced testing guidelines with best practices for preventing cross-worker test flakes in parallel execution environments, including guidance on safely managing shared storage paths and temporary directory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->