### PR TITLE
Lead the empty state with a tagline, not a status

### DIFF
--- a/app/Actions/CheckForChangesAction.php
+++ b/app/Actions/CheckForChangesAction.php
@@ -12,8 +12,11 @@ final readonly class CheckForChangesAction
         private GitDiffService $gitDiffService,
     ) {}
 
-    public function handle(string $repoPath, ?string $globalGitignorePath = null): string
+    /**
+     * @return array{fingerprint: string, count: int}
+     */
+    public function handle(string $repoPath, ?string $globalGitignorePath = null): array
     {
-        return $this->gitDiffService->getWorkingDirectoryFingerprint($repoPath, $globalGitignorePath);
+        return $this->gitDiffService->getWorkingDirectoryStatus($repoPath, $globalGitignorePath);
     }
 }

--- a/app/Services/GitDiffService.php
+++ b/app/Services/GitDiffService.php
@@ -196,6 +196,14 @@ class GitDiffService
 
     public function getWorkingDirectoryFingerprint(string $repoPath, ?string $globalGitignorePath = null): string
     {
+        return $this->getWorkingDirectoryStatus($repoPath, $globalGitignorePath)['fingerprint'];
+    }
+
+    /**
+     * @return array{fingerprint: string, count: int}
+     */
+    public function getWorkingDirectoryStatus(string $repoPath, ?string $globalGitignorePath = null): array
+    {
         $excludes = $this->ignoreService->getExcludePathspecs($repoPath);
 
         $nameStatus = $this->git->run($repoPath, [
@@ -217,7 +225,6 @@ class GitDiffService
             ),
         ]);
 
-        // Filter untracked files through the same excludes as getFileList
         $lines = array_filter($lines, function (string $line) use ($excludes) {
             if (! str_starts_with($line, "?\t")) {
                 return true;
@@ -228,7 +235,10 @@ class GitDiffService
 
         sort($lines);
 
-        return hash('xxh128', implode("\n", $lines));
+        return [
+            'fingerprint' => hash('xxh128', implode("\n", $lines)),
+            'count' => count($lines),
+        ];
     }
 
     public function fileDiffFingerprint(string $repoPath, string $path, ?DiffTarget $target = null): string

--- a/resources/views/components/arm-commit-button.blade.php
+++ b/resources/views/components/arm-commit-button.blade.php
@@ -1,0 +1,57 @@
+@props([
+    'confirm',
+    'label' => null,
+    'confirmLabel' => 'Confirm?',
+    'icon' => null,
+    'iconConfirm' => null,
+    'tooltip' => null,
+    'ariaLabel' => null,
+    'variant' => 'ghost',
+    'size' => 'sm',
+    'duration' => 3000,
+    'buttonClass' => '',
+])
+
+@php
+    $resolvedIconConfirm = $iconConfirm ?? $icon;
+    $resolvedAriaLabel = $ariaLabel ?? $label ?? 'Action';
+    $armedTooltip = 'Click again to confirm — cancels in '.(int) round($duration / 1000).'s';
+@endphp
+
+<div
+    x-data="{
+        armed: false,
+        timer: null,
+        arm() { this.armed = true; this.timer = setTimeout(() => this.disarm(), {{ (int) $duration }}); },
+        disarm() { this.armed = false; if (this.timer) { clearTimeout(this.timer); this.timer = null; } },
+        handle() { if (!this.armed) { this.arm(); return; } this.disarm(); {{ $confirm }}; },
+    }"
+    @keydown.escape.window="disarm()"
+    @click.outside="disarm()"
+    {{ $attributes->only('class')->class('relative inline-flex') }}
+>
+    <flux:button
+        variant="{{ $variant }}"
+        size="{{ $size }}"
+        x-bind:tooltip="armed ? @js($armedTooltip) : @js($tooltip)"
+        x-bind:aria-label="armed ? @js($confirmLabel) : @js($resolvedAriaLabel)"
+        @click.stop.prevent="handle()"
+        x-bind:class="armed && '!text-red-500 dark:!text-red-400 hover:!bg-red-500/10'"
+        class="{{ $buttonClass }}"
+    >
+        @if($icon)
+            <flux:icon x-show="!armed" icon="{{ $icon }}" variant="outline" />
+            <flux:icon x-show="armed" x-cloak icon="{{ $resolvedIconConfirm }}" variant="outline" />
+        @endif
+        @if($label !== null)
+            <span x-text="armed ? @js($confirmLabel) : @js($label)"></span>
+        @endif
+    </flux:button>
+    <div
+        aria-hidden="true"
+        class="pointer-events-none absolute inset-x-1 -bottom-px h-0.5 origin-left rounded-full bg-red-500/70"
+        x-bind:style="armed
+            ? 'transform:scaleX(0); transition:transform {{ (int) $duration }}ms linear'
+            : 'transform:scaleX(1); opacity:0; transition:none'"
+    ></div>
+</div>

--- a/resources/views/components/arm-commit-button.blade.php
+++ b/resources/views/components/arm-commit-button.blade.php
@@ -1,20 +1,13 @@
 @props([
-    'confirm',
-    'label' => null,
-    'confirmLabel' => 'Confirm?',
-    'icon' => null,
-    'iconConfirm' => null,
+    'icon',
     'tooltip' => null,
     'ariaLabel' => null,
-    'variant' => 'ghost',
-    'size' => 'sm',
+    'confirmLabel' => 'Confirm?',
     'duration' => 3000,
-    'buttonClass' => '',
 ])
 
 @php
-    $resolvedIconConfirm = $iconConfirm ?? $icon;
-    $resolvedAriaLabel = $ariaLabel ?? $label ?? 'Action';
+    $resolvedAriaLabel = $ariaLabel ?? $tooltip ?? 'Action';
     $armedTooltip = 'Click again to confirm — cancels in '.(int) round($duration / 1000).'s';
 @endphp
 
@@ -22,30 +15,36 @@
     x-data="{
         armed: false,
         timer: null,
-        arm() { this.armed = true; this.timer = setTimeout(() => this.disarm(), {{ (int) $duration }}); },
-        disarm() { this.armed = false; if (this.timer) { clearTimeout(this.timer); this.timer = null; } },
-        handle() { if (!this.armed) { this.arm(); return; } this.disarm(); {{ $confirm }}; },
+        arm() {
+            this.armed = true;
+            this.timer = setTimeout(() => this.disarm(), {{ (int) $duration }});
+        },
+        disarm() {
+            if (! this.armed) return;
+            this.armed = false;
+            clearTimeout(this.timer);
+            this.timer = null;
+        },
+        handle() {
+            if (! this.armed) { this.arm(); return; }
+            this.disarm();
+            this.$dispatch('confirmed');
+        },
+        destroy() { clearTimeout(this.timer); },
     }"
     @keydown.escape.window="disarm()"
     @click.outside="disarm()"
