### PR TITLE
Add branch comparison shortcut

### DIFF
--- a/app/Actions/IsSinceBaseViewAction.php
+++ b/app/Actions/IsSinceBaseViewAction.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Services\GitMetadataService;
+
+final readonly class IsSinceBaseViewAction
+{
+    public function __construct(
+        private GitMetadataService $gitMetadataService,
+    ) {}
+
+    /**
+     * True when `$diffFrom` resolves to the same SHA as the merge-base of
+     * `$baseBranch` and HEAD — i.e., the current rangeToWorking view is
+     * exactly "since {base}". Used by the page to render the header label.
+     */
+    public function handle(string $repoPath, ?string $baseBranch, string $diffFrom): bool
+    {
+        $base = $baseBranch !== null ? trim($baseBranch) : '';
+
+        if ($base === '' || $diffFrom === 'HEAD') {
+            return false;
+        }
+
+        $mergeBase = $this->gitMetadataService->getMergeBase($repoPath, $base, 'HEAD');
+
+        if ($mergeBase === null) {
+            return false;
+        }
+
+        $diffFromSha = $this->gitMetadataService->resolveRef($repoPath, $diffFrom);
+
+        return $diffFromSha !== null && $diffFromSha === $mergeBase;
+    }
+}

--- a/app/Actions/IsSinceBaseViewAction.php
+++ b/app/Actions/IsSinceBaseViewAction.php
@@ -14,7 +14,7 @@ final readonly class IsSinceBaseViewAction
 
     /**
      * True when `$diffFrom` resolves to the same SHA as the merge-base of
-     * `$baseBranch` and HEAD — i.e., the current rangeToWorking view is
+     * `$baseBranch` and HEAD - i.e., the current rangeToWorking view is
      * exactly "since {base}". Used by the page to render the header label.
      */
     public function handle(string $repoPath, ?string $baseBranch, string $diffFrom): bool

