### PR TITLE
Add wire:smart-poll directive for focus-aware polling

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -8,7 +8,6 @@ git push --tags
 ```
 
 - Server-side ruleset "Protect release tags" rejects `v*` tag pushes on any SHA without green CI. Required checks: lint, types, test-js, test-core, test-browser, benchmark-perf. Admin bypass enabled for yanking bad tags. Because the ruleset is the CI gate, `release.yml` only runs the macOS build.
-- **`test-js` was added after the original ruleset was created — add it to the ruleset's required-checks list in GitHub settings before relying on it for release gating.**
 - Build runs on `macos-15` (arm64), publishes to GitHub Releases as **draft**
 - Publish the draft via `gh release edit vX.Y.Z --draft=false`
 - Tag must be `vX.Y.Z` (semver with `v` prefix). Version injected from tag automatically.

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -7,7 +7,8 @@ git tag v1.2.0
 git push --tags
 ```
 
-- Server-side ruleset "Protect release tags" rejects `v*` tag pushes on any SHA without green CI (all 5 checks: lint, types, test-core, test-browser, benchmark-perf). Admin bypass enabled for yanking bad tags. Because the ruleset is the CI gate, `release.yml` only runs the macOS build.
+- Server-side ruleset "Protect release tags" rejects `v*` tag pushes on any SHA without green CI. Required checks: lint, types, test-js, test-core, test-browser, benchmark-perf. Admin bypass enabled for yanking bad tags. Because the ruleset is the CI gate, `release.yml` only runs the macOS build.
+- **`test-js` was added after the original ruleset was created — add it to the ruleset's required-checks list in GitHub settings before relying on it for release gating.**
 - Build runs on `macos-15` (arm64), publishes to GitHub Releases as **draft**
 - Publish the draft via `gh release edit vX.Y.Z --draft=false`
 - Tag must be `vX.Y.Z` (semver with `v` prefix). Version injected from tag automatically.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,17 @@ jobs:
             phpstan-${{ runner.os }}-php${{ env.PHP_VERSION }}-
       - run: composer test:types
 
+  test-js:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+      - run: npm ci --prefer-offline --no-audit --no-fund
+      - run: npm test
+
   # Core suite is sharded for wall-clock speed while preserving one required
   # aggregate check (`test-core`) for branch protection and release gating.
   test-core-shard:

--- a/composer.json
+++ b/composer.json
@@ -71,8 +71,10 @@
         "test:browser:headed": "@php artisan test --testsuite=Browser --headed",
         "test:perf": "@php artisan rfa:benchmark-perf",
         "test:perf:smoke": "@php artisan test --testsuite=Performance",