-    {{ $attributes->only('class')->class('relative inline-flex') }}
+    {{ $attributes->class('relative inline-flex') }}
 >
     <flux:button
-        variant="{{ $variant }}"
-        size="{{ $size }}"
+        variant="ghost"
+        size="sm"
         x-bind:tooltip="armed ? @js($armedTooltip) : @js($tooltip)"
         x-bind:aria-label="armed ? @js($confirmLabel) : @js($resolvedAriaLabel)"
         @click.stop.prevent="handle()"
         x-bind:class="armed && '!text-red-500 dark:!text-red-400 hover:!bg-red-500/10'"
-        class="{{ $buttonClass }}"
     >
-        @if($icon)
-            <flux:icon x-show="!armed" icon="{{ $icon }}" variant="outline" />
-            <flux:icon x-show="armed" x-cloak icon="{{ $resolvedIconConfirm }}" variant="outline" />
-        @endif
-        @if($label !== null)
-            <span x-text="armed ? @js($confirmLabel) : @js($label)"></span>
-        @endif
+        <flux:icon icon="{{ $icon }}" variant="outline" />
     </flux:button>
     <div
         aria-hidden="true"

--- a/resources/views/components/arm-commit-button.blade.php
+++ b/resources/views/components/arm-commit-button.blade.php
@@ -41,16 +41,18 @@
         size="sm"
         x-bind:tooltip="armed ? @js($armedTooltip) : @js($tooltip)"
         x-bind:aria-label="armed ? @js($confirmLabel) : @js($resolvedAriaLabel)"
+        x-bind:aria-pressed="armed"
         @click.stop.prevent="handle()"
-        x-bind:class="armed && '!text-red-500 dark:!text-red-400 hover:!bg-red-500/10'"
+        x-bind:class="armed && '!text-gh-red hover:!bg-gh-red/10'"
     >
-        <flux:icon icon="{{ $icon }}" variant="outline" />
+        <flux:icon :icon="$icon" variant="outline" />
     </flux:button>
     <div
         aria-hidden="true"
-        class="pointer-events-none absolute inset-x-1 -bottom-px h-0.5 origin-left rounded-full bg-red-500/70"
+        class="pointer-events-none absolute inset-x-1 -bottom-px h-0.5 origin-left rounded-full bg-gh-red/70"
         x-bind:style="armed
             ? 'transform:scaleX(0); transition:transform {{ (int) $duration }}ms linear'
             : 'transform:scaleX(1); opacity:0; transition:none'"
     ></div>
+    <span class="sr-only" aria-live="polite" x-text="armed ? @js($armedTooltip) : ''"></span>
 </div>

--- a/resources/views/livewire/submit-bar.blade.php
+++ b/resources/views/livewire/submit-bar.blade.php
@@ -56,9 +56,8 @@
                     <div class="flex items-center gap-3">
                         <x-arm-commit-button
                             icon="trash"
-                            aria-label="Clear all comments"
                             tooltip="Clear all comments"
-                            confirm="$wire.clearAllComments()"
+                            @confirmed="$wire.clearAllComments()"
                         />
                         <span class="w-px h-4 bg-gh-border"></span>
                     </div>

--- a/resources/views/livewire/submit-bar.blade.php
+++ b/resources/views/livewire/submit-bar.blade.php
@@ -1,13 +1,32 @@
 {{-- Fixed bottom submit bar --}}
 <div class="fixed bottom-0 left-0 right-0 z-50 bg-gh-bg/80 backdrop-blur-sm border-t border-gh-border">
     @if($submitted)
-        <div class="px-5 py-3.5 flex items-center justify-between">
-            <div class="flex items-center gap-3">
-                <flux:icon icon="check-circle" variant="outline" class="text-gh-green" />
-                <span class="font-semibold tracking-brutal">Review submitted</span>
-                <span class="font-mono text-xs text-gh-muted px-2 py-0.5 rounded border border-gh-border">{{ $exportResult }}</span>
+        <div class="px-5 py-3.5 flex items-center justify-between gap-4">
+            <div class="flex items-center gap-3 min-w-0">
+                <flux:icon icon="check-circle" variant="outline" class="text-gh-green shrink-0" />
+                <span class="font-semibold tracking-brutal shrink-0">Review submitted</span>
+                <span class="font-mono text-xs text-gh-muted px-2 py-0.5 rounded border border-gh-border truncate">{{ $exportResult }}</span>
             </div>
-            <span class="text-xs text-gh-muted">Copied to clipboard &mdash; Ctrl+C to exit</span>
+            <div class="flex items-center gap-2 shrink-0">
+                <span class="font-mono text-[11px] text-gh-muted">Copied to clipboard</span>
+                <flux:button
+                    size="sm"
+                    icon="clipboard-document"
+                    icon:variant="outline"
+                    @click="$dispatch('copy-to-clipboard', { text: @js($exportResult), toast: 'Copied again' })"
+                >
+                    Copy again
+                </flux:button>
+                <flux:button
+                    variant="primary"
+                    size="sm"
+                    icon="pencil-square"
+                    icon:variant="outline"
+                    wire:click="startNewReview"
+                >
+                    Start a new review
+                </flux:button>
+            </div>
         </div>
     @else
         <div class="px-5 py-3.5 flex items-center gap-4"

