### PR TITLE
Replace string line types with LineType enum

### DIFF
--- a/app/Actions/BuildDiffContextAction.php
+++ b/app/Actions/BuildDiffContextAction.php
@@ -39,9 +39,8 @@ final readonly class BuildDiffContextAction
             $fileId = $file['id'];
 
             if (! array_key_exists($fileId, $loaded)) {
-                $cacheKey = DiffCacheKey::for($repoPath, $fileId);
-                $cached = Cache::get($cacheKey);
-                $loaded[$fileId] = is_array($cached) && ($cached['lineTypesAreEnum'] ?? false)
+                $cached = Cache::get(DiffCacheKey::for($repoPath, $fileId));
+                $loaded[$fileId] = DiffCacheKey::isCurrentShape($cached)
                     ? $cached
                     : $this->loadFileDiffAction->handle($repoPath, $file['path'], $file['isUntracked'] ?? false);
             }

--- a/app/Actions/BuildDiffContextAction.php
+++ b/app/Actions/BuildDiffContextAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\Enums\DiffSide;
+use App\Enums\LineType;
 use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
 
@@ -39,12 +40,14 @@ final readonly class BuildDiffContextAction
 
             if (! array_key_exists($fileId, $loaded)) {
                 $cacheKey = DiffCacheKey::for($repoPath, $fileId);
-                $loaded[$fileId] = Cache::get($cacheKey)
-                    ?? $this->loadFileDiffAction->handle($repoPath, $file['path'], $file['isUntracked'] ?? false);
+                $cached = Cache::get($cacheKey);
+                $loaded[$fileId] = is_array($cached) && ($cached['lineTypesAreEnum'] ?? false)
+                    ? $cached
+                    : $this->loadFileDiffAction->handle($repoPath, $file['path'], $file['isUntracked'] ?? false);
             }
 
             $diffData = $loaded[$fileId];