+        "test:js": "npm test --silent",
         "test:all": [
             "@composer test",
+            "@composer test:js",
             "@composer test:browser",
             "@composer test:perf:smoke"
         ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,621 @@
     "packages": {
         "": {
             "devDependencies": {
-                "playwright": "^1.59.1"
+                "happy-dom": "^20.9.0",
+                "playwright": "^1.59.1",
+                "vitest": "^4.1.5"
+            }
+        },
+        "node_modules/@emnapi/core": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.127.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+            "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+            "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+            "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+            "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+            "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
+                "@napi-rs/wasm-runtime": "^1.1.4"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+            "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+            "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+            "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "25.6.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+            "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~7.19.0"
+            }
+        },
+        "node_modules/@types/whatwg-mimetype": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+            "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+            "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.5",
+                "@vitest/utils": "4.1.5",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+            "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.5",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+            "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+            "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.5",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+            "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.5",
+                "@vitest/utils": "4.1.5",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+            "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+            "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.5",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/entities": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
             }
         },
         "node_modules/fsevents": {
@@ -21,6 +635,352 @@
             ],
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/happy-dom": {
+            "version": "20.9.0",
+            "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+            "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": ">=20.0.0",
+                "@types/whatwg-mimetype": "^3.0.2",
+                "@types/ws": "^8.18.1",
+                "entities": "^7.0.1",
+                "whatwg-mimetype": "^3.0.0",
+                "ws": "^8.18.3"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/obug": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT"
+        },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/playwright": {
@@ -53,6 +1013,391 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.12",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+            "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.11",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/rolldown": {
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+            "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.127.0",
+                "@rolldown/pluginutils": "1.0.0-rc.17"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+            }
+        },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+            "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
+        "node_modules/undici-types": {
+            "version": "7.19.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+            "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/vite": {
+            "version": "8.0.10",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+            "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.4",
+                "postcss": "^8.5.10",
+                "rolldown": "1.0.0-rc.17",
+                "tinyglobby": "^0.2.16"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.1.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite/node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/vitest": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+            "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.5",
+                "@vitest/mocker": "4.1.5",
+                "@vitest/pretty-format": "4.1.5",
+                "@vitest/runner": "4.1.5",
+                "@vitest/snapshot": "4.1.5",
+                "@vitest/spy": "4.1.5",
+                "@vitest/utils": "4.1.5",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.5",
+                "@vitest/browser-preview": "4.1.5",
+                "@vitest/browser-webdriverio": "4.1.5",
+                "@vitest/coverage-istanbul": "4.1.5",
+                "@vitest/coverage-v8": "4.1.5",
+                "@vitest/ui": "4.1.5",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+            "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ws": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,12 @@
 {
     "private": true,
+    "scripts": {
+        "test": "vitest run",
+        "test:watch": "vitest"
+    },
     "devDependencies": {
-        "playwright": "^1.59.1"
+        "happy-dom": "^20.9.0",
+        "playwright": "^1.59.1",
+        "vitest": "^4.1.5"
     }
 }

--- a/public/js/CLAUDE.md
+++ b/public/js/CLAUDE.md
@@ -1,0 +1,59 @@
+# public/js/ Conventions
+
+Loose browser scripts that back Alpine components, Alpine stores, Livewire
+custom directives, and global wiring (find-in-page, session recovery, etc.).
+
+## No build process
+
+Scripts here are loaded directly via `<script src="/js/foo.js">` from `resources/views/layouts/app.blade.php`. There is no bundler — no Vite, no esbuild, no transpile.
+
+- Don't `import` from npm packages. Write what runs natively in the target Chromium (Electron 38+).
+- Don't use TypeScript.
+- If a feature needs npm-only logic, lift it into a Pest-tested PHP path instead.
+
+## Wrap helpers in an IIFE
+
+When a file has local helpers, wrap top-level code in `(function () { ... })();` so those helpers don't leak onto `window`. Anything intentionally global is assigned explicitly (see `window.contextMenuState` in `context-menu.js`).
+
+One-shot wiring with no helpers (e.g. `session-recovery.js`) can skip the IIFE — a bare `document.addEventListener('livewire:init', ...)` is fine.
+
+## Bootstrap via `alpine:init` / `livewire:init`
+
+Don't run setup at script-evaluation time — Alpine and Livewire may not be ready yet. Canonical idiom:
+
+```js
+window.Alpine ? init() : document.addEventListener('alpine:init', init);
+```
+
+For scripts that touch Livewire (custom directives, request interceptors), use `livewire:init` instead.
+
+## Guard against SPA-navigation re-execution
+
+Livewire's `wire:navigate` swaps the body and re-runs head scripts. Without a guard, listeners stack and stores get re-registered on every navigation. Pattern (see `keymap-store.js`):
+
+```js
+if (window.__fooAttached) return;
+window.__fooAttached = true;
+```
+
+If the script keeps per-page state that doesn't survive navigation (e.g. registered keymap bindings), clear it on `livewire:navigating`.
+
+## Testable scripts use the UMD shape
+
+If a script has logic worth testing (timers, parsers, state machines, custom directives), shape it like `smart-poll.js`:
+
+- IIFE that auto-installs in the browser
+- exports its internals when `module.exports` is detected
+
+Tests live in `tests/Js/<name>.test.js` (Vitest + happy-dom). Run with `composer test:js` (or `npm test`). See `tests/CLAUDE.md` for the testing conventions.
+
+## Where new scripts go: public/js vs inline blade
+
+Inline `x-data="{ ... }"` in a blade SFC is fine for trivial component state — a handful of fields, simple toggles, no shared logic. Extract to `public/js/` when any of these hold:
+
+- The factory has non-trivial logic (loops, async, computed getters, Livewire calls beyond `$wire.method()`).
+- More than one component needs it (`context-menu.js`, the `smart-poll` directive).
+- It's a global concern: an Alpine store, a custom Livewire directive, a request interceptor, a keyboard registry.
+- It has logic worth unit-testing — that requires the UMD shape, which requires extraction.
+
+Keep extracted Alpine factories named after the component they back (`branch-explorer.js`, `diff-file.js`); name global concerns after the concern (`keymap-store.js`, `smart-poll.js`).

--- a/public/js/smart-poll.js
+++ b/public/js/smart-poll.js
@@ -1,32 +1,13 @@
-/**
- * `wire:smart-poll` — focus-aware Livewire poll directive.
- *
- * Drop-in alternative to `wire:poll` that backs off when the window loses
- * focus and pauses entirely when the document is hidden. Intervals are read
- * fresh from `data-focus`/`data-blur` on every tick, so a component re-render
- * (e.g. status-driven intervals on `update-banner`) updates the cadence
- * without re-attaching the directive.
- *
- * Usage:
- *   <div
- *       wire:smart-poll="poll"
- *       data-focus="10s"
- *       data-blur="5m"
- *   ></div>
- *
- * Durations accept the same suffixes as `wire:poll`: `ms`, `s`, `m`, `h`
- * (default `ms` if unspecified, matching Livewire). Missing or unparseable
- * values pause that mode — useful for "only poll when focused".
- *
- * On regaining focus (window focus or tab visibility) we fire one immediate
- * tick before resuming the focused-cadence interval, so foregrounding feels
- * instant instead of waiting up to a full focused interval.
- */
+// `wire:smart-poll` — focus-aware Livewire poll directive. The directive's
+// public contract lives in `resources/CLAUDE.md` ("Polling"); this file owns
+// the timing primitive `startSmartPoll`, which is also exposed on
+// `window.smartPoll` for Alpine blocks that poll non-Livewire endpoints.
 (function (root, factory) {
     const api = factory();
     if (typeof module !== 'undefined' && module.exports) {
         module.exports = api;
     } else if (root) {
+        root.smartPoll = api;
         api.autoInstall(root);
     }
 })(typeof window !== 'undefined' ? window : null, function () {
@@ -46,13 +27,73 @@
     }
 
     /**
-     * Builds the per-element directive callback. Exported separately from the
-     * Livewire registration so tests can drive it without spinning up Livewire.
+     * Drives a focus-aware polling loop. Pauses while the document is hidden,
+     * fires one immediate tick on regaining focus, and serializes overlapping
+     * ticks via an inflight guard.
      *
-     * @param {object} deps
-     * @param {Window}   deps.window
-     * @param {Document} deps.document
+     * @param {object} opts
+     * @param {Window}   opts.window
+     * @param {Document} opts.document
+     * @param {() => number|null} opts.getInterval  ms until next tick, or null to pause.
+     * @param {() => Promise<void>|void} opts.onTick
+     * @returns {() => void} stop() — clears the timer and detaches listeners.
      */
+    function startSmartPoll({ window: win, document: doc, getInterval, onTick }) {
+        let timeoutId = null;
+        let inflight = false;
+        let lastFocused = isFocused(doc);
+
+        function schedule() {
+            clearTimeout(timeoutId);
+            timeoutId = null;
+            const ms = getInterval();
+            if (ms === null) return;
+            timeoutId = setTimeout(tick, ms);
+        }
+
+        async function tick() {
+            if (inflight || doc.hidden) {
+                schedule();
+                return;
+            }
+            inflight = true;
+            try {
+                await onTick();
+            } catch (e) {
+                // Caller surfaces errors elsewhere; we just retry next tick.
+            } finally {
+                inflight = false;
+            }
+            schedule();
+        }
+
+        function onTransition() {
+            const focusedNow = isFocused(doc);
+            if (!lastFocused && focusedNow) {
+                lastFocused = true;
+                clearTimeout(timeoutId);
+                timeoutId = null;
+                tick();
+                return;
+            }
+            lastFocused = focusedNow;
+            schedule();
+        }
+
+        win.addEventListener('focus', onTransition);
+        win.addEventListener('blur', onTransition);
+        doc.addEventListener('visibilitychange', onTransition);
+
+        schedule();
+
+        return function stop() {
+            clearTimeout(timeoutId);
+            win.removeEventListener('focus', onTransition);
+            win.removeEventListener('blur', onTransition);
+            doc.removeEventListener('visibilitychange', onTransition);
+        };
+    }
+
     function createDirectiveHandler(deps) {
         const win = deps.window;
         const doc = deps.document;
@@ -60,65 +101,18 @@
         return function attach({ el, directive, component, cleanup }) {
             const method = ((directive && directive.expression) || '').trim() || 'poll';
 
-            let timeoutId = null;
-            let inflight = false;
-            let lastFocused = isFocused(doc);
-
-            function readInterval() {
-                if (doc.hidden) return null;
-                const attr = doc.hasFocus() ? 'focus' : 'blur';
-                return parseDuration(el.dataset[attr]);
-            }
-
-            function schedule() {
-                clearTimeout(timeoutId);
-                timeoutId = null;
-                const ms = readInterval();
-                if (ms === null) return;
-                timeoutId = setTimeout(tick, ms);
-            }
-
-            async function tick() {
-                if (inflight || doc.hidden) {
-                    schedule();
-                    return;
-                }
-                inflight = true;
-                try {
-                    await component.$wire.call(method);
-                } catch (e) {
-                    // Swallow — Livewire surfaces network errors elsewhere; we just retry next tick.
-                } finally {
-                    inflight = false;
-                }
-                schedule();
-            }
-
-            function onTransition() {
-                const focusedNow = isFocused(doc);
-                if (!lastFocused && focusedNow) {
-                    lastFocused = true;
-                    clearTimeout(timeoutId);
-                    timeoutId = null;
-                    tick();
-                    return;
-                }
-                lastFocused = focusedNow;
-                schedule();
-            }
-
-            win.addEventListener('focus', onTransition);
-            win.addEventListener('blur', onTransition);
-            doc.addEventListener('visibilitychange', onTransition);
-
-            schedule();
-
-            cleanup(() => {
-                clearTimeout(timeoutId);
-                win.removeEventListener('focus', onTransition);
-                win.removeEventListener('blur', onTransition);
-                doc.removeEventListener('visibilitychange', onTransition);
+            const stop = startSmartPoll({
+                window: win,
+                document: doc,
+                getInterval() {
+                    if (doc.hidden) return null;
+                    const attr = doc.hasFocus() ? 'focus' : 'blur';
+                    return parseDuration(el.dataset[attr]);
+                },
+                onTick: () => component.$wire.call(method),
             });
+
+            cleanup(stop);
         };
     }
 
@@ -138,5 +132,5 @@
         }
     }
 
-    return { parseDuration, isFocused, createDirectiveHandler, install, autoInstall };
+    return { parseDuration, isFocused, startSmartPoll, createDirectiveHandler, install, autoInstall };
 });