--- a/resources/views/livewire/submit-bar.blade.php
+++ b/resources/views/livewire/submit-bar.blade.php
@@ -8,11 +8,11 @@
                 <span class="font-mono text-xs text-gh-muted px-2 py-0.5 rounded border border-gh-border truncate">{{ $exportResult }}</span>
             </div>
             <div class="flex items-center gap-2 shrink-0">
-                <span class="font-mono text-[11px] text-gh-muted">Copied to clipboard</span>
                 <flux:button
                     size="sm"
                     icon="clipboard-document"
                     icon:variant="outline"
+                    tooltip="Already on your clipboard — re-copy if you've copied something else since"
                     @click="$dispatch('copy-to-clipboard', { text: @js($exportResult), toast: 'Copied again' })"
                 >
                     Copy again

--- a/resources/views/livewire/submit-bar.blade.php
+++ b/resources/views/livewire/submit-bar.blade.php
@@ -54,21 +54,12 @@
                 </template>
                 <template x-if="commentCount + draftCount > 0">
                     <div class="flex items-center gap-3">
-                        <flux:tooltip content="Clear all comments">
-                            <flux:button
-                                variant="ghost"
-                                size="sm"
-                                icon="trash"
-                                icon:variant="outline"
-                                @click="
-                                    let parts = [];
-                                    if (commentCount > 0) parts.push(commentCount + ' comment' + (commentCount === 1 ? '' : 's'));
-                                    if (draftCount > 0) parts.push(draftCount + ' draft' + (draftCount === 1 ? '' : 's'));
-                                    if (confirm('Clear ' + parts.join(' and ') + '?')) $wire.clearAllComments()
-                                "
-                                class="hover:!text-red-400"
-                            />
-                        </flux:tooltip>
+                        <x-arm-commit-button
+                            icon="trash"
+                            aria-label="Clear all comments"
+                            tooltip="Clear all comments"
+                            confirm="$wire.clearAllComments()"
+                        />
                         <span class="w-px h-4 bg-gh-border"></span>
                     </div>
                 </template>

--- a/resources/views/livewire/undo-toast.blade.php
+++ b/resources/views/livewire/undo-toast.blade.php
@@ -91,23 +91,34 @@
     role="status"
     aria-live="polite"
     data-testid="undo-toast"
-    class="fixed bottom-20 left-1/2 -translate-x-1/2 z-50"
+    class="fixed bottom-20 left-1/2 -translate-x-1/2 z-50 max-w-sm"
 >
-    <div class="bg-gh-surface border border-gh-border rounded font-mono text-xs flex items-center gap-3 shadow-lg"
-        :class="current?.type === 'discard' ? 'px-5 py-3 min-w-[360px] border-l-2 border-l-gh-accent' : 'px-4 py-2.5'">
-        <span x-text="current?.message" class="text-gh-text" :class="current?.type === 'discard' ? 'flex-1' : ''"></span>
-        <button @click="undo()" class="text-gh-link hover:underline font-medium" data-testid="undo-button">Undo</button>
-        <template x-if="current?.type === 'discard'">
-            <button @click="dismiss()" class="text-gh-muted hover:text-gh-text font-medium" data-testid="undo-ok-button">OK</button>
-        </template>
-        <span class="text-gh-muted" x-text="remaining + 's'"></span>
-        {{-- Progress bar --}}
-        <div class="w-16 h-0.5 bg-gh-border rounded-full overflow-hidden">
-            <div class="h-full bg-gh-muted transition-all duration-1000 ease-linear rounded-full"
-                :style="{ width: (remaining / 10 * 100) + '%' }"></div>
+    {{-- Visual language matches flux:toast: rounded-xl, shadow-lg, surface bg + border --}}
+    <div class="p-2 flex rounded-xl shadow-lg bg-gh-surface border border-gh-border"
+        :class="current?.type === 'discard' && 'border-l-2 border-l-gh-accent'">
+        <div class="flex-1 flex items-center gap-3 py-1.5 px-2.5 text-sm">
+            <span x-text="current?.message" class="font-medium text-gh-text"></span>
+            <button
+                @click="undo()"
+                class="font-medium text-gh-link hover:underline shrink-0"
+                data-testid="undo-button"
+            >Undo</button>
+            <template x-if="current?.type === 'discard'">
+                <button
+                    @click="dismiss()"
+                    class="font-medium text-gh-muted hover:text-gh-text shrink-0"
+                    data-testid="undo-ok-button"
+                >OK</button>
+            </template>
+            <span class="font-mono text-xs text-gh-muted tabular-nums shrink-0" x-text="remaining + 's'"></span>
         </div>
-        <button @click="dismiss()" class="text-gh-muted hover:text-gh-text" aria-label="Dismiss" x-show="current?.type !== 'discard'">
-            <flux:icon icon="x-mark" variant="outline" class="!size-3.5" />
+        <button
+            @click="dismiss()"
+            class="inline-flex items-center justify-center rounded-md size-8 text-gh-muted hover:text-gh-text hover:bg-gh-hover-bg shrink-0"
+            aria-label="Dismiss"
+            x-show="current?.type !== 'discard'"
+        >
+            <flux:icon icon="x-mark" variant="outline" class="!size-4" />
         </button>
     </div>
 </div>

--- a/resources/views/livewire/undo-toast.blade.php
+++ b/resources/views/livewire/undo-toast.blade.php
@@ -93,7 +93,6 @@
     data-testid="undo-toast"
     class="fixed bottom-20 left-1/2 -translate-x-1/2 z-50 max-w-sm"
 >