--- a/app/Actions/ResolveBranchBaseAction.php
+++ b/app/Actions/ResolveBranchBaseAction.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\DTOs\BranchBaseResult;
+use App\Exceptions\GitCommandException;
+use App\Services\GitMetadataService;
+use App\Services\GitProcessService;
+use Illuminate\Support\Facades\Log;
+
+final readonly class ResolveBranchBaseAction
+{
+    public function __construct(
+        private GitMetadataService $gitMetadataService,
+        private GitProcessService $gitProcessService,
+    ) {}
+
+    /**
+     * Compute the diff range "since base branch" for the current HEAD.
+     *
+     * Returns one of five outcomes encoded as a {@see BranchBaseResult}:
+     *  - Ready          → base resolved, HEAD is ahead, range hashes returned
+     *  - UpToDate       → base resolved but HEAD has no commits ahead of it
+     *  - NotConfigured  → no base branch set on the project
+     *  - MissingRef     → base branch is configured but the ref isn't local
+     *  - OnBaseBranch   → current branch is the configured base
+     *
+     * `currentBranch` is the working branch (typically the project's branch).
+     * Pass `null` (or empty string) for detached HEAD — the action treats it
+     * the same as "not on the base branch."
+     */
+    public function handle(string $repoPath, ?string $baseBranch, ?string $currentBranch): BranchBaseResult
+    {
+        $base = $baseBranch !== null ? trim($baseBranch) : '';
+
+        if ($base === '') {
+            return BranchBaseResult::notConfigured();
+        }
+
+        if ($currentBranch !== null && trim($currentBranch) === $base) {
+            return BranchBaseResult::onBaseBranch($base);
+        }
+
+        $baseSha = $this->gitMetadataService->resolveRef($repoPath, $base);
+
+        if ($baseSha === null) {
+            return BranchBaseResult::missingRef($base);
+        }
+
+        $mergeBase = $this->gitMetadataService->getMergeBase($repoPath, $base, 'HEAD');
+
+        if ($mergeBase === null) {
+            // Unrelated histories — treat like a missing ref so the UI surfaces
+            // an actionable state rather than silently doing nothing.
+            return BranchBaseResult::missingRef($base);
+        }
+
+        $hashes = $this->commitsBetween($repoPath, $mergeBase, 'HEAD');
+
+        if ($hashes === []) {
+            return BranchBaseResult::upToDate($base, $mergeBase);
+        }
+
+        return BranchBaseResult::ready($base, $mergeBase, $hashes);
+    }
+
+    /**
+     * Returns the commit hashes in `from..to`, newest-first, matching the
+     * order the picker renders commits. Empty when `to` is at or behind `from`.
+     *
+     * @return list<string>
+     */
+    private function commitsBetween(string $repoPath, string $from, string $to): array
+    {
+        try {
+            $output = $this->gitProcessService->run($repoPath, [
+                'log', '--format=%H', $from.'..'.$to,
+            ]);
+        } catch (GitCommandException $e) {
+            Log::warning('Failed to list commits in range', [
+                'repo' => $repoPath, 'from' => $from, 'to' => $to, 'error' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
+
+        return collect(explode("\n", trim($output)))
+            ->filter()
+            ->values()
+            ->all();
+    }
+}

--- a/app/Actions/ResolveBranchBaseAction.php
+++ b/app/Actions/ResolveBranchBaseAction.php
@@ -21,14 +21,14 @@ final readonly class ResolveBranchBaseAction
      * Compute the diff range "since base branch" for the current HEAD.
      *
      * Returns one of five outcomes encoded as a {@see BranchBaseResult}:
-     *  - Ready          → base resolved, HEAD is ahead, range hashes returned
-     *  - UpToDate       → base resolved but HEAD has no commits ahead of it
-     *  - NotConfigured  → no base branch set on the project
-     *  - MissingRef     → base branch is configured but the ref isn't local
-     *  - OnBaseBranch   → current branch is the configured base
+     *  - Ready          - base resolved, HEAD is ahead, range hashes returned
+     *  - UpToDate       - base resolved but HEAD has no commits ahead of it
+     *  - NotConfigured  - no base branch set on the project
+     *  - MissingRef     - base branch is configured but the ref isn't local
+     *  - OnBaseBranch   - current branch is the configured base
      *
      * `currentBranch` is the working branch (typically the project's branch).
-     * Pass `null` (or empty string) for detached HEAD — the action treats it
+     * Pass `null` (or empty string) for detached HEAD - the action treats it
      * the same as "not on the base branch."
      */
     public function handle(string $repoPath, ?string $baseBranch, ?string $currentBranch): BranchBaseResult
@@ -52,7 +52,7 @@ final readonly class ResolveBranchBaseAction
         $mergeBase = $this->gitMetadataService->getMergeBase($repoPath, $base, 'HEAD');
 
         if ($mergeBase === null) {
-            // Unrelated histories — treat like a missing ref so the UI surfaces
+            // Unrelated histories - treat like a missing ref so the UI surfaces
             // an actionable state rather than silently doing nothing.
             return BranchBaseResult::missingRef($base);
         }

--- a/app/Actions/UpdateProjectSettingAction.php
+++ b/app/Actions/UpdateProjectSettingAction.php
@@ -8,7 +8,7 @@ use App\Models\Project;
 
 final readonly class UpdateProjectSettingAction
 {
-    private const ALLOWED_ATTRIBUTES = ['respect_global_gitignore', 'branch'];
+    private const ALLOWED_ATTRIBUTES = ['respect_global_gitignore', 'branch', 'default_base_branch'];
 
     /** @param array<string, mixed> $attributes */
     public function handle(int $projectId, array $attributes): void

--- a/app/DTOs/BranchBaseResult.php
+++ b/app/DTOs/BranchBaseResult.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+use App\Enums\BranchBaseState;
+
+final readonly class BranchBaseResult
+{
+    /**
+     * @param  list<string>  $hashesInRange  newest-first commit shas in `base..HEAD`; empty unless state is Ready.
+     */
+    public function __construct(
+        public BranchBaseState $state,
+        public ?string $baseBranch,
+        public ?string $baseSha,
+        public array $hashesInRange,
+    ) {}
+
+    public static function notConfigured(): self
+    {
+        return new self(BranchBaseState::NotConfigured, null, null, []);
+    }
+
+    public static function missingRef(string $baseBranch): self
+    {
+        return new self(BranchBaseState::MissingRef, $baseBranch, null, []);
+    }
+
+    public static function onBaseBranch(string $baseBranch): self
+    {
+        return new self(BranchBaseState::OnBaseBranch, $baseBranch, null, []);
+    }
+
+    public static function upToDate(string $baseBranch, string $baseSha): self
+    {
+        return new self(BranchBaseState::UpToDate, $baseBranch, $baseSha, []);
+    }
+
+    /** @param  list<string>  $hashesInRange */
+    public static function ready(string $baseBranch, string $baseSha, array $hashesInRange): self
+    {
+        return new self(BranchBaseState::Ready, $baseBranch, $baseSha, $hashesInRange);
+    }
+
+    /** @return array{state: string, baseBranch: ?string, baseSha: ?string, hashesInRange: list<string>, commitCount: int} */
+    public function toArray(): array
+    {
+        return [
+            'state' => $this->state->value,
+            'baseBranch' => $this->baseBranch,
+            'baseSha' => $this->baseSha,
+            'hashesInRange' => $this->hashesInRange,
+            'commitCount' => count($this->hashesInRange),
+        ];
+    }
+}

--- a/app/Enums/BranchBaseState.php
+++ b/app/Enums/BranchBaseState.php
@@ -6,7 +6,7 @@ namespace App\Enums;
 
 enum BranchBaseState: string
 {
-    /** Base configured, resolved, and ahead of HEAD — ready to apply. */
+    /** Base configured, resolved, and HEAD is ahead of it - ready to apply. */
     case Ready = 'ready';
 
     /** No base branch configured for this project. */
@@ -18,6 +18,6 @@ enum BranchBaseState: string
     /** Base branch name configured but the ref isn't present locally. */
     case MissingRef = 'missing_ref';
 
-    /** HEAD is currently on the configured base branch — comparing to itself is nonsense. */
+    /** HEAD is currently on the configured base branch - comparing to itself is nonsense. */
     case OnBaseBranch = 'on_base_branch';
 }

--- a/app/Enums/BranchBaseState.php
+++ b/app/Enums/BranchBaseState.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum BranchBaseState: string
+{
+    /** Base configured, resolved, and ahead of HEAD — ready to apply. */
+    case Ready = 'ready';
+
+    /** No base branch configured for this project. */
+    case NotConfigured = 'not_configured';
+
+    /** Base resolved but HEAD has no commits ahead of it. */
+    case UpToDate = 'up_to_date';
+
+    /** Base branch name configured but the ref isn't present locally. */
+    case MissingRef = 'missing_ref';
+
+    /** HEAD is currently on the configured base branch — comparing to itself is nonsense. */
+    case OnBaseBranch = 'on_base_branch';
+}

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -27,6 +27,7 @@ class Project extends Model
         'remote_url',
         'global_gitignore_path',
         'respect_global_gitignore',
+        'default_base_branch',
     ];
 
     /** @return HasMany<ReviewSession, $this> */

--- a/app/Services/GitMetadataService.php
+++ b/app/Services/GitMetadataService.php
@@ -205,6 +205,27 @@ class GitMetadataService
         return $line !== '' && ! str_contains($line, ' ');
     }
 
+    /**
+     * Compute the best common ancestor (merge-base) of two refs. Returns null
+     * when either ref is unknown or the histories don't intersect (orphan
+     * branches).
+     */
+    public function getMergeBase(string $repoPath, string $a, string $b): ?string
+    {
+        if ($this->looksLikeFlag($a) || $this->looksLikeFlag($b)) {
+            return null;
+        }
+
+        try {
+            $output = trim($this->git->run($repoPath, ['merge-base', $a, $b]));
+
+            return $output !== '' ? $output : null;
+        } catch (GitCommandException) {
+            // Unrelated histories or missing ref — both are non-fatal here.
+            return null;
+        }
+    }
+
     public function getChildCommit(string $repoPath, string $hash): ?string
     {
         try {

--- a/database/migrations/2026_04_29_120147_add_default_base_branch_to_projects.php
+++ b/database/migrations/2026_04_29_120147_add_default_base_branch_to_projects.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->string('default_base_branch')->nullable()->after('remote_url');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dropColumn('default_base_branch');
+        });
+    }
+};

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -14,11 +14,20 @@
      * @param {string[]} input.selectedHashes        subset of commits[].hash, any order.
      * @param {boolean}  input.workingTreeSelected
      * @param {string}   input.projectSlug
+     * @param {{state: string, baseSha: string|null, hashesInRange: string[]}|null} [input.sinceBase]
      * @returns {{kind: 'noop'} | {kind: 'navigate', url: string} | {kind: 'alert', message: string}}
      */
-    function decideSelection({ commits, selectedHashes, workingTreeSelected, projectSlug }) {
+    function decideSelection({ commits, selectedHashes, workingTreeSelected, projectSlug, sinceBase = null }) {
         const hasAnySelection = workingTreeSelected || selectedHashes.length > 0;
         if (!hasAnySelection) return { kind: 'noop' };
+
+        if (
+            sinceBase?.state === 'ready'
+            && sinceBase.baseSha
+            && isSinceBaseExactly({ selectedHashes, workingTreeSelected, hashesInRange: sinceBase.hashesInRange })
+        ) {
+            return { kind: 'navigate', url: `/p/${projectSlug}/rw/${encodeURIComponent(sinceBase.baseSha)}` };
+        }
 
         const indices = [...new Set(
             selectedHashes
@@ -26,12 +35,12 @@
                 .filter(i => i >= 0)
         )].sort((a, b) => a - b);
 
-        // Working tree alone → plain working-tree view.
+        // Working tree alone - plain working-tree view.
         if (workingTreeSelected && indices.length === 0) {
             return { kind: 'navigate', url: `/p/${projectSlug}` };
         }
 
-        // All hashes were unknown to `commits` — treat as nothing real selected.
+        // All hashes were unknown to `commits` - treat as nothing real selected.
         // Without this guard, the single-commit branch below dereferences
         // `commits[undefined].hash` and throws.
         if (indices.length === 0) return { kind: 'noop' };
@@ -42,7 +51,7 @@
         if (indices[indices.length - 1] - indices[0] + 1 !== indices.length) {
             return {
                 kind: 'alert',
-                message: 'Selection is not contiguous — pick every commit between the oldest and newest you want to review.',
+                message: 'Selection is not contiguous - pick every commit between the oldest and newest you want to review.',
             };
         }
 
@@ -52,7 +61,7 @@
         if (violatesTipAnchor({ selectedHashes, workingTreeSelected, commits })) {
             return {
                 kind: 'alert',
-                message: 'Selection is not contiguous — working tree must be paired with the newest commits.',
+                message: 'Selection is not contiguous - working tree must be paired with the newest commits.',
             };
         }
 
@@ -74,7 +83,7 @@
 
     /**
      * Returns true when the current selection state is exactly "everything in base..HEAD
-     * plus working tree" — i.e., the user clicked the "Since {base}" row and hasn't trimmed.
+     * plus working tree" - i.e., the user clicked the "Since {base}" row and hasn't trimmed.
      *
      * @param {object} input
      * @param {string[]} input.selectedHashes
@@ -90,7 +99,7 @@
 
     /**
      * Working tree extends a diff through HEAD's working state, so a selection
-     * that pairs WT with commits MUST include the tip — otherwise the user is
+     * that pairs WT with commits MUST include the tip - otherwise the user is
      * asking for a diff that excludes HEAD's commit while still including its
      * working tree, which has no coherent diff range. Used as both a guard
      * (in the picker's auto-untick) and a backstop (in `decideSelection`).
@@ -113,6 +122,7 @@
             open: false,
             search: '',
             selectedIndex: 0,
+            currentBranch,
             selectedBranch: currentBranch,
             allBranches: branches,
             activeCommitHash,
@@ -133,7 +143,7 @@
 
             /**
              * Showing the "Since {base}" row only makes sense for the project's
-             * current branch — the configured base is HEAD-relative, not relative
+             * current branch - the configured base is HEAD-relative, not relative
              * to whichever branch the picker happens to be displaying. The
              * `on_base_branch` state is also hidden because comparing a branch
              * to itself is nonsense.
@@ -212,7 +222,7 @@
                 const branch = this.allFiltered[this.selectedIndex];
                 if (!branch) return;
                 if (branch.name === this.selectedBranch && this.$wire.commits.length > 0) return;
-                // Selected branch is actually changing — stale hashes no longer apply.
+                // Selected branch is actually changing - stale hashes no longer apply.
                 const branchChanged = this.selectedBranch !== branch.name;
                 this.selectedBranch = branch.name;
                 const id = ++this._loadId;
@@ -282,6 +292,47 @@
 
             copyHash(hash) {
                 navigator.clipboard.writeText(hash).catch(() => {});
+            },
+
+            openRemoteContext(event, type, params, label) {
+                this.$dispatch('open-remote-menu', {
+                    target: 'direct',
+                    type,
+                    params,
+                    label,
+                    projectSlug: this.projectSlug,
+                    clientX: event.clientX,
+                    clientY: event.clientY,
+                });
+            },
+
+            handleRemoteContextMenu(event) {
+                const trigger = event.target.closest('[data-remote-context]');
+
+                if (!trigger) return;
+
+                const type = trigger.dataset.remoteType;
+
+                if (!type) return;
+
+                let params = {};
+                try {
+                    params = JSON.parse(trigger.dataset.remoteParams || '{}');
+                } catch {
+                    params = {};
+                }
+
+                event.preventDefault();
+                this.openRemoteContext(event, type, params, trigger.dataset.remoteLabel || 'on remote');
+            },
+
+            openSelectionRemoteContext(event) {
+                if (this.activeCommitHash) {
+                    this.openRemoteContext(event, 'commit', { sha: this.activeCommitHash }, `commit ${this.activeCommitHash.slice(0, 7)}`);
+                    return;
+                }
+
+                this.openRemoteContext(event, 'branch', { name: this.currentBranch }, `branch ${this.currentBranch}`);
             },
 
             viewCommit(hash) {
@@ -358,7 +409,7 @@
                 this.workingTreeSelected = false;
                 if (typeof window !== 'undefined' && window.Flux?.toast) {
                     window.Flux.toast({
-                        text: 'Working tree removed — it includes HEAD\'s commit, so the tip must stay selected.',
+                        text: 'Working tree removed - it includes HEAD\'s commit, so the tip must stay selected.',
                         variant: 'info',
                     });
                 }
@@ -400,7 +451,7 @@
                 const onPointerOver = (e) => {
                     if (!active) return;
                     if (e.buttons === 0) {
-                        // Mouse released outside the window — recover on first re-entry.
+                        // Mouse released outside the window - recover on first re-entry.
                         // Release wasn't in-window, so there's no trailing click to swallow.
                         endDrag(false);
                         return;
@@ -451,6 +502,7 @@
                     selectedHashes: this.selectedHashes,
                     workingTreeSelected: this.workingTreeSelected,
                     projectSlug: this.projectSlug,
+                    sinceBase: this.$wire.branchBase,
                 });
 
                 if (result.kind === 'noop') return;

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -48,7 +48,11 @@
 
         // Commits are listed newest-first; lowest index = tip, highest = oldest.
         // Working tree is conceptually at index -1 (one step newer than the tip).
-        // When WT is selected alongside commits, the commits must start at index 0.
+        // When WT is selected alongside commits, the commits must start at
+        // index 0. Normally the Alpine state machine auto-unticks WT before
+        // the user can press Apply on a violating selection (see
+        // `_enforceWorkingTreeTipAnchor`), so this branch is a backstop for
+        // anything that might bypass it (programmatic state, future code).
         if (workingTreeSelected && indices.length > 0 && indices[0] !== 0) {
             return {
                 kind: 'alert',
@@ -296,6 +300,7 @@
                     this.selectedHashes.push(hash);
                 }
                 this.lastSelectionIndex = idx;
+                this._enforceWorkingTreeTipAnchor();
             },
 
             toggleWorkingTreeSelection(event) {
@@ -319,6 +324,33 @@
                 this.selectedHashes = [];
                 this.workingTreeSelected = false;
                 this.lastSelectionIndex = -1;
+            },
+
+            /**
+             * Working tree extends the diff through HEAD's working state, so a
+             * selection that pairs WT with commits MUST include the tip —
+             * otherwise the user is asking for a diff that excludes HEAD's
+             * commit while still including its working tree, which has no
+             * coherent diff range. When the user's last action would leave
+             * that invariant violated (e.g. unticking the tip while WT is
+             * selected), auto-untick WT and explain via a toast. Quietly
+             * fixing the state after the action feels less hostile than
+             * blocking the action itself.
+             */
+            _enforceWorkingTreeTipAnchor() {
+                if (!this.workingTreeSelected) return;
+                if (this.selectedHashes.length === 0) return;
+                const tip = this.$wire.commits[0];
+                if (!tip) return;
+                if (this.selectedHashes.includes(tip.hash)) return;
+
+                this.workingTreeSelected = false;
+                if (typeof window !== 'undefined' && window.Flux?.toast) {
+                    window.Flux.toast({
+                        text: 'Working tree removed — it includes HEAD\'s commit, so the tip must stay selected.',
+                        variant: 'info',
+                    });
+                }
             },
 
             /**
@@ -372,6 +404,7 @@
                     const start = Math.min(idx, hovered);
                     const end = Math.max(idx, hovered);
                     this.selectedHashes = this.$wire.commits.slice(start, end + 1).map(c => c.hash);
+                    this._enforceWorkingTreeTipAnchor();
                 };
 
                 const endDrag = (swallowClick) => {

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -46,14 +46,10 @@
             };
         }
 
-        // Commits are listed newest-first; lowest index = tip, highest = oldest.
-        // Working tree is conceptually at index -1 (one step newer than the tip).
-        // When WT is selected alongside commits, the commits must start at
-        // index 0. Normally the Alpine state machine auto-unticks WT before
-        // the user can press Apply on a violating selection (see
-        // `_enforceWorkingTreeTipAnchor`), so this branch is a backstop for
-        // anything that might bypass it (programmatic state, future code).
-        if (workingTreeSelected && indices.length > 0 && indices[0] !== 0) {
+        // Backstop for the tip-anchor invariant. Normally the Alpine state
+        // machine auto-unticks WT (see `_enforceWorkingTreeTipAnchor`); this
+        // catches any bypass (programmatic state, future code).
+        if (violatesTipAnchor({ selectedHashes, workingTreeSelected, commits })) {
             return {
                 kind: 'alert',
                 message: 'Selection is not contiguous — working tree must be paired with the newest commits.',
@@ -90,6 +86,26 @@
         if (selectedHashes.length !== hashesInRange.length) return false;
         const set = new Set(hashesInRange);
         return selectedHashes.every(h => set.has(h));
+    }
+
+    /**
+     * Working tree extends a diff through HEAD's working state, so a selection
+     * that pairs WT with commits MUST include the tip — otherwise the user is
+     * asking for a diff that excludes HEAD's commit while still including its
+     * working tree, which has no coherent diff range. Used as both a guard
+     * (in the picker's auto-untick) and a backstop (in `decideSelection`).
+     *
+     * @param {object} input
+     * @param {string[]} input.selectedHashes
+     * @param {boolean}  input.workingTreeSelected
+     * @param {Array<{hash: string}>} input.commits  newest-first; index 0 = tip.
+     */
+    function violatesTipAnchor({ selectedHashes, workingTreeSelected, commits }) {
+        if (!workingTreeSelected) return false;
+        if (selectedHashes.length === 0) return false;
+        const tip = commits[0];
+        if (!tip) return false;
+        return !selectedHashes.includes(tip.hash);
     }
 
     function createBranchExplorer({ currentBranch, activeCommitHash, activeDiffFrom, projectSlug, branches }) {
@@ -327,22 +343,17 @@
             },
 
             /**
-             * Working tree extends the diff through HEAD's working state, so a
-             * selection that pairs WT with commits MUST include the tip —
-             * otherwise the user is asking for a diff that excludes HEAD's
-             * commit while still including its working tree, which has no
-             * coherent diff range. When the user's last action would leave
-             * that invariant violated (e.g. unticking the tip while WT is
-             * selected), auto-untick WT and explain via a toast. Quietly
-             * fixing the state after the action feels less hostile than
-             * blocking the action itself.
+             * Auto-fix the tip-anchor invariant after the user's last action,
+             * so e.g. unticking the tip while WT is selected silently unticks
+             * WT (with a toast) instead of blocking on Apply. Quietly fixing
+             * the state feels less hostile than rejecting the action.
              */
             _enforceWorkingTreeTipAnchor() {
-                if (!this.workingTreeSelected) return;
-                if (this.selectedHashes.length === 0) return;
-                const tip = this.$wire.commits[0];
-                if (!tip) return;
-                if (this.selectedHashes.includes(tip.hash)) return;
+                if (!violatesTipAnchor({
+                    selectedHashes: this.selectedHashes,
+                    workingTreeSelected: this.workingTreeSelected,
+                    commits: this.$wire.commits,
+                })) return;
 
                 this.workingTreeSelected = false;
                 if (typeof window !== 'undefined' && window.Flux?.toast) {
@@ -470,5 +481,5 @@
         }
     }
 
-    return { decideSelection, isSinceBaseExactly, createBranchExplorer, install, autoInstall };
+    return { decideSelection, isSinceBaseExactly, violatesTipAnchor, createBranchExplorer, install, autoInstall };
 });

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -72,6 +72,22 @@
         return { kind: 'navigate', url: `/p/${projectSlug}/${newest.hash}/${baseRef}` };
     }
 
