### PR TITLE
Add copy file paths menu to sidebar and status strip

### DIFF
--- a/resources/views/components/copy-paths-menu.blade.php
+++ b/resources/views/components/copy-paths-menu.blade.php
@@ -1,0 +1,30 @@
+@props([
+    'testidPrefix',
+])
+
+{{-- Renders a dropdown that copies the current visibly-filtered file list as
+     names, relative paths, or full paths. Inherits Alpine state from the
+     parent ⚡review-page scope: `visibleFileCount`, `copyVisibleFilePaths`. --}}
+<div data-testid="{{ $testidPrefix }}" x-show="visibleFileCount > 0" x-cloak>
+    <flux:dropdown position="bottom" align="end">
+        <flux:tooltip>
+            <flux:button variant="ghost" size="xs" icon="square-2-stack" icon:variant="outline"
+                aria-label="Copy file paths"
+                data-testid="{{ $testidPrefix }}-trigger" />
+            <flux:tooltip.content>
+                <span x-text="`Copy paths for ${visibleFileCount} ${visibleFileCount === 1 ? 'file' : 'files'}`"></span>
+            </flux:tooltip.content>
+        </flux:tooltip>
+        <flux:menu>
+            <flux:menu.item icon="document" icon:variant="outline" @click="copyVisibleFilePaths('name')">
+                Copy file names
+            </flux:menu.item>
+            <flux:menu.item icon="document-duplicate" icon:variant="outline" @click="copyVisibleFilePaths('relative')">
+                Copy relative paths
+            </flux:menu.item>
+            <flux:menu.item icon="link" icon:variant="outline" @click="copyVisibleFilePaths('full')">
+                Copy full paths
+            </flux:menu.item>
+        </flux:menu>
+    </flux:dropdown>
+</div>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1444,29 +1444,7 @@ new #[Layout('layouts.app')] class extends Component
                     </div>
                 </div>
                 @if(count($sourceFiles) > 0)
-                    <div data-testid="status-strip-copy-paths" x-show="visibleFileCount > 0">
-                        <flux:dropdown position="bottom" align="end">
-                            <flux:tooltip>
-                                <flux:button variant="ghost" size="xs" icon="square-2-stack" icon:variant="outline"
-                                    aria-label="Copy file paths"
-                                    data-testid="status-strip-copy-paths-trigger" />
-                                <flux:tooltip.content>
-                                    <span x-text="`Copy paths for ${visibleFileCount} ${visibleFileCount === 1 ? 'file' : 'files'}`"></span>
-                                </flux:tooltip.content>
-                            </flux:tooltip>
-                            <flux:menu>
-                                <flux:menu.item icon="document" icon:variant="outline" @click="copyVisibleFilePaths('name')">
-                                    Copy file names
-                                </flux:menu.item>
-                                <flux:menu.item icon="document-duplicate" icon:variant="outline" @click="copyVisibleFilePaths('relative')">
-                                    Copy relative paths
-                                </flux:menu.item>
-                                <flux:menu.item icon="link" icon:variant="outline" @click="copyVisibleFilePaths('full')">
-                                    Copy full paths
-                                </flux:menu.item>
-                            </flux:menu>
-                        </flux:dropdown>
-                    </div>
+                    <x-copy-paths-menu testid-prefix="status-strip-copy-paths" />
                 @endif
             </div>
         </div>
@@ -1582,29 +1560,7 @@ new #[Layout('layouts.app')] class extends Component
                 <div class="flex items-center justify-between mb-3">
                     <span class="section-label text-gh-muted">Files</span>
                     @if(count($sourceFiles) > 0)