-    {{-- Visual language matches flux:toast: rounded-xl, shadow-lg, surface bg + border --}}
     <div class="p-2 flex rounded-xl shadow-lg bg-gh-surface border border-gh-border"
         :class="current?.type === 'discard' && 'border-l-2 border-l-gh-accent'">
         <div class="flex-1 flex items-center gap-3 py-1.5 px-2.5 text-sm">

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -317,10 +317,8 @@ new class extends Component {
                 <span class="text-gh-red">-{{ $file['deletions'] }}</span>
             @endif
 
-            {{-- Comment indicator: ghost when no comments, full when comments exist --}}
-            <div class="flex items-center gap-0.5"
-                 :class="$wire.fileComments.length === 0 && 'opacity-30 group-hover:opacity-100 transition-opacity'"
-            >
+            {{-- Comment indicator: always visible (primary action) --}}
+            <div class="flex items-center gap-0.5">
                 <flux:button
                     x-ref="fileCommentBtn"
                     tooltip="Add file comment"

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -863,6 +863,12 @@ new #[Layout('layouts.app')] class extends Component
         $affectedFileIds->each(fn (string $fileId) => $this->dispatchFileComments($fileId));
     }
 
+    public function startNewReview(): void
+    {
+        $this->submitted = false;
+        $this->exportResult = null;
+    }
+
     // endregion: Review State & Export
 
     // region: Computed, Helpers & Persistence

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1268,6 +1268,7 @@ new #[Layout('layouts.app')] class extends Component
                     <div data-testid="change-polling" x-data="{
                         hasChanges: false,
                         fingerprint: null,
+                        currentCount: 0,
                         polling: null,
                         async check() {
                             try {
@@ -1277,6 +1278,7 @@ new #[Layout('layouts.app')] class extends Component
                                     this.fingerprint = data.fingerprint;
                                 } else if (data.fingerprint !== this.fingerprint) {
                                     this.hasChanges = true;
+                                    this.currentCount = data.count ?? 0;
                                 }
                             } catch {}
                         },
@@ -1287,12 +1289,18 @@ new #[Layout('layouts.app')] class extends Component
                             }, 60000);
                         },
                         softRefresh() { $wire.softRefresh(); },
-                        hardReload() { window.location.reload(); }
+                        hardReload() { window.location.reload(); },
+                        get tooltip() {
+                            if (!this.hasChanges) return 'Refresh · ⌘R · ⌘⇧R to hard reload';
+                            const n = this.currentCount;
+                            const noun = n === 1 ? 'file' : 'files';
+                            return `${n} ${noun} changed externally — click to refresh`;
+                        }
                     }"
                     x-init="startPolling();
                         $store.keymap.register('⌘R', () => softRefresh(), { allowInEditable: true });
                         $store.keymap.register('⌘⇧R', () => hardReload(), { allowInEditable: true });"
