### PR TITLE
Make "Hide reviewed" considerate: animate, undo, and surface recents

### DIFF
--- a/resources/CLAUDE.md
+++ b/resources/CLAUDE.md
@@ -32,6 +32,59 @@
 - Adaptive density: chrome elements breathe, code areas stay compact
 - Prefer plain text + font styling over Flux badges for inline stats
 
+## UX Principles
+
+These are the rules of thumb we audit against. They're drawn from Material Design Motion, Apple HIG, Nielsen Norman Group research, WCAG 2.3.x, and the Doherty Threshold (sub-400ms responsiveness). When auditing or adding new UI, walk through this list.
+
+### Motion
+- **Durations**: 150–250ms for ordinary state changes; never exceed 400ms (perceived as lag).
+- **Easing**: `ease-out` for elements leaving (fast start, soft landing — reads as "departing"); `ease-in-out` or Material's standard easing `cubic-bezier(0.4, 0.0, 0.2, 1)` for state changes that stay on-screen.
+- **Direction**: prefer **fade + vertical height-collapse** over horizontal slides for items that belong to a list. Horizontal slides break Gestalt continuity and pull the eye away from the surrounding rows. Use `x-collapse` for height (already loaded) and a CSS opacity transition for the fade — they compose.
+- **Asymmetric timing**: leaving slightly faster than entering. Re-appearing items (undo) get the slower entry to draw the eye back to where the change happened.
+- **In-flight cancellation**: never block interaction during a transition. Alpine's `x-show` + `x-collapse` snap to the final state when toggled mid-flight — don't reimplement.
+
+### Reversibility
+- Every action that hides, deletes, or moves user-visible content must offer undo. The bar is high: silent destructive UI is the bug, not the recovery affordance.
+- Reuse the central undo mechanism: dispatch `undo-available` from PHP (`resources/views/livewire/undo-toast.blade.php`) and add a case to `ReviewPage::undo()`. ⌘Z is wired centrally — don't reimplement per-component.
+- Payload shape: `{ type: string, payload: mixed, message: string, ttl?: int }`. Keep `payload` self-contained so the undo handler doesn't need ambient state.
+
+### Coalescing
+- Repeated same-type undo entries within **3 seconds** merge into one stack entry. Avoids toast spam during bursts (e.g., marking 10 files in a row). Implemented in `undo-toast.blade.php`'s `push()`.
+- Counter-pattern: don't coalesce across different types or across long gaps — the user's intent has shifted.
+
+### Accessibility
+- Honor `prefers-reduced-motion`: the global rule in `resources/css/app.css` collapses transition/animation durations to ~0ms. Don't fight it with inline styles or `!important` overrides.
+- Use `aria-live="polite"` for transient feedback (toasts already do this).
+- Provide keyboard parity for any mouse-only action. ⌘Z for undo, `/` for filter focus, `Esc` to clear.
+- Focus must not jump unexpectedly when items are added/removed.
+
+### Spatial continuity
+- Items that belong to a list reflow vertically when added/removed; don't slide them in/out horizontally on a vertical list.
+- When hiding many items in a burst, batch-acknowledge (one coalesced toast) rather than animating each individually.
+- Provide an in-place recovery surface for hidden items when feasible (e.g., the "Recently reviewed" sidebar group on `⚡review-page` shows the last 5 marked-reviewed files so the user can un-mark without leaving Hide-reviewed mode).
+
+### Feedback latency (Doherty Threshold)
+- Perceived latency under 100ms = "instant"; under 400ms = "responsive"; above = "lag".
+- Use `skipRender()` aggressively on Livewire actions whose UI update is handled client-side via Alpine. The `skipRender` table in this file is the canonical reference — extend it when adding new actions.
+- Never wait for the server before showing visual feedback for actions whose outcome is locally predictable.
+
+### Anti-patterns to flag in audits
+- Instant DOM-style hide (`display: none`) on user-initiated actions without motion or acknowledgment.
+- Horizontal slide-in/out on rows of a vertical list.
+- Animations longer than 400ms or shorter than 100ms.
+- Missing `prefers-reduced-motion` fallback (covered globally now — flag any per-component overrides that bypass it).
+- Destructive or hide-from-view actions without an undo path.
+- Toasts that stack visually (one toast per action) rather than coalescing during bursts.
+- Server round-trip required to render the result of a purely visual toggle.
+- Loss of focus or scroll position when items reflow.
+
+### References
+- [Material Design — Motion](https://m3.material.io/styles/motion/overview): durations, easing, choreography.
+- [Apple HIG — Motion](https://developer.apple.com/design/human-interface-guidelines/motion): subtlety, reduce-motion semantics.
+- Nielsen Norman Group — animation duration research (sub-400ms perceived as responsive).
+- WCAG 2.3.3 (Animation from Interactions) and Success Criterion on `prefers-reduced-motion`.
+- Doherty Threshold (1982): sub-400ms feedback for productivity.
+
 ## Livewire SFC Components
 
 Page components live in `resources/views/pages/` (namespace `pages::`). Non-page components live in `resources/views/livewire/` (default namespace).
@@ -100,11 +153,12 @@ ReviewPage (`resources/views/pages/⚡review-page.blade.php`) renders N DiffFile
 | `collapse-all-files` | ReviewPage Alpine `$dispatch` | DiffFile Alpine `@window` | none |
 | `expand-all-files` | ReviewPage Alpine `$dispatch` | DiffFile Alpine `@window` | none |
 | `expand-file` | ReviewPage Alpine `$dispatch` | DiffFile Alpine `@window` | `{id}` |
-| `undo-available` | ReviewPage PHP dispatch | undo-toast Alpine `@window` | `{type: 'delete'\|'clear-all'\|'discard', payload: comment[]\|int, message: string}` |
+| `undo-available` | ReviewPage PHP dispatch | undo-toast Alpine `@window` | `{type: 'delete'\|'clear-all'\|'discard'\|'mark-reviewed', payload: comment[]\|int\|{filePaths: string[]}, message: string}` |
+| `reviewed-files-reverted` | ReviewPage PHP dispatch (`unmarkReviewed`) | DiffFile + ReviewPage Alpine `@window` | `{fileIds: string[]}` |
 | `discard-file` | DiffFile Alpine `$dispatch` | ReviewPage `#[On]` | `{fileId}` |
 | `fingerprint-reset` | ReviewPage PHP dispatch | change-polling Alpine `@window` | none |
 | `show-remote-menu` | DiffFile Alpine `$dispatch` | ReviewPage Alpine `@window` | `{target: 'file'\|'line', fileId, filePath, oldPath, side?, start?, end?, clientX, clientY}` |
 
 ### Known Debt
 
-- **diff-file's Alpine `reviewed` state isn't reset by `reset-reviewed-files`.** The DiffFile's local `reviewed` mirror (initialized from the `isReviewed` Livewire prop, driving the checkbox and auto-collapse) has no `@reset-reviewed-files.window` listener. If any flow fires `reset-reviewed-files`, the review-page sidebar clears its `reviewedFiles` map and the comments-drawer refreshes, but individual diff-file checkboxes can visually remain checked until the component re-hydrates. Today this is masked because reset paths are paired with full reloads / navigation. Fix is a one-line handler: `@reset-reviewed-files.window="reviewed = false; collapsed = false"` on the diff-file root. Deferred to keep the mirror decision reversible; migrating the whole file to `@entangle('isReviewed').live` would be the alternative but requires moving `toggleReviewed` from review-page into diff-file.
+_(Empty — the previous "diff-file `reset-reviewed-files` listener" item was resolved alongside the mark-reviewed undo work; the listener now exists on diff-file's root.)_

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -14,3 +14,16 @@
     scrollbar-width: thin;
     scrollbar-color: gray transparent;
 }
+
+/* Honor OS-level reduce-motion: collapse durations to ~instant so animations
+   never become a barrier for users with vestibular disorders. See WCAG 2.3.3. */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}

--- a/resources/views/livewire/undo-toast.blade.php
+++ b/resources/views/livewire/undo-toast.blade.php
@@ -3,6 +3,7 @@
     x-data="{
         stack: [],
         intervalId: null,
+        coalesceWindowMs: 3000,
 
         get current() { return this.stack[0] ?? null },
         get visible() { return this.current !== null },
@@ -12,11 +13,30 @@
         },
 
         push(detail) {
+            // Coalesce: bursts of same-type 'mark-reviewed' within 3s merge into one
+            // toast so power users marking many files don't see a wall of toasts.
+            const top = this.stack[0];
+            const ttl = detail.ttl ?? 10;
+            if (
+                detail.type === 'mark-reviewed'
+                && top && top.type === 'mark-reviewed'
+                && (Date.now() - top.createdAt) < this.coalesceWindowMs
+                && Array.isArray(detail.payload?.filePaths)
+                && Array.isArray(top.payload?.filePaths)
+            ) {
+                top.payload.filePaths.push(...detail.payload.filePaths);
+                top.createdAt = Date.now();
+                top.expiresAt = Date.now() + ttl * 1000;
+                const n = top.payload.filePaths.length;
+                top.message = n + ' files marked as reviewed';
+                return;
+            }
             this.stack.unshift({
                 type: detail.type,
                 payload: detail.payload,
                 message: detail.message ?? 'Action completed',
-                expiresAt: Date.now() + (detail.ttl ?? 10) * 1000,
+                createdAt: Date.now(),
+                expiresAt: Date.now() + ttl * 1000,
             });
             this.startTicker();
         },