--- a/public/js/smart-poll.js
+++ b/public/js/smart-poll.js
@@ -1,0 +1,115 @@
+/**
+ * `wire:smart-poll` — focus-aware Livewire poll directive.
+ *
+ * Drop-in alternative to `wire:poll` that backs off when the window loses
+ * focus and pauses entirely when the document is hidden. Intervals are read
+ * fresh from `data-focus`/`data-blur` on every tick, so a component re-render
+ * (e.g. status-driven intervals on `update-banner`) updates the cadence
+ * without re-attaching the directive.
+ *
+ * Usage:
+ *   <div
+ *       wire:smart-poll="poll"
+ *       data-focus="10s"
+ *       data-blur="5m"
+ *   ></div>
+ *
+ * Durations accept the same suffixes as `wire:poll`: `ms`, `s`, `m`, `h`
+ * (default `ms` if unspecified, matching Livewire). Missing or unparseable
+ * values pause that mode — useful for "only poll when focused".
+ *
+ * On regaining focus (window focus or tab visibility) we fire one immediate
+ * tick before resuming the focused-cadence interval, so foregrounding feels
+ * instant instead of waiting up to a full focused interval.
+ */
+(function () {
+    const UNIT_MS = { ms: 1, s: 1000, m: 60000, h: 3600000 };
+
+    function parseDuration(value) {
+        if (value === undefined || value === null || value === '') return null;
+        const match = String(value).trim().match(/^(\d+)(ms|s|m|h)?$/);
+        if (!match) return null;
+        const n = parseInt(match[1], 10);
+        const unit = match[2] || 'ms';
+        return n * UNIT_MS[unit];
+    }
+
+    function isFocused() {
+        return !document.hidden && document.hasFocus();
+    }
+
+    function init() {
+        if (typeof window.Livewire === 'undefined' || window.__smartPollAttached) return;
+        window.__smartPollAttached = true;
+
+        window.Livewire.directive('smart-poll', ({ el, directive, component, cleanup }) => {
+            const method = (directive.expression || '').trim() || 'poll';
+
+            let timeoutId = null;
+            let inflight = false;
+            let lastFocused = isFocused();
+
+            function readInterval() {
+                if (document.hidden) return null;
+                const attr = document.hasFocus() ? 'focus' : 'blur';
+                return parseDuration(el.dataset[attr]);
+            }
+
+            function schedule() {
+                clearTimeout(timeoutId);
+                timeoutId = null;
+                const ms = readInterval();
+                if (ms === null) return;
+                timeoutId = setTimeout(tick, ms);
+            }
+
+            async function tick() {
+                if (inflight || document.hidden) {
+                    schedule();
+                    return;
+                }
+                inflight = true;
+                try {
+                    await component.$wire.call(method);
+                } catch (e) {
+                    // Swallow — Livewire surfaces network errors elsewhere; we just retry next tick.
+                } finally {
+                    inflight = false;
+                }
+                schedule();
+            }
+
+            function onTransition() {
+                const focusedNow = isFocused();
+                if (!lastFocused && focusedNow) {
+                    lastFocused = true;
+                    clearTimeout(timeoutId);
+                    timeoutId = null;
+                    tick();
+                    return;
+                }
+                lastFocused = focusedNow;
+                schedule();
+            }
+
+            window.addEventListener('focus', onTransition);
+            window.addEventListener('blur', onTransition);
+            document.addEventListener('visibilitychange', onTransition);
+
+            schedule();
+
+            cleanup(() => {
+                clearTimeout(timeoutId);
+                window.removeEventListener('focus', onTransition);
+                window.removeEventListener('blur', onTransition);
+                document.removeEventListener('visibilitychange', onTransition);
+            });
+        });
+    }
+
+    if (typeof window.Livewire !== 'undefined') {
+        init();
+    } else {
+        document.addEventListener('livewire:init', init);
+    }
+})();

--- a/public/js/smart-poll.js
+++ b/public/js/smart-poll.js
@@ -22,7 +22,14 @@
  * tick before resuming the focused-cadence interval, so foregrounding feels
  * instant instead of waiting up to a full focused interval.
  */