-                    @fingerprint-reset.window="fingerprint = null; hasChanges = false; clearInterval(polling); startPolling();"
+                    @fingerprint-reset.window="fingerprint = null; hasChanges = false; currentCount = 0; clearInterval(polling); startPolling();"
                     @refresh-completed.window="
                         const n = $event.detail?.changedCount ?? 0;
                         Flux.toast({
@@ -1302,11 +1310,12 @@ new #[Layout('layouts.app')] class extends Component
                     "
                     class="relative flex items-center">
                         <flux:button variant="ghost" size="sm" icon="arrow-path" icon:variant="outline"
-                            tooltip="Refresh · ⌘R · ⌘⇧R to hard reload"
-                            aria-label="Refresh · ⌘R · ⌘⇧R to hard reload"
+                            x-bind:tooltip="tooltip"
+                            x-bind:aria-label="tooltip"
+                            x-bind:class="hasChanges && '!text-amber-500 dark:!text-amber-400'"
                             wire:click.preserve-scroll="softRefresh" />
                         <span x-show="hasChanges" x-cloak
-                            class="absolute -top-0.5 -right-0.5 flex h-2.5 w-2.5">
+                            class="pointer-events-none absolute -top-0.5 -right-0.5 flex h-2.5 w-2.5">
                             <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-400 opacity-75"></span>
                             <span class="relative inline-flex rounded-full h-2.5 w-2.5 bg-amber-500"></span>
                         </span>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1227,33 +1227,7 @@ new #[Layout('layouts.app')] class extends Component
                 @endif
                 <livewire:comments-drawer :repo-path="$repoPath" :project-id="$projectId ?: null" />
             </div>
-            <div class="flex items-center gap-2.5 text-xs">
-                {{-- Stats --}}
-                <span class="font-mono text-gh-muted"
-                    x-text="fileFilter === '' && !hideReviewed
-                        ? '{{ count($sourceFiles) }} {{ Str::plural('file', count($sourceFiles)) }}'
-                        : sourceFileEntries.filter(f => fileMatchesFilter(f.path, f.id)).length + '/{{ count($sourceFiles) }} files'"
-                >{{ count($sourceFiles) }} {{ Str::plural('file', count($sourceFiles)) }}</span>
-                <span class="font-mono text-gh-green">+{{ collect($sourceFiles)->sum('additions') }}</span>
-                <span class="font-mono text-gh-red">-{{ collect($sourceFiles)->sum('deletions') }}</span>
-
-                {{-- Reviewed progress --}}
-                <div x-show="reviewedCount > 0" x-cloak class="flex items-center gap-1.5">
-                    <span class="w-px h-3.5 bg-gh-border"></span>
-                    <div class="flex flex-col items-center min-w-[2.5rem]">
-                        <span data-testid="reviewed-counter" class="font-mono text-gh-muted" x-text="reviewedCount + '/{{ count($sourceFiles) }} reviewed'"></span>
-                        <div class="w-full h-0.5 bg-gh-border/50 rounded-full overflow-hidden mt-0.5">
-                            <div class="h-full bg-gh-green/70 rounded-full transition-all duration-300" :style="'width:' + Math.round(reviewedCount / {{ count($sourceFiles) }} * 100) + '%'"></div>
-                        </div>
-                    </div>
-                </div>
-
-                @if(count($reviewPairs) > 0)
-                    <span class="font-mono text-xs text-gh-muted px-1.5 py-0.5 rounded border border-gh-border">{{ count($reviewPairs) }} {{ Str::plural('review', count($reviewPairs)) }}</span>
-                @endif
-
-                <span class="w-px h-4 bg-gh-border"></span>
-
+            <div class="flex items-center gap-2 text-xs">
                 {{-- Hide reviewed toggle --}}
                 <div x-show="reviewedCount > 0" x-cloak class="grid place-items-center">
                     <flux:button variant="ghost" size="sm" icon="eye-slash" icon:variant="outline"
@@ -1281,6 +1255,8 @@ new #[Layout('layouts.app')] class extends Component
                         @click="$store.settings.collapseAll = true; $dispatch('collapse-all-files')"
                         x-show="!$store.settings.collapseAll" />
                 </div>
+
+                <span class="w-px h-4 bg-gh-border" aria-hidden="true"></span>
 
                 @if(! $this->isCommitMode())
                     <div data-testid="change-polling" x-data="{
@@ -1331,8 +1307,6 @@ new #[Layout('layouts.app')] class extends Component
                     </div>
                 @endif
 
-                <span class="w-px h-4 bg-gh-border"></span>
-
                 {{-- Settings --}}
                 @if(! $this->isCommitMode())
                     <flux:dropdown position="bottom" align="end">
@@ -1349,6 +1323,28 @@ new #[Layout('layouts.app')] class extends Component
                 <livewire:theme-switcher />
             </div>
         </header>
+
+        {{-- Status strip: state, not actions --}}
+        <div data-testid="status-strip" class="bg-gh-bg/60 border-b border-gh-border px-5 py-1 flex items-center gap-3 font-mono text-[11px] text-gh-muted">
+            <span
+                x-text="fileFilter === '' && !hideReviewed
+                    ? '{{ count($sourceFiles) }} {{ Str::plural('file', count($sourceFiles)) }}'
+                    : sourceFileEntries.filter(f => fileMatchesFilter(f.path, f.id)).length + '/{{ count($sourceFiles) }} files'"
+            >{{ count($sourceFiles) }} {{ Str::plural('file', count($sourceFiles)) }}</span>
+            <span class="text-gh-green">+{{ collect($sourceFiles)->sum('additions') }}</span>
+            <span class="text-gh-red">-{{ collect($sourceFiles)->sum('deletions') }}</span>
+
+            @if(count($reviewPairs) > 0)
+                <span class="px-1.5 py-px rounded border border-gh-border">{{ count($reviewPairs) }} {{ Str::plural('review', count($reviewPairs)) }}</span>
+            @endif
+
+            <div x-show="reviewedCount > 0" x-cloak class="ml-auto flex items-center gap-2">
+                <span data-testid="reviewed-counter" x-text="reviewedCount + '/{{ count($sourceFiles) }} reviewed'"></span>
+                <div class="w-24 h-0.5 bg-gh-border/50 rounded-full overflow-hidden">
+                    <div class="h-full bg-gh-green/70 rounded-full transition-all duration-300" :style="'width:' + Math.round(reviewedCount / {{ count($sourceFiles) }} * 100) + '%'"></div>
+                </div>
+            </div>
+        </div>
     </div>
 
     {{-- Branch divergence banner + polling island (working-tree mode only) --}}

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1277,8 +1277,11 @@ new #[Layout('layouts.app')] class extends Component
                                 if (this.fingerprint === null) {
                                     this.fingerprint = data.fingerprint;
                                 } else if (data.fingerprint !== this.fingerprint) {
-                                    this.hasChanges = true;
-                                    this.currentCount = data.count ?? 0;
+                                    const newCount = data.count ?? 0;
+                                    if (! this.hasChanges || this.currentCount !== newCount) {
+                                        this.hasChanges = true;
+                                        this.currentCount = newCount;
+                                    }
                                 }
                             } catch {}
                         },
@@ -1447,9 +1450,8 @@ new #[Layout('layouts.app')] class extends Component
                         @if(count($reviewPairs) > 1)
                             <x-arm-commit-button
                                 icon="trash"
-                                aria-label="Delete all reviews"
                                 tooltip="Delete all reviews"
-                                confirm="$wire.deleteAllReviewPairs()"
+                                @confirmed="$wire.deleteAllReviewPairs()"
                             />
                         @endif
                     </div>
@@ -1461,9 +1463,8 @@ new #[Layout('layouts.app')] class extends Component
                             </button>
                             <x-arm-commit-button
                                 icon="trash"
-                                aria-label="Delete review"
                                 tooltip="Delete review"
-                                confirm="$wire.deleteReviewPair('{{ $pair['basename'] }}')"
+                                @confirmed="$wire.deleteReviewPair('{{ $pair['basename'] }}')"
                                 class="opacity-0 group-hover:opacity-100 transition-opacity ml-auto"
                             />
                         </div>
@@ -1595,9 +1596,8 @@ new #[Layout('layouts.app')] class extends Component
                                 </button>
                                 <x-arm-commit-button
                                     icon="trash"
-                                    aria-label="Permanently delete"
                                     tooltip="Permanently delete"
-                                    confirm="$wire.permanentlyDeleteTrashed({{ $trashed['id'] }})"
+                                    @confirmed="$wire.permanentlyDeleteTrashed({{ $trashed['id'] }})"
                                     class="opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
                                 />
                             </div>
@@ -1662,9 +1662,8 @@ new #[Layout('layouts.app')] class extends Component
                                 <span class="ml-auto">
                                     <x-arm-commit-button
                                         icon="trash"