+    /**
+     * Returns true when the current selection state is exactly "everything in base..HEAD
+     * plus working tree" — i.e., the user clicked the "Since {base}" row and hasn't trimmed.
+     *
+     * @param {object} input
+     * @param {string[]} input.selectedHashes
+     * @param {boolean}  input.workingTreeSelected
+     * @param {string[]} input.hashesInRange
+     */
+    function isSinceBaseExactly({ selectedHashes, workingTreeSelected, hashesInRange }) {
+        if (!workingTreeSelected) return false;
+        if (selectedHashes.length !== hashesInRange.length) return false;
+        const set = new Set(hashesInRange);
+        return selectedHashes.every(h => set.has(h));
+    }
+
     function createBranchExplorer({ currentBranch, activeCommitHash, activeDiffFrom, projectSlug, branches }) {
         return {
             open: false,
@@ -93,6 +109,30 @@
 
             get hasAnySelection() {
                 return this.workingTreeSelected || this.selectedHashes.length > 0;
+            },
+
+            /**
+             * Showing the "Since {base}" row only makes sense for the project's
+             * current branch — the configured base is HEAD-relative, not relative
+             * to whichever branch the picker happens to be displaying. The
+             * `on_base_branch` state is also hidden because comparing a branch
+             * to itself is nonsense.
+             */
+            get sinceBaseRowVisible() {
+                if (this.selectedBranch !== currentBranch) return false;
+                const base = this.$wire.branchBase;
+                if (!base) return false;
+                return base.state !== 'on_base_branch';
+            },
+
+            get sinceBaseSelected() {
+                const base = this.$wire.branchBase;
+                if (!base || base.state !== 'ready') return false;
+                return isSinceBaseExactly({
+                    selectedHashes: this.selectedHashes,
+                    workingTreeSelected: this.workingTreeSelected,
+                    hashesInRange: base.hashesInRange,
+                });
             },
 
             get selectionBadge() {
@@ -128,7 +168,13 @@
                 this.selectedIndex = 0;
                 this.clearSelection();
                 Alpine.store('overlays').open('branch-explorer');
-                await this.$wire.loadBranches();
+                // Resolve base info before loading commits so the commit-load
+                // can extend its window to cover all base..HEAD hashes when the
+                // configured base is more than `pageSize` commits behind.
+                await Promise.all([
+                    this.$wire.loadBranches(),
+                    this.$wire.loadBranchBase(),
+                ]);
                 this.allBranches = this.$wire.branches;
                 const currentIdx = this.allFiltered.findIndex(b => b.name === this.selectedBranch);
                 if (currentIdx >= 0) this.selectedIndex = currentIdx;
@@ -275,6 +321,29 @@
                 this.lastSelectionIndex = -1;
             },
 
+            /**
+             * Click handler for the "Since {base}" row. Fills the multi-select
+             * with every commit in `base..HEAD` plus working tree, so the user
+             * sees scope visually and can trim before pressing Apply. Toggles
+             * off when invoked while the exact since-base shape is already
+             * selected.
+             */
+            selectSinceBase() {
+                const base = this.$wire.branchBase;
+                if (!base || base.state !== 'ready') return;
+
+                if (this.sinceBaseSelected) {
+                    this.clearSelection();
+                    return;
+                }
+
+                this.selectedHashes = [...base.hashesInRange];
+                this.workingTreeSelected = true;
+                // Reset shift-click anchor so a subsequent shift-click on a
+                // commit doesn't extend from a stale index.
+                this.lastSelectionIndex = -1;
+            },
+
             // Press-and-hold on a commit's checkbox, then drag across rows to extend
             // the selection from the anchor. Mirrors the diff-file line-range gesture
             // so the app has one "mouse path selects a range" pattern, not two.
@@ -368,5 +437,5 @@
         }
     }
 