--- a/resources/views/livewire/undo-toast.blade.php
+++ b/resources/views/livewire/undo-toast.blade.php
@@ -24,11 +24,18 @@
                 && Array.isArray(detail.payload?.filePaths)
                 && Array.isArray(top.payload?.filePaths)
             ) {
-                top.payload.filePaths.push(...detail.payload.filePaths);
+                // Dedupe so the displayed count never inflates when the same file
+                // is marked → un-marked → marked again within the coalesce window.
+                top.payload.filePaths = Array.from(new Set([
+                    ...top.payload.filePaths,
+                    ...detail.payload.filePaths,
+                ]));
                 top.createdAt = Date.now();
                 top.expiresAt = Date.now() + ttl * 1000;
                 const n = top.payload.filePaths.length;
-                top.message = n + ' files marked as reviewed';
+                top.message = n === 1
+                    ? '1 file marked as reviewed'
+                    : n + ' files marked as reviewed';
                 return;
             }
             this.stack.unshift({

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -228,6 +228,8 @@ new class extends Component {
     @collapse-all-files.window="autoExpandedForComment = false; collapsed = true"
     @expand-all-files.window="autoExpandedForComment = false; collapsed = false"
     @expand-file.window="if ($event.detail.id === fileId) { autoExpandedForComment = false; collapsed = false }"
+    @reset-reviewed-files.window="reviewed = false; collapsed = false"
+    @reviewed-files-reverted.window="if ($event.detail.fileIds?.includes(fileId)) { reviewed = false; collapsed = false }"
     class="group"
 >
     {{-- File header --}}

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -76,6 +76,15 @@ new #[Layout('layouts.app')] class extends Component
     /** @var array<string, string> */
     public array $reviewedFiles = [];
 
+    /**
+     * MRU-ordered file IDs marked as reviewed during the current "Hide reviewed" session.
+     * Surfaced as a sticky "Recently reviewed" sidebar group so the user can un-mark
+     * without leaving Hide-reviewed mode. Capped at 5; reset when the user shows all files.
+     *
+     * @var array<int, string>
+     */
+    public array $recentlyReviewedIds = [];
+
     public ?string $activeFileId = null;
 
     /** @var array<int, array<string, mixed>> */
@@ -704,8 +713,65 @@ new #[Layout('layouts.app')] class extends Component
         match ($type) {
             'delete', 'clear-all' => $this->restoreComments($payload),
             'discard' => $this->restoreDiscardedFile($payload),
+            'mark-reviewed' => $this->unmarkReviewed($payload['filePaths'] ?? []),
             default => null,
         };
+    }
+
+    /**
+     * Undo handler for "mark-reviewed". Re-runs the toggle for each path so persistence
+     * mirrors the user's path back to unreviewed; broadcasts a reset event so DiffFile's
+     * Alpine `reviewed` mirror flips off.
+     *
+     * @param  array<int, string>  $filePaths
+     */
+    public function unmarkReviewed(array $filePaths): void
+    {
+        if (empty($filePaths)) {
+            return;
+        }
+
+        $action = app(ToggleReviewedAction::class);
+        $target = $this->buildDiffTarget();
+        $reverted = [];
+
+        foreach ($filePaths as $filePath) {
+            if (! array_key_exists($filePath, $this->reviewedFiles)) {
+                continue;
+            }
+
+            $result = $action->handle(
+                $this->reviewedFiles,
+                $filePath,
+                $this->files,
+                $this->repoPath,
+                $target,
+                $this->projectId ?: null,
+            );
+
+            if ($result === null) {
+                continue;
+            }
+
+            $this->reviewedFiles = $result;
+            $reverted[] = $filePath;
+        }
+
+        if (empty($reverted)) {
+            return;
+        }
+
+        $revertedIds = collect($this->files)
+            ->whereIn('path', $reverted)
+            ->pluck('id')
+            ->all();
+
+        $this->recentlyReviewedIds = array_values(array_filter(
+            $this->recentlyReviewedIds,
+            fn (string $id): bool => ! in_array($id, $revertedIds, true),
+        ));
+
+        $this->dispatch('reviewed-files-reverted', fileIds: $revertedIds);
     }
 
     // endregion: Trash & Discard
@@ -715,6 +781,8 @@ new #[Layout('layouts.app')] class extends Component
     #[On('toggle-reviewed')]
     public function toggleReviewed(string $filePath): void
     {
+        $wasReviewed = array_key_exists($filePath, $this->reviewedFiles);
+
         $result = app(ToggleReviewedAction::class)->handle(
             $this->reviewedFiles,
             $filePath,
@@ -729,6 +797,39 @@ new #[Layout('layouts.app')] class extends Component
         }
 
         $this->reviewedFiles = $result;
+
+        $isNowReviewed = array_key_exists($filePath, $this->reviewedFiles);
+        $fileId = collect($this->files)->firstWhere('path', $filePath)['id'] ?? null;
+
+        if (! $wasReviewed && $isNowReviewed) {
+            // Promote to MRU front of "Recently reviewed", dedupe, cap at 5.
+            if ($fileId !== null) {
+                $this->recentlyReviewedIds = array_values(array_unique(
+                    array_merge([$fileId], $this->recentlyReviewedIds)
+                ));
+                $this->recentlyReviewedIds = array_slice($this->recentlyReviewedIds, 0, 5);
+            }
+
+            $this->dispatch(
+                'undo-available',
+                type: 'mark-reviewed',
+                payload: ['filePaths' => [$filePath]],
+                message: 'Marked '.basename($filePath).' as reviewed',
+            );
+        } elseif ($wasReviewed && ! $isNowReviewed && $fileId !== null) {
+            // User un-marked manually; remove from recents so the group stays accurate.
+            $this->recentlyReviewedIds = array_values(array_filter(
+                $this->recentlyReviewedIds,
+                fn (string $id): bool => $id !== $fileId,
+            ));
+        }
+
+        $this->skipRender();
+    }
+
+    public function clearRecentlyReviewed(): void
+    {
+        $this->recentlyReviewedIds = [];
         $this->skipRender();
     }
 
@@ -906,6 +1007,22 @@ new #[Layout('layouts.app')] class extends Component
         hideReviewed: false,
         fileFilter: '',
         sourceFileEntries: @js(collect($sourceFiles)->map(fn($f) => ['id' => $f['id'], 'path' => $f['path']])->values()->all()),
+        filesById: @js(collect($sourceFiles)->mapWithKeys(fn($f) => [$f['id'] => [
+            'path' => $f['path'],
+            'badgeLabel' => match($f['status']) {
+                'added' => 'A',
+                'deleted' => 'D',
+                'renamed' => 'R',
+                'commented' => 'C',
+                default => 'M',
+            },
+            'badgeClass' => match($f['status']) {
+                'added' => 'text-gh-green',
+                'deleted' => 'text-gh-red',
+                'commented' => 'text-gh-muted',
+                default => 'text-amber-500 dark:text-amber-400',
+            },
+        ]])->all()),
         sidebarWidth: $store.settings.sidebarWidth,
         resizing: false,
         remoteMenu: { open: false, x: 0, y: 0, projectSlug: '', type: '', params: {}, label: '' },
@@ -1003,6 +1120,7 @@ new #[Layout('layouts.app')] class extends Component
     }"
     @file-reviewed-changed.window="reviewedFiles[$event.detail.id] = $event.detail.reviewed"
     @reset-reviewed-files.window="reviewedFiles = {}"
+    @reviewed-files-reverted.window="($event.detail.fileIds || []).forEach(id => { reviewedFiles[id] = false })"
     @show-remote-menu.window="showRemoteMenu($event)"
     @copy-to-clipboard.window="
         navigator.clipboard.writeText($event.detail.text).then(() => {
@@ -1156,7 +1274,7 @@ new #[Layout('layouts.app')] class extends Component
                     <flux:button variant="ghost" size="sm" icon="eye" icon:variant="outline"
                         tooltip="Show all files"
                         class="col-start-1 row-start-1"
-                        @click="hideReviewed = false"
+                        @click="hideReviewed = false; $wire.clearRecentlyReviewed()"
                         x-show="hideReviewed" x-cloak />
                 </div>
 
@@ -1361,6 +1479,39 @@ new #[Layout('layouts.app')] class extends Component
                     x-ref="fileFilterInput"
                     @keydown.escape="fileFilter = ''; $el.blur()"
                 />
+                {{-- Recently reviewed: surfaces just-marked files in Hide-reviewed mode so the user can un-mark in place --}}
+                <template x-if="hideReviewed && $wire.recentlyReviewedIds.length">
+                    <div data-testid="recently-reviewed-group" class="mb-3">
+                        <div class="flex items-center justify-between mb-2">
+                            <span class="section-label text-gh-muted">Recently reviewed</span>
+                            <button type="button"
+                                @click="$wire.clearRecentlyReviewed()"
+                                class="text-[10px] uppercase tracking-wider text-gh-muted hover:text-gh-text transition-colors"
+                                title="Clear recently reviewed list">Clear</button>
+                        </div>
+                        <template x-for="id in $wire.recentlyReviewedIds" :key="id">
+                            <div
+                                x-show="filesById[id] && (fileFilter === '' || filesById[id].path.toLowerCase().includes(fileFilter.toLowerCase()))"
+                                x-collapse.duration.200ms
+                                class="w-full text-left px-2.5 py-2 rounded text-xs hover:bg-gh-border/30 flex items-center gap-2.5 group transition-opacity duration-150 ease-out text-gh-muted/70"
+                            >
+                                <button type="button" @click="scrollToFile(id)" class="flex items-center gap-2.5 min-w-0 flex-1">
+                                    <span class="font-mono font-medium shrink-0" :class="filesById[id]?.badgeClass" x-text="filesById[id]?.badgeLabel"></span>
+                                    <span class="truncate font-mono line-through opacity-80" :title="filesById[id]?.path" x-text="filesById[id]?.path"></span>
+                                </button>
+                                <flux:tooltip content="Un-mark as reviewed">
+                                    <button type="button"
+                                        @click="$wire.dispatch('toggle-reviewed', { filePath: filesById[id]?.path }); $dispatch('file-reviewed-changed', { id, reviewed: false })"
+                                        class="shrink-0 size-3.5 flex items-center justify-center text-gh-green hover:text-gh-text transition-colors"
+                                        aria-label="Un-mark as reviewed">
+                                        <flux:icon icon="check" variant="outline" class="!size-3.5" />
+                                    </button>
+                                </flux:tooltip>
+                            </div>
+                        </template>
+                        <div class="border-b border-gh-border my-3"></div>
+                    </div>
+                </template>
                 @foreach($sourceFiles as $file)
                     @php
                         [$badgeColor, $badgeLabel] = match($file['status']) {
@@ -1373,8 +1524,12 @@ new #[Layout('layouts.app')] class extends Component
                     @endphp
                     <div
                         x-show="fileMatchesFilter(@js($file['path']), '{{ $file['id'] }}')"
-                        class="w-full text-left px-2.5 py-2 rounded text-xs hover:bg-gh-border/30 flex items-center gap-2.5 group transition-colors"
-                        :class="activeFile === '{{ $file['id'] }}' ? 'bg-gh-link/10 text-gh-link' : 'text-gh-muted'"
+                        x-collapse.duration.200ms
+                        class="w-full text-left px-2.5 py-2 rounded text-xs hover:bg-gh-border/30 flex items-center gap-2.5 group transition-[opacity,colors] duration-150 ease-out"
+                        :class="[
+                            activeFile === '{{ $file['id'] }}' ? 'bg-gh-link/10 text-gh-link' : 'text-gh-muted',
+                            fileMatchesFilter(@js($file['path']), '{{ $file['id'] }}') ? 'opacity-100' : 'opacity-0',
+                        ]"
                     >
                         <button @click="scrollToFile('{{ $file['id'] }}')" class="flex items-center gap-2.5 min-w-0 flex-1">
                             <span class="font-mono font-medium shrink-0 {{ match($badgeLabel) { 'A' => 'text-gh-green', 'D' => 'text-gh-red', 'C' => 'text-gh-muted', default => 'text-amber-500 dark:text-amber-400' } }}">{{ $badgeLabel }}</span>
@@ -1537,7 +1692,11 @@ new #[Layout('layouts.app')] class extends Component
                 {{-- Source Files --}}
                 @php $singleFile = count($sourceFiles) === 1 && count($reviewPairs) === 0; @endphp
                 @foreach($sourceFiles as $file)
-                    <div id="{{ $file['id'] }}" class="border-b border-gh-border" x-show="fileMatchesFilter(@js($file['path']), '{{ $file['id'] }}')">
+                    <div id="{{ $file['id'] }}"
+                         class="border-b border-gh-border transition-opacity duration-150 ease-out"
+                         x-show="fileMatchesFilter(@js($file['path']), '{{ $file['id'] }}')"
+                         x-collapse.duration.200ms
+                         :class="fileMatchesFilter(@js($file['path']), '{{ $file['id'] }}') ? 'opacity-100' : 'opacity-0'">
                         <livewire:diff-file
                             :key="$file['id']"
                             :file="$file"

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -41,6 +41,9 @@ new #[Layout('layouts.app')] class extends Component
 {
     use InteractsWithRemoteLinks;
 
+    /** Undo-toast `type` for the "marked file as reviewed" action. */
+    private const UNDO_TYPE_MARK_REVIEWED = 'mark-reviewed';
+
     /** @var array<int, array<string, mixed>> */
     public array $files = [];
 
@@ -713,18 +716,12 @@ new #[Layout('layouts.app')] class extends Component
         match ($type) {
             'delete', 'clear-all' => $this->restoreComments($payload),
             'discard' => $this->restoreDiscardedFile($payload),
-            'mark-reviewed' => $this->unmarkReviewed($payload['filePaths'] ?? []),
+            self::UNDO_TYPE_MARK_REVIEWED => $this->unmarkReviewed($payload['filePaths'] ?? []),
             default => null,
         };
     }
 
-    /**
-     * Undo handler for "mark-reviewed". Re-runs the toggle for each path so persistence
-     * mirrors the user's path back to unreviewed; broadcasts a reset event so DiffFile's
-     * Alpine `reviewed` mirror flips off.
-     *
-     * @param  array<int, string>  $filePaths
-     */
+    /** @param array<int, string> $filePaths */
     public function unmarkReviewed(array $filePaths): void
     {
         if (empty($filePaths)) {
@@ -761,10 +758,11 @@ new #[Layout('layouts.app')] class extends Component
             return;
         }
 
-        $revertedIds = collect($this->files)
-            ->whereIn('path', $reverted)
-            ->pluck('id')
-            ->all();
+        $pathToId = array_column($this->files, 'id', 'path');
+        $revertedIds = array_values(array_filter(array_map(
+            fn (string $path): ?string => $pathToId[$path] ?? null,
+            $reverted,
+        )));
 
         $this->recentlyReviewedIds = array_values(array_filter(
             $this->recentlyReviewedIds,
@@ -802,26 +800,29 @@ new #[Layout('layouts.app')] class extends Component
         $fileId = collect($this->files)->firstWhere('path', $filePath)['id'] ?? null;
 
         if (! $wasReviewed && $isNowReviewed) {
-            // Promote to MRU front of "Recently reviewed", dedupe, cap at 5.
             if ($fileId !== null) {
-                $this->recentlyReviewedIds = array_values(array_unique(
-                    array_merge([$fileId], $this->recentlyReviewedIds)
-                ));
-                $this->recentlyReviewedIds = array_slice($this->recentlyReviewedIds, 0, 5);
+                $this->recentlyReviewedIds = array_slice(
+                    array_values(array_unique(array_merge([$fileId], $this->recentlyReviewedIds))),
+                    0, 5,
+                );
             }
 
             $this->dispatch(
                 'undo-available',
-                type: 'mark-reviewed',
+                type: self::UNDO_TYPE_MARK_REVIEWED,
                 payload: ['filePaths' => [$filePath]],
                 message: 'Marked '.basename($filePath).' as reviewed',
             );
         } elseif ($wasReviewed && ! $isNowReviewed && $fileId !== null) {
-            // User un-marked manually; remove from recents so the group stays accurate.
             $this->recentlyReviewedIds = array_values(array_filter(
                 $this->recentlyReviewedIds,
                 fn (string $id): bool => $id !== $fileId,
             ));
+
+            // Single un-mark transition uses the same broadcast as bulk undo so the
+            // sidebar's reviewedFiles map and DiffFile's `reviewed` mirror flip in lockstep
+            // — callers (e.g. the "Recently reviewed" group) don't have to dual-dispatch.
+            $this->dispatch('reviewed-files-reverted', fileIds: [$fileId]);
         }
 
         $this->skipRender();
@@ -1501,7 +1502,7 @@ new #[Layout('layouts.app')] class extends Component
                                 </button>
                                 <flux:tooltip content="Un-mark as reviewed">
                                     <button type="button"
-                                        @click="$wire.dispatch('toggle-reviewed', { filePath: filesById[id]?.path }); $dispatch('file-reviewed-changed', { id, reviewed: false })"
+                                        @click="$wire.dispatch('toggle-reviewed', { filePath: filesById[id]?.path })"
                                         class="shrink-0 size-3.5 flex items-center justify-center text-gh-green hover:text-gh-text transition-colors"
                                         aria-label="Un-mark as reviewed">
                                         <flux:icon icon="check" variant="outline" class="!size-3.5" />

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -728,40 +728,22 @@ new #[Layout('layouts.app')] class extends Component
             return;
         }
 
-        $action = app(ToggleReviewedAction::class);
-        $target = $this->buildDiffTarget();
-        $reverted = [];
+        // Delete by path directly so the undo survives a refresh: if content-hash drift
+        // dropped the entry from $reviewedFiles between mark and undo, the action's
+        // toggle would no-op and the DB row would linger despite the toast firing.
+        \App\Models\ReviewedFile::query()
+            ->forProjectOrRepo($this->projectId ?: null, $this->repoPath)
+            ->whereIn('file_path', $filePaths)
+            ->delete();
 
         foreach ($filePaths as $filePath) {
-            if (! array_key_exists($filePath, $this->reviewedFiles)) {
-                continue;
-            }
-
-            $result = $action->handle(
-                $this->reviewedFiles,
-                $filePath,
-                $this->files,
-                $this->repoPath,
-                $target,
-                $this->projectId ?: null,
-            );
-
-            if ($result === null) {
-                continue;
-            }
-
-            $this->reviewedFiles = $result;
-            $reverted[] = $filePath;
-        }
-
-        if (empty($reverted)) {
-            return;
+            unset($this->reviewedFiles[$filePath]);
         }
 
         $pathToId = array_column($this->files, 'id', 'path');
         $revertedIds = array_values(array_filter(array_map(
             fn (string $path): ?string => $pathToId[$path] ?? null,
-            $reverted,
+            $filePaths,
         )));
 
         $this->recentlyReviewedIds = array_values(array_filter(
@@ -769,7 +751,11 @@ new #[Layout('layouts.app')] class extends Component
             fn (string $id): bool => ! in_array($id, $revertedIds, true),
         ));
 
-        $this->dispatch('reviewed-files-reverted', fileIds: $revertedIds);
+        if (! empty($revertedIds)) {
+            $this->dispatch('reviewed-files-reverted', fileIds: $revertedIds);
+        }
+
+        $this->skipRender();
     }
 
     // endregion: Trash & Discard
@@ -797,7 +783,10 @@ new #[Layout('layouts.app')] class extends Component
         $this->reviewedFiles = $result;
 
         $isNowReviewed = array_key_exists($filePath, $this->reviewedFiles);
-        $fileId = collect($this->files)->firstWhere('path', $filePath)['id'] ?? null;
+        // Source-file lookup (not $this->files) so review-pair artifacts
+        // (.json/.md) never consume a slot in the "Recently reviewed" group —
+        // that group renders from sourceFiles only.
+        $fileId = collect($this->sourceFiles)->firstWhere('path', $filePath)['id'] ?? null;
 
         if (! $wasReviewed && $isNowReviewed) {
             if ($fileId !== null) {

--- a/tests/Unit/Livewire/ReviewPageReviewedUndoTest.php
+++ b/tests/Unit/Livewire/ReviewPageReviewedUndoTest.php
@@ -99,12 +99,19 @@ test('un-marking a file does not dispatch undo-available', function () {
         ->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
         ->assertDispatched('undo-available');
 
-    // The second dispatch is its own request; effects reset, and the un-mark must
-    // produce no new undo-available dispatch.
     $component->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
         ->assertNotDispatched('undo-available');
 
     expect($component->get('reviewedFiles'))->toBe([]);
+});
+
+test('un-marking a file dispatches reviewed-files-reverted so DiffFile + sidebar mirror flip in lockstep', function () {
+    Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
+        ->assertDispatched('reviewed-files-reverted', function (string $event, array $params) {
+            return $params['fileIds'] === ['id-foo'];
+        });
 });
 
 test('undo mark-reviewed restores file to unreviewed state', function () {

--- a/tests/Unit/Livewire/ReviewPageReviewedUndoTest.php
+++ b/tests/Unit/Livewire/ReviewPageReviewedUndoTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Actions\BackfillGlobalGitignoreAction;
 use App\Actions\GetFileListAction;
+use App\Actions\GroupReviewFilesAction;
 use App\Actions\ResolveProjectAction;
 use App\Actions\SessionStateAction;
 use App\DTOs\DiffTarget;
@@ -218,4 +219,69 @@ test('clearRecentlyReviewed skips parent re-render', function () {
         ->call('clearRecentlyReviewed');
 
     expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue();
+});
+
+test('unmarkReviewed skips parent re-render to avoid 1+N child hydration', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
+        ->call('undo', 'mark-reviewed', ['filePaths' => ['src/Foo.php']]);
+
+    expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue();
+});
+
+test('undo mark-reviewed deletes the DB row even when reviewedFiles map dropped the entry (refresh / hash drift)', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php');
+
+    expect(ReviewedFile::where('file_path', 'src/Foo.php')->count())->toBe(1);
+
+    // Simulate hash drift / refresh dropping the path from the in-memory map while
+    // the DB row remains. The toast still holds the path and undo must clean up the row.
+    $component->set('reviewedFiles', []);
+    $component->call('undo', 'mark-reviewed', ['filePaths' => ['src/Foo.php']]);
+
+    expect(ReviewedFile::where('file_path', 'src/Foo.php')->count())->toBe(0);
+});
+
+test('marking a review-pair artifact does not consume a "Recently reviewed" slot', function () {
+    // Bind a GroupReviewFilesAction that puts notes.json into reviewPairs and
+    // leaves Foo as the only source file. The page-level $files still includes
+    // the pair artifact, so toggleReviewed must look it up via $sourceFiles.
+    app()->bind(GroupReviewFilesAction::class, fn () => new class
+    {
+        public function handle(array $files): array
+        {
+            $pairs = [];
+            $source = [];
+            foreach ($files as $f) {
+                if (str_ends_with($f['path'], 'notes.json')) {
+                    $pairs[] = ['basename' => 'notes', 'id' => $f['id'], 'displayName' => 'notes'];
+                } else {
+                    $source[] = $f;
+                }
+            }
+
+            return ['reviewPairs' => $pairs, 'sourceFiles' => $source];
+        }
+    });
+
+    $files = [
+        ['id' => 'id-foo', 'path' => 'src/Foo.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 1, 'deletions' => 0, 'isBinary' => false, 'isUntracked' => false],
+        ['id' => 'id-pair', 'path' => 'reviews/notes.json', 'status' => 'added', 'oldPath' => null, 'additions' => 1, 'deletions' => 0, 'isBinary' => false, 'isUntracked' => false],
+    ];
+    app()->bind(GetFileListAction::class, fn () => new class($files)
+    {
+        public function __construct(private array $files) {}
+
+        public function handle(string $repoPath, bool $clearCache = true, ?int $projectId = null, ?string $globalGitignorePath = null, ?DiffTarget $target = null): array
+        {
+            return $this->files;
+        }
+    });
+
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('toggle-reviewed', filePath: 'reviews/notes.json');
+
+    expect($component->get('recentlyReviewedIds'))->toBe([]);
+    expect($component->get('reviewedFiles'))->toHaveKey('reviews/notes.json');
 });

--- a/tests/Unit/Livewire/ReviewPageReviewedUndoTest.php
+++ b/tests/Unit/Livewire/ReviewPageReviewedUndoTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\BackfillGlobalGitignoreAction;
+use App\Actions\GetFileListAction;
+use App\Actions\ResolveProjectAction;
+use App\Actions\SessionStateAction;
+use App\DTOs\DiffTarget;
+use App\Models\Project;
+use App\Models\ReviewedFile;
+use App\Services\GitFileContentService;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+beforeEach(function () {
+    $this->files = [
+        ['id' => 'id-foo', 'path' => 'src/Foo.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 5, 'deletions' => 2, 'isBinary' => false, 'isUntracked' => false],
+        ['id' => 'id-bar', 'path' => 'src/Bar.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 3, 'deletions' => 1, 'isBinary' => false, 'isUntracked' => false],
+        ['id' => 'id-baz', 'path' => 'src/Baz.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 1, 'deletions' => 0, 'isBinary' => false, 'isUntracked' => false],
+        ['id' => 'id-qux', 'path' => 'src/Qux.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 1, 'deletions' => 0, 'isBinary' => false, 'isUntracked' => false],
+        ['id' => 'id-zap', 'path' => 'src/Zap.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 1, 'deletions' => 0, 'isBinary' => false, 'isUntracked' => false],
+        ['id' => 'id-six', 'path' => 'src/Six.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 1, 'deletions' => 0, 'isBinary' => false, 'isUntracked' => false],
+    ];
+
+    $this->project = Project::create([
+        'slug' => 'test-project',
+        'name' => 'Test Project',
+        'path' => '/tmp/repo',
+        'git_common_dir' => '/tmp/repo/.git',
+        'branch' => 'main',
+        'global_gitignore_path' => null,
+        'respect_global_gitignore' => true,
+    ]);
+
+    $project = $this->project;
+    $files = $this->files;
+
+    app()->bind(ResolveProjectAction::class, fn () => new class($project)
+    {
+        public function __construct(private Project $project) {}
+
+        public function handle(string $slug, bool $touch = false): ?array
+        {
+            return $this->project->toArray();
+        }
+    });
+
+    app()->bind(GetFileListAction::class, fn () => new class($files)
+    {
+        public function __construct(private array $files) {}
+
+        public function handle(string $repoPath, bool $clearCache = true, ?int $projectId = null, ?string $globalGitignorePath = null, ?DiffTarget $target = null): array
+        {
+            return $this->files;
+        }
+    });
+
+    app()->bind(SessionStateAction::class, fn () => new class
+    {
+        public function handle(string $repoPath, array $currentFiles, ?int $projectId = null, ?DiffTarget $target = null): array
+        {
+            return ['comments' => [], 'reviewedFiles' => [], 'globalComment' => '', 'orphanedPaths' => []];
+        }
+
+        public function saveGlobalNote(string $repoPath, string $globalComment, ?int $projectId = null): void {}
+    });
+
+    $gitFileContentMock = Mockery::mock(GitFileContentService::class);
+    $gitFileContentMock->shouldReceive('hashAt')->andReturn('mock-hash');
+    app()->instance(GitFileContentService::class, $gitFileContentMock);
+
+    app()->bind(BackfillGlobalGitignoreAction::class, fn () => new class
+    {
+        public function handle(int $projectId, string $repoPath): ?string
+        {
+            return null;
+        }
+    });
+});
+
+// -- Undo toast for mark-reviewed --
+
+test('marking a file reviewed dispatches undo-available with mark-reviewed payload', function () {
+    Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
+        ->assertDispatched('undo-available', function (string $event, array $params) {
+            return $params['type'] === 'mark-reviewed'
+                && $params['payload'] === ['filePaths' => ['src/Foo.php']]
+                && str_contains($params['message'], 'Foo.php');
+        });
+});
+
+test('un-marking a file does not dispatch undo-available', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
+        ->assertDispatched('undo-available');
+
+    // The second dispatch is its own request; effects reset, and the un-mark must
+    // produce no new undo-available dispatch.
+    $component->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
+        ->assertNotDispatched('undo-available');
+
+    expect($component->get('reviewedFiles'))->toBe([]);
+});
+
+test('undo mark-reviewed restores file to unreviewed state', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php');
+
+    expect($component->get('reviewedFiles'))->toHaveKey('src/Foo.php');
+
+    $component->call('undo', 'mark-reviewed', ['filePaths' => ['src/Foo.php']]);
+
+    expect($component->get('reviewedFiles'))->not->toHaveKey('src/Foo.php');
+    expect(ReviewedFile::where('file_path', 'src/Foo.php')->count())->toBe(0);
+});
+
+test('undo mark-reviewed dispatches reviewed-files-reverted with affected file ids', function () {
+    Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
+        ->dispatch('toggle-reviewed', filePath: 'src/Bar.php')
+        ->call('undo', 'mark-reviewed', ['filePaths' => ['src/Foo.php', 'src/Bar.php']])
+        ->assertDispatched('reviewed-files-reverted', function (string $event, array $params) {
+            return collect($params['fileIds'])->sort()->values()->all() === ['id-bar', 'id-foo'];
+        });
+});
+
+test('undo mark-reviewed silently ignores unknown paths', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->call('undo', 'mark-reviewed', ['filePaths' => ['src/Nonexistent.php']]);
+
+    expect($component->get('reviewedFiles'))->toBe([]);
+});
+
+// -- Recently reviewed list --
+
+test('marking a file pushes its id onto recentlyReviewedIds (MRU front)', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
+        ->dispatch('toggle-reviewed', filePath: 'src/Bar.php');
+
+    expect($component->get('recentlyReviewedIds'))->toBe(['id-bar', 'id-foo']);
+});
+
+test('recentlyReviewedIds caps at 5 (oldest evicted)', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
+        ->dispatch('toggle-reviewed', filePath: 'src/Bar.php')
+        ->dispatch('toggle-reviewed', filePath: 'src/Baz.php')
+        ->dispatch('toggle-reviewed', filePath: 'src/Qux.php')
+        ->dispatch('toggle-reviewed', filePath: 'src/Zap.php')
+        ->dispatch('toggle-reviewed', filePath: 'src/Six.php');
+
+    $ids = $component->get('recentlyReviewedIds');
+
+    expect($ids)->toHaveCount(5);
+    expect($ids)->toBe(['id-six', 'id-zap', 'id-qux', 'id-baz', 'id-bar']);
+    expect($ids)->not->toContain('id-foo');
+});
+
+test('un-marking a file removes it from recentlyReviewedIds', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
+        ->dispatch('toggle-reviewed', filePath: 'src/Bar.php')
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php');
+
+    expect($component->get('recentlyReviewedIds'))->toBe(['id-bar']);
+});
+
+test('undo mark-reviewed removes reverted ids from recentlyReviewedIds', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
+        ->dispatch('toggle-reviewed', filePath: 'src/Bar.php')
+        ->call('undo', 'mark-reviewed', ['filePaths' => ['src/Foo.php']]);
+
+    expect($component->get('recentlyReviewedIds'))->toBe(['id-bar']);
+});
+
+test('clearRecentlyReviewed empties the list without un-marking files', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
+        ->dispatch('toggle-reviewed', filePath: 'src/Bar.php')
+        ->call('clearRecentlyReviewed');
+
+    expect($component->get('recentlyReviewedIds'))->toBe([]);
+    expect($component->get('reviewedFiles'))->toHaveKeys(['src/Foo.php', 'src/Bar.php']);
+});
+
+test('marking the same file twice does not duplicate in recentlyReviewedIds', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php');
+
+    expect($component->get('recentlyReviewedIds'))->toBe(['id-foo']);
+});
+
+test('toggleReviewed still skips parent re-render after these changes', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php');
+
+    expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue();
+});
+
+test('clearRecentlyReviewed skips parent re-render', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->call('clearRecentlyReviewed');
+
+    expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue();
+});


### PR DESCRIPTION
Three layered improvements so marking a file reviewed no longer feels
abrupt or hard to recover from:

- Mark-reviewed undo toast (⌘Z), routed through the existing
  undo-available stack with a 3s coalesce window so power users marking
  many files in a row see one merged toast.
- Fade + height-collapse on file wrappers (sidebar row + main content)
  with a global prefers-reduced-motion fallback in app.css.
- "Recently reviewed" sidebar group: last 5 LIFO files stay visible,
  dimmed and struck, with an in-place un-mark control. Only shown in
  Hide-reviewed mode; cleared on Show-all and via an explicit Clear.

Resolves the diff-file reset-reviewed-files debt by adding the listener
on diff-file's root.

Documents the underlying UX principles (motion durations/easing,
reversibility, coalescing, accessibility, Doherty threshold) in
resources/CLAUDE.md so we have a checklist for future audits across
the rest of the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Recently reviewed" sticky sidebar showing a capped, deduped MRU of recently marked files
  * New undo event to revert reviewed files; undo now removes reviewed records and updates UI

* **Accessibility**
  * Respect for users' reduced-motion preference (animations/transitions effectively disabled)

* **Bug Fixes**
  * Improved sync between reviewed state, undo, and UI mirrors

* **Tests**
  * Comprehensive tests covering undo, MRU behavior, and reviewed-state edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->