-                                        aria-label="Delete review"
                                         tooltip="Delete review"
-                                        confirm="$wire.deleteReviewPair('{{ $pair['basename'] }}')"
+                                        @confirmed="$wire.deleteReviewPair('{{ $pair['basename'] }}')"
                                     />
                                 </span>
                             </div>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1347,7 +1347,7 @@ new #[Layout('layouts.app')] class extends Component
             <span
                 x-text="fileFilter === '' && !hideReviewed
                     ? '{{ count($sourceFiles) }} {{ Str::plural('file', count($sourceFiles)) }}'
-                    : sourceFileEntries.filter(f => fileMatchesFilter(f.path, f.id)).length + '/{{ count($sourceFiles) }} files'"
+                    : sourceFileEntries.filter(f => fileMatchesFilter(f.path, f.id)).length + '/{{ count($sourceFiles) }} {{ Str::plural('file', count($sourceFiles)) }}'"
             >{{ count($sourceFiles) }} {{ Str::plural('file', count($sourceFiles)) }}</span>
             <span class="text-gh-green">+{{ collect($sourceFiles)->sum('additions') }}</span>
             <span class="text-gh-red">-{{ collect($sourceFiles)->sum('deletions') }}</span>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1436,10 +1436,12 @@ new #[Layout('layouts.app')] class extends Component
                     <div class="flex items-center justify-between mb-3">
                         <span class="section-label text-gh-muted">Reviews</span>
                         @if(count($reviewPairs) > 1)
-                            <button class="text-gh-muted hover:text-red-400 transition-colors"
-                                @click="if (confirm('Delete all review files?')) $wire.deleteAllReviewPairs()">
-                                <flux:icon icon="trash" variant="outline" class="!size-4" />
-                            </button>
+                            <x-arm-commit-button
+                                icon="trash"
+                                aria-label="Delete all reviews"
+                                tooltip="Delete all reviews"
+                                confirm="$wire.deleteAllReviewPairs()"
+                            />
                         @endif
                     </div>
                     @foreach($reviewPairs as $pair)
@@ -1448,10 +1450,13 @@ new #[Layout('layouts.app')] class extends Component
                             <button @click="scrollToFile('{{ $pair['id'] }}')" class="truncate text-left font-mono" title="{{ $pair['basename'] }}">
                                 {{ $pair['displayName'] }}
                             </button>
-                            <button class="opacity-0 group-hover:opacity-100 transition-opacity text-red-400 hover:text-red-300 shrink-0 ml-auto"
-                                @click="if (confirm('Delete this review?')) $wire.deleteReviewPair('{{ $pair['basename'] }}')">
-                                <flux:icon icon="trash" variant="outline" class="!size-4" />
-                            </button>
+                            <x-arm-commit-button
+                                icon="trash"
+                                aria-label="Delete review"
+                                tooltip="Delete review"
+                                confirm="$wire.deleteReviewPair('{{ $pair['basename'] }}')"
+                                class="opacity-0 group-hover:opacity-100 transition-opacity ml-auto"
+                            />
                         </div>
                     @endforeach
                     <div class="border-b border-gh-border my-3"></div>
@@ -1579,10 +1584,13 @@ new #[Layout('layouts.app')] class extends Component
                                     class="opacity-0 group-hover:opacity-100 transition-opacity text-gh-green hover:text-green-400 shrink-0">
                                     <flux:icon icon="arrow-uturn-left" variant="outline" class="!size-3.5" />
                                 </button>
-                                <button @click="if (confirm('Permanently delete?')) $wire.permanentlyDeleteTrashed({{ $trashed['id'] }})" title="Delete permanently"
-                                    class="opacity-0 group-hover:opacity-100 transition-opacity text-red-400 hover:text-red-300 shrink-0">
-                                    <flux:icon icon="trash" variant="outline" class="!size-3.5" />
-                                </button>
+                                <x-arm-commit-button
+                                    icon="trash"
+                                    aria-label="Permanently delete"
+                                    tooltip="Permanently delete"
+                                    confirm="$wire.permanentlyDeleteTrashed({{ $trashed['id'] }})"
+                                    class="opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+                                />
                             </div>
                         @endforeach
                     </div>
@@ -1643,8 +1651,12 @@ new #[Layout('layouts.app')] class extends Component
                                     <span class="text-[10px] font-mono text-gh-muted">.md</span>
                                 @endif
                                 <span class="ml-auto">
-                                    <flux:button variant="ghost" size="sm" icon="trash" icon:variant="outline"
-                                        @click="if (confirm('Delete this review?')) $wire.deleteReviewPair('{{ $pair['basename'] }}')" />
+                                    <x-arm-commit-button
+                                        icon="trash"
+                                        aria-label="Delete review"
+                                        tooltip="Delete review"
+                                        confirm="$wire.deleteReviewPair('{{ $pair['basename'] }}')"
+                                    />
                                 </span>
                             </div>
                             <div x-show="!collapsed" x-collapse.duration.150ms>

--- a/resources/views/pages/⚡select-repo-page.blade.php
+++ b/resources/views/pages/⚡select-repo-page.blade.php
@@ -119,10 +119,9 @@ new #[Layout('layouts.app')] class extends Component
     <main class="flex-1 flex items-center justify-center px-6 py-10">
         @if($totalProjects === 0)
             <div class="text-center">
-                <p class="rfa-logo text-5xl text-gh-muted/30 mb-6">rfa</p>
-                <flux:heading class="mb-3 font-display tracking-brutal">No repos yet</flux:heading>
+                <p class="rfa-logo text-7xl text-gh-fg mb-3 tracking-brutal-tight">rfa</p>
+                <p class="font-mono text-sm text-gh-muted mb-10">Be in the loop.</p>
                 @native