-(function () {
+(function (root, factory) {
+    const api = factory();
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    } else if (root) {
+        api.autoInstall(root);
+    }
+})(typeof window !== 'undefined' ? window : null, function () {
     const UNIT_MS = { ms: 1, s: 1000, m: 60000, h: 3600000 };
 
     function parseDuration(value) {
@@ -34,24 +41,32 @@
         return n * UNIT_MS[unit];
     }
 
-    function isFocused() {
-        return !document.hidden && document.hasFocus();
+    function isFocused(doc) {
+        return !doc.hidden && doc.hasFocus();
     }
 
-    function init() {
-        if (typeof window.Livewire === 'undefined' || window.__smartPollAttached) return;
-        window.__smartPollAttached = true;
+    /**
+     * Builds the per-element directive callback. Exported separately from the
+     * Livewire registration so tests can drive it without spinning up Livewire.
+     *
+     * @param {object} deps
+     * @param {Window}   deps.window
+     * @param {Document} deps.document
+     */
+    function createDirectiveHandler(deps) {
+        const win = deps.window;
+        const doc = deps.document;
 
-        window.Livewire.directive('smart-poll', ({ el, directive, component, cleanup }) => {
-            const method = (directive.expression || '').trim() || 'poll';
+        return function attach({ el, directive, component, cleanup }) {
+            const method = ((directive && directive.expression) || '').trim() || 'poll';
 
             let timeoutId = null;
             let inflight = false;
-            let lastFocused = isFocused();
+            let lastFocused = isFocused(doc);
 
             function readInterval() {
-                if (document.hidden) return null;
-                const attr = document.hasFocus() ? 'focus' : 'blur';
+                if (doc.hidden) return null;
+                const attr = doc.hasFocus() ? 'focus' : 'blur';
                 return parseDuration(el.dataset[attr]);
             }
 
@@ -64,7 +79,7 @@
             }
 
             async function tick() {
-                if (inflight || document.hidden) {
+                if (inflight || doc.hidden) {
                     schedule();
                     return;
                 }
@@ -80,7 +95,7 @@
             }
 
             function onTransition() {
-                const focusedNow = isFocused();
+                const focusedNow = isFocused(doc);
                 if (!lastFocused && focusedNow) {
                     lastFocused = true;
                     clearTimeout(timeoutId);
@@ -92,24 +107,36 @@
                 schedule();
             }
 
-            window.addEventListener('focus', onTransition);
-            window.addEventListener('blur', onTransition);
-            document.addEventListener('visibilitychange', onTransition);
+            win.addEventListener('focus', onTransition);
+            win.addEventListener('blur', onTransition);
+            doc.addEventListener('visibilitychange', onTransition);
 
             schedule();
 
             cleanup(() => {
                 clearTimeout(timeoutId);
-                window.removeEventListener('focus', onTransition);
-                window.removeEventListener('blur', onTransition);
-                document.removeEventListener('visibilitychange', onTransition);
+                win.removeEventListener('focus', onTransition);
+                win.removeEventListener('blur', onTransition);
+                doc.removeEventListener('visibilitychange', onTransition);
             });
-        });
+        };
     }
 
-    if (typeof window.Livewire !== 'undefined') {
-        init();
-    } else {
-        document.addEventListener('livewire:init', init);
+    function install(root) {
+        if (typeof root.Livewire === 'undefined' || root.__smartPollAttached) return false;
+        root.__smartPollAttached = true;
+        const handler = createDirectiveHandler({ window: root, document: root.document });
+        root.Livewire.directive('smart-poll', handler);
+        return true;
     }
-})();
+
+    function autoInstall(root) {
+        if (root.Livewire) {
+            install(root);
+        } else {
+            root.document.addEventListener('livewire:init', () => install(root));
+        }
+    }
+
+    return { parseDuration, isFocused, createDirectiveHandler, install, autoInstall };
+});

--- a/public/js/smart-poll.js
+++ b/public/js/smart-poll.js
@@ -19,7 +19,8 @@
         if (!match) return null;
         const n = parseInt(match[1], 10);
         const unit = match[2] || 'ms';
-        return n * UNIT_MS[unit];
+        const ms = n * UNIT_MS[unit];
+        return ms > 0 ? ms : null;
     }
 
     function isFocused(doc) {
@@ -41,17 +42,20 @@
     function startSmartPoll({ window: win, document: doc, getInterval, onTick }) {
         let timeoutId = null;
         let inflight = false;
+        let stopped = false;
         let lastFocused = isFocused(doc);
 
         function schedule() {
             clearTimeout(timeoutId);
             timeoutId = null;
+            if (stopped) return;
             const ms = getInterval();
             if (ms === null) return;
             timeoutId = setTimeout(tick, ms);
         }
 
         async function tick() {
+            if (stopped) return;
             if (inflight || doc.hidden) {
                 schedule();
                 return;
@@ -87,7 +91,9 @@
         schedule();
 
         return function stop() {
+            stopped = true;
             clearTimeout(timeoutId);
+            timeoutId = null;
             win.removeEventListener('focus', onTransition);
             win.removeEventListener('blur', onTransition);
             doc.removeEventListener('visibilitychange', onTransition);

--- a/resources/CLAUDE.md
+++ b/resources/CLAUDE.md
@@ -127,7 +127,7 @@ Behavior:
 When NOT to use it:
 - Sub-second cadence requirements (use `wire:poll` directly — but reconsider whether you actually need that).
 - `keep-alive`-style heartbeats — keep using `wire:poll.{N}s.keep-alive`.
-- Pure Alpine timers that don't call into Livewire — they should still respect focus/visibility, but mirror the helper functions in `change-polling` on `⚡review-page.blade.php` instead of going through this directive.
+- Pure Alpine timers that don't call into Livewire — call `window.smartPoll.startSmartPoll({ window, document, getInterval, onTick })` from `init()` and stop it from `destroy()`. Same focus/visibility/inflight semantics as the directive; see `change-polling` on `⚡review-page.blade.php` for the canonical shape.
 
 The arch test `wire:smart-poll always pairs data-focus and data-blur` enforces the contract.
 

--- a/resources/CLAUDE.md
+++ b/resources/CLAUDE.md
@@ -108,6 +108,29 @@ Use `$this->redirect($url, navigate: true)` — not raw `$this->redirect($url)`,
 - Raw `$this->redirect()` or synchronous `window.location` writes from a **nested child** get clobbered by the parent's post-response DOM processing — the server action completes but the browser never navigates. Hit on `add-project-menu` (child of `project-picker`).
 - `Window::get('main')->url(...)` is for main-process listeners (`HandleDeepLink`, `HandleMenuItemClicked`), not in-renderer Livewire actions.
 
+### Polling: prefer `wire:smart-poll` over `wire:poll`
+
+`wire:poll` keeps firing at the same cadence whether or not the user is on the window. With multiple stacked pollers (head-divergence, update-banner, change-detection) that adds up to a constant request stream even on a backgrounded window. Use `wire:smart-poll` (custom directive registered in `public/js/smart-poll.js`) for any new component that doesn't need sub-second responsiveness.
+
+```blade
+<div wire:smart-poll="poll" data-focus="10s" data-blur="5m"></div>
+```
+
+Behavior:
+- `data-focus` runs while `document.hasFocus() && !document.hidden`.
+- `data-blur` runs while the window is unfocused but visible.
+- Polling pauses entirely when `document.hidden`.
+- Refocusing the window fires one immediate tick before resuming the focused cadence — foregrounding feels instant.
+- Intervals are re-read on every tick, so a Blade re-render with new `data-*` values picks up the new cadence on the next tick (see `update-banner.blade.php`'s `pollCadence()` for the status-driven pattern).
+- Durations accept the same suffixes as `wire:poll`: `ms`, `s`, `m`, `h`. Missing values pause that mode (e.g. omit `data-blur` for "only poll while focused").
+
+When NOT to use it:
+- Sub-second cadence requirements (use `wire:poll` directly — but reconsider whether you actually need that).
+- `keep-alive`-style heartbeats — keep using `wire:poll.{N}s.keep-alive`.
+- Pure Alpine timers that don't call into Livewire — they should still respect focus/visibility, but mirror the helper functions in `change-polling` on `⚡review-page.blade.php` instead of going through this directive.
+
+The arch test `wire:smart-poll always pairs data-focus and data-blur` enforces the contract.
+
 ### Parent-Child: Avoid 1+N Re-renders
 
 ReviewPage (`resources/views/pages/⚡review-page.blade.php`) renders N DiffFile children (`resources/views/livewire/⚡diff-file.blade.php`) - one per changed file. Livewire re-hydrates ALL children when a parent re-renders. With `#[Reactive]` props, Livewire's JS interceptor bundles every reactive child into every parent request - even if the prop didn't change. This hits `TooManyComponentsException` (default limit ~20) on repos with many files.

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -12,6 +12,7 @@
     <script src="/js/keymap-store.js"></script>
     <script src="/js/page-search.js"></script>
     <script src="/js/session-recovery.js"></script>
+    <script src="/js/smart-poll.js"></script>
     <script>
         tailwind.config = {
             darkMode: 'class',

--- a/resources/views/livewire/head-divergence-poller.blade.php
+++ b/resources/views/livewire/head-divergence-poller.blade.php
@@ -64,4 +64,4 @@ new class extends Component
 };
 ?>
 
-<div wire:poll.2s="poll" class="hidden"></div>
+<div wire:smart-poll="poll" data-focus="10s" data-blur="5m" class="hidden"></div>

--- a/resources/views/livewire/update-banner.blade.php
+++ b/resources/views/livewire/update-banner.blade.php
@@ -197,11 +197,31 @@ new class extends Component
 
         return $text ? trim(strip_tags($text)) : $text;
     }
+
+    /**
+     * Smart-poll cadence per status. Active flows (checking/downloading) need a
+     * tight focused loop so the progress UI feels live, but idle/terminal
+     * states only need to catch cache TTL expiry — minutes are enough.
+     *
+     * @return array{focus: string, blur: string}
+     */
+    public function pollCadence(): array
+    {
+        return match (true) {
+            in_array($this->status, ['checking', 'downloading'], true) => ['focus' => '2s', 'blur' => '30s'],
+            $this->status === null => ['focus' => '1m', 'blur' => '30m'],
+            default => ['focus' => '30s', 'blur' => '5m'],
+        };
+    }
 };
 ?>
 
+@php($cadence = $this->pollCadence())
+
 <div
-    wire:poll.{{ match(true) { $status === null => '5s', in_array($status, ['checking', 'downloading']) => '2s', default => '30s' } }}="refreshState"
+    wire:smart-poll="refreshState"
+    data-focus="{{ $cadence['focus'] }}"
+    data-blur="{{ $cadence['blur'] }}"
 >
     @if($status === 'checking')
         <div

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1269,11 +1269,7 @@ new #[Layout('layouts.app')] class extends Component
                         hasChanges: false,
                         fingerprint: null,
                         currentCount: 0,
-                        timer: null,
-                        // Focus-aware cadence: matches the head-poller / update-banner pattern
-                        // — tight when the user is here, lazy when they're not.
-                        focusedMs: 60000,
-                        blurredMs: 300000,
+                        stopPoll: null,
                         async check() {
                             try {
                                 const res = await fetch('/api/changes/{{ $projectId }}');
@@ -1289,38 +1285,6 @@ new #[Layout('layouts.app')] class extends Component
                                 }
                             } catch {}
                         },
-                        currentInterval() {
-                            if (document.hidden) return null;
-                            return document.hasFocus() ? this.focusedMs : this.blurredMs;
-                        },
-                        scheduleNext() {
-                            clearTimeout(this.timer);
-                            this.timer = null;
-                            const ms = this.currentInterval();
-                            if (ms === null) return;
-                            this.timer = setTimeout(() => this.tick(), ms);
-                        },
-                        async tick() {
-                            if (!document.hidden) await this.check();
-                            this.scheduleNext();
-                        },
-                        startPolling() {
-                            clearTimeout(this.timer);
-                            this.lastFocused = document.hasFocus() && !document.hidden;
-                            this.check();
-                            this.scheduleNext();
-                        },
-                        onFocusChange() {
-                            const focusedNow = document.hasFocus() && !document.hidden;
-                            if (!this.lastFocused && focusedNow) {
-                                this.lastFocused = true;
-                                clearTimeout(this.timer);
-                                this.tick();
-                                return;
-                            }
-                            this.lastFocused = focusedNow;
-                            this.scheduleNext();
-                        },
                         softRefresh() { $wire.softRefresh(); },
                         hardReload() { window.location.reload(); },
                         get tooltip() {
@@ -1328,15 +1292,22 @@ new #[Layout('layouts.app')] class extends Component
                             const n = this.currentCount;
                             const noun = n === 1 ? 'file' : 'files';
                             return `${n} ${noun} changed externally — click to refresh`;
-                        }
+                        },
+                        init() {
+                            this.stopPoll = window.smartPoll.startSmartPoll({
+                                window,
+                                document,
+                                getInterval: () => window.smartPoll.isFocused(document) ? 60000 : (document.hidden ? null : 300000),
+                                onTick: () => this.check(),
+                            });
+                            $store.keymap.register('⌘R', () => this.softRefresh(), { allowInEditable: true });
+                            $store.keymap.register('⌘⇧R', () => this.hardReload(), { allowInEditable: true });
+                        },
+                        destroy() {
+                            if (this.stopPoll) this.stopPoll();
+                        },
                     }"
-                    x-init="startPolling();
-                        $store.keymap.register('⌘R', () => softRefresh(), { allowInEditable: true });
-                        $store.keymap.register('⌘⇧R', () => hardReload(), { allowInEditable: true });"
-                    @focus.window="onFocusChange()"
-                    @blur.window="onFocusChange()"
-                    @visibilitychange.document="onFocusChange()"
-                    @fingerprint-reset.window="fingerprint = null; hasChanges = false; currentCount = 0; startPolling();"
+                    @fingerprint-reset.window="fingerprint = null; hasChanges = false; currentCount = 0; check();"
                     @refresh-completed.window="
                         const n = $event.detail?.changedCount ?? 0;
                         Flux.toast({

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1294,6 +1294,7 @@ new #[Layout('layouts.app')] class extends Component
                             return `${n} ${noun} changed externally — click to refresh`;
                         },
                         init() {
+                            this.check();
                             this.stopPoll = window.smartPoll.startSmartPoll({
                                 window,
                                 document,

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1269,7 +1269,11 @@ new #[Layout('layouts.app')] class extends Component
                         hasChanges: false,
                         fingerprint: null,
                         currentCount: 0,
-                        polling: null,
+                        timer: null,
+                        // Focus-aware cadence: matches the head-poller / update-banner pattern
+                        // — tight when the user is here, lazy when they're not.
+                        focusedMs: 60000,
+                        blurredMs: 300000,
                         async check() {
                             try {
                                 const res = await fetch('/api/changes/{{ $projectId }}');
@@ -1285,11 +1289,37 @@ new #[Layout('layouts.app')] class extends Component
                                 }
                             } catch {}
                         },
+                        currentInterval() {
+                            if (document.hidden) return null;
+                            return document.hasFocus() ? this.focusedMs : this.blurredMs;
+                        },
+                        scheduleNext() {
+                            clearTimeout(this.timer);
+                            this.timer = null;
+                            const ms = this.currentInterval();
+                            if (ms === null) return;
+                            this.timer = setTimeout(() => this.tick(), ms);
+                        },
+                        async tick() {
+                            if (!document.hidden) await this.check();
+                            this.scheduleNext();
+                        },
                         startPolling() {
+                            clearTimeout(this.timer);
+                            this.lastFocused = document.hasFocus() && !document.hidden;
                             this.check();
-                            this.polling = setInterval(() => {
-                                if (!document.hidden) this.check();
-                            }, 60000);
+                            this.scheduleNext();
+                        },
+                        onFocusChange() {
+                            const focusedNow = document.hasFocus() && !document.hidden;
+                            if (!this.lastFocused && focusedNow) {
+                                this.lastFocused = true;
+                                clearTimeout(this.timer);
+                                this.tick();
+                                return;
+                            }
+                            this.lastFocused = focusedNow;
+                            this.scheduleNext();
                         },
                         softRefresh() { $wire.softRefresh(); },
                         hardReload() { window.location.reload(); },
@@ -1303,7 +1333,10 @@ new #[Layout('layouts.app')] class extends Component
                     x-init="startPolling();
                         $store.keymap.register('⌘R', () => softRefresh(), { allowInEditable: true });
                         $store.keymap.register('⌘⇧R', () => hardReload(), { allowInEditable: true });"
-                    @fingerprint-reset.window="fingerprint = null; hasChanges = false; currentCount = 0; clearInterval(polling); startPolling();"
+                    @focus.window="onFocusChange()"
+                    @blur.window="onFocusChange()"
+                    @visibilitychange.document="onFocusChange()"
+                    @fingerprint-reset.window="fingerprint = null; hasChanges = false; currentCount = 0; startPolling();"
                     @refresh-completed.window="
                         const n = $event.detail?.changedCount ?? 0;
                         Flux.toast({

--- a/tests/Arch/BladeConventionsTest.php
+++ b/tests/Arch/BladeConventionsTest.php
@@ -62,6 +62,22 @@ test('keepalive component uses wire:poll.keep-alive', function () {
     expect($content)->toMatch('/wire:poll\.\d+s\.keep-alive/');
 });
 
+test('wire:smart-poll always pairs data-focus and data-blur', function () {
+    $violations = [];
+    foreach (bladeFiles() as $file) {
+        $content = file_get_contents($file);
+        preg_match_all('/<[^>]*\bwire:smart-poll\b[^>]*>/s', $content, $matches);
+        foreach ($matches[0] as $tag) {
+            $hasFocus = preg_match('/\bdata-focus=/', $tag);
+            $hasBlur = preg_match('/\bdata-blur=/', $tag);
+            if (! $hasFocus || ! $hasBlur) {
+                $violations[] = basename($file).": {$tag}";
+            }
+        }
+    }
+    expect($violations)->toBeEmpty();
+});
+
 test('no hardcoded dark class on html element', function () {
     $violations = [];
     foreach (bladeFiles() as $file) {

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -14,20 +14,7 @@
 
 ## JS unit tests
 
-For loose scripts in `public/js/` that have non-trivial logic (timers, DOM
-event handling, state machines), add Vitest unit tests under `tests/Js/`.
-
-- File pattern: `tests/Js/*.test.js` (picked up by `vitest.config.js`).
-- Environment: `happy-dom` — provides `window`, `document`, events, but no
-  network. Override `document.hasFocus()` and `document.hidden` via
-  `vi.spyOn` / `Object.defineProperty` when driving focus transitions.
-- Use `vi.useFakeTimers()` + `vi.advanceTimersByTimeAsync(ms)` for any
-  `setTimeout`/`setInterval` logic. Real timers in DOM tests are flaky.
-- Loose scripts are imported via UMD-style detection: the file checks for
-  `module.exports` at evaluation and exports its internals to Node, while
-  still auto-installing in the browser. See `public/js/smart-poll.js`.
-- Don't import the production script in a way that triggers `autoInstall` —
-  the UMD wrapper handles that. Importing the default export is enough.
+See `tests/Js/CLAUDE.md`.
 
 ## Parallel test isolation
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -7,9 +7,27 @@
 - Single-process fallback: `composer test:serial` (when debugging worker isolation)
 - Arch only: `composer test:arch`
 - Browser: `composer test:browser`
+- JS unit (Vitest + happy-dom): `composer test:js`
 - Perf benchmark: `composer test:perf`
 - Perf smoke suite: `composer test:perf:smoke`
 - Full local suite pass: `composer test:all`
+
+## JS unit tests
+
+For loose scripts in `public/js/` that have non-trivial logic (timers, DOM
+event handling, state machines), add Vitest unit tests under `tests/Js/`.
+
+- File pattern: `tests/Js/*.test.js` (picked up by `vitest.config.js`).
+- Environment: `happy-dom` — provides `window`, `document`, events, but no
+  network. Override `document.hasFocus()` and `document.hidden` via
+  `vi.spyOn` / `Object.defineProperty` when driving focus transitions.
+- Use `vi.useFakeTimers()` + `vi.advanceTimersByTimeAsync(ms)` for any
+  `setTimeout`/`setInterval` logic. Real timers in DOM tests are flaky.
+- Loose scripts are imported via UMD-style detection: the file checks for
+  `module.exports` at evaluation and exports its internals to Node, while
+  still auto-installing in the browser. See `public/js/smart-poll.js`.
+- Don't import the production script in a way that triggers `autoInstall` —
+  the UMD wrapper handles that. Importing the default export is enough.
 
 ## Parallel test isolation
 

--- a/tests/Js/CLAUDE.md
+++ b/tests/Js/CLAUDE.md
@@ -1,0 +1,48 @@
+# JS unit tests (Vitest + happy-dom)
+
+For loose scripts in `public/js/` that have non-trivial logic (timers, DOM
+event handling, state machines), add unit tests here.
+
+## Setup
+
+- File pattern: `tests/Js/*.test.js` (picked up by `vitest.config.js`).
+- Run: `composer test:js` (or `npm test` / `npm run test:watch`).
+- Environment: `happy-dom` — provides `window`, `document`, events, but no
+  network.
+
+## Driving focus / visibility
+
+happy-dom defaults to focused + visible. Override per test:
+
+```js
+vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+Object.defineProperty(document, 'hidden', { configurable: true, get: () => true });
+```
+
+## Timers
+
+Always use fake timers for `setTimeout` / `setInterval` logic — real timers
+in DOM tests are flaky:
+
+```js
+vi.useFakeTimers();
+await vi.advanceTimersByTimeAsync(10_000);
+```
+
+## Importing production scripts
+
+Scripts in `public/js/` use a UMD-style wrapper: they check for
+`module.exports` at evaluation and export their internals to Node, while
+still auto-installing in the browser. See `public/js/smart-poll.js` for the
+canonical shape.
+
+Import the default export and destructure:
+
+```js
+import smartPoll from '../../public/js/smart-poll.js';
+const { parseDuration, createDirectiveHandler, install } = smartPoll;
+```
+
+Don't call `autoInstall(window)` from a test — the UMD wrapper only invokes
+it when the script is loaded as a `<script src>` in the browser, never when
+imported under Node.

--- a/tests/Js/smart-poll.test.js
+++ b/tests/Js/smart-poll.test.js
@@ -1,0 +1,265 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import smartPoll from '../../public/js/smart-poll.js';
+
+const { parseDuration, createDirectiveHandler, install } = smartPoll;
+
+// happy-dom's `document.hasFocus` returns true by default and `document.hidden`
+// is false. We override per test via `vi.spyOn` so we can drive focus
+// transitions deterministically.
+function setFocus(focused) {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(focused);
+}
+
+function setHidden(hidden) {
+    Object.defineProperty(document, 'hidden', {
+        configurable: true,
+        get: () => hidden,
+    });
+}
+
+describe('parseDuration', () => {
+    it.each([
+        ['10s', 10_000],
+        ['5m', 300_000],
+        ['2h', 7_200_000],
+        ['250ms', 250],
+        ['  30s  ', 30_000],
+        // Default unit matches Livewire's `wire:poll` (ms).
+        ['1500', 1500],
+    ])('parses %j as %i ms', (input, expected) => {
+        expect(parseDuration(input)).toBe(expected);
+    });
+
+    it.each([null, undefined, '', 'abc', '5x', 's', '-1s', '1.5s'])(
+        'returns null for invalid input %j',
+        (input) => {
+            expect(parseDuration(input)).toBeNull();
+        }
+    );
+});
+
+describe('createDirectiveHandler', () => {
+    let cleanupCallbacks;
+    let component;
+    let el;
+    let attach;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        setFocus(true);
+        setHidden(false);
+
+        cleanupCallbacks = [];
+        component = {
+            $wire: { call: vi.fn(() => Promise.resolve()) },
+        };
+        el = document.createElement('div');
+        document.body.appendChild(el);
+
+        const handler = createDirectiveHandler({ window, document });
+        attach = (overrides = {}) => {
+            handler({
+                el,
+                directive: { expression: 'poll' },
+                component,
+                cleanup: (cb) => cleanupCallbacks.push(cb),
+                ...overrides,
+            });
+        };
+    });
+
+    afterEach(() => {
+        cleanupCallbacks.forEach((cb) => cb());
+        vi.useRealTimers();
+        document.body.innerHTML = '';
+    });
+
+    it('calls the component method on the focused interval', async () => {
+        el.dataset.focus = '10s';
+        el.dataset.blur = '5m';
+
+        attach();
+
+        expect(component.$wire.call).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(9_999);
+        expect(component.$wire.call).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(component.$wire.call).toHaveBeenCalledTimes(1);
+        expect(component.$wire.call).toHaveBeenCalledWith('poll');
+    });
+
+    it('uses the blur interval when window is unfocused', async () => {
+        el.dataset.focus = '10s';
+        el.dataset.blur = '5m';
+        setFocus(false);
+
+        attach();
+
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(component.$wire.call).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(290_000);
+        expect(component.$wire.call).toHaveBeenCalledTimes(1);
+    });
+
+    it('pauses entirely when document is hidden', async () => {
+        el.dataset.focus = '10s';
+        el.dataset.blur = '5m';
+        setHidden(true);
+
+        attach();
+
+        await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+        expect(component.$wire.call).not.toHaveBeenCalled();
+    });
+
+    it('fires immediate tick when window regains focus', async () => {
+        el.dataset.focus = '10s';
+        el.dataset.blur = '5m';
+        setFocus(false);
+
+        attach();
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(component.$wire.call).not.toHaveBeenCalled();
+
+        setFocus(true);
+        window.dispatchEvent(new Event('focus'));
+
+        // setTimeout(0) — the immediate tick goes through the same
+        // `inflight` guard so we still need to flush microtasks/timers.
+        await vi.advanceTimersByTimeAsync(0);
+        expect(component.$wire.call).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-reads data attributes on every tick', async () => {
+        el.dataset.focus = '10s';
+        el.dataset.blur = '5m';
+
+        attach();
+
+        // Simulate a Livewire morph BEFORE the first tick: the in-flight
+        // setTimeout was scheduled with the old '10s', so it still fires
+        // after 10s. The schedule() call _inside_ that first tick then
+        // re-reads the morphed `data-focus` for the next interval.
+        el.dataset.focus = '2s';
+
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(component.$wire.call).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(2_000);
+        expect(component.$wire.call).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not stack ticks while a request is in flight', async () => {
+        el.dataset.focus = '10s';
+        el.dataset.blur = '5m';
+
+        let resolveCall;
+        component.$wire.call = vi.fn(
+            () => new Promise((resolve) => {
+                resolveCall = resolve;
+            })
+        );
+
+        attach();
+
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(component.$wire.call).toHaveBeenCalledTimes(1);
+
+        // While the first call is still inflight, advancing by another
+        // interval shouldn't fire a second call.
+        await vi.advanceTimersByTimeAsync(20_000);
+        expect(component.$wire.call).toHaveBeenCalledTimes(1);
+
+        resolveCall();
+        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(component.$wire.call).toHaveBeenCalledTimes(2);
+    });
+
+    it('defaults to "poll" when no expression is given', async () => {
+        el.dataset.focus = '10s';
+        attach({ directive: { expression: '' } });
+
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(component.$wire.call).toHaveBeenCalledWith('poll');
+    });
+
+    it('omitting data-blur pauses while unfocused', async () => {
+        el.dataset.focus = '10s';
+        // intentionally no data-blur
+        setFocus(false);
+
+        attach();
+
+        await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+        expect(component.$wire.call).not.toHaveBeenCalled();
+
+        // Refocusing should resume polling immediately.
+        setFocus(true);
+        window.dispatchEvent(new Event('focus'));
+        await vi.advanceTimersByTimeAsync(0);
+        expect(component.$wire.call).toHaveBeenCalledTimes(1);
+    });
+
+    it('cleanup detaches all listeners and clears timer', async () => {
+        el.dataset.focus = '10s';
+        attach();
+
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(component.$wire.call).toHaveBeenCalledTimes(1);
+
+        cleanupCallbacks.forEach((cb) => cb());
+
+        // No more ticks after cleanup.
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(component.$wire.call).toHaveBeenCalledTimes(1);
+
+        // Focus events shouldn't trigger anything either.
+        setFocus(false);
+        window.dispatchEvent(new Event('blur'));
+        setFocus(true);
+        window.dispatchEvent(new Event('focus'));
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(component.$wire.call).toHaveBeenCalledTimes(1);
+    });
+
+    it('survives a method that throws and continues polling', async () => {
+        el.dataset.focus = '10s';
+        component.$wire.call = vi.fn(() => Promise.reject(new Error('boom')));
+
+        attach();
+
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(component.$wire.call).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(component.$wire.call).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('install', () => {
+    afterEach(() => {
+        delete window.Livewire;
+        delete window.__smartPollAttached;
+    });
+
+    it('registers wire:smart-poll with Livewire and is idempotent', () => {
+        const directive = vi.fn();
+        window.Livewire = { directive };
+
+        expect(install(window)).toBe(true);
+        expect(directive).toHaveBeenCalledTimes(1);
+        expect(directive).toHaveBeenCalledWith('smart-poll', expect.any(Function));
+
+        expect(install(window)).toBe(false);
+        expect(directive).toHaveBeenCalledTimes(1);
+    });
+
+    it('is a no-op when Livewire is not present', () => {
+        expect(install(window)).toBe(false);
+    });
+});

--- a/tests/Js/smart-poll.test.js
+++ b/tests/Js/smart-poll.test.js
@@ -36,6 +36,11 @@ describe('parseDuration', () => {
             expect(parseDuration(input)).toBeNull();
         }
     );
+
+    // Non-positive durations would tight-loop setTimeout, so treat them as "pause".
+    it.each(['0', '0s', '0ms', '0m'])('returns null for non-positive %j', (input) => {
+        expect(parseDuration(input)).toBeNull();
+    });
 });
 
 describe('createDirectiveHandler', () => {
@@ -238,6 +243,49 @@ describe('createDirectiveHandler', () => {
 
         await vi.advanceTimersByTimeAsync(10_000);
         expect(component.$wire.call).toHaveBeenCalledTimes(2);
+    });
+
+    it('pauses on visibilitychange to hidden and resumes on visible', async () => {
+        el.dataset.focus = '10s';
+        attach();
+
+        setHidden(true);
+        document.dispatchEvent(new Event('visibilitychange'));
+
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(component.$wire.call).not.toHaveBeenCalled();
+
+        setHidden(false);
+        document.dispatchEvent(new Event('visibilitychange'));
+
+        // Visible-again is treated as a refocus → immediate tick.
+        await vi.advanceTimersByTimeAsync(0);
+        expect(component.$wire.call).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not re-arm after stop() runs while a tick is in flight', async () => {
+        el.dataset.focus = '10s';
+
+        let resolveCall;
+        component.$wire.call = vi.fn(
+            () => new Promise((resolve) => {
+                resolveCall = resolve;
+            })
+        );
+
+        attach();
+
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(component.$wire.call).toHaveBeenCalledTimes(1);
+
+        // Tear down while the request is still pending.
+        cleanupCallbacks.forEach((cb) => cb());
+
+        // Resolving the in-flight call must not install a new timer.
+        resolveCall();
+        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(component.$wire.call).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/tests/Unit/Livewire/UpdateBannerTest.php
+++ b/tests/Unit/Livewire/UpdateBannerTest.php
@@ -259,4 +259,5 @@ test('pollCadence returns expected pairs per status', function (?string $status,
     'up-to-date' => ['up-to-date', '30s', '5m'],
     'ready' => ['ready', '30s', '5m'],
     'error' => ['error', '30s', '5m'],
+    'checked-dev' => ['checked-dev', '30s', '5m'],
 ]);

--- a/tests/Unit/Livewire/UpdateBannerTest.php
+++ b/tests/Unit/Livewire/UpdateBannerTest.php
@@ -202,7 +202,7 @@ test('does not render a custom renderer message bridge', function () {
         ->assertDontSeeHtml("window.addEventListener('message'");
 });
 
-test('uses fast polling during download', function () {
+test('uses fast smart-poll during download', function () {
     Cache::put('native-update-state', [
         'status' => 'downloading',
         'version' => '1.2.0',
@@ -210,22 +210,28 @@ test('uses fast polling during download', function () {
     ]);
 
     Livewire::test('update-banner')
-        ->assertSeeHtml('wire:poll.2s');
+        ->assertSeeHtml('wire:smart-poll="refreshState"')
+        ->assertSeeHtml('data-focus="2s"')
+        ->assertSeeHtml('data-blur="30s"');
 });
 
-test('uses fast polling during checking', function () {
+test('uses fast smart-poll during checking', function () {
     Cache::put('native-update-state', ['status' => 'checking'], now()->addSeconds(15));
 
     Livewire::test('update-banner')
-        ->assertSeeHtml('wire:poll.2s');
+        ->assertSeeHtml('wire:smart-poll="refreshState"')
+        ->assertSeeHtml('data-focus="2s"')
+        ->assertSeeHtml('data-blur="30s"');
 });
 
-test('uses idle polling when no state', function () {
+test('uses idle smart-poll when no state', function () {
     Livewire::test('update-banner')
-        ->assertSeeHtml('wire:poll.5s');
+        ->assertSeeHtml('wire:smart-poll="refreshState"')
+        ->assertSeeHtml('data-focus="1m"')
+        ->assertSeeHtml('data-blur="30m"');
 });
 
-test('uses standard polling for passive states', function () {
+test('uses standard smart-poll for passive states', function () {
     Cache::put('native-update-state', [
         'status' => 'ready',
         'version' => '1.2.0',
@@ -233,5 +239,24 @@ test('uses standard polling for passive states', function () {
     ]);
 
     Livewire::test('update-banner')
-        ->assertSeeHtml('wire:poll.30s');
+        ->assertSeeHtml('wire:smart-poll="refreshState"')
+        ->assertSeeHtml('data-focus="30s"')
+        ->assertSeeHtml('data-blur="5m"');
 });
+
+test('pollCadence returns expected pairs per status', function (?string $status, string $focus, string $blur) {
+    if ($status !== null) {
+        Cache::put('native-update-state', ['status' => $status], now()->addMinutes(5));
+    }
+
+    $instance = Livewire::test('update-banner')->instance();
+
+    expect($instance->pollCadence())->toBe(['focus' => $focus, 'blur' => $blur]);
+})->with([
+    'idle (null)' => [null, '1m', '30m'],
+    'checking' => ['checking', '2s', '30s'],
+    'downloading' => ['downloading', '2s', '30s'],
+    'up-to-date' => ['up-to-date', '30s', '5m'],
+    'ready' => ['ready', '30s', '5m'],
+    'error' => ['error', '30s', '5m'],
+]);

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'happy-dom',
+        include: ['tests/Js/**/*.test.js'],
+        globals: false,
+        clearMocks: true,
+        restoreMocks: true,
+    },
+});


### PR DESCRIPTION
Introduces a new `wire:smart-poll` custom Livewire directive that intelligently adjusts polling cadence based on window focus and document visibility, reducing unnecessary requests when the app is backgrounded.

## Summary

Replaces constant-rate `wire:poll` with a focus-aware alternative that respects user attention. The directive accepts separate `data-focus` and `data-blur` intervals, pauses entirely when the document is hidden, and fires an immediate tick when the window regains focus for responsive UX.

## Key Changes

- **New `public/js/smart-poll.js`**: UMD-shaped module exporting `startSmartPoll()` timing primitive and `createDirectiveHandler()` for Livewire integration
  - Parses duration strings (`10s`, `5m`, `2h`, `250ms`) with millisecond default
  - Manages focus/blur/visibility transitions with immediate-tick-on-focus behavior
  - Serializes overlapping ticks via inflight guard to prevent request stacking
  - Auto-installs as `wire:smart-poll` directive when Livewire is available

- **Comprehensive test suite** (`tests/Js/smart-poll.test.js`): 265 lines of Vitest + happy-dom tests covering duration parsing, focus transitions, visibility pausing, cleanup, and error resilience

- **Updated polling components**:
  - `update-banner.blade.php`: New `pollCadence()` method returns status-driven focus/blur pairs; replaced `wire:poll.Xs` with `wire:smart-poll` + data attributes
  - `head-divergence-poller.blade.php`: Switched from `wire:poll.2s` to `wire:smart-poll` with `data-focus="10s" data-blur="5m"`
  - `⚡review-page.blade.php`: Migrated change-detection polling to `window.smartPoll.startSmartPoll()` for non-Livewire endpoints

- **Test infrastructure**:
  - Added `vitest.config.js` with happy-dom environment
  - New `tests/Js/CLAUDE.md` documenting JS testing conventions
  - Updated `tests/Unit/Livewire/UpdateBannerTest.php` to verify smart-poll attributes and cadence logic
  - Added arch test enforcing `data-focus` + `data-blur` pairing on all `wire:smart-poll` tags

- **CI/CD**: Added `test-js` job to GitHub Actions; npm test scripts in `package.json`

- **Documentation**: Updated `resources/CLAUDE.md` with smart-poll rationale and usage guide

## Implementation Details

- **Timing primitive** (`startSmartPoll`): Decoupled from Livewire so Alpine blocks and other non-Livewire endpoints can reuse the same focus-aware logic
- **Interval re-reading**: Cadence attributes are read on every tick, allowing Blade re-renders to update polling behavior mid-flight without restarting the directive
- **Error resilience**: Rejected promises don't break the polling loop; errors are caught and the next tick schedules normally
- **Idempotent installation**: Guard flag prevents double-registration on SPA navigation

https://claude.ai/code/session_01Ro44ibLVPfVaiHtri2Q6eE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smart polling functionality that pauses polling when the browser tab is inactive or hidden, resuming immediately upon regaining focus.
  * Updated polling components to use dynamic timing based on focus state (faster when active, slower when idle).

* **Documentation**
  * Added guidelines for smart polling directive usage and implementation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->