-    return { decideSelection, createBranchExplorer, install, autoInstall };
+    return { decideSelection, isSinceBaseExactly, createBranchExplorer, install, autoInstall };
 });

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -3,13 +3,11 @@
 use App\Actions\GetBranchListAction;
 use App\Actions\GetCommitHistoryAction;
 use App\Actions\ResolveBranchBaseAction;
-use App\Concerns\InteractsWithRemoteLinks;
 use Livewire\Attributes\Locked;
+use Livewire\Attributes\Renderless;
 use Livewire\Component;
 
 new class extends Component {
-    use InteractsWithRemoteLinks;
-
     #[Locked]
     public string $repoPath = '';
 
@@ -58,11 +56,13 @@ new class extends Component {
 
     private int $pageSize = 50;
 
+    #[Renderless]
     public function loadBranches(): void
     {
         $this->branches = app(GetBranchListAction::class)->handle($this->repoPath);
     }
 
+    #[Renderless]
     public function loadBranchBase(): void
     {
         $result = app(ResolveBranchBaseAction::class)->handle(
@@ -78,9 +78,10 @@ new class extends Component {
      * Load commits for the displayed branch. When the picker is showing the
      * project's current branch and the configured base is more than `pageSize`
      * commits behind, the limit is bumped so every commit in `base..HEAD`
-     * is loaded — otherwise the auto-select on the "Since {base}" row would
+     * is loaded - otherwise the auto-select on the "Since {base}" row would
      * tick checkboxes that aren't rendered.
      */
+    #[Renderless]
     public function loadCommits(string $branch): void
     {
         $limit = $this->effectiveCommitLimit($branch);
@@ -90,6 +91,7 @@ new class extends Component {
         $this->hasMore = count($commits) >= $limit;
     }
 
+    #[Renderless]
     public function loadMore(string $branch): void
     {
         $offset = count($this->commits);
@@ -126,10 +128,11 @@ new class extends Component {
     x-init="$store.keymap.register('⌘B', () => open ? closePanel() : openPanel())"
     @keydown.window="handleKeydown($event)"
     @open-selection-drawer.window="openPanel()"
+    @if($hasRemote) @contextmenu="handleRemoteContextMenu($event)" @endif
     x-effect="if (open && !$store.overlays.is('branch-explorer')) closePanel()"
 >
     <div class="inline-flex items-stretch rounded-md border border-gh-border/70 bg-gh-surface/30 hover:border-gh-text/30 transition-colors">
-        <div @if($hasRemote) x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" @endif class="inline-flex">
+        <div @if($hasRemote) @contextmenu.prevent="openRemoteContext($event, 'branch', { name: currentBranch }, 'branch ' + currentBranch)" @endif class="inline-flex">
             <flux:tooltip content="Switch branch · ⌘B">
                 <button
                     type="button"
@@ -143,19 +146,11 @@ new class extends Component {
                     <span class="tracking-tight">{{ $currentBranch }}</span>
                 </button>
             </flux:tooltip>
-            @if($hasRemote)
-                <x-remote-link-menu
-                    :project-slug="$projectSlug"
-                    type="branch"
-                    :params="['name' => $currentBranch]"
-                    label="branch"
-                />
-            @endif
         </div>
 
         <span class="w-px self-stretch bg-gh-border/70" aria-hidden="true"></span>
 
-        <div @if($hasRemote) x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" @endif class="inline-flex">
+        <div @if($hasRemote) @contextmenu.prevent="openSelectionRemoteContext($event)" @endif class="inline-flex">
             <flux:tooltip content="{{ $selectionTitle }} · ⌘B">
                 <button
                     type="button"
@@ -170,23 +165,6 @@ new class extends Component {
                     <x-chevron-icon variant="mono" />
                 </button>
             </flux:tooltip>
-            @if($hasRemote)
-                @if($activeCommitHash !== null)
-                    <x-remote-link-menu
-                        :project-slug="$projectSlug"
-                        type="commit"
-                        :params="['sha' => $activeCommitHash]"
-                        label="commit"
-                    />
-                @else
-                    <x-remote-link-menu
-                        :project-slug="$projectSlug"
-                        type="branch"
-                        :params="['name' => $currentBranch]"
-                        label="branch"
-                    />
-                @endif
-            @endif
         </div>
     </div>
 
@@ -218,7 +196,14 @@ new class extends Component {
                                     <span class="section-label text-gh-muted">Local</span>
                                 </div>
                                 <template x-for="(branch, i) in filteredLocal" :key="branch.name">
-                                    <div @if($hasRemote) x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" @endif>
+                                    <div
+                                        @if($hasRemote)
+                                            data-remote-context
+                                            data-remote-type="branch"
+                                            :data-remote-params="JSON.stringify({ name: branch.name })"
+                                            :data-remote-label="'branch ' + branch.name"
+                                        @endif
+                                    >
                                         <button
                                             @click="selectBranchAt(i)"
                                             class="w-full text-left px-3 py-2 text-xs font-mono flex items-center gap-2 transition-colors cursor-pointer"
@@ -229,14 +214,6 @@ new class extends Component {
                                             <span class="shrink-0 w-3" x-show="!branch.isCurrent"></span>
                                             <span class="truncate" x-text="branch.name"></span>
                                         </button>
-                                        @if($hasRemote)
-                                            <x-remote-link-menu
-                                                :project-slug="$projectSlug"
-                                                type-js="'branch'"
-                                                params-js="{ name: branch.name }"
-                                                label-js="'branch ' + branch.name"
-                                            />
-                                        @endif
                                     </div>
                                 </template>
                             </div>
@@ -249,7 +226,14 @@ new class extends Component {
                                     <span class="section-label text-gh-muted">Remote</span>
                                 </div>
                                 <template x-for="(branch, j) in filteredRemote" :key="branch.name">
-                                    <div @if($hasRemote) x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" @endif>
+                                    <div
+                                        @if($hasRemote)
+                                            data-remote-context
+                                            data-remote-type="branch"
+                                            :data-remote-params="JSON.stringify({ name: branch.remote && branch.name.startsWith(branch.remote + '/') ? branch.name.slice(branch.remote.length + 1) : branch.name })"
+                                            :data-remote-label="'branch ' + branch.name"
+                                        @endif
+                                    >
                                         <button
                                             @click="selectBranchAt(filteredLocal.length + j)"
                                             class="w-full text-left px-3 py-2 text-xs font-mono flex items-center gap-2 transition-colors cursor-pointer"
@@ -259,14 +243,6 @@ new class extends Component {
                                             <span class="shrink-0 w-3"></span>
                                             <span class="truncate" x-text="branch.name"></span>
                                         </button>
-                                        @if($hasRemote)
-                                            <x-remote-link-menu
-                                                :project-slug="$projectSlug"
-                                                type-js="'branch'"
-                                                params-js="{ name: branch.remote && branch.name.startsWith(branch.remote + '/') ? branch.name.slice(branch.remote.length + 1) : branch.name }"
-                                                label-js="'branch ' + branch.name"
-                                            />
-                                        @endif
                                     </div>
                                 </template>
                             </div>
@@ -460,7 +436,12 @@ new class extends Component {
                                 data-testid="commit-row"
                                 :data-commit-hash="commit.hash"
                                 :data-commit-idx="commitIdx"
-                                @if($hasRemote) x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" @endif
+                                @if($hasRemote)
+                                    data-remote-context
+                                    data-remote-type="commit"
+                                    :data-remote-params="JSON.stringify({ sha: commit.hash })"
+                                    :data-remote-label="'commit ' + commit.shortHash"
+                                @endif
                                 class="px-4 py-2.5 border-b border-gh-border/50 hover:bg-gh-border/20 transition-colors group cursor-pointer"
                                 @click="viewCommit(commit.hash)"
                                 :class="{
@@ -502,14 +483,6 @@ new class extends Component {
                                         ></button>
                                     </div>
                                 </div>
-                                @if($hasRemote)
-                                    <x-remote-link-menu
-                                        :project-slug="$projectSlug"
-                                        type-js="'commit'"
-                                        params-js="{ sha: commit.hash }"
-                                        label-js="'commit ' + commit.shortHash"
-                                    />
-                                @endif
                             </div>
                         </template>
 

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -2,6 +2,7 @@
 
 use App\Actions\GetBranchListAction;
 use App\Actions\GetCommitHistoryAction;
+use App\Actions\ResolveBranchBaseAction;
 use App\Concerns\InteractsWithRemoteLinks;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
@@ -34,11 +35,24 @@ new class extends Component {
     #[Locked]
     public string $selectionTitle = 'Working tree changes';
 
+    /** Configured project base branch (e.g. 'dev'). Empty means the user hasn't set one yet. */
+    #[Locked]
+    public string $defaultBaseBranch = '';
+
     /** @var array{local: list<array<string, mixed>>, remote: list<array<string, mixed>>, current: string} */
     public array $branches = ['local' => [], 'remote' => [], 'current' => ''];
 
     /** @var list<array<string, mixed>> */
     public array $commits = [];
+
+    /**
+     * Result of {@see ResolveBranchBaseAction} for the project's current branch.
+     * Surfaced so the picker can render the "Since {base}" row and pre-fill
+     * checkboxes when clicked.
+     *
+     * @var array{state: string, baseBranch: ?string, baseSha: ?string, hashesInRange: list<string>, commitCount: int}|null
+     */
+    public ?array $branchBase = null;
 
     public bool $hasMore = false;
 
@@ -49,12 +63,31 @@ new class extends Component {
         $this->branches = app(GetBranchListAction::class)->handle($this->repoPath);
     }
 
+    public function loadBranchBase(): void
+    {
+        $result = app(ResolveBranchBaseAction::class)->handle(
+            $this->repoPath,
+            $this->defaultBaseBranch !== '' ? $this->defaultBaseBranch : null,
+            $this->currentBranch !== '' ? $this->currentBranch : null,
+        );
+
+        $this->branchBase = $result->toArray();
+    }
+
+    /**
+     * Load commits for the displayed branch. When the picker is showing the
+     * project's current branch and the configured base is more than `pageSize`
+     * commits behind, the limit is bumped so every commit in `base..HEAD`
+     * is loaded — otherwise the auto-select on the "Since {base}" row would
+     * tick checkboxes that aren't rendered.
+     */
     public function loadCommits(string $branch): void
     {
-        $commits = app(GetCommitHistoryAction::class)->handle($this->repoPath, $this->pageSize, 0, $branch);
+        $limit = $this->effectiveCommitLimit($branch);
+        $commits = app(GetCommitHistoryAction::class)->handle($this->repoPath, $limit, 0, $branch);
 
         $this->commits = $commits;
-        $this->hasMore = count($commits) >= $this->pageSize;
+        $this->hasMore = count($commits) >= $limit;
     }
 
     public function loadMore(string $branch): void
@@ -64,6 +97,15 @@ new class extends Component {
 
         $this->commits = array_merge($this->commits, $more);
         $this->hasMore = count($more) >= $this->pageSize;
+    }
+
+    private function effectiveCommitLimit(string $branch): int
+    {
+        if ($branch !== $this->currentBranch || $this->branchBase === null) {
+            return $this->pageSize;
+        }
+
+        return max($this->pageSize, $this->branchBase['commitCount']);
     }
 };
 
@@ -285,6 +327,95 @@ new class extends Component {
 
                     {{-- Commits list --}}
                     <div class="overflow-y-auto flex-1">
+                        {{-- "Since {base}" shortcut: a single click fills the
+                             multi-select with every commit in base..HEAD plus
+                             working tree, so the user can trim before applying. --}}
+                        <template x-if="sinceBaseRowVisible">
+                            <div data-testid="since-base-row">
+                                {{-- Ready: clickable shortcut --}}
+                                <template x-if="$wire.branchBase.state === 'ready'">
+                                    <div
+                                        class="px-4 py-2.5 border-b border-gh-border/50 hover:bg-gh-border/20 transition-colors group cursor-pointer"
+                                        @click="selectSinceBase()"
+                                        :class="{ 'bg-gh-link/5 border-l-2 border-l-gh-link': sinceBaseSelected }"
+                                        :aria-pressed="sinceBaseSelected"
+                                    >
+                                        <div class="flex items-start gap-2">
+                                            <span
+                                                class="mt-0.5 size-4 shrink-0 grid place-items-center rounded border transition-colors"
+                                                :class="sinceBaseSelected
+                                                    ? 'border-gh-link bg-gh-link/20 text-gh-link'
+                                                    : 'border-gh-border opacity-0 group-hover:opacity-100'"
+                                                aria-hidden="true"
+                                            >
+                                                <template x-if="sinceBaseSelected">
+                                                    <flux:icon icon="check" variant="outline" class="!size-3" />
+                                                </template>
+                                            </span>
+                                            <div class="min-w-0 flex-1">
+                                                <div class="text-xs text-gh-text truncate font-medium tracking-tight">
+                                                    Since <span class="font-mono" x-text="$wire.branchBase.baseBranch"></span>
+                                                </div>
+                                                <span
+                                                    class="block mt-0.5 text-[10px] font-mono text-gh-muted"
+                                                    x-text="$wire.branchBase.commitCount + ' commit' + ($wire.branchBase.commitCount === 1 ? '' : 's') + ' + uncommitted changes'"
+                                                ></span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </template>
+
+                                {{-- Up to date with base: dimmed, not actionable --}}
+                                <template x-if="$wire.branchBase.state === 'up_to_date'">
+                                    <div class="px-4 py-2.5 border-b border-gh-border/50">
+                                        <div class="flex items-start gap-2 opacity-60">
+                                            <span class="mt-0.5 size-4 shrink-0" aria-hidden="true"></span>
+                                            <div class="min-w-0 flex-1">
+                                                <div class="text-xs text-gh-text truncate tracking-tight">
+                                                    Up to date with <span class="font-mono" x-text="$wire.branchBase.baseBranch"></span>
+                                                </div>
+                                                <span class="block mt-0.5 text-[10px] font-mono text-gh-muted">no commits ahead</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </template>
+
+                                {{-- Missing ref: actionable hint --}}
+                                <template x-if="$wire.branchBase.state === 'missing_ref'">
+                                    <div class="px-4 py-2.5 border-b border-gh-border/50">
+                                        <div class="flex items-start gap-2">
+                                            <span class="mt-0.5 size-4 shrink-0 text-gh-muted" aria-hidden="true">
+                                                <flux:icon icon="exclamation-triangle" variant="outline" class="!size-3.5" />
+                                            </span>
+                                            <div class="min-w-0 flex-1">
+                                                <div class="text-xs text-gh-text truncate tracking-tight">
+                                                    Run <span class="font-mono">git fetch</span> to compare with <span class="font-mono" x-text="$wire.branchBase.baseBranch"></span>
+                                                </div>
+                                                <span class="block mt-0.5 text-[10px] font-mono text-gh-muted">base ref not found locally</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </template>
+
+                                {{-- Not configured: nudge to settings --}}
+                                <template x-if="$wire.branchBase.state === 'not_configured'">
+                                    <div class="px-4 py-2.5 border-b border-gh-border/50">
+                                        <div class="flex items-start gap-2 opacity-80">
+                                            <span class="mt-0.5 size-4 shrink-0 text-gh-muted" aria-hidden="true">
+                                                <flux:icon icon="cog-6-tooth" variant="outline" class="!size-3.5" />
+                                            </span>
+                                            <div class="min-w-0 flex-1">
+                                                <div class="text-xs text-gh-text truncate tracking-tight">Pick a base branch to compare against</div>
+                                                <span class="block mt-0.5 text-[10px] font-mono text-gh-muted">set it from the project settings menu</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </template>
+
+                                {{-- on_base_branch: hidden entirely (comparing X..X is nonsense) --}}
+                            </div>
+                        </template>
+
                         <div
                             data-testid="working-tree-row"
                             class="px-4 py-2.5 border-b border-gh-border/50 hover:bg-gh-border/20 transition-colors group cursor-pointer"

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1061,6 +1061,26 @@ new #[Layout('layouts.app')] class extends Component
         remoteMenu: { open: false, x: 0, y: 0, projectSlug: '', type: '', params: {}, label: '', disabled: false, disabledReason: '' },
         showRemoteMenu($event) {
             const d = $event.detail;
+            const margin = 8;
+
+            if (d.target === 'direct') {
+                const menuW = 220;
+                const menuH = 80;
+                this.remoteMenu = {
+                    open: true,
+                    x: Math.min(d.clientX, window.innerWidth - menuW - margin),
+                    y: Math.min(d.clientY, window.innerHeight - menuH - margin),
+                    projectSlug: d.projectSlug || @js($projectSlug),
+                    type: d.type,
+                    params: d.params || {},
+                    label: d.label || 'on remote',
+                    disabled: false,
+                    disabledReason: '',
+                };
+
+                return;
+            }
+
             const projectBranch = @js($projectBranch);
             const diffFrom = @js($diffFrom);
             const diffTo = @js($diffTo);
@@ -1097,7 +1117,6 @@ new #[Layout('layouts.app')] class extends Component
             const disabledReason = disabled
                 ? (d.status === 'added' ? 'File not pushed to remote yet' : 'File was removed at this commit')
                 : '';
-            const margin = 8;
             const menuW = 220;
             const menuH = disabled ? 110 : 80;
             this.remoteMenu = {
@@ -1252,19 +1271,25 @@ new #[Layout('layouts.app')] class extends Component
 
         <header class="bg-gh-bg/80 backdrop-blur-sm border-b border-gh-border px-5 py-3.5 flex items-center justify-between">
             <div class="flex items-center gap-2">
-                <div @if($hasRemote) x-data="contextMenu()" @contextmenu.prevent="openCtx($event)" @endif class="inline-flex">
+                <div
+                    @if($hasRemote)
+                        @contextmenu.prevent="$dispatch('open-remote-menu', {
+                            target: 'direct',
+                            type: 'repo',
+                            params: {},
+                            label: 'repository',
+                            projectSlug: @js($projectSlug),
+                            clientX: $event.clientX,
+                            clientY: $event.clientY,
+                        })"
+                    @endif
+                    class="inline-flex"
+                >
                     @native
                         <livewire:project-picker :current-slug="$projectSlug" :project-name="$projectName" />
                     @else
                         <span class="font-display font-bold tracking-brutal-tight text-base">{{ $projectName }}</span>
                     @endnative
-                    @if($hasRemote)
-                        <x-remote-link-menu
-                            :project-slug="$projectSlug"
-                            type="repo"
-                            label="repository"
-                        />
-                    @endif
                 </div>
                 @php
                     $shortFrom = $diffFrom === 'HEAD' ? 'HEAD' : substr($diffFrom, 0, 7);
@@ -1285,6 +1310,7 @@ new #[Layout('layouts.app')] class extends Component
                 @if($projectBranch)
                     <x-header-separator />
                     <livewire:branch-explorer
+                        :key="'branch-explorer-'.$projectId.'-'.md5($projectBranch.'|'.$defaultBaseBranch)"
                         :repo-path="$repoPath"
                         :current-branch="$projectBranch"
                         :project-slug="$projectSlug"
@@ -1435,7 +1461,7 @@ new #[Layout('layouts.app')] class extends Component
                                     id="default-base-branch-input"
                                     data-testid="default-base-branch-input"
                                     wire:model.live.debounce.400ms="defaultBaseBranch"
-                                    placeholder="dev, master, main…"
+                                    placeholder="dev, master, main..."
                                     size="sm"
                                     variant="filled"
                                     class="!font-mono text-xs"

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -11,6 +11,7 @@ use App\Actions\ExportReviewAction;
 use App\Actions\GetCurrentHeadAction;
 use App\Actions\GetFileListAction;
 use App\Actions\GroupReviewFilesAction;
+use App\Actions\IsSinceBaseViewAction;
 use App\Actions\LoadCommitMetadataAction;
 use App\Actions\ResolveCommitAction;
 use App\Actions\ResolveProjectAction;
@@ -97,11 +98,17 @@ new #[Layout('layouts.app')] class extends Component
 
     public ?string $globalGitignorePath = null;
 
+    public string $defaultBaseBranch = '';
+
     #[Locked]
     public string $diffFrom = 'HEAD';
 
     #[Locked]
     public ?string $diffTo = null;
+
+    /** True when the active rangeToWorking diff equals `default_base_branch..HEAD..working`. */
+    #[Locked]
+    public bool $isSinceBaseView = false;
 
     /** @var array{shortHash: string, message: string, author: string, prevHash: ?string, nextHash: ?string}|null */
     #[Locked]
@@ -153,6 +160,7 @@ new #[Layout('layouts.app')] class extends Component
 
         $this->respectGlobalGitignore = $project['respect_global_gitignore'] ?? true;
         $this->globalGitignorePath = $project['global_gitignore_path'] ?: null;
+        $this->defaultBaseBranch = (string) ($project['default_base_branch'] ?? '');
 
         // Commit mode: resolve hash to full SHA
         if ($hash !== null) {
@@ -188,6 +196,8 @@ new #[Layout('layouts.app')] class extends Component
             $this->globalGitignorePath = app(BackfillGlobalGitignoreAction::class)
                 ->handle($this->projectId, $this->repoPath);
         }
+
+        $this->isSinceBaseView = $this->detectSinceBaseView();
 
         $this->rehydrateForTarget();
         $this->checkHeadDivergence();
@@ -226,6 +236,21 @@ new #[Layout('layouts.app')] class extends Component
             : DiffTarget::rangeToWorking($this->diffFrom);
     }
 
+    /**
+     * True when the current rangeToWorking view is exactly `base..working` for
+     * the project's configured base branch. Drives the "Since {base}" header
+     * label so the user can tell at a glance which view they're in.
+     */
+    private function detectSinceBaseView(): bool
+    {
+        if ($this->diffTo !== null || $this->defaultBaseBranch === '' || $this->diffFrom === 'HEAD') {
+            return false;
+        }
+
+        return app(IsSinceBaseViewAction::class)
+            ->handle($this->repoPath, $this->defaultBaseBranch, $this->diffFrom);
+    }
+
     private function loadCommitInfo(): void
     {
         if ($this->diffTo === null) {
@@ -254,6 +279,18 @@ new #[Layout('layouts.app')] class extends Component
         }
 
         $this->groupFiles();
+    }
+
+    public function updatedDefaultBaseBranch(): void
+    {
+        $value = trim($this->defaultBaseBranch);
+        $this->defaultBaseBranch = $value;
+
+        app(UpdateProjectSettingAction::class)->handle($this->projectId, [
+            'default_base_branch' => $value === '' ? null : $value,
+        ]);
+
+        $this->isSinceBaseView = $this->detectSinceBaseView();
     }
 
     public function updatedRespectGlobalGitignore(): void
@@ -1235,6 +1272,9 @@ new #[Layout('layouts.app')] class extends Component
                     if ($diffTo === null && $diffFrom === 'HEAD') {
                         $selectionLabel = 'Working tree';
                         $selectionTitle = 'Working tree changes';
+                    } elseif ($isSinceBaseView) {
+                        $selectionLabel = 'Since '.$defaultBaseBranch;
+                        $selectionTitle = 'All changes since '.$defaultBaseBranch.' (commits + uncommitted)';
                     } elseif ($diffTo === null) {
                         $selectionLabel = 'WT · '.$shortFrom;
                         $selectionTitle = 'Working tree + commits through '.$diffFrom;
@@ -1257,6 +1297,7 @@ new #[Layout('layouts.app')] class extends Component
                         :has-remote="$hasRemote"
                         :selection-label="$selectionLabel"
                         :selection-title="$selectionTitle"
+                        :default-base-branch="$defaultBaseBranch"
                     />
                 @endif
                 <livewire:comments-drawer :repo-path="$repoPath" :project-id="$projectId ?: null" />
@@ -1389,6 +1430,24 @@ new #[Layout('layouts.app')] class extends Component
                             <flux:menu.item keep-open>
                                 <flux:checkbox wire:model.live="respectGlobalGitignore" label="Global .gitignore" class="text-xs whitespace-nowrap" />
                             </flux:menu.item>
+                            <flux:menu.separator />
+                            <div class="px-3 py-2 w-56 space-y-1.5" wire:ignore.self>
+                                <label for="default-base-branch-input" class="block text-[10px] font-display font-semibold uppercase tracking-brutal text-gh-muted">
+                                    Base branch
+                                </label>
+                                <flux:input
+                                    id="default-base-branch-input"
+                                    data-testid="default-base-branch-input"
+                                    wire:model.live.debounce.400ms="defaultBaseBranch"
+                                    placeholder="dev, master, main…"
+                                    size="sm"
+                                    variant="filled"
+                                    class="!font-mono text-xs"
+                                />
+                                <p class="text-[10px] font-mono text-gh-muted/80 leading-snug">
+                                    Used by the "Since {base}" shortcut in the branch picker.
+                                </p>
+                            </div>
                         </flux:menu>
                     </flux:dropdown>
                 @endif

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1269,22 +1269,18 @@ new #[Layout('layouts.app')] class extends Component
                 @php
                     $shortFrom = $diffFrom === 'HEAD' ? 'HEAD' : substr($diffFrom, 0, 7);
                     $shortTo = $diffTo ? substr($diffTo, 0, 7) : null;
-                    if ($diffTo === null && $diffFrom === 'HEAD') {
-                        $selectionLabel = 'Working tree';
-                        $selectionTitle = 'Working tree changes';
-                    } elseif ($isSinceBaseView) {
-                        $selectionLabel = 'Since '.$defaultBaseBranch;
-                        $selectionTitle = 'All changes since '.$defaultBaseBranch.' (commits + uncommitted)';
-                    } elseif ($diffTo === null) {
-                        $selectionLabel = 'WT · '.$shortFrom;
-                        $selectionTitle = 'Working tree + commits through '.$diffFrom;
-                    } elseif ($diffFrom === $diffTo.'^') {
-                        $selectionLabel = $shortTo;
-                        $selectionTitle = $commitInfo['message'] ?? $diffTo;
-                    } else {
-                        $selectionLabel = $shortFrom.'..'.$shortTo;
-                        $selectionTitle = 'Range '.$diffFrom.'..'.$diffTo;
-                    }
+                    [$selectionLabel, $selectionTitle] = match (true) {
+                        $diffTo === null && $diffFrom === 'HEAD'
+                            => ['Working tree', 'Working tree changes'],
+                        $isSinceBaseView
+                            => ['Since '.$defaultBaseBranch, 'All changes since '.$defaultBaseBranch.' (commits + uncommitted)'],
+                        $diffTo === null
+                            => ['WT · '.$shortFrom, 'Working tree + commits through '.$diffFrom],
+                        $diffFrom === $diffTo.'^'
+                            => [$shortTo, $commitInfo['message'] ?? $diffTo],
+                        default
+                            => [$shortFrom.'..'.$shortTo, 'Range '.$diffFrom.'..'.$diffTo],
+                    };
                 @endphp
                 @if($projectBranch)
                     <x-header-separator />

--- a/tests/Browser/SelectionWorkingTreeRowTest.php
+++ b/tests/Browser/SelectionWorkingTreeRowTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Project;
+
 test('branch-explorer panel shows a Working tree row at the top of the commit list', function () {
     $this->setUpCommitHistoryRepo();
 
@@ -14,6 +16,22 @@ test('branch-explorer panel shows a Working tree row at the top of the commit li
 
     $firstRow = $page->page()->locator('[data-testid="working-tree-row"], [data-testid="commit-row"]')->first();
     expect($firstRow->getAttribute('data-testid'))->toBe('working-tree-row');
+
+    $page->assertNoJavaScriptErrors();
+});
+
+test('branch-explorer commit rows keep their Alpine scope when remote menus are enabled', function () {
+    $this->setUpCommitHistoryRepo();
+
+    Project::where('slug', $this->testProjectSlug)
+        ->update(['remote_url' => 'git@github.com:acme/example.git']);
+
+    $page = $this->visit($this->projectUrl());
+
+    $page->page()->getByLabel('Open selection drawer')->click();
+    $page->page()->getByTestId('commit-row')->first()->waitFor();
+
+    $page->assertNoJavaScriptErrors();
 });
 
 test('Working tree row shows active state when viewing the working tree', function () {

--- a/tests/Js/branch-explorer.test.js
+++ b/tests/Js/branch-explorer.test.js
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import branchExplorer from '../../public/js/branch-explorer.js';
 
-const { decideSelection, install } = branchExplorer;
+const { decideSelection, isSinceBaseExactly, install } = branchExplorer;
 
 // Newest-first commit list. Index 0 = tip.
 const commits = [
@@ -163,6 +163,54 @@ describe('decideSelection — input cleaning', () => {
         // Without this guard, the function dereferences `commits[undefined].hash`
         // in the single-commit branch and throws.
         expect(decide({ selectedHashes })).toEqual({ kind: 'noop' });
+    });
+});
+
+describe('isSinceBaseExactly', () => {
+    const range = ['aaa1', 'bbb2', 'ccc3'];
+
+    it('returns true when WT + every range hash is selected (any order)', () => {
+        expect(isSinceBaseExactly({
+            selectedHashes: ['ccc3', 'aaa1', 'bbb2'],
+            workingTreeSelected: true,
+            hashesInRange: range,
+        })).toBe(true);
+    });
+
+    it('returns false when working tree is not selected', () => {
+        expect(isSinceBaseExactly({
+            selectedHashes: ['aaa1', 'bbb2', 'ccc3'],
+            workingTreeSelected: false,
+            hashesInRange: range,
+        })).toBe(false);
+    });
+
+    it('returns false when selection is missing a hash from the range', () => {
+        expect(isSinceBaseExactly({
+            selectedHashes: ['aaa1', 'bbb2'],
+            workingTreeSelected: true,
+            hashesInRange: range,
+        })).toBe(false);
+    });
+
+    it('returns false when selection has an extra hash beyond the range', () => {
+        expect(isSinceBaseExactly({
+            selectedHashes: ['aaa1', 'bbb2', 'ccc3', 'extra'],
+            workingTreeSelected: true,
+            hashesInRange: range,
+        })).toBe(false);
+    });
+
+    it('returns true for the empty range when only WT is selected', () => {
+        // The picker only renders the "Since {base}" row in the Ready state,
+        // which guarantees a non-empty range — but the helper must still handle
+        // the edge case sensibly so a future caller doesn't get a false positive
+        // from an unintended state.
+        expect(isSinceBaseExactly({
+            selectedHashes: [],
+            workingTreeSelected: true,
+            hashesInRange: [],
+        })).toBe(true);
     });
 });
 

--- a/tests/Js/branch-explorer.test.js
+++ b/tests/Js/branch-explorer.test.js
@@ -143,6 +143,40 @@ describe('decideSelection — working tree + commits', () => {
         expect(result.message).toContain('pick every commit');
         expect(result.message).not.toContain('paired with the newest commits');
     });
+
+    it('uses the resolved merge-base for an exact since-base selection', () => {
+        expect(decideSelection({
+            commits,
+            selectedHashes: ['aaa1', 'bbb2', 'ccc3'],
+            workingTreeSelected: true,
+            projectSlug: slug,
+            sinceBase: {
+                state: 'ready',
+                baseSha: '1234567890abcdef1234567890abcdef12345678',
+                hashesInRange: ['aaa1', 'bbb2', 'ccc3'],
+            },
+        })).toEqual({
+            kind: 'navigate',
+            url: '/p/myproj/rw/1234567890abcdef1234567890abcdef12345678',
+        });
+    });
+
+    it('falls back to the trimmed range when since-base selection is edited', () => {
+        expect(decideSelection({
+            commits,
+            selectedHashes: ['aaa1', 'bbb2'],
+            workingTreeSelected: true,
+            projectSlug: slug,
+            sinceBase: {
+                state: 'ready',
+                baseSha: '1234567890abcdef1234567890abcdef12345678',
+                hashesInRange: ['aaa1', 'bbb2', 'ccc3'],
+            },
+        })).toEqual({
+            kind: 'navigate',
+            url: '/p/myproj/rw/bbb2%5E',
+        });
+    });
 });
 
 describe('decideSelection — input cleaning', () => {

--- a/tests/Js/branch-explorer.test.js
+++ b/tests/Js/branch-explorer.test.js
@@ -1,7 +1,23 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import branchExplorer from '../../public/js/branch-explorer.js';
 
-const { decideSelection, isSinceBaseExactly, install } = branchExplorer;
+const { decideSelection, isSinceBaseExactly, createBranchExplorer, install } = branchExplorer;
+
+/** Minimal factory wrapper for tests that exercise the Alpine state machine
+ *  directly. Provides a stub `$wire` that the production code reads from. */
+function makeAlpine({ commits = [], branchBase = null, currentBranch = 'main' } = {}) {
+    const a = createBranchExplorer({
+        currentBranch,
+        activeCommitHash: null,
+        activeDiffFrom: 'HEAD',
+        projectSlug: 'p',
+        branches: { local: [], remote: [] },
+    });
+    a.$wire = { commits, branchBase };
+    return a;
+}
+
+const noopEvent = () => ({ stopPropagation: () => {}, shiftKey: false });
 
 // Newest-first commit list. Index 0 = tip.
 const commits = [
@@ -211,6 +227,84 @@ describe('isSinceBaseExactly', () => {
             workingTreeSelected: true,
             hashesInRange: [],
         })).toBe(true);
+    });
+});
+
+describe('working-tree tip anchor', () => {
+    const commits = [
+        { hash: 'tip' }, // 0 = newest
+        { hash: 'mid' }, // 1
+        { hash: 'old' }, // 2 = oldest
+    ];
+
+    afterEach(() => {
+        delete window.Flux;
+    });
+
+    it('auto-unticks working tree when the tip commit is unticked', () => {
+        const a = makeAlpine({ commits });
+        a.workingTreeSelected = true;
+        a.selectedHashes = ['tip', 'mid', 'old'];
+
+        a.toggleSelection('tip', 0, noopEvent());
+
+        expect(a.selectedHashes).toEqual(['mid', 'old']);
+        expect(a.workingTreeSelected).toBe(false);
+    });
+
+    it('keeps working tree selected when a non-tip commit is unticked', () => {
+        const a = makeAlpine({ commits });
+        a.workingTreeSelected = true;
+        a.selectedHashes = ['tip', 'mid', 'old'];
+
+        a.toggleSelection('old', 2, noopEvent());
+
+        expect(a.selectedHashes).toEqual(['tip', 'mid']);
+        expect(a.workingTreeSelected).toBe(true);
+    });
+
+    it('does not affect a working-tree-only selection', () => {
+        const a = makeAlpine({ commits });
+        a.workingTreeSelected = true;
+        a.selectedHashes = [];
+
+        // Toggling a hash that wasn't selected just adds it; the invariant
+        // only matters when the resulting state would pair WT with non-tip
+        // commits. Adding the tip is always fine.
+        a.toggleSelection('tip', 0, noopEvent());
+
+        expect(a.selectedHashes).toEqual(['tip']);
+        expect(a.workingTreeSelected).toBe(true);
+    });
+
+    it('shows an explanatory toast when WT is auto-unticked', () => {
+        const toast = vi.fn();
+        window.Flux = { toast };
+
+        const a = makeAlpine({ commits });
+        a.workingTreeSelected = true;
+        a.selectedHashes = ['tip', 'mid'];
+
+        a.toggleSelection('tip', 0, noopEvent());
+
+        expect(toast).toHaveBeenCalledTimes(1);
+        expect(toast.mock.calls[0][0]).toMatchObject({ variant: 'info' });
+        expect(toast.mock.calls[0][0].text).toContain('Working tree removed');
+    });
+
+    it('does not toast when the invariant is already satisfied', () => {
+        const toast = vi.fn();
+        window.Flux = { toast };
+
+        const a = makeAlpine({ commits });
+        a.workingTreeSelected = true;
+        a.selectedHashes = ['tip'];
+
+        // Untick a commit that's not in the selection — adds it, doesn't violate.
+        a.toggleSelection('mid', 1, noopEvent());
+
+        expect(toast).not.toHaveBeenCalled();
+        expect(a.workingTreeSelected).toBe(true);
     });
 });
 

--- a/tests/Unit/Actions/IsSinceBaseViewActionTest.php
+++ b/tests/Unit/Actions/IsSinceBaseViewActionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Actions\IsSinceBaseViewAction;
+use App\Services\GitMetadataService;
+use App\Services\GitProcessService;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    $this->tmpDir = $this->createTempDirectory('rfa_since_base_view_test_');
+    $this->initTestRepo($this->tmpDir);
+
+    File::put($this->tmpDir.'/a.txt', "v1\n");
+    $this->commitTestRepo($this->tmpDir, 'shared');
+    $this->sharedSha = trim($this->runTestRepoCommand($this->tmpDir, 'git rev-parse HEAD'));
+
+    $this->action = new IsSinceBaseViewAction(new GitMetadataService(new GitProcessService));
+});
+
+test('returns true when diffFrom resolves to the merge-base SHA', function () {
+    $this->runTestRepoCommand($this->tmpDir, 'git checkout -b feature');
+    File::put($this->tmpDir.'/a.txt', "v2\n");
+    $this->commitTestRepo($this->tmpDir, 'feature commit');
+
+    expect($this->action->handle($this->tmpDir, 'main', $this->sharedSha))->toBeTrue();
+});
+
+test('returns true when diffFrom is the merge-base parent caret form', function () {
+    $this->runTestRepoCommand($this->tmpDir, 'git checkout -b feature');
+    File::put($this->tmpDir.'/a.txt', "v2\n");
+    $this->commitTestRepo($this->tmpDir, 'first ahead');
+    $first = trim($this->runTestRepoCommand($this->tmpDir, 'git rev-parse HEAD'));
+
+    // The picker emits `/rw/{oldestHash}^` when WT + commits are selected;
+    // `{oldestHash}^` resolves to the merge-base for a contiguous since-base
+    // selection, so the page should treat this view as "Since {base}".
+    expect($this->action->handle($this->tmpDir, 'main', $first.'^'))->toBeTrue();
+});
+
+test('returns false when diffFrom is HEAD', function () {
+    expect($this->action->handle($this->tmpDir, 'main', 'HEAD'))->toBeFalse();
+});
+
+test('returns false when base is null or empty', function () {
+    expect($this->action->handle($this->tmpDir, null, $this->sharedSha))->toBeFalse()
+        ->and($this->action->handle($this->tmpDir, '', $this->sharedSha))->toBeFalse();
+});
+
+test('returns false when base ref is missing', function () {
+    expect($this->action->handle($this->tmpDir, 'origin/nonexistent', $this->sharedSha))->toBeFalse();
+});
+
+test('returns false when diffFrom resolves to a different SHA', function () {
+    $this->runTestRepoCommand($this->tmpDir, 'git checkout -b feature');
+    File::put($this->tmpDir.'/a.txt', "v2\n");
+    $this->commitTestRepo($this->tmpDir, 'first ahead');
+    $first = trim($this->runTestRepoCommand($this->tmpDir, 'git rev-parse HEAD'));
+
+    // diffFrom is the feature commit itself, not the merge-base.
+    expect($this->action->handle($this->tmpDir, 'main', $first))->toBeFalse();
+});

--- a/tests/Unit/Actions/ResolveBranchBaseActionTest.php
+++ b/tests/Unit/Actions/ResolveBranchBaseActionTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use App\Actions\ResolveBranchBaseAction;
+use App\Enums\BranchBaseState;
+use App\Services\GitMetadataService;
+use App\Services\GitProcessService;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    $this->tmpDir = $this->createTempDirectory('rfa_branch_base_test_');
+    $this->initTestRepo($this->tmpDir);
+
+    File::put($this->tmpDir.'/a.txt', "root\n");
+    $this->commitTestRepo($this->tmpDir, 'shared');
+    $this->sharedSha = trim($this->runTestRepoCommand($this->tmpDir, 'git rev-parse HEAD'));
+
+    $this->action = new ResolveBranchBaseAction(
+        new GitMetadataService(new GitProcessService),
+        new GitProcessService,
+    );
+});
+
+test('returns Ready with newest-first hashes when feature branch is ahead of base', function () {
+    $this->runTestRepoCommand($this->tmpDir, 'git checkout -b feature');
+
+    File::put($this->tmpDir.'/b.txt', "first\n");
+    $this->commitTestRepo($this->tmpDir, 'first ahead');
+    $first = trim($this->runTestRepoCommand($this->tmpDir, 'git rev-parse HEAD'));
+
+    File::put($this->tmpDir.'/b.txt', "second\n");
+    $this->commitTestRepo($this->tmpDir, 'second ahead');
+    $second = trim($this->runTestRepoCommand($this->tmpDir, 'git rev-parse HEAD'));
+
+    $result = $this->action->handle($this->tmpDir, 'main', 'feature');
+
+    expect($result->state)->toBe(BranchBaseState::Ready)
+        ->and($result->baseBranch)->toBe('main')
+        ->and($result->baseSha)->toBe($this->sharedSha)
+        ->and($result->hashesInRange)->toBe([$second, $first]);
+});
+
+test('returns UpToDate when HEAD has no commits ahead of the base', function () {
+    $this->runTestRepoCommand($this->tmpDir, 'git checkout -b feature');
+
+    $result = $this->action->handle($this->tmpDir, 'main', 'feature');
+
+    expect($result->state)->toBe(BranchBaseState::UpToDate)
+        ->and($result->baseBranch)->toBe('main')
+        ->and($result->baseSha)->toBe($this->sharedSha)
+        ->and($result->hashesInRange)->toBeEmpty();
+});
+
+test('returns OnBaseBranch when current branch is the configured base', function () {
+    $result = $this->action->handle($this->tmpDir, 'main', 'main');
+
+    expect($result->state)->toBe(BranchBaseState::OnBaseBranch)
+        ->and($result->baseBranch)->toBe('main')
+        ->and($result->baseSha)->toBeNull()
+        ->and($result->hashesInRange)->toBeEmpty();
+});
+
+test('returns NotConfigured when base is null', function () {
+    $result = $this->action->handle($this->tmpDir, null, 'feature');
+
+    expect($result->state)->toBe(BranchBaseState::NotConfigured)
+        ->and($result->baseBranch)->toBeNull();
+});
+
+test('returns NotConfigured when base is empty or whitespace', function () {
+    $result = $this->action->handle($this->tmpDir, '   ', 'feature');
+
+    expect($result->state)->toBe(BranchBaseState::NotConfigured);
+});
+
+test('returns MissingRef when base branch does not exist locally', function () {
+    $result = $this->action->handle($this->tmpDir, 'origin/nonexistent', 'main');
+
+    expect($result->state)->toBe(BranchBaseState::MissingRef)
+        ->and($result->baseBranch)->toBe('origin/nonexistent');
+});
+
+test('treats detached HEAD (null currentBranch) as not on base branch', function () {
+    $this->runTestRepoCommand($this->tmpDir, 'git checkout -b feature');
+    File::put($this->tmpDir.'/b.txt', "first\n");
+    $this->commitTestRepo($this->tmpDir, 'first ahead');
+
+    $result = $this->action->handle($this->tmpDir, 'main', null);
+
+    expect($result->state)->toBe(BranchBaseState::Ready)
+        ->and($result->hashesInRange)->toHaveCount(1);
+});
+
+test('handles dash-prefixed base branch as missing ref (not as a flag)', function () {
+    $result = $this->action->handle($this->tmpDir, '--exec=bad', 'main');
+
+    expect($result->state)->toBe(BranchBaseState::MissingRef);
+});

--- a/tests/Unit/GitMetadataServiceTest.php
+++ b/tests/Unit/GitMetadataServiceTest.php
@@ -148,6 +148,53 @@ test('getCommitParents returns empty array for root commit', function () {
     expect($parents)->toBeEmpty();
 });
 
+// -- getMergeBase tests --
+
+test('getMergeBase returns common ancestor of diverged branches', function () {
+    $this->initTestRepo($this->tmpDir);
+    File::put($this->tmpDir.'/file.txt', "v1\n");
+    $this->commitTestRepo($this->tmpDir, 'shared');
+
+    $shared = $this->service->resolveRef($this->tmpDir, 'HEAD');
+
+    $this->runTestRepoCommand($this->tmpDir, 'git checkout -b feature');
+    File::put($this->tmpDir.'/file.txt', "v2\n");
+    $this->commitTestRepo($this->tmpDir, 'feature only');
+
+    $this->runTestRepoCommand($this->tmpDir, 'git checkout main');
+
+    expect($this->service->getMergeBase($this->tmpDir, 'main', 'feature'))->toBe($shared);
+});
+
+test('getMergeBase returns the older ref when one is an ancestor of the other', function () {
+    $this->initTestRepo($this->tmpDir);
+    File::put($this->tmpDir.'/file.txt', "v1\n");
+    $this->commitTestRepo($this->tmpDir, 'first');
+
+    $first = $this->service->resolveRef($this->tmpDir, 'HEAD');
+
+    File::put($this->tmpDir.'/file.txt', "v2\n");
+    $this->commitTestRepo($this->tmpDir, 'second');
+
+    expect($this->service->getMergeBase($this->tmpDir, $first, 'HEAD'))->toBe($first);
+});
+
+test('getMergeBase returns null for unknown ref', function () {
+    $this->initTestRepo($this->tmpDir);
+    File::put($this->tmpDir.'/file.txt', "v1\n");
+    $this->commitTestRepo($this->tmpDir, 'first');
+
+    expect($this->service->getMergeBase($this->tmpDir, 'HEAD', 'nonexistent-xyz'))->toBeNull();
+});
+
+test('getMergeBase returns null for ref starting with dash', function () {
+    $this->initTestRepo($this->tmpDir);
+    File::put($this->tmpDir.'/file.txt', "v1\n");
+    $this->commitTestRepo($this->tmpDir, 'first');
+
+    expect($this->service->getMergeBase($this->tmpDir, 'HEAD', '--exec=bad'))->toBeNull();
+});
+
 // -- getChildCommit tests --
 
 test('getChildCommit returns child hash', function () {


### PR DESCRIPTION
## Summary
- add a default base branch comparison shortcut for review selection
- fix branch explorer Alpine scope/runtime errors from remote context menus
- add regressions for exact since-base navigation and drawer console errors

## Verification
- vendor/bin/pint --dirty --format agent
- composer test:types
- composer test
- composer test:js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects can now configure a default base branch to compare commits against.
  * Added "Since {base}" shortcut in branch explorer for quick access to commits relative to the base.
  * Enhanced branch comparisons to display commits ahead of the configured base branch.

* **Tests**
  * Added comprehensive unit and browser tests for branch base resolution functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->