-                    <flux:text variant="subtle" size="sm" class="mb-6">Open a git repository or scan a folder to get started</flux:text>
                     <livewire:add-project-menu variant="expanded" />
                 @else
                     <flux:text variant="subtle" size="sm">Run <code class="font-mono bg-gh-border/50 px-1.5 py-0.5 rounded text-xs">rfa</code> from a git repository to get started</flux:text>

--- a/resources/views/pages/⚡select-repo-page.blade.php
+++ b/resources/views/pages/⚡select-repo-page.blade.php
@@ -119,7 +119,7 @@ new #[Layout('layouts.app')] class extends Component
     <main class="flex-1 flex items-center justify-center px-6 py-10">
         @if($totalProjects === 0)
             <div class="text-center">
-                <p class="rfa-logo text-7xl text-gh-fg mb-3 tracking-brutal-tight">rfa</p>
+                <h1 class="rfa-logo text-7xl text-gh-fg mb-3 tracking-brutal-tight">rfa</h1>
                 <p class="font-mono text-sm text-gh-muted mb-10">Be in the loop.</p>
                 @native
                     <livewire:add-project-menu variant="expanded" />

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,9 +32,9 @@ Route::get('/api/status/{project}', function (Project $project) {
 Route::get('/api/changes/{project}', function (Project $project) {
     $globalGitignorePath = $project->respect_global_gitignore ? $project->global_gitignore_path : null;
 
-    $fingerprint = app(CheckForChangesAction::class)->handle($project->path, $globalGitignorePath);
-
-    return response()->json(['fingerprint' => $fingerprint]);
+    return response()->json(
+        app(CheckForChangesAction::class)->handle($project->path, $globalGitignorePath)
+    );
 })->name('api.changes');
 
 Route::get('/api/image/{project}/{ref}/{path}', function (Project $project, string $ref, string $path) {

--- a/tests/Browser/SelectRepoFlowTest.php
+++ b/tests/Browser/SelectRepoFlowTest.php
@@ -39,5 +39,5 @@ test('deleting the final repo reveals the empty state', function () {
         $page->page()->getByText($this->projectName($i))->first()->waitFor(['state' => 'hidden']);
     }
 
-    $page->assertSee('No repos yet');
+    $page->assertSee('Be in the loop.');
 });

--- a/tests/Browser/UndoCommentTest.php
+++ b/tests/Browser/UndoCommentTest.php
@@ -72,11 +72,9 @@ test('clear all comments shows undo toast and click undo restores all', function
 
     addInlineComment($page, 'Bulk undo comment');
 
-    // Auto-accept confirm dialog
-    $page->script('window.confirm = function() { return true; }');
-
-    // Click clear all button
+    // arm-commit pattern: first click arms, second click commits
     $page->page()->getByLabel('Clear all comments')->click();
+    $page->page()->getByLabel('Confirm?')->click();
 
     // Wait for toast
     $page->assertSee('Cleared 1 comment');

--- a/tests/Feature/ApiRoutesTest.php
+++ b/tests/Feature/ApiRoutesTest.php
@@ -33,20 +33,20 @@ test('status route returns 404 for missing project', function () {
 
 // -- /api/changes --
 
-test('changes route returns fingerprint json', function () {
+test('changes route returns fingerprint and count json', function () {
     $project = Project::factory()->create();
 
     app()->bind(CheckForChangesAction::class, fn () => new class
     {
-        public function handle(string $repoPath, ?string $globalGitignorePath = null): string
+        public function handle(string $repoPath, ?string $globalGitignorePath = null): array
         {
-            return 'abc123fingerprint';
+            return ['fingerprint' => 'abc123fingerprint', 'count' => 7];
         }
     });
 
     $this->getJson("/api/changes/{$project->id}")
         ->assertOk()
-        ->assertJson(['fingerprint' => 'abc123fingerprint']);
+        ->assertJson(['fingerprint' => 'abc123fingerprint', 'count' => 7]);
 });
 
 test('changes route returns 404 for missing project', function () {

--- a/tests/Feature/DeleteCurrentRepoFlowTest.php
+++ b/tests/Feature/DeleteCurrentRepoFlowTest.php
@@ -39,5 +39,5 @@ test('deleting the last repo lands on select-repo empty state', function () {
         ->call('removeProject', $only->id)
         ->assertRedirect(route('select-repo'));
 
-    $this->get(route('select-repo'))->assertSee('No repos yet');
+    $this->get(route('select-repo'))->assertSee('Be in the loop.');
 });

--- a/tests/Unit/Actions/CheckForChangesActionTest.php
+++ b/tests/Unit/Actions/CheckForChangesActionTest.php
@@ -18,51 +18,70 @@ beforeEach(function () {
     $this->commitTestRepo($this->tmpDir, 'init');
 });
 
-test('returns non-empty string hash', function () {
+test('returns fingerprint and count for changed repo', function () {
     File::put($this->tmpDir.'/file.txt', "changed\n");
 
     $action = new CheckForChangesAction(new GitDiffService(new GitProcessService, new IgnoreService));
-    $hash = $action->handle($this->tmpDir);
+    $result = $action->handle($this->tmpDir);
 
-    expect($hash)->toBeString()->not->toBeEmpty();
+    expect($result)
+        ->toHaveKey('fingerprint')
+        ->toHaveKey('count');
+    expect($result['fingerprint'])->toBeString()->not->toBeEmpty();
+    expect($result['count'])->toBe(1);
 });
 
-test('returns same hash for unchanged repo', function () {
+test('returns same fingerprint for unchanged repo', function () {
     File::put($this->tmpDir.'/file.txt', "changed\n");
 
     $action = new CheckForChangesAction(new GitDiffService(new GitProcessService, new IgnoreService));
-    $hash1 = $action->handle($this->tmpDir);
-    $hash2 = $action->handle($this->tmpDir);
+    $first = $action->handle($this->tmpDir);
+    $second = $action->handle($this->tmpDir);
 
-    expect($hash1)->toBe($hash2);
+    expect($first['fingerprint'])->toBe($second['fingerprint']);
+    expect($first['count'])->toBe($second['count']);
 });
 
-test('returns different hash after file modification', function () {
+test('returns different fingerprint after file modification', function () {
     $action = new CheckForChangesAction(new GitDiffService(new GitProcessService, new IgnoreService));
     $before = $action->handle($this->tmpDir);
 
     File::put($this->tmpDir.'/file.txt', "changed\n");
     $after = $action->handle($this->tmpDir);
 
-    expect($after)->not->toBe($before);
+    expect($after['fingerprint'])->not->toBe($before['fingerprint']);
+    expect($after['count'])->toBe(1);
+    expect($before['count'])->toBe(0);
 });
 
-test('returns different hash after adding untracked file', function () {
+test('returns different fingerprint after adding untracked file', function () {
     $action = new CheckForChangesAction(new GitDiffService(new GitProcessService, new IgnoreService));
     $before = $action->handle($this->tmpDir);
 
     File::put($this->tmpDir.'/newfile.txt', "hello\n");
     $after = $action->handle($this->tmpDir);
 
-    expect($after)->not->toBe($before);
+    expect($after['fingerprint'])->not->toBe($before['fingerprint']);
+    expect($after['count'])->toBe(1);
 });
 
-test('returns different hash after deleting tracked file', function () {
+test('returns different fingerprint after deleting tracked file', function () {
     $action = new CheckForChangesAction(new GitDiffService(new GitProcessService, new IgnoreService));
     $before = $action->handle($this->tmpDir);
 
     File::delete($this->tmpDir.'/file.txt');
     $after = $action->handle($this->tmpDir);
 
-    expect($after)->not->toBe($before);
+    expect($after['fingerprint'])->not->toBe($before['fingerprint']);
+    expect($after['count'])->toBe(1);
+});
+
+test('count tracks multiple changes', function () {
+    File::put($this->tmpDir.'/file.txt', "changed\n");
+    File::put($this->tmpDir.'/another.txt', "new\n");
+
+    $action = new CheckForChangesAction(new GitDiffService(new GitProcessService, new IgnoreService));
+    $result = $action->handle($this->tmpDir);
+
+    expect($result['count'])->toBe(2);
 });

--- a/tests/Unit/Actions/CheckForChangesActionTest.php
+++ b/tests/Unit/Actions/CheckForChangesActionTest.php
@@ -42,7 +42,7 @@ test('returns same fingerprint for unchanged repo', function () {
     expect($first['count'])->toBe($second['count']);
 });
 
-test('returns different fingerprint after file modification', function () {
+test('returns different fingerprint and count after file modification', function () {
     $action = new CheckForChangesAction(new GitDiffService(new GitProcessService, new IgnoreService));
     $before = $action->handle($this->tmpDir);
 
@@ -54,7 +54,7 @@ test('returns different fingerprint after file modification', function () {
     expect($before['count'])->toBe(0);
 });
 
-test('returns different fingerprint after adding untracked file', function () {
+test('returns different fingerprint and count after adding untracked file', function () {
     $action = new CheckForChangesAction(new GitDiffService(new GitProcessService, new IgnoreService));
     $before = $action->handle($this->tmpDir);
 
@@ -65,7 +65,7 @@ test('returns different fingerprint after adding untracked file', function () {
     expect($after['count'])->toBe(1);
 });
 
-test('returns different fingerprint after deleting tracked file', function () {
+test('returns different fingerprint and count after deleting tracked file', function () {
     $action = new CheckForChangesAction(new GitDiffService(new GitProcessService, new IgnoreService));
     $before = $action->handle($this->tmpDir);
 

--- a/tests/Unit/Livewire/ReviewPageTest.php
+++ b/tests/Unit/Livewire/ReviewPageTest.php
@@ -239,6 +239,17 @@ test('submitReview refreshes file list and populates reviewPairs', function () {
     expect($component->get('submitted'))->toBeTrue();
 });
 
+test('startNewReview returns the submit bar to the input state', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project']);
+    $component->set('submitted', true);
+    $component->set('exportResult', 'address my comments on these changes in @.rfa/foo.md');
+
+    $component->call('startNewReview');
+
+    expect($component->get('submitted'))->toBeFalse();
+    expect($component->get('exportResult'))->toBeNull();
+});
+
 // -- Clear all comments --
 
 test('clearAllComments empties comments and saves', function () {

--- a/tests/Unit/Livewire/SelectRepoPageTest.php
+++ b/tests/Unit/Livewire/SelectRepoPageTest.php
@@ -11,12 +11,12 @@ uses(TestCase::class, LazilyRefreshDatabase::class);
 
 test('renders the empty state when no repos exist', function () {
     Livewire::test('pages::select-repo-page')
-        ->assertSee('No repos yet')
+        ->assertSee('Be in the loop.')
         ->assertStatus(200);
 });
 
 test('select-repo route serves the empty state when no repos exist', function () {
-    $this->get(route('select-repo'))->assertSee('No repos yet');
+    $this->get(route('select-repo'))->assertSee('Be in the loop.');
 });
 
 test('root route redirects to select-repo when no repos exist', function () {


### PR DESCRIPTION
The first-launch screen previously read "No repos yet" — a status, not an
identity. Replace the status heading with the tagline "Be in the loop." so
the wordmark + tagline + CTA carry the page; drop the redundant "Open a git
repository or scan a folder" subtext that the CTA already implies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation button pattern for destructive actions requiring double-click confirmation
  * New "Copy again" and "Start a new review" action buttons in submission controls

* **Improvements**
  * Enhanced change detection with improved external modification tracking
  * Refined status display on review page with dedicated header strip
  * Updated undo toast visual layout and typography
  * Standardized deletion interactions with confirmation pattern

<!-- end of auto-generated comment: release notes by coderabbit.ai -->