-                        <div data-testid="sidebar-copy-paths" x-show="visibleFileCount > 0">
-                            <flux:dropdown position="bottom" align="end">
-                                <flux:tooltip>
-                                    <flux:button variant="ghost" size="xs" icon="square-2-stack" icon:variant="outline"
-                                        aria-label="Copy file paths"
-                                        data-testid="sidebar-copy-paths-trigger" />
-                                    <flux:tooltip.content>
-                                        <span x-text="`Copy paths for ${visibleFileCount} ${visibleFileCount === 1 ? 'file' : 'files'}`"></span>
-                                    </flux:tooltip.content>
-                                </flux:tooltip>
-                                <flux:menu>
-                                    <flux:menu.item icon="document" icon:variant="outline" @click="copyVisibleFilePaths('name')">
-                                        Copy file names
-                                    </flux:menu.item>
-                                    <flux:menu.item icon="document-duplicate" icon:variant="outline" @click="copyVisibleFilePaths('relative')">
-                                        Copy relative paths
-                                    </flux:menu.item>
-                                    <flux:menu.item icon="link" icon:variant="outline" @click="copyVisibleFilePaths('full')">
-                                        Copy full paths
-                                    </flux:menu.item>
-                                </flux:menu>
-                            </flux:dropdown>
-                        </div>
+                        <x-copy-paths-menu testid-prefix="sidebar-copy-paths" />
                     @endif
                 </div>
                 <flux:input

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1090,6 +1090,31 @@ new #[Layout('layouts.app')] class extends Component
             const i = path.lastIndexOf('/');
             return i === -1 ? path : path.slice(i + 1);
         },