-            if (! $diffData || ($diffData['tooLarge'] ?? false) || array_key_exists('error', $diffData)) {
+            if (($diffData['tooLarge'] ?? false) || array_key_exists('error', $diffData)) {
                 continue;
             }
 
@@ -60,8 +63,8 @@ final readonly class BuildDiffContextAction
                     }
                     if ($lineNum >= $comment['startLine'] && $lineNum <= ($comment['endLine'] ?? $comment['startLine'])) {
                         $prefix = match ($line['type']) {
-                            'add' => '+',
-                            'remove' => '-',
+                            LineType::Add => '+',
+                            LineType::Remove => '-',
                             default => ' ',
                         };
                         $lines[] = $prefix.$line['content'];

--- a/app/Actions/ExpandDiffGapAction.php
+++ b/app/Actions/ExpandDiffGapAction.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Enums\LineType;
+
 final readonly class ExpandDiffGapAction
 {
     /**
@@ -11,7 +13,7 @@ final readonly class ExpandDiffGapAction
      *
      * @param  list<array{header: string, oldStart: int, oldCount: int, newStart: int, newCount: int, lines: list<array>}>  $hunks
      * @param  int  $hunkIndex  0 = leading gap, count($hunks) = trailing gap (sentinel, not an actual index), else middle gap before hunks[$hunkIndex]
-     * @param  list<array{type: string, newLineNum: ?int, oldLineNum: ?int, content: string, highlightedContent: string}>  $fullDiffLines  All lines from the full-context diff's single hunk
+     * @param  list<array{type: LineType, newLineNum: ?int, oldLineNum: ?int, content: string, highlightedContent: string}>  $fullDiffLines  All lines from the full-context diff's single hunk
      * @param  ?int  $lineCount  Lines to expand (null = full gap)
      * @param  ?int  $newFileLineCount  Total lines in new file (needed for trailing gap boundary)
      * @return list<array> Modified hunks
@@ -66,7 +68,7 @@ final readonly class ExpandDiffGapAction
             ->filter(fn (array $line): bool => ($line['newLineNum'] ?? null) !== null
                 && $line['newLineNum'] >= $gapNewStart
                 && $line['newLineNum'] <= $gapNewEnd
-                && $line['type'] === 'context')
+                && $line['type'] === LineType::Context)
             ->values()
             ->all();
 

--- a/app/Actions/LoadFileDiffAction.php
+++ b/app/Actions/LoadFileDiffAction.php
@@ -13,6 +13,7 @@ use App\Services\GitDiffService;
 use App\Services\MarkdownRegionService;
 use App\Services\MarkdownTableAlignerService;
 use App\Services\SyntaxHighlightService;
+use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 
@@ -94,15 +95,7 @@ final readonly class LoadFileDiffAction
 
         if ($cacheKey) {
             $cached = Cache::get($cacheKey);
-            if ($cached !== null
-                && array_key_exists('syntaxStyles', $cached)
-                && array_key_exists('isSymlink', $cached)
-                && array_key_exists('tableAligned', $cached)
-                && array_key_exists('newFileLineCount', $cached)
-                && array_key_exists('headingsAnnotated', $cached)
-                && array_key_exists('gridLayout', $cached)
-                && array_key_exists('lineTypesAreEnum', $cached)
-            ) {
+            if (DiffCacheKey::isCurrentShape($cached)) {
                 return $cached;
             }
             $result = $compute();

--- a/app/Actions/LoadFileDiffAction.php
+++ b/app/Actions/LoadFileDiffAction.php
@@ -88,6 +88,7 @@ final readonly class LoadFileDiffAction
                 'newFileLineCount' => $newFileLineCount,
                 'headingsAnnotated' => true,
                 'gridLayout' => true,
+                'lineTypesAreEnum' => true,
             ];
         };
 
@@ -100,6 +101,7 @@ final readonly class LoadFileDiffAction
                 && array_key_exists('newFileLineCount', $cached)
                 && array_key_exists('headingsAnnotated', $cached)
                 && array_key_exists('gridLayout', $cached)
+                && array_key_exists('lineTypesAreEnum', $cached)
             ) {
                 return $cached;
             }

--- a/app/Console/Benchmark/DiffFixtureFactory.php
+++ b/app/Console/Benchmark/DiffFixtureFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Console\Benchmark;
 
 use App\DTOs\FileListEntry;
+use App\Enums\LineType;
 
 /**
  * @phpstan-type FileEntryData array{
@@ -20,7 +21,7 @@ use App\DTOs\FileListEntry;
  *     lastModified: ?string
  * }
  * @phpstan-type DiffLineData array{
- *     type: string,
+ *     type: LineType,
  *     content: string,
  *     oldLineNum: ?int,
  *     newLineNum: ?int,
@@ -141,7 +142,7 @@ final class DiffFixtureFactory
 
                 if ($mod === 0) {
                     $lines[] = [
-                        'type' => 'remove',
+                        'type' => LineType::Remove,
                         'content' => "    \$old_var_{$hunkIndex}_{$lineIndex} = getValue();",
                         'oldLineNum' => $currentOldLine++,
                         'newLineNum' => null,
@@ -154,7 +155,7 @@ final class DiffFixtureFactory
 
                 if ($mod === 1) {
                     $lines[] = [
-                        'type' => 'add',
+                        'type' => LineType::Add,
                         'content' => "    \$new_var_{$hunkIndex}_{$lineIndex} = getUpdatedValue();",
                         'oldLineNum' => null,
                         'newLineNum' => $currentNewLine++,
@@ -166,7 +167,7 @@ final class DiffFixtureFactory
                 }
 
                 $lines[] = [
-                    'type' => 'context',
+                    'type' => LineType::Context,
                     'content' => "    // context line {$hunkIndex}:{$lineIndex}",
                     'oldLineNum' => $currentOldLine++,
                     'newLineNum' => $currentNewLine++,
@@ -202,6 +203,7 @@ final class DiffFixtureFactory
             'isBinary' => false,
             'tooLarge' => false,
             'syntaxStyles' => '.hl-variable{color:#e36209;}.dark .hl-variable{color:#ffab70;}.hl-comment{color:#6a737d;}.dark .hl-comment{color:#6a737d;}',
+            'lineTypesAreEnum' => true,
         ];
     }
 

--- a/app/DTOs/DiffLine.php
+++ b/app/DTOs/DiffLine.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace App\DTOs;
 
+use App\Enums\LineType;
+
 class DiffLine
 {
     /**
      * @param  int[]  $headingAncestors
      */
     public function __construct(
-        public readonly string $type, // 'context', 'add', 'remove'
+        public readonly LineType $type,
         public readonly string $content,
         public readonly ?int $oldLineNum,
         public readonly ?int $newLineNum,

--- a/app/Enums/LineType.php
+++ b/app/Enums/LineType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum LineType: string
+{
+    case Add = 'add';
+    case Remove = 'remove';
+    case Context = 'context';
+}

--- a/app/Services/DiffParser.php
+++ b/app/Services/DiffParser.php
@@ -7,6 +7,7 @@ namespace App\Services;
 use App\DTOs\DiffLine;
 use App\DTOs\FileDiff;
 use App\DTOs\Hunk;
+use App\Enums\LineType;
 
 class DiffParser
 {
@@ -123,10 +124,10 @@ class DiffParser
                     if ($hunk !== null) {
                         $hunks[] = $hunk;
                         foreach ($hunk->lines as $dl) {
-                            if ($dl->type === 'add') {
+                            if ($dl->type === LineType::Add) {
                                 $additions++;
                             }
-                            if ($dl->type === 'remove') {
+                            if ($dl->type === LineType::Remove) {
                                 $deletions++;
                             }
                         }
@@ -145,10 +146,10 @@ class DiffParser
             if ($hunk !== null) {
                 $hunks[] = $hunk;
                 foreach ($hunk->lines as $dl) {
-                    if ($dl->type === 'add') {
+                    if ($dl->type === LineType::Add) {
                         $additions++;
                     }
-                    if ($dl->type === 'remove') {
+                    if ($dl->type === LineType::Remove) {
                         $deletions++;
                     }
                 }
@@ -159,11 +160,11 @@ class DiffParser
         $symlinkTarget = null;
         if ($isSymlink && ! empty($hunks)) {
             foreach ($hunks[0]->lines as $dl) {
-                if ($dl->type === 'add') {
+                if ($dl->type === LineType::Add) {
                     $symlinkTarget = $dl->content;
                     break;
                 }
-                if ($dl->type === 'remove' && $symlinkTarget === null) {
+                if ($dl->type === LineType::Remove && $symlinkTarget === null) {
                     $symlinkTarget = $dl->content;
                 }
             }
@@ -205,7 +206,7 @@ class DiffParser
 
             if ($raw === '') {
                 // Empty context line (trailing newlines in diff)
-                $diffLines[] = new DiffLine('context', '', $oldLine, $newLine);
+                $diffLines[] = new DiffLine(LineType::Context, '', $oldLine, $newLine);
                 $oldLine++;
                 $newLine++;
 
@@ -217,15 +218,15 @@ class DiffParser
 
             match ($prefix) {
                 '+' => (function () use (&$diffLines, $content, &$newLine) {
-                    $diffLines[] = new DiffLine('add', $content, null, $newLine);
+                    $diffLines[] = new DiffLine(LineType::Add, $content, null, $newLine);
                     $newLine++;
                 })(),
                 '-' => (function () use (&$diffLines, $content, &$oldLine) {
-                    $diffLines[] = new DiffLine('remove', $content, $oldLine, null);
+                    $diffLines[] = new DiffLine(LineType::Remove, $content, $oldLine, null);
                     $oldLine++;
                 })(),
                 default => (function () use (&$diffLines, $content, &$oldLine, &$newLine) {
-                    $diffLines[] = new DiffLine('context', $content, $oldLine, $newLine);
+                    $diffLines[] = new DiffLine(LineType::Context, $content, $oldLine, $newLine);
                     $oldLine++;
                     $newLine++;
                 })(),

--- a/app/Services/MarkdownRegionService.php
+++ b/app/Services/MarkdownRegionService.php
@@ -6,6 +6,7 @@ namespace App\Services;
 
 use App\DTOs\DiffLine;
 use App\DTOs\Hunk;
+use App\Enums\LineType;
 use App\Support\MarkdownPath;
 
 class MarkdownRegionService
@@ -38,7 +39,7 @@ class MarkdownRegionService
         foreach ($hunks as $hunk) {
             $newLines = [];
             foreach ($hunk->lines as $line) {
-                $isNewSide = $line->type !== 'remove';
+                $isNewSide = $line->type !== LineType::Remove;
                 $fence = $isNewSide ? $this->fenceMarker($line->content) : null;
 
                 if ($fence !== null) {

--- a/app/Services/SyntaxHighlightService.php
+++ b/app/Services/SyntaxHighlightService.php
@@ -6,6 +6,7 @@ namespace App\Services;
 
 use App\DTOs\DiffLine;
 use App\DTOs\Hunk;
+use App\Enums\LineType;
 use App\Support\GrammarMap;
 use Illuminate\Support\Facades\Log;
 use Phiki\Grammar\Grammar;
@@ -91,10 +92,10 @@ class SyntaxHighlightService
         $newIndices = [];
 
         foreach ($lines as $i => $line) {
-            if ($line->type === 'remove') {
+            if ($line->type === LineType::Remove) {
                 $oldIndices[] = $i;
                 $oldCode[] = $line->content;
-            } elseif ($line->type === 'add') {
+            } elseif ($line->type === LineType::Add) {
                 $newIndices[] = $i;
                 $newCode[] = $line->content;
             } else {
@@ -111,7 +112,7 @@ class SyntaxHighlightService
         $highlighted = [];
 
         foreach ($oldIndices as $pos => $lineIndex) {
-            if (isset($oldHighlighted[$pos]) && $lines[$lineIndex]->type === 'remove') {
+            if (isset($oldHighlighted[$pos]) && $lines[$lineIndex]->type === LineType::Remove) {
                 $highlighted[$lineIndex] = $oldHighlighted[$pos];
             }
         }

--- a/app/Support/DiffCacheKey.php
+++ b/app/Support/DiffCacheKey.php
@@ -15,4 +15,22 @@ final class DiffCacheKey
     {
         return 'rfa_diff_v8_'.hash('xxh128', $projectIdOrRepoPath.':'.$contextKey.':'.$fileId);
     }
+
+    /**
+     * Each historical shape change adds a marker key; missing any means the
+     * entry predates a format change and must be recomputed.
+     *
+     * @phpstan-assert-if-true array<string, mixed> $cached
+     */
+    public static function isCurrentShape(mixed $cached): bool
+    {
+        return is_array($cached)
+            && array_key_exists('syntaxStyles', $cached)
+            && array_key_exists('isSymlink', $cached)
+            && array_key_exists('tableAligned', $cached)
+            && array_key_exists('newFileLineCount', $cached)
+            && array_key_exists('headingsAnnotated', $cached)
+            && array_key_exists('gridLayout', $cached)
+            && array_key_exists('lineTypesAreEnum', $cached);
+    }
 }

--- a/resources/views/components/diff/line.blade.php
+++ b/resources/views/components/diff/line.blade.php
@@ -8,18 +8,20 @@
 ])
 
 @php
+    use App\Enums\LineType;
+
     $type = $line['type'];
     $oldNum = $line['oldLineNum'] ?? null;
     $newNum = $line['newLineNum'] ?? null;
     $lineNum = $newNum ?? $oldNum;
     [$bgClass, $oldNumBgClass, $newNumBgClass, $prefix, $prefixColor] = match($type) {
-        'add' => ['bg-gh-add-bg', '', 'bg-gh-add-line', '+', 'text-gh-green'],
-        'remove' => ['bg-gh-del-bg', 'bg-gh-del-line', '', '-', 'text-gh-red'],
+        LineType::Add => ['bg-gh-add-bg', '', 'bg-gh-add-line', '+', 'text-gh-green'],
+        LineType::Remove => ['bg-gh-del-bg', 'bg-gh-del-line', '', '-', 'text-gh-red'],
         default => ['', '', '', ' ', 'text-gh-muted/30'],
     };
     $lineSide = match($type) {
-        'remove' => 'left',
-        'add' => 'right',
+        LineType::Remove => 'left',
+        LineType::Add => 'right',
         default => 'context',
     };
     $headingId = $line['headingId'] ?? null;
@@ -27,8 +29,8 @@
     $ancestorJs = $headingAncestors === [] ? null : json_encode($headingAncestors);
 
     $lineComments = match($type) {
-        'remove' => $commentsByLine["left:{$oldNum}"] ?? [],
-        'add' => $commentsByLine["right:{$newNum}"] ?? [],
+        LineType::Remove => $commentsByLine["left:{$oldNum}"] ?? [],
+        LineType::Add => $commentsByLine["right:{$newNum}"] ?? [],
         default => [
             ...($commentsByLine["left:{$oldNum}"] ?? []),
             ...($commentsByLine["right:{$newNum}"] ?? []),
@@ -38,7 +40,7 @@
 
 <div
     class="diff-line"
-    data-type="{{ $type }}"
+    data-type="{{ $type->value }}"
     :class="isLineSideInSelection({{ $lineNum ?? 'null' }}, @js($lineSide)) ? 'line-selected' : ''"
     @mouseenter="onDragOver({{ $newNum ?? 'null' }}, {{ $oldNum ?? 'null' }})"
     @if($hasRemote && $lineNum !== null) @contextmenu.prevent="onLineContextmenu($event, {{ $lineNum }}, '{{ $lineSide === 'left' ? 'old' : 'new' }}')" @endif
@@ -66,7 +68,7 @@
             class="inline-flex align-middle -my-0.5 mr-1 size-4 items-center justify-center text-gh-muted/60 hover:text-gh-text"
         ><flux:icon icon="chevron-down" variant="outline" class="!size-3" x-show="!foldedHeadings[{{ $headingId }}]" /><flux:icon icon="chevron-right" variant="outline" class="!size-3" x-show="foldedHeadings[{{ $headingId }}]" x-cloak /></button>@endif{!! $line['highlightedContent'] ?? e($line['content']) !!}</div>
 
-    @if($type === 'context')
+    @if($type === LineType::Context)
         {{-- Mirror cell: shown only in split mode (CSS hides in unified). --}}
         <div class="diff-cell diff-cell-content diff-cell-content-mirror {{ $bgClass }}" aria-hidden="true">{!! $line['highlightedContent'] ?? e($line['content']) !!}</div>
     @endif

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -49,7 +49,10 @@ new class extends Component {
 
     public function hydrate(): void
     {
-        $this->diffData = Cache::get($this->diffCacheKey());
+        $cached = Cache::get($this->diffCacheKey());
+        $this->diffData = is_array($cached) && ($cached['lineTypesAreEnum'] ?? false)
+            ? $cached
+            : null;
     }
 
     /** @param array<int, array<string, mixed>> $comments */

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -50,9 +50,7 @@ new class extends Component {
     public function hydrate(): void
     {
         $cached = Cache::get($this->diffCacheKey());
-        $this->diffData = is_array($cached) && ($cached['lineTypesAreEnum'] ?? false)
-            ? $cached
-            : null;
+        $this->diffData = DiffCacheKey::isCurrentShape($cached) ? $cached : null;
     }
 
     /** @param array<int, array<string, mixed>> $comments */

--- a/tests/Unit/Actions/ExpandDiffGapActionTest.php
+++ b/tests/Unit/Actions/ExpandDiffGapActionTest.php
@@ -2,13 +2,14 @@
 
 use App\Actions\ExpandDiffGapAction;
 use App\Console\Benchmark\DiffFixtureFactory;
+use App\Enums\LineType;
 
 function buildFullContextLines(int $totalLines): array
 {
     $lines = [];
     for ($i = 1; $i <= $totalLines; $i++) {
         $lines[] = [
-            'type' => 'context',
+            'type' => LineType::Context,
             'content' => "    // line {$i}",
             'oldLineNum' => $i,
             'newLineNum' => $i,

--- a/tests/Unit/CsvAlignerServiceTest.php
+++ b/tests/Unit/CsvAlignerServiceTest.php
@@ -2,6 +2,7 @@
 
 use App\DTOs\DiffLine;
 use App\DTOs\Hunk;
+use App\Enums\LineType;
 use App\Services\CsvAlignerService;
 
 beforeEach(function () {
@@ -11,7 +12,7 @@ beforeEach(function () {
 test('returns hunks unchanged for non-csv files', function () {
     $hunks = [
         new Hunk('', 1, 1, 1, 1, [
-            new DiffLine('context', 'a,b,c', 1, 1),
+            new DiffLine(LineType::Context, 'a,b,c', 1, 1),
         ]),
     ];
 
@@ -23,9 +24,9 @@ test('returns hunks unchanged for non-csv files', function () {
 test('aligns simple csv columns', function () {
     $hunks = [
         new Hunk('', 1, 3, 1, 3, [
-            new DiffLine('context', 'name,age,city', 1, 1),
-            new DiffLine('context', 'Alice,30,NYC', 2, 2),
-            new DiffLine('context', 'Bob,25,Los Angeles', 3, 3),
+            new DiffLine(LineType::Context, 'name,age,city', 1, 1),
+            new DiffLine(LineType::Context, 'Alice,30,NYC', 2, 2),
+            new DiffLine(LineType::Context, 'Bob,25,Los Angeles', 3, 3),
         ]),
     ];
 
@@ -39,9 +40,9 @@ test('aligns simple csv columns', function () {
 test('handles mixed diff types in group', function () {
     $hunks = [
         new Hunk('', 1, 3, 1, 3, [
-            new DiffLine('context', 'col,value', 1, 1),
-            new DiffLine('remove', 'short,x', 2, null),
-            new DiffLine('add', 'a much longer cell,updated', null, 2),
+            new DiffLine(LineType::Context, 'col,value', 1, 1),
+            new DiffLine(LineType::Remove, 'short,x', 2, null),
+            new DiffLine(LineType::Add, 'a much longer cell,updated', null, 2),
         ]),
     ];
 
@@ -50,16 +51,16 @@ test('handles mixed diff types in group', function () {
     $lines = $result[0]->lines;
     expect($lines[0]->content)->toBe('col               ,value');
     expect($lines[1]->content)->toBe('short             ,x');
-    expect($lines[1]->type)->toBe('remove');
+    expect($lines[1]->type)->toBe(LineType::Remove);
     expect($lines[2]->content)->toBe('a much longer cell,updated');
-    expect($lines[2]->type)->toBe('add');
+    expect($lines[2]->type)->toBe(LineType::Add);
 });
 
 test('does not pad the last column', function () {
     $hunks = [
         new Hunk('', 1, 2, 1, 2, [
-            new DiffLine('context', 'a,b', 1, 1),
-            new DiffLine('context', 'longer,c', 2, 2),
+            new DiffLine(LineType::Context, 'a,b', 1, 1),
+            new DiffLine(LineType::Context, 'longer,c', 2, 2),
         ]),
     ];
 
@@ -72,8 +73,8 @@ test('does not pad the last column', function () {
 test('preserves quoted fields containing commas', function () {
     $hunks = [
         new Hunk('', 1, 2, 1, 2, [
-            new DiffLine('context', '"Smith, John",30,NYC', 1, 1),
-            new DiffLine('context', 'Alice,25,LA', 2, 2),
+            new DiffLine(LineType::Context, '"Smith, John",30,NYC', 1, 1),
+            new DiffLine(LineType::Context, 'Alice,25,LA', 2, 2),
         ]),
     ];
 
@@ -86,8 +87,8 @@ test('preserves quoted fields containing commas', function () {
 test('preserves escaped double quotes inside quoted fields', function () {
     $hunks = [
         new Hunk('', 1, 2, 1, 2, [
-            new DiffLine('context', '"he said ""hi""",x', 1, 1),
-            new DiffLine('context', 'short,y', 2, 2),
+            new DiffLine(LineType::Context, '"he said ""hi""",x', 1, 1),
+            new DiffLine(LineType::Context, 'short,y', 2, 2),
         ]),
     ];
 
@@ -100,8 +101,8 @@ test('preserves escaped double quotes inside quoted fields', function () {
 test('skips alignment when a line has an unterminated quote', function () {
     $hunks = [
         new Hunk('', 1, 2, 1, 2, [
-            new DiffLine('context', '"starts here', 1, 1),
-            new DiffLine('context', 'continues",x', 2, 2),
+            new DiffLine(LineType::Context, '"starts here', 1, 1),
+            new DiffLine(LineType::Context, 'continues",x', 2, 2),
         ]),
     ];
 
@@ -113,8 +114,8 @@ test('skips alignment when a line has an unterminated quote', function () {
 test('skips alignment for single-column csv', function () {
     $hunks = [
         new Hunk('', 1, 2, 1, 2, [
-            new DiffLine('context', 'apple', 1, 1),
-            new DiffLine('context', 'banana', 2, 2),
+            new DiffLine(LineType::Context, 'apple', 1, 1),
+            new DiffLine(LineType::Context, 'banana', 2, 2),
         ]),
     ];
 
@@ -126,8 +127,8 @@ test('skips alignment for single-column csv', function () {
 test('handles rows with different column counts', function () {
     $hunks = [
         new Hunk('', 1, 2, 1, 2, [
-            new DiffLine('context', 'a,b,c', 1, 1),
-            new DiffLine('add', 'x,y', null, 2),
+            new DiffLine(LineType::Context, 'a,b,c', 1, 1),
+            new DiffLine(LineType::Add, 'x,y', null, 2),
         ]),
     ];
 
@@ -141,11 +142,11 @@ test('handles rows with different column counts', function () {
 test('handles multiple groups separated by blank lines', function () {
     $hunks = [
         new Hunk('', 1, 5, 1, 5, [
-            new DiffLine('context', 'a,b', 1, 1),
-            new DiffLine('context', 'longer,x', 2, 2),
-            new DiffLine('context', '', 3, 3),
-            new DiffLine('context', 'c,d', 4, 4),
-            new DiffLine('context', 'y,much longer', 5, 5),
+            new DiffLine(LineType::Context, 'a,b', 1, 1),
+            new DiffLine(LineType::Context, 'longer,x', 2, 2),
+            new DiffLine(LineType::Context, '', 3, 3),
+            new DiffLine(LineType::Context, 'c,d', 4, 4),
+            new DiffLine(LineType::Context, 'y,much longer', 5, 5),
         ]),
     ];
 
@@ -167,8 +168,8 @@ test('handles empty hunks', function () {
 test('preserves line numbers and types', function () {
     $hunks = [
         new Hunk('', 10, 2, 10, 2, [
-            new DiffLine('context', 'a,b', 10, 10),
-            new DiffLine('add', 'longer,x', null, 11),
+            new DiffLine(LineType::Context, 'a,b', 10, 10),
+            new DiffLine(LineType::Add, 'longer,x', null, 11),
         ]),
     ];
 
@@ -176,7 +177,7 @@ test('preserves line numbers and types', function () {
 
     expect($result[0]->lines[0]->oldLineNum)->toBe(10)
         ->and($result[0]->lines[0]->newLineNum)->toBe(10)
-        ->and($result[0]->lines[1]->type)->toBe('add')
+        ->and($result[0]->lines[1]->type)->toBe(LineType::Add)
         ->and($result[0]->lines[1]->oldLineNum)->toBeNull()
         ->and($result[0]->lines[1]->newLineNum)->toBe(11);
 });
@@ -184,8 +185,8 @@ test('preserves line numbers and types', function () {
 test('returns hunks unchanged when all columns already aligned', function () {
     $hunks = [
         new Hunk('', 1, 2, 1, 2, [
-            new DiffLine('context', 'aaa,bbb', 1, 1),
-            new DiffLine('context', 'xxx,yyy', 2, 2),
+            new DiffLine(LineType::Context, 'aaa,bbb', 1, 1),
+            new DiffLine(LineType::Context, 'xxx,yyy', 2, 2),
         ]),
     ];
 
@@ -197,8 +198,8 @@ test('returns hunks unchanged when all columns already aligned', function () {
 test('handles multi-byte characters using display width', function () {
     $hunks = [
         new Hunk('', 1, 2, 1, 2, [
-            new DiffLine('context', 'name,city', 1, 1),
-            new DiffLine('context', '日本,Tokyo', 2, 2),
+            new DiffLine(LineType::Context, 'name,city', 1, 1),
+            new DiffLine(LineType::Context, '日本,Tokyo', 2, 2),
         ]),
     ];
 

--- a/tests/Unit/DiffLineTest.php
+++ b/tests/Unit/DiffLineTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\DTOs\DiffLine;
+use App\Enums\LineType;
 use Faker\Factory as Faker;
 
 beforeEach(function () {
@@ -9,7 +10,7 @@ beforeEach(function () {
 });
 
 test('toArray returns all properties', function () {
-    $type = $this->faker->randomElement(['context', 'add', 'remove']);
+    $type = $this->faker->randomElement(LineType::cases());
     $content = $this->faker->sentence();
     $oldLineNum = $this->faker->numberBetween(1, 500);
     $newLineNum = $this->faker->numberBetween(1, 500);
@@ -25,7 +26,7 @@ test('toArray returns all properties', function () {
 });
 
 test('toArray handles null line numbers', function () {
-    $line = new DiffLine('add', $this->faker->sentence(), null, $this->faker->numberBetween(1, 100));
+    $line = new DiffLine(LineType::Add, $this->faker->sentence(), null, $this->faker->numberBetween(1, 100));
 
     $array = $line->toArray();
 
@@ -36,7 +37,7 @@ test('toArray handles null line numbers', function () {
 test('toArray includes highlightedContent when set', function () {
     $highlighted = '<span style="color:#000">code</span>';
 
-    $line = new DiffLine('add', 'code', null, 1, $highlighted);
+    $line = new DiffLine(LineType::Add, 'code', null, 1, $highlighted);
 
     $array = $line->toArray();
 
@@ -45,7 +46,7 @@ test('toArray includes highlightedContent when set', function () {
 });
 
 test('toArray omits highlightedContent when null', function () {
-    $line = new DiffLine('context', 'code', 1, 1);
+    $line = new DiffLine(LineType::Context, 'code', 1, 1);
 
     expect($line->toArray())->not->toHaveKey('highlightedContent');
 });

--- a/tests/Unit/DiffParserTest.php
+++ b/tests/Unit/DiffParserTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\LineType;
 use App\Services\DiffParser;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
@@ -21,7 +22,7 @@ test('parses simple modification', function () {
     expect($files[0]->hunks)->toHaveCount(1);
 
     $lines = $files[0]->hunks[0]->lines;
-    expect($lines[0]->type)->toBe('context');
+    expect($lines[0]->type)->toBe(LineType::Context);
     expect($lines[0]->content)->toBe('<?php');
     expect($lines[0]->oldLineNum)->toBe(1);
     expect($lines[0]->newLineNum)->toBe(1);

--- a/tests/Unit/FileDiffTest.php
+++ b/tests/Unit/FileDiffTest.php
@@ -3,6 +3,7 @@
 use App\DTOs\DiffLine;
 use App\DTOs\FileDiff;
 use App\DTOs\Hunk;
+use App\Enums\LineType;
 use Faker\Factory as Faker;
 
 beforeEach(function () {
@@ -12,8 +13,8 @@ beforeEach(function () {
 
 test('toArray returns all expected keys', function () {
     $lines = [
-        new DiffLine('context', $this->faker->sentence(), 1, 1),
-        new DiffLine('add', $this->faker->sentence(), null, 2),
+        new DiffLine(LineType::Context, $this->faker->sentence(), 1, 1),
+        new DiffLine(LineType::Add, $this->faker->sentence(), null, 2),
     ];
 
     $hunk = new Hunk('fn()', 1, 1, 1, 2, $lines);
@@ -55,7 +56,7 @@ test('toArray handles empty hunks', function () {
 
 test('withHunks returns new instance with replaced hunks', function () {
     $original = new FileDiff('f.php', 'modified', null, [], 1, 0);
-    $newHunks = [new Hunk('fn()', 1, 1, 1, 1, [new DiffLine('add', 'new', null, 1)])];
+    $newHunks = [new Hunk('fn()', 1, 1, 1, 1, [new DiffLine(LineType::Add, 'new', null, 1)])];
 
     $updated = $original->withHunks($newHunks);
 

--- a/tests/Unit/HunkTest.php
+++ b/tests/Unit/HunkTest.php
@@ -2,6 +2,7 @@
 
 use App\DTOs\DiffLine;
 use App\DTOs\Hunk;
+use App\Enums\LineType;
 use Faker\Factory as Faker;
 
 beforeEach(function () {
@@ -15,9 +16,9 @@ test('toArray serializes header, starts, counts, and lines', function () {
     $newStart = $this->faker->numberBetween(1, 100);
 
     $lines = [
-        new DiffLine('context', $this->faker->sentence(), $oldStart, $newStart),
-        new DiffLine('remove', $this->faker->sentence(), $oldStart + 1, null),
-        new DiffLine('add', $this->faker->sentence(), null, $newStart + 1),
+        new DiffLine(LineType::Context, $this->faker->sentence(), $oldStart, $newStart),
+        new DiffLine(LineType::Remove, $this->faker->sentence(), $oldStart + 1, null),
+        new DiffLine(LineType::Add, $this->faker->sentence(), null, $newStart + 1),
     ];
 
     $hunk = new Hunk($header, $oldStart, 2, $newStart, 2, $lines);
@@ -31,8 +32,8 @@ test('toArray serializes header, starts, counts, and lines', function () {
     expect($array['newCount'])->toBe(2);
     expect($array['lines'])->toHaveCount(3);
     expect($array['lines'][0])->toBe($lines[0]->toArray());
-    expect($array['lines'][1]['type'])->toBe('remove');
-    expect($array['lines'][2]['type'])->toBe('add');
+    expect($array['lines'][1]['type'])->toBe(LineType::Remove);
+    expect($array['lines'][2]['type'])->toBe(LineType::Add);
 });
 
 test('toArray handles empty lines', function () {

--- a/tests/Unit/Livewire/DiffFileTest.php
+++ b/tests/Unit/Livewire/DiffFileTest.php
@@ -3,6 +3,7 @@
 use App\Actions\LoadFileDiffAction;
 use App\Console\Benchmark\DiffFixtureFactory;
 use App\DTOs\DiffTarget;
+use App\Enums\LineType;
 use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
 use Livewire\Features\SupportTesting\Testable;
@@ -330,7 +331,7 @@ function buildContextHunk(int $startLine, int $lineCount = 3): array
     for ($i = 0; $i < $lineCount; $i++) {
         $lineNum = $startLine + $i;
         $lines[] = [
-            'type' => 'context',
+            'type' => LineType::Context,
             'content' => "// line {$lineNum}",
             'oldLineNum' => $lineNum,
             'newLineNum' => $lineNum,

--- a/tests/Unit/MarkdownTableAlignerServiceTest.php
+++ b/tests/Unit/MarkdownTableAlignerServiceTest.php
@@ -2,6 +2,7 @@
 
 use App\DTOs\DiffLine;
 use App\DTOs\Hunk;
+use App\Enums\LineType;
 use App\Services\MarkdownTableAlignerService;
 
 beforeEach(function () {
@@ -11,7 +12,7 @@ beforeEach(function () {
 test('returns hunks unchanged for non-markdown files', function () {
     $hunks = [
         new Hunk('', 1, 1, 1, 1, [
-            new DiffLine('context', '| col1 | col2 |', 1, 1),
+            new DiffLine(LineType::Context, '| col1 | col2 |', 1, 1),
         ]),
     ];
 
@@ -23,7 +24,7 @@ test('returns hunks unchanged for non-markdown files', function () {
 test('returns hunks unchanged when no tables present', function () {
     $hunks = [
         new Hunk('', 1, 1, 1, 1, [
-            new DiffLine('context', 'just some text', 1, 1),
+            new DiffLine(LineType::Context, 'just some text', 1, 1),
         ]),
     ];
 
@@ -35,10 +36,10 @@ test('returns hunks unchanged when no tables present', function () {
 test('aligns simple table columns', function () {
     $hunks = [
         new Hunk('', 1, 4, 1, 4, [
-            new DiffLine('context', '| Name | Description | Notes |', 1, 1),
-            new DiffLine('context', '|---|---|---|', 2, 2),
-            new DiffLine('context', '| a | A longer description | n |', 3, 3),
-            new DiffLine('context', '| longer name | b | some notes here |', 4, 4),
+            new DiffLine(LineType::Context, '| Name | Description | Notes |', 1, 1),
+            new DiffLine(LineType::Context, '|---|---|---|', 2, 2),
+            new DiffLine(LineType::Context, '| a | A longer description | n |', 3, 3),
+            new DiffLine(LineType::Context, '| longer name | b | some notes here |', 4, 4),
         ]),
     ];
 
@@ -54,10 +55,10 @@ test('aligns simple table columns', function () {
 test('handles mixed diff types in table group', function () {
     $hunks = [
         new Hunk('', 1, 3, 1, 3, [
-            new DiffLine('context', '| Col | Value |', 1, 1),
-            new DiffLine('context', '|---|---|', 2, 2),
-            new DiffLine('remove', '| short | x |', 3, null),
-            new DiffLine('add', '| a much longer cell | updated |', null, 3),
+            new DiffLine(LineType::Context, '| Col | Value |', 1, 1),
+            new DiffLine(LineType::Context, '|---|---|', 2, 2),
+            new DiffLine(LineType::Remove, '| short | x |', 3, null),
+            new DiffLine(LineType::Add, '| a much longer cell | updated |', null, 3),
         ]),
     ];
 
@@ -67,17 +68,17 @@ test('handles mixed diff types in table group', function () {
     // All lines aligned to the widest content across all types
     expect($lines[0]->content)->toBe('| Col                | Value   |');
     expect($lines[2]->content)->toBe('| short              | x       |');
-    expect($lines[2]->type)->toBe('remove');
+    expect($lines[2]->type)->toBe(LineType::Remove);
     expect($lines[3]->content)->toBe('| a much longer cell | updated |');
-    expect($lines[3]->type)->toBe('add');
+    expect($lines[3]->type)->toBe(LineType::Add);
 });
 
 test('extends separator row dashes to match column width', function () {
     $hunks = [
         new Hunk('', 1, 3, 1, 3, [
-            new DiffLine('context', '| Header One | H2 |', 1, 1),
-            new DiffLine('context', '|---|---|', 2, 2),
-            new DiffLine('context', '| data | d |', 3, 3),
+            new DiffLine(LineType::Context, '| Header One | H2 |', 1, 1),
+            new DiffLine(LineType::Context, '|---|---|', 2, 2),
+            new DiffLine(LineType::Context, '| data | d |', 3, 3),
         ]),
     ];
 
@@ -89,9 +90,9 @@ test('extends separator row dashes to match column width', function () {
 test('preserves separator alignment markers', function () {
     $hunks = [
         new Hunk('', 1, 3, 1, 3, [
-            new DiffLine('context', '| Left Longer | Center Longer | Right Longer |', 1, 1),
-            new DiffLine('context', '|:---|:---:|---:|', 2, 2),
-            new DiffLine('context', '| data | data | data |', 3, 3),
+            new DiffLine(LineType::Context, '| Left Longer | Center Longer | Right Longer |', 1, 1),
+            new DiffLine(LineType::Context, '|:---|:---:|---:|', 2, 2),
+            new DiffLine(LineType::Context, '| data | data | data |', 3, 3),
         ]),
     ];
 
@@ -109,8 +110,8 @@ test('preserves separator alignment markers', function () {
 test('handles tables with different column counts', function () {
     $hunks = [
         new Hunk('', 1, 2, 1, 2, [
-            new DiffLine('context', '| a | b | c |', 1, 1),
-            new DiffLine('add', '| x | y |', null, 2),
+            new DiffLine(LineType::Context, '| a | b | c |', 1, 1),
+            new DiffLine(LineType::Add, '| x | y |', null, 2),
         ]),
     ];
 
@@ -125,9 +126,9 @@ test('handles tables with different column counts', function () {
 test('preserves indented tables', function () {
     $hunks = [
         new Hunk('', 1, 3, 1, 3, [
-            new DiffLine('context', '    | Col | Value |', 1, 1),
-            new DiffLine('context', '    |---|---|', 2, 2),
-            new DiffLine('context', '    | longer | x |', 3, 3),
+            new DiffLine(LineType::Context, '    | Col | Value |', 1, 1),
+            new DiffLine(LineType::Context, '    |---|---|', 2, 2),
+            new DiffLine(LineType::Context, '    | longer | x |', 3, 3),
         ]),
     ];
 
@@ -143,8 +144,8 @@ test('preserves indented tables', function () {
 test('does not align non-table pipe lines', function () {
     $hunks = [
         new Hunk('', 1, 2, 1, 2, [
-            new DiffLine('context', 'echo foo | grep bar', 1, 1),
-            new DiffLine('context', 'cat file | wc -l', 2, 2),
+            new DiffLine(LineType::Context, 'echo foo | grep bar', 1, 1),
+            new DiffLine(LineType::Context, 'cat file | wc -l', 2, 2),
         ]),
     ];
 
@@ -156,13 +157,13 @@ test('does not align non-table pipe lines', function () {
 test('handles multiple table groups in one hunk', function () {
     $hunks = [
         new Hunk('', 1, 7, 1, 7, [
-            new DiffLine('context', '| a | b |', 1, 1),
-            new DiffLine('context', '|---|---|', 2, 2),
-            new DiffLine('context', '| longer | x |', 3, 3),
-            new DiffLine('context', '', 4, 4),
-            new DiffLine('context', '| c | d |', 5, 5),
-            new DiffLine('context', '|---|---|', 6, 6),
-            new DiffLine('context', '| y | much longer |', 7, 7),
+            new DiffLine(LineType::Context, '| a | b |', 1, 1),
+            new DiffLine(LineType::Context, '|---|---|', 2, 2),
+            new DiffLine(LineType::Context, '| longer | x |', 3, 3),
+            new DiffLine(LineType::Context, '', 4, 4),
+            new DiffLine(LineType::Context, '| c | d |', 5, 5),
+            new DiffLine(LineType::Context, '|---|---|', 6, 6),
+            new DiffLine(LineType::Context, '| y | much longer |', 7, 7),
         ]),
     ];
 
@@ -186,9 +187,9 @@ test('handles empty hunks', function () {
 test('processes mdx files', function () {
     $hunks = [
         new Hunk('', 1, 3, 1, 3, [
-            new DiffLine('context', '| Short | Value |', 1, 1),
-            new DiffLine('context', '|---|---|', 2, 2),
-            new DiffLine('context', '| a longer name | x |', 3, 3),
+            new DiffLine(LineType::Context, '| Short | Value |', 1, 1),
+            new DiffLine(LineType::Context, '|---|---|', 2, 2),
+            new DiffLine(LineType::Context, '| a longer name | x |', 3, 3),
         ]),
     ];
 
@@ -201,9 +202,9 @@ test('processes mdx files', function () {
 test('preserves line numbers and types', function () {
     $hunks = [
         new Hunk('', 10, 3, 10, 3, [
-            new DiffLine('context', '| a | b |', 10, 10),
-            new DiffLine('context', '|---|---|', 11, 11),
-            new DiffLine('add', '| longer | x |', null, 12),
+            new DiffLine(LineType::Context, '| a | b |', 10, 10),
+            new DiffLine(LineType::Context, '|---|---|', 11, 11),
+            new DiffLine(LineType::Add, '| longer | x |', null, 12),
         ]),
     ];
 
@@ -211,7 +212,7 @@ test('preserves line numbers and types', function () {
 
     expect($result[0]->lines[0]->oldLineNum)->toBe(10)
         ->and($result[0]->lines[0]->newLineNum)->toBe(10)
-        ->and($result[0]->lines[2]->type)->toBe('add')
+        ->and($result[0]->lines[2]->type)->toBe(LineType::Add)
         ->and($result[0]->lines[2]->oldLineNum)->toBeNull()
         ->and($result[0]->lines[2]->newLineNum)->toBe(12);
 });

--- a/tests/Unit/Services/MarkdownRegionServiceTest.php
+++ b/tests/Unit/Services/MarkdownRegionServiceTest.php
@@ -2,6 +2,7 @@
 
 use App\DTOs\DiffLine;
 use App\DTOs\Hunk;
+use App\Enums\LineType;
 use App\Services\MarkdownRegionService;
 
 beforeEach(function () {
@@ -15,11 +16,12 @@ function mdHunk(array $lines, int $startNewLine = 1, int $startOldLine = 1): Hun
     $oldLine = $startOldLine;
     foreach ($lines as $spec) {
         [$type, $content] = $spec;
+        $lineType = LineType::from($type);
         $diffLines[] = new DiffLine(
-            type: $type,
+            type: $lineType,
             content: $content,
-            oldLineNum: $type === 'add' ? null : $oldLine++,
-            newLineNum: $type === 'remove' ? null : $newLine++,
+            oldLineNum: $lineType === LineType::Add ? null : $oldLine++,
+            newLineNum: $lineType === LineType::Remove ? null : $newLine++,
         );
     }
 
@@ -271,7 +273,7 @@ test('heading ids are stable across recomputes (driven by new line number)', fun
 
 test('preserves existing line fields when annotating', function () {
     $line = new DiffLine(
-        type: 'context',
+        type: LineType::Context,
         content: '# Title',
         oldLineNum: 3,
         newLineNum: 3,

--- a/tests/Unit/SyntaxHighlightServiceTest.php
+++ b/tests/Unit/SyntaxHighlightServiceTest.php
@@ -2,6 +2,7 @@
 
 use App\DTOs\DiffLine;
 use App\DTOs\Hunk;
+use App\Enums\LineType;
 use App\Services\SyntaxHighlightService;
 
 beforeEach(function () {
@@ -11,9 +12,9 @@ beforeEach(function () {
 test('highlights PHP hunks', function () {
     $hunks = [
         new Hunk('', 1, 3, 1, 3, [
-            new DiffLine('context', '<?php', 1, 1),
-            new DiffLine('remove', 'echo "old";', 2, null),
-            new DiffLine('add', 'echo "new";', null, 2),
+            new DiffLine(LineType::Context, '<?php', 1, 1),
+            new DiffLine(LineType::Remove, 'echo "old";', 2, null),
+            new DiffLine(LineType::Add, 'echo "new";', null, 2),
         ]),
     ];
 
@@ -29,7 +30,7 @@ test('highlights PHP hunks', function () {
 test('returns unmodified hunks for unknown grammar', function () {
     $hunks = [
         new Hunk('', 1, 0, 1, 1, [
-            new DiffLine('add', 'hello', null, 1),
+            new DiffLine(LineType::Add, 'hello', null, 1),
         ]),
     ];
 
@@ -48,7 +49,7 @@ test('handles empty hunks', function () {
 test('context lines get new-side highlighting', function () {
     $hunks = [
         new Hunk('', 1, 1, 1, 1, [
-            new DiffLine('context', '$x = 1;', 1, 1),
+            new DiffLine(LineType::Context, '$x = 1;', 1, 1),
         ]),
     ];
 
@@ -61,7 +62,7 @@ test('context lines get new-side highlighting', function () {
 test('removed lines get old-side highlighting', function () {
     $hunks = [
         new Hunk('', 1, 1, 1, 0, [
-            new DiffLine('remove', '$old = true;', 1, null),
+            new DiffLine(LineType::Remove, '$old = true;', 1, null),
         ]),
     ];
 
@@ -74,7 +75,7 @@ test('removed lines get old-side highlighting', function () {
 test('preserves original content field', function () {
     $hunks = [
         new Hunk('', 1, 0, 1, 1, [
-            new DiffLine('add', 'echo "hello";', null, 1),
+            new DiffLine(LineType::Add, 'echo "hello";', null, 1),
         ]),
     ];
 
@@ -86,11 +87,11 @@ test('preserves original content field', function () {
 test('highlights mixed add/remove/context hunk with asymmetric sides', function () {
     $hunks = [
         new Hunk('@@ -1,4 +1,3 @@', 1, 4, 1, 3, [
-            new DiffLine('context', '<?php', 1, 1),
-            new DiffLine('remove', '$a = 1;', 2, null),
-            new DiffLine('remove', '$b = 2;', 3, null),
-            new DiffLine('add', '$c = 3;', null, 2),
-            new DiffLine('context', 'return true;', 4, 3),
+            new DiffLine(LineType::Context, '<?php', 1, 1),
+            new DiffLine(LineType::Remove, '$a = 1;', 2, null),
+            new DiffLine(LineType::Remove, '$b = 2;', 3, null),
+            new DiffLine(LineType::Add, '$c = 3;', null, 2),
+            new DiffLine(LineType::Context, 'return true;', 4, 3),
         ]),
     ];
 
@@ -107,9 +108,9 @@ test('highlights mixed add/remove/context hunk with asymmetric sides', function 
 test('handles hunk with only context lines', function () {
     $hunks = [
         new Hunk('', 1, 3, 1, 3, [
-            new DiffLine('context', '<?php', 1, 1),
-            new DiffLine('context', '', 2, 2),
-            new DiffLine('context', 'return true;', 3, 3),
+            new DiffLine(LineType::Context, '<?php', 1, 1),
+            new DiffLine(LineType::Context, '', 2, 2),
+            new DiffLine(LineType::Context, 'return true;', 3, 3),
         ]),
     ];
 
@@ -129,16 +130,16 @@ test('multi-hunk diff highlights all hunks independently', function () {
     // from distant hunks would break the tokenizer's grammar state
     $hunks = [
         new Hunk('@@ -5,3 +5,6 @@', 5, 3, 5, 6, [
-            new DiffLine('context', 'use Illuminate\Support\Str;', 5, 5),
-            new DiffLine('add', '// A comment block', null, 6),
-            new DiffLine('add', '// that spans lines', null, 7),
-            new DiffLine('context', '', 6, 8),
-            new DiffLine('context', 'class Example {', 7, 9),
+            new DiffLine(LineType::Context, 'use Illuminate\Support\Str;', 5, 5),
+            new DiffLine(LineType::Add, '// A comment block', null, 6),
+            new DiffLine(LineType::Add, '// that spans lines', null, 7),
+            new DiffLine(LineType::Context, '', 6, 8),
+            new DiffLine(LineType::Context, 'class Example {', 7, 9),
         ]),
         new Hunk('@@ -20,3 +23,3 @@', 20, 3, 23, 3, [
-            new DiffLine('context', '    public function run(): void {', 20, 23),
-            new DiffLine('remove', '        $old = true;', 21, null),
-            new DiffLine('add', '        foreach ($items as $i) {', null, 24),
+            new DiffLine(LineType::Context, '    public function run(): void {', 20, 23),
+            new DiffLine(LineType::Remove, '        $old = true;', 21, null),
+            new DiffLine(LineType::Add, '        foreach ($items as $i) {', null, 24),
         ]),
     ];
 
@@ -166,7 +167,7 @@ test('multi-hunk diff highlights all hunks independently', function () {
 test('style map has entries with different light and dark colors', function () {
     $hunks = [
         new Hunk('', 1, 0, 1, 1, [
-            new DiffLine('add', 'echo "hello";', null, 1),
+            new DiffLine(LineType::Add, 'echo "hello";', null, 1),
         ]),
     ];
 
@@ -182,7 +183,7 @@ test('style map has entries with different light and dark colors', function () {
 test('getStyleMap returns expected structure', function () {
     $hunks = [
         new Hunk('', 1, 0, 1, 1, [
-            new DiffLine('add', 'echo "hello";', null, 1),
+            new DiffLine(LineType::Add, 'echo "hello";', null, 1),
         ]),
     ];
 
@@ -200,9 +201,9 @@ test('getStyleMap returns expected structure', function () {
 test('output uses class not style attribute', function () {
     $hunks = [
         new Hunk('', 1, 3, 1, 3, [
-            new DiffLine('context', '<?php', 1, 1),
-            new DiffLine('remove', 'echo "old";', 2, null),
-            new DiffLine('add', 'echo "new";', null, 2),
+            new DiffLine(LineType::Context, '<?php', 1, 1),
+            new DiffLine(LineType::Remove, 'echo "old";', 2, null),
+            new DiffLine(LineType::Add, 'echo "new";', null, 2),
         ]),
     ];
 
@@ -219,7 +220,7 @@ test('output uses class not style attribute', function () {
 test('no background-color in style map values', function () {
     $hunks = [
         new Hunk('', 1, 0, 1, 1, [
-            new DiffLine('add', 'echo "hello";', null, 1),
+            new DiffLine(LineType::Add, 'echo "hello";', null, 1),
         ]),
     ];
 
@@ -235,9 +236,9 @@ test('no background-color in style map values', function () {
 test('all class names in highlighted HTML have matching style map entries', function () {
     $hunks = [
         new Hunk('', 1, 3, 1, 3, [
-            new DiffLine('context', '<?php', 1, 1),
-            new DiffLine('remove', 'echo "old";', 2, null),
-            new DiffLine('add', 'echo "new";', null, 2),
+            new DiffLine(LineType::Context, '<?php', 1, 1),
+            new DiffLine(LineType::Remove, 'echo "old";', 2, null),
+            new DiffLine(LineType::Add, 'echo "new";', null, 2),
         ]),
     ];
 
@@ -264,7 +265,7 @@ test('all class names in highlighted HTML have matching style map entries', func
 test('returns Hunk DTOs not arrays', function () {
     $hunks = [
         new Hunk('', 1, 1, 1, 1, [
-            new DiffLine('add', '$x = 1;', null, 1),
+            new DiffLine(LineType::Add, '$x = 1;', null, 1),
         ]),
     ];
 


### PR DESCRIPTION
This PR replaces all string-based line type representations with a dedicated `LineType` enum, improving type safety and maintainability throughout the codebase.

## Summary
Introduced a new `LineType` enum with three cases (`Add`, `Remove`, `Context`) to replace hardcoded string values like `'add'`, `'remove'`, and `'context'` that were previously used to represent diff line types.

## Key Changes

- **New Enum**: Created `app/Enums/LineType.php` with three enum cases backed by string values
- **DiffLine DTO**: Updated `DiffLine` class to use `LineType` instead of `string` for the `type` property
- **DiffParser**: Converted all string comparisons to use `LineType` enum cases
- **Services**: Updated `SyntaxHighlightService`, `MarkdownRegionService`, and related services to work with the enum
- **Views**: Modified Blade template to use enum cases in match expressions and convert enum to string value with `->value` when needed for HTML attributes
- **Cache Validation**: Enhanced `DiffCacheKey::isCurrentShape()` to validate the new `lineTypesAreEnum` marker, ensuring cached data is invalidated when the format changes
- **Tests**: Updated all test files to instantiate `DiffLine` objects with `LineType` enum cases instead of strings
- **Benchmark Fixtures**: Updated fixture factory to use enum cases for generated test data

## Implementation Details

- The enum uses string backing values (`'add'`, `'remove'`, `'context'`) to maintain compatibility with serialized data and HTML attributes
- Cache invalidation is handled through a new `lineTypesAreEnum` marker in the cache shape validation
- All match expressions now use enum cases, providing better IDE support and compile-time checking
- The Blade template uses `$type->value` to convert the enum to its string representation for HTML data attributes

https://claude.ai/code/session_01Wtbu1D6XkyeXwqo54KZBvB