+        repoPath: @js($repoPath),
+        get visibleFileCount() {
+            return this.sourceFileEntries.filter(f => this.fileMatchesFilter(f.path, f.id)).length;
+        },
+        buildFullPath(path) {
+            const repo = this.repoPath || '';
+            if (!repo) return path;
+            return repo.replace(/\/+$/, '') + '/' + path;
+        },
+        copyVisibleFilePaths(kind) {
+            const files = this.sourceFileEntries.filter(f => this.fileMatchesFilter(f.path, f.id));
+            if (files.length === 0) return;
+            const lines = files.map(f => {
+                if (kind === 'name') return this.pathBase(f.path);
+                if (kind === 'full') return this.buildFullPath(f.path);
+                return f.path;
+            });
+            const labelMap = { name: 'file name', relative: 'relative path', full: 'full path' };
+            const label = labelMap[kind] || 'path';
+            const noun = files.length === 1 ? label : label + 's';
+            this.$dispatch('copy-to-clipboard', {
+                text: lines.join('\n'),
+                toast: `Copied ${files.length} ${noun}`,
+            });
+        },
         scrollToFile(id) {
             this.activeFile = id;
             this.$dispatch('expand-file', { id });
@@ -1411,11 +1436,38 @@ new #[Layout('layouts.app')] class extends Component
                 <span class="px-1.5 py-px rounded border border-gh-border">{{ count($reviewPairs) }} {{ Str::plural('review', count($reviewPairs)) }}</span>
             @endif
 
-            <div x-show="reviewedCount > 0" x-cloak class="ml-auto flex items-center gap-2">
-                <span data-testid="reviewed-counter" x-text="reviewedCount + '/{{ count($sourceFiles) }} reviewed'"></span>
-                <div class="w-24 h-0.5 bg-gh-border/50 rounded-full overflow-hidden">
-                    <div class="h-full bg-gh-green/70 rounded-full transition-all duration-300" :style="'width:' + Math.round(reviewedCount / {{ count($sourceFiles) }} * 100) + '%'"></div>
+            <div class="ml-auto flex items-center gap-2">
+                <div x-show="reviewedCount > 0" x-cloak class="flex items-center gap-2">
+                    <span data-testid="reviewed-counter" x-text="reviewedCount + '/{{ count($sourceFiles) }} reviewed'"></span>
+                    <div class="w-24 h-0.5 bg-gh-border/50 rounded-full overflow-hidden">
+                        <div class="h-full bg-gh-green/70 rounded-full transition-all duration-300" :style="'width:' + Math.round(reviewedCount / {{ count($sourceFiles) }} * 100) + '%'"></div>
+                    </div>
                 </div>
+                @if(count($sourceFiles) > 0)
+                    <div data-testid="status-strip-copy-paths" x-show="visibleFileCount > 0">
+                        <flux:dropdown position="bottom" align="end">
+                            <flux:tooltip>
+                                <flux:button variant="ghost" size="xs" icon="square-2-stack" icon:variant="outline"
+                                    aria-label="Copy file paths"
+                                    data-testid="status-strip-copy-paths-trigger" />
+                                <flux:tooltip.content>
+                                    <span x-text="`Copy paths for ${visibleFileCount} ${visibleFileCount === 1 ? 'file' : 'files'}`"></span>
+                                </flux:tooltip.content>
+                            </flux:tooltip>
+                            <flux:menu>
+                                <flux:menu.item icon="document" icon:variant="outline" @click="copyVisibleFilePaths('name')">
+                                    Copy file names
+                                </flux:menu.item>
+                                <flux:menu.item icon="document-duplicate" icon:variant="outline" @click="copyVisibleFilePaths('relative')">
+                                    Copy relative paths
+                                </flux:menu.item>
+                                <flux:menu.item icon="link" icon:variant="outline" @click="copyVisibleFilePaths('full')">
+                                    Copy full paths
+                                </flux:menu.item>
+                            </flux:menu>
+                        </flux:dropdown>
+                    </div>
+                @endif
             </div>
         </div>
     </div>
@@ -1527,7 +1579,34 @@ new #[Layout('layouts.app')] class extends Component
                     <div class="border-b border-gh-border my-3"></div>
                 @endif
 
-                <span class="section-label text-gh-muted mb-3 block">Files</span>
+                <div class="flex items-center justify-between mb-3">
+                    <span class="section-label text-gh-muted">Files</span>
+                    @if(count($sourceFiles) > 0)
+                        <div data-testid="sidebar-copy-paths" x-show="visibleFileCount > 0">
+                            <flux:dropdown position="bottom" align="end">
+                                <flux:tooltip>
+                                    <flux:button variant="ghost" size="xs" icon="square-2-stack" icon:variant="outline"
+                                        aria-label="Copy file paths"
+                                        data-testid="sidebar-copy-paths-trigger" />
+                                    <flux:tooltip.content>
+                                        <span x-text="`Copy paths for ${visibleFileCount} ${visibleFileCount === 1 ? 'file' : 'files'}`"></span>
+                                    </flux:tooltip.content>
+                                </flux:tooltip>
+                                <flux:menu>
+                                    <flux:menu.item icon="document" icon:variant="outline" @click="copyVisibleFilePaths('name')">
+                                        Copy file names
+                                    </flux:menu.item>
+                                    <flux:menu.item icon="document-duplicate" icon:variant="outline" @click="copyVisibleFilePaths('relative')">
+                                        Copy relative paths
+                                    </flux:menu.item>
+                                    <flux:menu.item icon="link" icon:variant="outline" @click="copyVisibleFilePaths('full')">
+                                        Copy full paths
+                                    </flux:menu.item>
+                                </flux:menu>
+                            </flux:dropdown>
+                        </div>
+                    @endif
+                </div>
                 <flux:input
                     x-model.debounce.150ms="fileFilter"
                     placeholder="Filter files..."

--- a/tests/Browser/FileInteractionTest.php
+++ b/tests/Browser/FileInteractionTest.php
@@ -280,9 +280,11 @@ test('copy full paths prepends repo path to each entry', function () {
 
     $result = $page->script('window.__copiedText');
     expect($result)->not->toBeNull();
-    foreach (explode("\n", $result) as $line) {
-        expect($line)->toStartWith($this->testRepoPath.'/');
-    }
+
+    $expectedRepoPath = realpath($this->testRepoPath) ?: $this->testRepoPath;
+
+    collect(explode("\n", $result))
+        ->each(fn (string $line) => expect($line)->toStartWith($expectedRepoPath.'/'));
 });
 
 test('copy menu hides when filter excludes all files', function () {
@@ -292,4 +294,7 @@ test('copy menu hides when filter excludes all files', function () {
 
     $page->page()->getByTestId('sidebar-copy-paths')->waitFor(['state' => 'hidden']);
     $page->page()->getByTestId('status-strip-copy-paths')->waitFor(['state' => 'hidden']);
+
+    expect($page->page()->getByTestId('sidebar-copy-paths')->isHidden())->toBeTrue();
+    expect($page->page()->getByTestId('status-strip-copy-paths')->isHidden())->toBeTrue();
 });

--- a/tests/Browser/FileInteractionTest.php
+++ b/tests/Browser/FileInteractionTest.php
@@ -231,3 +231,65 @@ test('clicking delete x removes a comment', function () {
 
     $page->assertDontSee('Delete me');
 });
+
+test('sidebar copy file names dispatches newline-joined basenames', function () {
+    $page = $this->visitAndLoad($this->projectUrl());
+
+    $page->script("
+        window.__copiedText = null;
+        window.addEventListener('copy-to-clipboard', e => window.__copiedText = e.detail.text);
+    ");
+
+    $page->page()->getByTestId('sidebar-copy-paths-trigger')->click();
+    $page->page()->getByRole('menuitem', ['name' => 'Copy file names'])->first()->click();
+
+    $result = $page->script('window.__copiedText');
+    expect($result)->not->toBeNull();
+    $lines = explode("\n", $result);
+    expect($lines)->toContain('hello.php')->toContain('utils.php')->toContain('config.php');
+    expect(count($lines))->toBe(3);
+});
+
+test('status strip copy relative paths dispatches relative paths', function () {
+    $page = $this->visitAndLoad($this->projectUrl());
+
+    $page->script("
+        window.__copiedText = null;
+        window.addEventListener('copy-to-clipboard', e => window.__copiedText = e.detail.text);
+    ");
+
+    $page->page()->getByTestId('status-strip-copy-paths-trigger')->click();
+    $page->page()->getByRole('menuitem', ['name' => 'Copy relative paths'])->first()->click();
+
+    $result = $page->script('window.__copiedText');
+    expect($result)->not->toBeNull();
+    $lines = explode("\n", $result);
+    expect($lines)->toContain('hello.php')->toContain('utils.php')->toContain('config.php');
+});
+
+test('copy full paths prepends repo path to each entry', function () {
+    $page = $this->visitAndLoad($this->projectUrl());
+
+    $page->script("
+        window.__copiedText = null;
+        window.addEventListener('copy-to-clipboard', e => window.__copiedText = e.detail.text);
+    ");
+
+    $page->page()->getByTestId('sidebar-copy-paths-trigger')->click();
+    $page->page()->getByRole('menuitem', ['name' => 'Copy full paths'])->first()->click();
+
+    $result = $page->script('window.__copiedText');
+    expect($result)->not->toBeNull();
+    foreach (explode("\n", $result) as $line) {
+        expect($line)->toStartWith($this->testRepoPath.'/');
+    }
+});
+
+test('copy menu hides when filter excludes all files', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $page->page()->getByPlaceholder('Filter files...')->fill('zzz-no-such-file');
+
+    $page->page()->getByTestId('sidebar-copy-paths')->waitFor(['state' => 'hidden']);
+    $page->page()->getByTestId('status-strip-copy-paths')->waitFor(['state' => 'hidden']);
+});


### PR DESCRIPTION
## Summary
This PR adds a new dropdown menu that allows users to copy visible (filtered) file paths in three different formats: file names only, relative paths, or full paths with repository prefix.

## Key Changes
- **New Component**: Created `copy-paths-menu.blade.php` - a reusable dropdown component that displays copy options for filtered files
- **Alpine Methods**: Added three new methods to the review page Alpine component:
  - `visibleFileCount` - computed property that counts files matching the current filter
  - `buildFullPath(path)` - constructs full paths by prepending the repository path
  - `copyVisibleFilePaths(kind)` - dispatches a `copy-to-clipboard` event with the appropriate format (name/relative/full)
- **UI Integration**: 
  - Added copy menu to the sidebar file list header
  - Added copy menu to the status strip (next to review counter)
  - Both menus respect the current file filter and hide when no files are visible
- **Comprehensive Tests**: Added four new browser tests covering:
  - Copying file names (basenames only)
  - Copying relative paths from status strip
  - Copying full paths with repository prefix
  - Menu visibility when filter excludes all files

## Implementation Details
- The copy menu is conditionally rendered only when there are source files available
- The menu respects the active file filter and only copies visible files
- Full paths are constructed by combining the repository path with relative file paths
- User feedback is provided via toast notifications showing the count and type of paths copied
- The component uses Alpine's `x-show` with `x-cloak` to prevent flash of unstyled content

https://claude.ai/code/session_016RRg56VsZEpNsrN3VRpTsm