### PR TITLE
Add support for linking external directories to projects

### DIFF
--- a/app/Actions/AddCommentAction.php
+++ b/app/Actions/AddCommentAction.php
@@ -57,8 +57,14 @@ final readonly class AddCommentAction
 
         $filePath = (string) $file['path'];
         $oldPath = ! empty($file['oldPath']) ? (string) $file['oldPath'] : null;
-        $contentHash = $this->resolveContentHash($repoPath, $target, $side, $filePath, $oldPath);
-        $originRef = $target->to() ?? GitRef::Working->value;
+        $isExternal = (bool) ($file['isExternal'] ?? false);
+        $externalAbsolutePath = $isExternal ? (string) ($file['externalAbsolutePath'] ?? '') : null;
+        $contentHash = $isExternal
+            ? $this->hashExternalFile($externalAbsolutePath)
+            : $this->resolveContentHash($repoPath, $target, $side, $filePath, $oldPath);
+        $originRef = $isExternal
+            ? GitRef::External->value
+            : ($target->to() ?? GitRef::Working->value);
 
         $id = 'c-'.Str::ulid();
 
@@ -106,5 +112,16 @@ final readonly class AddCommentAction
         $ref = $target->to() ?? GitRef::Working->value;
 
         return $this->gitFileContentService->hashAt($repoPath, $ref, $filePath);
+    }
+
+    private function hashExternalFile(?string $absolutePath): ?string
+    {
+        if ($absolutePath === null || $absolutePath === '' || ! is_file($absolutePath)) {
+            return null;
+        }
+
+        $hash = @hash_file('xxh128', $absolutePath);
+
+        return $hash === false ? null : $hash;
     }
 }

--- a/app/Actions/AddCommentAction.php
+++ b/app/Actions/AddCommentAction.php
@@ -43,11 +43,11 @@ final readonly class AddCommentAction
             return null;
         }
 
-        if ($side === 'file' && ($startLine !== null || $endLine !== null)) {
+        if ($side === DiffSide::File->value && ($startLine !== null || $endLine !== null)) {
             return null;
         }
 
-        if ($side !== 'file' && $startLine === null) {
+        if ($side !== DiffSide::File->value && $startLine === null) {
             return null;
         }
 
@@ -101,7 +101,7 @@ final readonly class AddCommentAction
 
     private function resolveContentHash(string $repoPath, DiffTarget $target, string $side, string $filePath, ?string $oldPath): ?string
     {
-        if ($side === 'left') {
+        if ($side === DiffSide::Left->value) {
             // For renames the file exists at `from` under its pre-rename path only.
             $leftPath = $oldPath ?? $filePath;
 

--- a/app/Actions/AddCommentAction.php
+++ b/app/Actions/AddCommentAction.php
@@ -58,9 +58,8 @@ final readonly class AddCommentAction
         $filePath = (string) $file['path'];
         $oldPath = ! empty($file['oldPath']) ? (string) $file['oldPath'] : null;
         $isExternal = (bool) ($file['isExternal'] ?? false);
-        $externalAbsolutePath = $isExternal ? (string) ($file['externalAbsolutePath'] ?? '') : null;
         $contentHash = $isExternal
-            ? $this->hashExternalFile($externalAbsolutePath)
+            ? $this->gitFileContentService->hashAtAbsolute((string) ($file['externalAbsolutePath'] ?? ''))
             : $this->resolveContentHash($repoPath, $target, $side, $filePath, $oldPath);
         $originRef = $isExternal
             ? GitRef::External->value
@@ -112,16 +111,5 @@ final readonly class AddCommentAction
         $ref = $target->to() ?? GitRef::Working->value;
 
         return $this->gitFileContentService->hashAt($repoPath, $ref, $filePath);
-    }
-
-    private function hashExternalFile(?string $absolutePath): ?string
-    {
-        if ($absolutePath === null || $absolutePath === '' || ! is_file($absolutePath)) {
-            return null;
-        }
-
-        $hash = @hash_file('xxh128', $absolutePath);
-
-        return $hash === false ? null : $hash;
     }
 }

--- a/app/Actions/GetFileListAction.php
+++ b/app/Actions/GetFileListAction.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\DTOs\DiffTarget;
+use App\Models\Project;
+use App\Services\ExternalFilesService;
 use App\Services\GitDiffService;
 use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
@@ -13,6 +15,7 @@ final readonly class GetFileListAction
 {
     public function __construct(
         private GitDiffService $gitDiffService,
+        private ExternalFilesService $externalFilesService,
     ) {}
 
     /**
@@ -27,6 +30,18 @@ final readonly class GetFileListAction
             ->map(fn ($entry): array => $entry->toArray())
             ->values()
             ->all();
+
+        if ($target->isWorkingDirectory() && $projectId !== null) {
+            $project = Project::find($projectId);
+
+            if ($project !== null) {
+                $external = collect($this->externalFilesService->getEntries((array) ($project->external_paths ?? [])))
+                    ->map(fn ($entry): array => $entry->toArray())
+                    ->all();
+
+                $files = [...$files, ...$external];
+            }
+        }
 
         if ($clearCache && ! $target->isImmutable()) {
             $projectKey = $projectId ?? $repoPath;

--- a/app/Actions/GetFileListAction.php
+++ b/app/Actions/GetFileListAction.php
@@ -45,11 +45,9 @@ final readonly class GetFileListAction
 
         if ($clearCache && ! $target->isImmutable()) {
             $projectKey = $projectId ?? $repoPath;
-            collect($files)
-                ->reject(fn (array $file): bool => $file['isExternal'] ?? false)
-                ->each(function (array $file) use ($projectKey, $target): void {
-                    Cache::forget(DiffCacheKey::for($projectKey, $file['id'], $target->contextKey()));
-                });
+            collect($files)->each(function (array $file) use ($projectKey, $target): void {
+                Cache::forget(DiffCacheKey::for($projectKey, $file['id'], $target->contextKey()));
+            });
         }
 
         return $files;

--- a/app/Actions/GetFileListAction.php
+++ b/app/Actions/GetFileListAction.php
@@ -45,9 +45,11 @@ final readonly class GetFileListAction
 
         if ($clearCache && ! $target->isImmutable()) {
             $projectKey = $projectId ?? $repoPath;
-            collect($files)->each(function (array $file) use ($projectKey, $target): void {
-                Cache::forget(DiffCacheKey::for($projectKey, $file['id'], $target->contextKey()));
-            });
+            collect($files)
+                ->reject(fn (array $file): bool => $file['isExternal'] ?? false)
+                ->each(function (array $file) use ($projectKey, $target): void {
+                    Cache::forget(DiffCacheKey::for($projectKey, $file['id'], $target->contextKey()));
+                });
         }
 
         return $files;

--- a/app/Actions/LinkExternalPathAction.php
+++ b/app/Actions/LinkExternalPathAction.php
@@ -34,9 +34,11 @@ final readonly class LinkExternalPathAction
      */
     public function handleByReference(string $reference, string $path, ?string $label = null): ?array
     {
-        $project = ctype_digit($reference)
-            ? Project::find((int) $reference)
-            : Project::where('slug', $reference)->orWhere('name', $reference)->first();
+        // Prefer slug/name so a project with a numeric slug or name (e.g.
+        // `"123"`) still resolves correctly. Only fall back to numeric ID
+        // when no slug/name match exists.
+        $project = Project::where('slug', $reference)->orWhere('name', $reference)->first()
+            ?? (ctype_digit($reference) ? Project::find((int) $reference) : null);
 
         return $this->handleForProject($project, $path, $label);
     }

--- a/app/Actions/LinkExternalPathAction.php
+++ b/app/Actions/LinkExternalPathAction.php
@@ -5,16 +5,19 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\Models\Project;
+use App\Services\ExternalFilesService;
 
 final readonly class LinkExternalPathAction
 {
+    public function __construct(
+        private ExternalFilesService $externalFilesService,
+    ) {}
+
     /**
-     * Append an external directory link to a project. Idempotent on `path`:
-     * the same absolute path is never added twice.
-     *
-     * Returns the project's updated `external_paths` value (a list of
-     * `{label: string, path: string}` rows), or null if the project does
-     * not exist or the path is invalid.
+     * Append an external directory link to a project. Idempotent on the
+     * canonical path: the same directory is never linked twice. Returns the
+     * project's updated `external_paths` value, or null if the project does
+     * not exist or the path is not a directory.
      *
      * @return list<array{label: string, path: string}>|null
      */
@@ -52,28 +55,18 @@ final readonly class LinkExternalPathAction
             return null;
         }
 
-        /** @var list<array{label: string, path: string}> $current */
-        $current = collect($project->external_paths ?? [])
-            ->filter(fn ($row): bool => is_array($row) && isset($row['path']) && is_string($row['path']))
-            ->map(fn (array $row): array => [
-                'label' => isset($row['label']) && is_string($row['label']) && trim($row['label']) !== ''
-                    ? $row['label']
-                    : basename((string) $row['path']),
-                'path' => (string) $row['path'],
-            ])
-            ->values()
-            ->all();
+        $current = $this->externalFilesService->normalizeForStorage((array) ($project->external_paths ?? []));
 
-        // Idempotent: skip if already linked at the same canonical path.
         foreach ($current as $row) {
             if (realpath($row['path']) === $real) {
                 return $current;
             }
         }
 
-        $finalLabel = $label !== null && trim($label) !== '' ? trim($label) : basename($real);
-
-        $current[] = ['label' => $finalLabel, 'path' => $real];
+        $current[] = [
+            'label' => $label !== null && trim($label) !== '' ? trim($label) : basename($real),
+            'path' => $real,
+        ];
 
         $project->forceFill(['external_paths' => $current])->save();
 

--- a/app/Actions/LinkExternalPathAction.php
+++ b/app/Actions/LinkExternalPathAction.php
@@ -63,8 +63,10 @@ final readonly class LinkExternalPathAction
             }
         }
 
+        $candidate = $label !== null && trim($label) !== '' ? trim($label) : basename($real);
+
         $current[] = [
-            'label' => $label !== null && trim($label) !== '' ? trim($label) : basename($real),
+            'label' => $this->externalFilesService->uniqueLabelFor($current, $candidate),
             'path' => $real,
         ];
 

--- a/app/Actions/LinkExternalPathAction.php
+++ b/app/Actions/LinkExternalPathAction.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Models\Project;
+
+final readonly class LinkExternalPathAction
+{
+    /**
+     * Append an external directory link to a project. Idempotent on `path`:
+     * the same absolute path is never added twice.
+     *
+     * Returns the project's updated `external_paths` value (a list of
+     * `{label: string, path: string}` rows), or null if the project does
+     * not exist or the path is invalid.
+     *
+     * @return list<array{label: string, path: string}>|null
+     */
+    public function handle(int $projectId, string $path, ?string $label = null): ?array
+    {
+        return $this->handleForProject(Project::find($projectId), $path, $label);
+    }
+
+    /**
+     * Same as `handle()` but accepts a slug/name/numeric id as a single string.
+     * Used by the CLI so console commands don't need to import the Project model.
+     *
+     * @return list<array{label: string, path: string}>|null
+     */
+    public function handleByReference(string $reference, string $path, ?string $label = null): ?array
+    {
+        $project = ctype_digit($reference)
+            ? Project::find((int) $reference)
+            : Project::where('slug', $reference)->orWhere('name', $reference)->first();
+
+        return $this->handleForProject($project, $path, $label);
+    }
+
+    /**
+     * @return list<array{label: string, path: string}>|null
+     */
+    private function handleForProject(?Project $project, string $path, ?string $label): ?array
+    {
+        if ($project === null) {
+            return null;
+        }
+
+        $real = realpath($path);
+        if ($real === false || ! is_dir($real)) {
+            return null;
+        }
+
+        /** @var list<array{label: string, path: string}> $current */
+        $current = collect($project->external_paths ?? [])
+            ->filter(fn ($row): bool => is_array($row) && isset($row['path']) && is_string($row['path']))
+            ->map(fn (array $row): array => [
+                'label' => isset($row['label']) && is_string($row['label']) && trim($row['label']) !== ''
+                    ? $row['label']
+                    : basename((string) $row['path']),
+                'path' => (string) $row['path'],
+            ])
+            ->values()
+            ->all();
+
+        // Idempotent: skip if already linked at the same canonical path.
+        foreach ($current as $row) {
+            if (realpath($row['path']) === $real) {
+                return $current;
+            }
+        }
+
+        $finalLabel = $label !== null && trim($label) !== '' ? trim($label) : basename($real);
+
+        $current[] = ['label' => $finalLabel, 'path' => $real];
+
+        $project->forceFill(['external_paths' => $current])->save();
+
+        return $current;
+    }
+}

--- a/app/Actions/LoadFileDiffAction.php
+++ b/app/Actions/LoadFileDiffAction.php
@@ -9,12 +9,14 @@ use App\DTOs\FileDiff;
 use App\Exceptions\GitCommandException;
 use App\Services\CsvAlignerService;
 use App\Services\DiffParser;
+use App\Services\ExternalFilesService;
 use App\Services\GitDiffService;
 use App\Services\MarkdownRegionService;
 use App\Services\MarkdownTableAlignerService;
 use App\Services\SyntaxHighlightService;
 use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
 
 final readonly class LoadFileDiffAction
@@ -26,16 +28,19 @@ final readonly class LoadFileDiffAction
         private MarkdownTableAlignerService $markdownTableAligner,
         private CsvAlignerService $csvAligner,
         private MarkdownRegionService $markdownRegionService,
+        private ExternalFilesService $externalFilesService,
     ) {}
 
     /** @return array{path: string, status: string, oldPath: ?string, hunks: array<int, array<string, mixed>>, additions: int, deletions: int, isBinary: bool, tooLarge: bool, syntaxStyles: string} */
-    public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, int $contextLines = 3, ?DiffTarget $target = null, ?string $oldPath = null): array
+    public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, int $contextLines = 3, ?DiffTarget $target = null, ?string $oldPath = null, ?string $externalAbsolutePath = null): array
     {
         $target ??= DiffTarget::workingDirectory();
 
-        $compute = function () use ($repoPath, $path, $isUntracked, $contextLines, $target, $oldPath): array {
+        $compute = function () use ($repoPath, $path, $isUntracked, $contextLines, $target, $oldPath, $externalAbsolutePath): array {
             try {
-                $rawDiff = $this->gitDiffService->getFileDiff($repoPath, $path, $isUntracked, contextLines: $contextLines, target: $target, oldPath: $oldPath);
+                $rawDiff = $externalAbsolutePath !== null
+                    ? $this->externalFilesService->buildDiff($externalAbsolutePath, $path)
+                    : $this->gitDiffService->getFileDiff($repoPath, $path, $isUntracked, contextLines: $contextLines, target: $target, oldPath: $oldPath);
             } catch (GitCommandException $e) {
                 Log::warning('Git diff failed', ['path' => $path, 'stderr' => $e->stderr]);
 
@@ -80,7 +85,7 @@ final readonly class LoadFileDiffAction
 
             $newFileLineCount = $fileDiff->status === 'deleted'
                 ? null
-                : $this->gitDiffService->getNewFileLineCount($repoPath, $path, $target);
+                : $this->newFileLineCount($repoPath, $path, $target, $externalAbsolutePath);
 
             return $fileDiff->withHunks($annotatedHunks)->toArray() + [
                 'tooLarge' => false,
@@ -106,5 +111,24 @@ final readonly class LoadFileDiffAction
         }
 
         return $compute();
+    }
+
+    private function newFileLineCount(string $repoPath, string $path, DiffTarget $target, ?string $externalAbsolutePath): ?int
+    {
+        if ($externalAbsolutePath === null) {
+            return $this->gitDiffService->getNewFileLineCount($repoPath, $path, $target);
+        }
+
+        if (! File::isFile($externalAbsolutePath)) {
+            return null;
+        }
+
+        $content = File::get($externalAbsolutePath);
+
+        if ($content === '') {
+            return 0;
+        }
+
+        return substr_count($content, "\n") + (str_ends_with($content, "\n") ? 0 : 1);
     }
 }

--- a/app/Actions/LoadFileDiffAction.php
+++ b/app/Actions/LoadFileDiffAction.php
@@ -16,7 +16,6 @@ use App\Services\MarkdownTableAlignerService;
 use App\Services\SyntaxHighlightService;
 use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
 
 final readonly class LoadFileDiffAction
@@ -85,7 +84,9 @@ final readonly class LoadFileDiffAction
 
             $newFileLineCount = $fileDiff->status === 'deleted'
                 ? null
-                : $this->newFileLineCount($repoPath, $path, $target, $externalAbsolutePath);
+                : ($externalAbsolutePath !== null
+                    ? $this->gitDiffService->countLinesInFile($externalAbsolutePath)
+                    : $this->gitDiffService->getNewFileLineCount($repoPath, $path, $target));
 
             return $fileDiff->withHunks($annotatedHunks)->toArray() + [
                 'tooLarge' => false,
@@ -111,24 +112,5 @@ final readonly class LoadFileDiffAction
         }
 
         return $compute();
-    }
-
-    private function newFileLineCount(string $repoPath, string $path, DiffTarget $target, ?string $externalAbsolutePath): ?int
-    {
-        if ($externalAbsolutePath === null) {
-            return $this->gitDiffService->getNewFileLineCount($repoPath, $path, $target);
-        }
-
-        if (! File::isFile($externalAbsolutePath)) {
-            return null;
-        }
-
-        $content = File::get($externalAbsolutePath);
-
-        if ($content === '') {
-            return 0;
-        }
-
-        return substr_count($content, "\n") + (str_ends_with($content, "\n") ? 0 : 1);
     }
 }

--- a/app/Actions/ResolveCommentAnchorAction.php
+++ b/app/Actions/ResolveCommentAnchorAction.php
@@ -32,9 +32,13 @@ final readonly class ResolveCommentAnchorAction
     {
         $fileIdByPath = [];
         $oldPathByPath = [];
+        $externalPathByPath = [];
         foreach ($currentFiles as $file) {
             $fileIdByPath[$file['path']] = $file['id'];
             $oldPathByPath[$file['path']] = $file['oldPath'] ?? null;
+            if (! empty($file['isExternal']) && ! empty($file['externalAbsolutePath'])) {
+                $externalPathByPath[$file['path']] = (string) $file['externalAbsolutePath'];
+            }
         }
 
         $resolved = [];
@@ -49,11 +53,26 @@ final readonly class ResolveCommentAnchorAction
             $storedHash = $row['file_content_hash'] ?? null;
             $fileId = $fileIdByPath[$filePath] ?? FileListEntry::idForPath($filePath);
             $storedSide = (string) ($row['side'] ?? 'right');
+            $storedOriginRef = (string) ($row['origin_ref'] ?? $row['originRef'] ?? GitRef::Working->value);
+            $isExternal = $storedOriginRef === GitRef::External->value;
 
             $anchorStatus = 'unplaced';
             $resolvedSide = $storedSide;
 
-            if ($storedHash !== null && $storedHash !== '' && isset($fileIdByPath[$filePath])) {
+            if ($isExternal) {
+                $absolute = $externalPathByPath[$filePath] ?? null;
+
+                if ($absolute !== null) {
+                    if ($storedHash === null || $storedHash === '') {
+                        $anchorStatus = 'placed';
+                    } else {
+                        $currentHash = is_file($absolute) ? @hash_file('xxh128', $absolute) : null;
+                        if ($currentHash !== false && $storedHash === $currentHash) {
+                            $anchorStatus = 'placed';
+                        }
+                    }
+                }
+            } elseif ($storedHash !== null && $storedHash !== '' && isset($fileIdByPath[$filePath])) {
                 // Renamed files: left-side content lives at `oldPath`; right-side stays
                 // at `path`. Without this, left comments on rename+edit diffs would be
                 // stamped unplaced and then silently dropped from submit.
@@ -87,7 +106,7 @@ final readonly class ResolveCommentAnchorAction
                 'startLine' => $this->intOrNull($row['start_line'] ?? $row['startLine'] ?? null),
                 'endLine' => $this->intOrNull($row['end_line'] ?? $row['endLine'] ?? null),
                 'body' => (string) ($row['body'] ?? ''),
-                'originRef' => (string) ($row['origin_ref'] ?? $row['originRef'] ?? GitRef::Working->value),
+                'originRef' => $storedOriginRef,
                 'fileContentHash' => $storedHash,
                 'lineSnippet' => $row['line_snippet'] ?? $row['lineSnippet'] ?? null,
                 'isDraft' => (bool) ($row['is_draft'] ?? $row['isDraft'] ?? false),

--- a/app/Actions/ResolveCommentAnchorAction.php
+++ b/app/Actions/ResolveCommentAnchorAction.php
@@ -63,13 +63,8 @@ final readonly class ResolveCommentAnchorAction
                 $absolute = $externalPathByPath[$filePath] ?? null;
 
                 if ($absolute !== null) {
-                    if ($storedHash === null || $storedHash === '') {
+                    if ($storedHash === null || $storedHash === '' || $storedHash === $this->gitFileContentService->hashAtAbsolute($absolute)) {
                         $anchorStatus = 'placed';
-                    } else {
-                        $currentHash = is_file($absolute) ? @hash_file('xxh128', $absolute) : null;
-                        if ($currentHash !== false && $storedHash === $currentHash) {
-                            $anchorStatus = 'placed';
-                        }
                     }
                 }
             } elseif ($storedHash !== null && $storedHash !== '' && isset($fileIdByPath[$filePath])) {

--- a/app/Actions/ResolveCommentAnchorAction.php
+++ b/app/Actions/ResolveCommentAnchorAction.php
@@ -6,6 +6,7 @@ namespace App\Actions;
 
 use App\DTOs\DiffTarget;
 use App\DTOs\FileListEntry;
+use App\Enums\DiffSide;
 use App\Enums\GitRef;
 use App\Services\GitFileContentService;
 
@@ -52,7 +53,7 @@ final readonly class ResolveCommentAnchorAction
 
             $storedHash = $row['file_content_hash'] ?? null;
             $fileId = $fileIdByPath[$filePath] ?? FileListEntry::idForPath($filePath);
-            $storedSide = (string) ($row['side'] ?? 'right');
+            $storedSide = (string) ($row['side'] ?? DiffSide::Right->value);
             $storedOriginRef = (string) ($row['origin_ref'] ?? $row['originRef'] ?? GitRef::Working->value);
             $isExternal = $storedOriginRef === GitRef::External->value;
 
@@ -75,18 +76,18 @@ final readonly class ResolveCommentAnchorAction
                 $leftHash = $this->gitFileContentService->hashAt($repoPath, $target->from(), $leftPath);
                 $rightHash = $this->gitFileContentService->hashAt($repoPath, $rightRef, $filePath);
 
-                $matchesStoredSide = ($storedSide === 'left' && $storedHash === $leftHash)
-                    || ($storedSide === 'right' && $storedHash === $rightHash)
-                    || ($storedSide === 'file' && ($storedHash === $leftHash || $storedHash === $rightHash));
+                $matchesStoredSide = ($storedSide === DiffSide::Left->value && $storedHash === $leftHash)
+                    || ($storedSide === DiffSide::Right->value && $storedHash === $rightHash)
+                    || ($storedSide === DiffSide::File->value && ($storedHash === $leftHash || $storedHash === $rightHash));
 
                 if ($matchesStoredSide) {
                     $anchorStatus = 'placed';
                 } elseif ($storedHash === $leftHash) {
                     $anchorStatus = 'placed';
-                    $resolvedSide = 'left';
+                    $resolvedSide = DiffSide::Left->value;
                 } elseif ($storedHash === $rightHash) {
                     $anchorStatus = 'placed';
-                    $resolvedSide = 'right';
+                    $resolvedSide = DiffSide::Right->value;
                 }
             } elseif (isset($fileIdByPath[$filePath])) {
                 $anchorStatus = 'placed';

--- a/app/Actions/SessionStateAction.php
+++ b/app/Actions/SessionStateAction.php
@@ -134,6 +134,18 @@ final readonly class SessionStateAction
 
             $storedHashes = $hashesByPath[$path];
 
+            // External files live outside the repo, so their reviewed-anchor
+            // hash must come from the absolute on-disk path rather than a
+            // git ref. Mismatch → un-review, matching the diff-anchor model.
+            if (($file['isExternal'] ?? false) && ! empty($file['externalAbsolutePath'])) {
+                $currentHash = $this->gitFileContentService->hashAtAbsolute((string) $file['externalAbsolutePath']);
+                if ($currentHash !== null && in_array($currentHash, $storedHashes, true)) {
+                    $reviewed[$path] = $currentHash;
+                }
+
+                continue;
+            }
+
             // Legacy rows (indexed `reviewed_files` arrays or immutable-context sessions)
             // were migrated with an empty `content_hash`. Treat those as "reviewed
             // regardless of content" so migrated users keep their state.

--- a/app/Actions/ToggleReviewedAction.php
+++ b/app/Actions/ToggleReviewedAction.php
@@ -17,7 +17,7 @@ final readonly class ToggleReviewedAction
 
     /**
      * @param  array<string, string>  $reviewedFiles  Current view state: {path => content_hash}.
-     * @param  array<int, array{id?: string, path: string, isUntracked?: bool}>  $knownFiles  Files in the current diff.
+     * @param  array<int, array{id?: string, path: string, isUntracked?: bool, isExternal?: bool, externalAbsolutePath?: ?string}>  $knownFiles  Files in the current diff.
      * @return array<string, string>|null Updated view state, or null when the file is unknown.
      */
     public function handle(
@@ -34,9 +34,9 @@ final readonly class ToggleReviewedAction
             return null;
         }
 
-        $contentHash = $repoPath !== ''
-            ? ($this->resolveContentHash($repoPath, $target, $filePath) ?? '')
-            : '';
+        $contentHash = ($file['isExternal'] ?? false) && ! empty($file['externalAbsolutePath'])
+            ? ($this->gitFileContentService->hashAtAbsolute((string) $file['externalAbsolutePath']) ?? '')
+            : ($repoPath !== '' ? ($this->resolveContentHash($repoPath, $target, $filePath) ?? '') : '');
 
         if (array_key_exists($filePath, $reviewedFiles)) {
             ReviewedFile::query()

--- a/app/Actions/UnlinkExternalPathAction.php
+++ b/app/Actions/UnlinkExternalPathAction.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\Models\Project;
+use App\Services\ExternalFilesService;
 
 final readonly class UnlinkExternalPathAction
 {
+    public function __construct(
+        private ExternalFilesService $externalFilesService,
+    ) {}
+
     /**
      * Remove the external path at $index from the project, returning the new
      * list. Out-of-range indices are no-ops. Comments tied to the removed
@@ -22,34 +27,16 @@ final readonly class UnlinkExternalPathAction
             return null;
         }
 
-        $current = array_values((array) ($project->external_paths ?? []));
+        $current = $this->externalFilesService->normalizeForStorage((array) ($project->external_paths ?? []));
 
         if ($index < 0 || $index >= count($current)) {
-            return $this->normalize($current);
+            return $current;
         }
 
         array_splice($current, $index, 1);
 
         $project->forceFill(['external_paths' => $current])->save();
 
-        return $this->normalize($current);
-    }
-
-    /**
-     * @param  array<int, mixed>  $rows
-     * @return list<array{label: string, path: string}>
-     */
-    private function normalize(array $rows): array
-    {
-        return collect($rows)
-            ->filter(fn ($row): bool => is_array($row) && isset($row['path']) && is_string($row['path']))
-            ->map(fn (array $row): array => [
-                'label' => isset($row['label']) && is_string($row['label']) && trim($row['label']) !== ''
-                    ? $row['label']
-                    : basename((string) $row['path']),
-                'path' => (string) $row['path'],
-            ])
-            ->values()
-            ->all();
+        return $current;
     }
 }

--- a/app/Actions/UnlinkExternalPathAction.php
+++ b/app/Actions/UnlinkExternalPathAction.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Models\Project;
+
+final readonly class UnlinkExternalPathAction
+{
+    /**
+     * Remove the external path at $index from the project, returning the new
+     * list. Out-of-range indices are no-ops. Comments tied to the removed
+     * mount remain in the DB but stop showing in the file list.
+     *
+     * @return list<array{label: string, path: string}>|null
+     */
+    public function handle(int $projectId, int $index): ?array
+    {
+        $project = Project::find($projectId);
+        if ($project === null) {
+            return null;
+        }
+
+        $current = array_values((array) ($project->external_paths ?? []));
+
+        if ($index < 0 || $index >= count($current)) {
+            return $this->normalize($current);
+        }
+
+        array_splice($current, $index, 1);
+
+        $project->forceFill(['external_paths' => $current])->save();
+
+        return $this->normalize($current);
+    }
+
+    /**
+     * @param  array<int, mixed>  $rows
+     * @return list<array{label: string, path: string}>
+     */
+    private function normalize(array $rows): array
+    {
+        return collect($rows)
+            ->filter(fn ($row): bool => is_array($row) && isset($row['path']) && is_string($row['path']))
+            ->map(fn (array $row): array => [
+                'label' => isset($row['label']) && is_string($row['label']) && trim($row['label']) !== ''
+                    ? $row['label']
+                    : basename((string) $row['path']),
+                'path' => (string) $row['path'],
+            ])
+            ->values()
+            ->all();
+    }
+}

--- a/app/Actions/UpdateProjectSettingAction.php
+++ b/app/Actions/UpdateProjectSettingAction.php
@@ -8,7 +8,7 @@ use App\Models\Project;
 
 final readonly class UpdateProjectSettingAction
 {
-    private const ALLOWED_ATTRIBUTES = ['respect_global_gitignore', 'branch', 'default_base_branch', 'external_paths'];
+    private const ALLOWED_ATTRIBUTES = ['respect_global_gitignore', 'branch', 'default_base_branch'];
 
     /** @param array<string, mixed> $attributes */
     public function handle(int $projectId, array $attributes): void

--- a/app/Actions/UpdateProjectSettingAction.php
+++ b/app/Actions/UpdateProjectSettingAction.php
@@ -8,7 +8,7 @@ use App\Models\Project;
 
 final readonly class UpdateProjectSettingAction
 {
-    private const ALLOWED_ATTRIBUTES = ['respect_global_gitignore', 'branch', 'default_base_branch'];
+    private const ALLOWED_ATTRIBUTES = ['respect_global_gitignore', 'branch', 'default_base_branch', 'external_paths'];
 
     /** @param array<string, mixed> $attributes */
     public function handle(int $projectId, array $attributes): void

--- a/app/Console/Benchmark/DiffFixtureFactory.php
+++ b/app/Console/Benchmark/DiffFixtureFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Console\Benchmark;
 
 use App\DTOs\FileListEntry;
+use App\Enums\DiffSide;
 use App\Enums\LineType;
 
 /**
@@ -213,7 +214,7 @@ final class DiffFixtureFactory
         $comments = [];
 
         for ($i = 0; $i < $count; $i++) {
-            $side = $i % 2 === 0 ? 'right' : 'left';
+            $side = $i % 2 === 0 ? DiffSide::Right->value : DiffSide::Left->value;
             $line = ($i + 1) * 5;
 
             $comments[] = [

--- a/app/Console/Benchmark/PerfScenarioRunner.php
+++ b/app/Console/Benchmark/PerfScenarioRunner.php
@@ -140,6 +140,7 @@ final class PerfScenarioRunner
                 int $contextLines = 3,
                 ?DiffTarget $target = null,
                 ?string $oldPath = null,
+                ?string $externalAbsolutePath = null,
             ): array {
                 return $this->diffData;
             }

--- a/app/Console/Commands/LinkExternalPathCommand.php
+++ b/app/Console/Commands/LinkExternalPathCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Actions\LinkExternalPathAction;
+use Illuminate\Console\Command;
+
+class LinkExternalPathCommand extends Command
+{
+    protected $signature = 'rfa:link-path {project : Project slug, name, or id} {path : Absolute directory path to link} {--label= : Optional display label (defaults to directory basename)}';
+
+    protected $description = 'Link an external directory to a project so its files appear in review as commentable entries';
+
+    public function handle(LinkExternalPathAction $action): int
+    {
+        $reference = (string) $this->argument('project');
+        $path = (string) $this->argument('path');
+        $label = $this->option('label');
+
+        $updated = $action->handleByReference($reference, $path, is_string($label) ? $label : null);
+
+        if ($updated === null) {
+            $this->error("Could not link path: project {$reference} not found, or path {$path} is not a directory.");
+
+            return self::FAILURE;
+        }
+
+        $this->info('Linked external paths:');
+        $this->table(
+            ['Label', 'Path'],
+            collect($updated)->map(fn (array $row) => [$row['label'], $row['path']]),
+        );
+
+        return self::SUCCESS;
+    }
+}

--- a/app/DTOs/FileListEntry.php
+++ b/app/DTOs/FileListEntry.php
@@ -21,6 +21,8 @@ class FileListEntry
         public readonly bool $isSymlink = false,
         public readonly ?string $symlinkTarget = null,
         public readonly ?string $fileSize = null,
+        public readonly bool $isExternal = false,
+        public readonly ?string $externalAbsolutePath = null,
     ) {}
 
     public static function idForPath(string $path): string
@@ -57,6 +59,8 @@ class FileListEntry
             'isSymlink' => $this->isSymlink,
             'symlinkTarget' => $this->symlinkTarget,
             'fileSize' => $this->fileSize,
+            'isExternal' => $this->isExternal,
+            'externalAbsolutePath' => $this->externalAbsolutePath,
         ];
     }
 }

--- a/app/Enums/GitRef.php
+++ b/app/Enums/GitRef.php
@@ -8,4 +8,7 @@ enum GitRef: string
 {
     /** Sentinel ref for the working copy on disk (vs a committed tree). */
     case Working = 'working';
+
+    /** Sentinel ref for files outside the repo, mounted via Project::external_paths. */
+    case External = 'external';
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -11,6 +11,13 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
+/**
+ * Stored as a JSON column. We type it loosely — defensive shape checks at the
+ * boundaries (LinkExternalPathAction, ExternalFilesService) handle malformed
+ * rows without relying on PHPStan-level guarantees the DB doesn't enforce.
+ *
+ * @property array<int, mixed>|null $external_paths
+ */
 #[ObservedBy(ProjectObserver::class)]
 class Project extends Model
 {
@@ -28,6 +35,7 @@ class Project extends Model
         'global_gitignore_path',
         'respect_global_gitignore',
         'default_base_branch',
+        'external_paths',
     ];
 
     /** @return HasMany<ReviewSession, $this> */
@@ -59,6 +67,7 @@ class Project extends Model
         return [
             'is_worktree' => 'boolean',
             'respect_global_gitignore' => 'boolean',
+            'external_paths' => 'array',
         ];
     }
 }

--- a/app/Services/ExternalFilesService.php
+++ b/app/Services/ExternalFilesService.php
@@ -17,6 +17,10 @@ class ExternalFilesService
 {
     public const MOUNT_PREFIX = 'external';
 
+    public function __construct(
+        private readonly GitDiffService $gitDiffService,
+    ) {}
+
     /**
      * Build synthetic FileListEntry rows for every configured external directory.
      * Each file is mounted under `external/<label>/<relative>` so the synthetic
@@ -27,7 +31,7 @@ class ExternalFilesService
      */
     public function getEntries(array $rawConfigs): array
     {
-        $configs = $this->normalizeConfigs($rawConfigs);
+        $configs = $this->resolvedConfigs($rawConfigs);
 
         if ($configs === []) {
             return [];
@@ -51,7 +55,7 @@ class ExternalFilesService
             return null;
         }
 
-        $configs = $this->normalizeConfigs($rawConfigs);
+        $configs = $this->resolvedConfigs($rawConfigs);
         $remainder = substr($mountPath, strlen(self::MOUNT_PREFIX) + 1);
 
         foreach ($configs as $config) {
@@ -61,8 +65,7 @@ class ExternalFilesService
                 continue;
             }
 
-            $relative = substr($remainder, strlen($prefix));
-            $candidate = $config['root'].DIRECTORY_SEPARATOR.$relative;
+            $candidate = $config['root'].DIRECTORY_SEPARATOR.substr($remainder, strlen($prefix));
 
             if (! File::isFile($candidate)) {
                 return null;
@@ -81,45 +84,37 @@ class ExternalFilesService
 
     /**
      * Build a synthetic unified diff for an external file: whole-file "added"
-     * view against /dev/null, mirroring the format `git diff` would produce
-     * for a brand-new file. Returns null if the file exceeds $maxBytes, ''
-     * for empty files, and a header-only diff for binaries.
+     * view against /dev/null, identical to what `git diff` produces for a
+     * brand-new file. Returns null if the file exceeds $maxBytes, '' for
+     * empty files, and a header-only diff for binaries.
      */
     public function buildDiff(string $absolutePath, string $mountPath, ?int $maxBytes = null): ?string
     {
         $maxBytes ??= (int) config('rfa.diff_max_bytes', 512_000);
 
-        if (! File::isFile($absolutePath)) {
-            return '';
-        }
+        return $this->gitDiffService->buildAddedFileDiff($absolutePath, $mountPath, $maxBytes);
+    }
 
-        if ($this->isBinary($absolutePath)) {
-            return "diff --git a/{$mountPath} b/{$mountPath}\nnew file mode 100644\nBinary files /dev/null and b/{$mountPath} differ\n";
-        }
-
-        $size = File::size($absolutePath);
-        if ($size > $maxBytes) {
-            return null;
-        }
-
-        $content = File::get($absolutePath);
-        if ($content === '') {
-            return "diff --git a/{$mountPath} b/{$mountPath}\nnew file mode 100644\n";
-        }
-
-        $lines = explode("\n", $content);
-        if (end($lines) === '') {
-            array_pop($lines);
-        }
-
-        $diff = "diff --git a/{$mountPath} b/{$mountPath}\n";
-        $diff .= "new file mode 100644\n";
-        $diff .= "--- /dev/null\n";
-        $diff .= "+++ b/{$mountPath}\n";
-        $diff .= '@@ -0,0 +1,'.count($lines)." @@\n";
-        $diff .= '+'.implode("\n+", $lines)."\n";
-
-        return $diff;
+    /**
+     * Normalize raw `external_paths` rows into the canonical storage shape used
+     * by Project::external_paths: `{label, path}` with a non-empty label that
+     * defaults to `basename($path)`. Tolerates malformed rows by dropping them.
+     *
+     * @param  array<int, mixed>  $raw
+     * @return list<array{label: string, path: string}>
+     */
+    public function normalizeForStorage(array $raw): array
+    {
+        return collect($raw)
+            ->filter(fn ($row): bool => is_array($row) && isset($row['path']) && is_string($row['path']))
+            ->map(fn (array $row): array => [
+                'label' => isset($row['label']) && is_string($row['label']) && trim($row['label']) !== ''
+                    ? $row['label']
+                    : basename((string) $row['path']),
+                'path' => (string) $row['path'],
+            ])
+            ->values()
+            ->all();
     }
 
     /**
@@ -148,25 +143,24 @@ class ExternalFilesService
             }
 
             $absolutePath = $file->getPathname();
+            $additions = $this->streamCountLines($absolutePath);
 
-            if ($this->isBinary($absolutePath)) {
+            // streamCountLines returns null for binary files in a single read
+            // pass; skip them rather than listing meaningless line counts.
+            if ($additions === null) {
                 continue;
             }
 
-            $relative = ltrim(substr($absolutePath, strlen($root)), DIRECTORY_SEPARATOR);
-            // Normalize Windows separators for the synthetic mount path.
-            $relative = str_replace(DIRECTORY_SEPARATOR, '/', $relative);
-
-            $mountPath = self::MOUNT_PREFIX.'/'.$config['label'].'/'.$relative;
+            $relative = str_replace(
+                DIRECTORY_SEPARATOR,
+                '/',
+                ltrim(substr($absolutePath, strlen($root)), DIRECTORY_SEPARATOR),
+            );
 
             $size = $file->getSize();
-            $content = $size > 0 ? @file_get_contents($absolutePath) : '';
-            $additions = is_string($content) && $content !== ''
-                ? substr_count($content, "\n") + (str_ends_with($content, "\n") ? 0 : 1)
-                : 0;
 
             $entries[] = new FileListEntry(
-                path: $mountPath,
+                path: self::MOUNT_PREFIX.'/'.$config['label'].'/'.$relative,
                 status: 'added',
                 oldPath: null,
                 additions: $additions,
@@ -188,31 +182,25 @@ class ExternalFilesService
     }
 
     /**
-     * Normalize raw config rows from the JSON column into a canonical shape:
-     * `{label: string, root: string}` with a real, absolute root.
+     * Resolve normalized rows to absolute roots ready for filesystem walking.
+     * Drops rows whose path no longer exists; disambiguates duplicate labels
+     * with a numeric suffix.
      *
-     * @param  array<int|string, mixed>  $raw
+     * @param  array<int, mixed>  $raw
      * @return list<array{label: string, root: string}>
      */
-    private function normalizeConfigs(array $raw): array
+    private function resolvedConfigs(array $raw): array
     {
         $usedLabels = [];
 
-        return collect($raw)
-            ->map(function ($entry) use (&$usedLabels): ?array {
-                if (! is_array($entry) || ! isset($entry['path']) || ! is_string($entry['path'])) {
-                    return null;
-                }
-
-                $root = realpath($entry['path']);
+        return collect($this->normalizeForStorage($raw))
+            ->map(function (array $row) use (&$usedLabels): ?array {
+                $root = realpath($row['path']);
                 if ($root === false || ! is_dir($root)) {
                     return null;
                 }
 
-                $label = isset($entry['label']) && is_string($entry['label']) && trim($entry['label']) !== ''
-                    ? $this->sanitizeLabel($entry['label'])
-                    : $this->sanitizeLabel(basename($root));
-
+                $label = $this->sanitizeLabel($row['label']);
                 $base = $label;
                 $suffix = 2;
                 while (isset($usedLabels[$label])) {
@@ -229,22 +217,43 @@ class ExternalFilesService
 
     private function sanitizeLabel(string $label): string
     {
-        $clean = preg_replace('/[^A-Za-z0-9._-]+/', '-', $label) ?? '';
-        $clean = trim($clean, '-');
+        $clean = trim((string) preg_replace('/[^A-Za-z0-9._-]+/', '-', $label), '-');
 
         return $clean === '' ? 'external' : $clean;
     }
 
-    private function isBinary(string $path): bool
+    /**
+     * Stream-count newlines while opportunistically detecting binary files
+     * (NUL byte in the first chunk). Returns null for binaries so the caller
+     * can skip them, 0 for empty/unreadable, and the line count otherwise.
+     * One disk pass per file — replaces the prior open+read+close-twice.
+     */
+    private function streamCountLines(string $absolutePath): ?int
     {
-        $handle = @fopen($path, 'rb');
+        $handle = @fopen($absolutePath, 'rb');
         if ($handle === false) {
-            return true;
+            return 0;
         }
 
-        $chunk = (string) fread($handle, 8192);
+        $count = 0;
+        $lastByte = '';
+        $firstChunk = true;
+        while (! feof($handle)) {
+            $chunk = (string) fread($handle, 65_536);
+            if ($chunk === '') {
+                break;
+            }
+            if ($firstChunk && str_contains($chunk, "\0")) {
+                fclose($handle);
+
+                return null;
+            }
+            $firstChunk = false;
+            $count += substr_count($chunk, "\n");
+            $lastByte = $chunk[strlen($chunk) - 1];
+        }
         fclose($handle);
 
-        return str_contains($chunk, "\0");
+        return $lastByte !== '' && $lastByte !== "\n" ? $count + 1 : $count;
     }
 }

--- a/app/Services/ExternalFilesService.php
+++ b/app/Services/ExternalFilesService.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\DTOs\FileListEntry;
+use Carbon\Carbon;
+use FilesystemIterator;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Number;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+class ExternalFilesService
+{
+    public const MOUNT_PREFIX = 'external';
+
+    /**
+     * Build synthetic FileListEntry rows for every configured external directory.
+     * Each file is mounted under `external/<label>/<relative>` so the synthetic
+     * path stays stable across sessions and yields the same file id.
+     *
+     * @param  array<int, mixed>  $rawConfigs  Raw rows from `Project::external_paths`.
+     * @return list<FileListEntry>
+     */
+    public function getEntries(array $rawConfigs): array
+    {
+        $configs = $this->normalizeConfigs($rawConfigs);
+
+        if ($configs === []) {
+            return [];
+        }
+
+        return collect($configs)
+            ->flatMap(fn (array $config): array => $this->entriesForConfig($config))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Resolve the absolute on-disk path for a given mount path under the supplied
+     * configs, or null if the mount doesn't match a configured external directory.
+     *
+     * @param  array<int, mixed>  $rawConfigs  Raw rows from `Project::external_paths`.
+     */
+    public function resolveAbsolutePath(array $rawConfigs, string $mountPath): ?string
+    {
+        if (! str_starts_with($mountPath, self::MOUNT_PREFIX.'/')) {
+            return null;
+        }
+
+        $configs = $this->normalizeConfigs($rawConfigs);
+        $remainder = substr($mountPath, strlen(self::MOUNT_PREFIX) + 1);
+
+        foreach ($configs as $config) {
+            $prefix = $config['label'].'/';
+
+            if (! str_starts_with($remainder, $prefix)) {
+                continue;
+            }
+
+            $relative = substr($remainder, strlen($prefix));
+            $candidate = $config['root'].DIRECTORY_SEPARATOR.$relative;
+
+            if (! File::isFile($candidate)) {
+                return null;
+            }
+
+            $real = realpath($candidate);
+            if ($real === false || ! str_starts_with($real, $config['root'].DIRECTORY_SEPARATOR)) {
+                return null;
+            }
+
+            return $real;
+        }
+
+        return null;
+    }
+
+    /**
+     * Build a synthetic unified diff for an external file: whole-file "added"
+     * view against /dev/null, mirroring the format `git diff` would produce
+     * for a brand-new file. Returns null if the file exceeds $maxBytes, ''
+     * for empty files, and a header-only diff for binaries.
+     */
+    public function buildDiff(string $absolutePath, string $mountPath, ?int $maxBytes = null): ?string
+    {
+        $maxBytes ??= (int) config('rfa.diff_max_bytes', 512_000);
+
+        if (! File::isFile($absolutePath)) {
+            return '';
+        }
+
+        if ($this->isBinary($absolutePath)) {
+            return "diff --git a/{$mountPath} b/{$mountPath}\nnew file mode 100644\nBinary files /dev/null and b/{$mountPath} differ\n";
+        }
+
+        $size = File::size($absolutePath);
+        if ($size > $maxBytes) {
+            return null;
+        }
+
+        $content = File::get($absolutePath);
+        if ($content === '') {
+            return "diff --git a/{$mountPath} b/{$mountPath}\nnew file mode 100644\n";
+        }
+
+        $lines = explode("\n", $content);
+        if (end($lines) === '') {
+            array_pop($lines);
+        }
+
+        $diff = "diff --git a/{$mountPath} b/{$mountPath}\n";
+        $diff .= "new file mode 100644\n";
+        $diff .= "--- /dev/null\n";
+        $diff .= "+++ b/{$mountPath}\n";
+        $diff .= '@@ -0,0 +1,'.count($lines)." @@\n";
+        $diff .= '+'.implode("\n+", $lines)."\n";
+
+        return $diff;
+    }
+
+    /**
+     * @param  array{label: string, root: string}  $config
+     * @return list<FileListEntry>
+     */
+    private function entriesForConfig(array $config): array
+    {
+        $root = $config['root'];
+
+        if (! is_dir($root)) {
+            return [];
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS),
+            RecursiveIteratorIterator::LEAVES_ONLY
+        );
+
+        $entries = [];
+
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            $absolutePath = $file->getPathname();
+
+            if ($this->isBinary($absolutePath)) {
+                continue;
+            }
+
+            $relative = ltrim(substr($absolutePath, strlen($root)), DIRECTORY_SEPARATOR);
+            // Normalize Windows separators for the synthetic mount path.
+            $relative = str_replace(DIRECTORY_SEPARATOR, '/', $relative);
+
+            $mountPath = self::MOUNT_PREFIX.'/'.$config['label'].'/'.$relative;
+
+            $size = $file->getSize();
+            $content = $size > 0 ? @file_get_contents($absolutePath) : '';
+            $additions = is_string($content) && $content !== ''
+                ? substr_count($content, "\n") + (str_ends_with($content, "\n") ? 0 : 1)
+                : 0;
+
+            $entries[] = new FileListEntry(
+                path: $mountPath,
+                status: 'added',
+                oldPath: null,
+                additions: $additions,
+                deletions: 0,
+                isBinary: false,
+                isUntracked: false,
+                lastModified: Carbon::createFromTimestamp($file->getMTime())->diffForHumans(short: true),
+                isSymlink: false,
+                symlinkTarget: null,
+                fileSize: Number::fileSize($size, precision: 1),
+                isExternal: true,
+                externalAbsolutePath: $absolutePath,
+            );
+        }
+
+        usort($entries, fn (FileListEntry $a, FileListEntry $b): int => strcmp($a->path, $b->path));
+
+        return $entries;
+    }
+
+    /**
+     * Normalize raw config rows from the JSON column into a canonical shape:
+     * `{label: string, root: string}` with a real, absolute root.
+     *
+     * @param  array<int|string, mixed>  $raw
+     * @return list<array{label: string, root: string}>
+     */
+    private function normalizeConfigs(array $raw): array
+    {
+        $usedLabels = [];
+
+        return collect($raw)
+            ->map(function ($entry) use (&$usedLabels): ?array {
+                if (! is_array($entry) || ! isset($entry['path']) || ! is_string($entry['path'])) {
+                    return null;
+                }
+
+                $root = realpath($entry['path']);
+                if ($root === false || ! is_dir($root)) {
+                    return null;
+                }
+
+                $label = isset($entry['label']) && is_string($entry['label']) && trim($entry['label']) !== ''
+                    ? $this->sanitizeLabel($entry['label'])
+                    : $this->sanitizeLabel(basename($root));
+
+                $base = $label;
+                $suffix = 2;
+                while (isset($usedLabels[$label])) {
+                    $label = $base.'-'.$suffix++;
+                }
+                $usedLabels[$label] = true;
+
+                return ['label' => $label, 'root' => $root];
+            })
+            ->filter()
+            ->values()
+            ->all();
+    }
+
+    private function sanitizeLabel(string $label): string
+    {
+        $clean = preg_replace('/[^A-Za-z0-9._-]+/', '-', $label) ?? '';
+        $clean = trim($clean, '-');
+
+        return $clean === '' ? 'external' : $clean;
+    }
+
+    private function isBinary(string $path): bool
+    {
+        $handle = @fopen($path, 'rb');
+        if ($handle === false) {
+            return true;
+        }
+
+        $chunk = (string) fread($handle, 8192);
+        fclose($handle);
+
+        return str_contains($chunk, "\0");
+    }
+}

--- a/app/Services/ExternalFilesService.php
+++ b/app/Services/ExternalFilesService.php
@@ -17,6 +17,13 @@ class ExternalFilesService
 {
     public const MOUNT_PREFIX = 'external';
 
+    /**
+     * Cap recursion depth so a misconfigured root (e.g. `$HOME`) can't pull a
+     * massive subtree into the file list. Eight levels comfortably covers
+     * design-note folders without inviting pathological walks.
+     */
+    public const MAX_DEPTH = 8;
+
     public function __construct(
         private readonly GitDiffService $gitDiffService,
     ) {}
@@ -133,6 +140,7 @@ class ExternalFilesService
             new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS),
             RecursiveIteratorIterator::LEAVES_ONLY
         );
+        $iterator->setMaxDepth(self::MAX_DEPTH);
 
         $entries = [];
 

--- a/app/Services/ExternalFilesService.php
+++ b/app/Services/ExternalFilesService.php
@@ -136,13 +136,18 @@ class ExternalFilesService
             return [];
         }
 
+        // Don't follow symlinks: a link inside the configured root could point
+        // anywhere on disk (e.g. `~`, `/etc`), which would walk out of scope
+        // and surface unrelated files. resolveAbsolutePath() also re-checks
+        // confinement on the read side; this is the matching write-side guard.
         $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS),
+            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
             RecursiveIteratorIterator::LEAVES_ONLY
         );
         $iterator->setMaxDepth(self::MAX_DEPTH);
 
         $entries = [];
+        $rootPrefix = $root.DIRECTORY_SEPARATOR;
 
         /** @var SplFileInfo $file */
         foreach ($iterator as $file) {
@@ -150,7 +155,13 @@ class ExternalFilesService
                 continue;
             }
 
-            $absolutePath = $file->getPathname();
+            // Defense in depth: drop entries whose canonical path leaves the
+            // configured root, even if a symlink slipped past the flag above.
+            $absolutePath = realpath($file->getPathname());
+            if ($absolutePath === false || ! str_starts_with($absolutePath, $rootPrefix)) {
+                continue;
+            }
+
             $additions = $this->streamCountLines($absolutePath);
 
             // streamCountLines returns null for binary files in a single read

--- a/app/Services/ExternalFilesService.php
+++ b/app/Services/ExternalFilesService.php
@@ -191,36 +191,51 @@ class ExternalFilesService
 
     /**
      * Resolve normalized rows to absolute roots ready for filesystem walking.
-     * Drops rows whose path no longer exists; disambiguates duplicate labels
-     * with a numeric suffix.
+     * Drops rows whose path no longer exists. Stored labels are used as-is
+     * (only sanitized) — disambiguation happens at link time so unlinking a
+     * sibling never renames a surviving mount.
      *
      * @param  array<int, mixed>  $raw
      * @return list<array{label: string, root: string}>
      */
     private function resolvedConfigs(array $raw): array
     {
-        $usedLabels = [];
-
         return collect($this->normalizeForStorage($raw))
-            ->map(function (array $row) use (&$usedLabels): ?array {
+            ->map(function (array $row): ?array {
                 $root = realpath($row['path']);
                 if ($root === false || ! is_dir($root)) {
                     return null;
                 }
 
-                $label = $this->sanitizeLabel($row['label']);
-                $base = $label;
-                $suffix = 2;
-                while (isset($usedLabels[$label])) {
-                    $label = $base.'-'.$suffix++;
-                }
-                $usedLabels[$label] = true;
-
-                return ['label' => $label, 'root' => $root];
+                return ['label' => $this->sanitizeLabel($row['label']), 'root' => $root];
             })
             ->filter()
             ->values()
             ->all();
+    }
+
+    /**
+     * Pick a sanitized, unique label for a new external path against the labels
+     * already used by other rows. Called at link time so the disambiguated
+     * label is persisted and stable across future unlinks.
+     *
+     * @param  list<array{label: string, path: string}>  $existing
+     */
+    public function uniqueLabelFor(array $existing, string $candidate): string
+    {
+        $base = $this->sanitizeLabel($candidate);
+        $taken = array_flip(array_map(fn (array $row): string => $this->sanitizeLabel($row['label']), $existing));
+
+        if (! isset($taken[$base])) {
+            return $base;
+        }
+
+        $suffix = 2;
+        while (isset($taken[$base.'-'.$suffix])) {
+            $suffix++;
+        }
+
+        return $base.'-'.$suffix;
     }
 
     private function sanitizeLabel(string $label): string

--- a/app/Services/GitDiffService.php
+++ b/app/Services/GitDiffService.php
@@ -293,40 +293,45 @@ class GitDiffService
             return "diff --git a/{$path} b/{$path}\nnew file mode {$mode}\n--- /dev/null\n+++ b/{$path}\n@@ -0,0 +1 @@\n+{$symlinkTarget}\n\\ No newline at end of file\n";
         }
 
-        if (! File::isFile($fullPath)) {
+        return $this->buildAddedFileDiff($fullPath, $path, $maxBytes);
+    }
+
+    /**
+     * Build a unified diff for a brand-new file (`/dev/null` → contents). Used
+     * for both untracked working-tree files and externally-mounted files; the
+     * format mirrors `git diff` output for new files exactly.
+     */
+    public function buildAddedFileDiff(string $absolutePath, string $diffPath, int $maxBytes): ?string
+    {
+        if (! File::isFile($absolutePath)) {
             return '';
         }
 
-        if ($this->isBinary($fullPath)) {
-            return "diff --git a/{$path} b/{$path}\nnew file mode 100644\nBinary files /dev/null and b/{$path} differ\n";
+        if ($this->isBinary($absolutePath)) {
+            return "diff --git a/{$diffPath} b/{$diffPath}\nnew file mode 100644\nBinary files /dev/null and b/{$diffPath} differ\n";
         }
 
-        $size = File::size($fullPath);
+        $size = File::size($absolutePath);
         if ($size > $maxBytes) {
             return null;
         }
 
-        $content = File::get($fullPath);
+        $content = File::get($absolutePath);
         if ($content === '') {
-            $diff = "diff --git a/{$path} b/{$path}\n";
-            $diff .= "new file mode 100644\n";
-
-            return $diff;
+            return "diff --git a/{$diffPath} b/{$diffPath}\nnew file mode 100644\n";
         }
 
         $lines = explode("\n", $content);
 
-        // Strip trailing empty element from files ending with \n
         if (end($lines) === '') {
             array_pop($lines);
         }
 
-        $diff = "diff --git a/{$path} b/{$path}\n";
+        $diff = "diff --git a/{$diffPath} b/{$diffPath}\n";
         $diff .= "new file mode 100644\n";
         $diff .= "--- /dev/null\n";
-        $diff .= "+++ b/{$path}\n";
+        $diff .= "+++ b/{$diffPath}\n";
         $diff .= '@@ -0,0 +1,'.count($lines)." @@\n";
-
         $diff .= '+'.implode("\n+", $lines)."\n";
 
         return $diff;
@@ -337,19 +342,7 @@ class GitDiffService
         $target ??= DiffTarget::workingDirectory();
 
         if ($target->isWorkingDirectory()) {
-            $fullPath = $repoPath.'/'.$path;
-
-            if (! File::isFile($fullPath)) {
-                return null;
-            }
-
-            $content = File::get($fullPath);
-
-            if ($content === '') {
-                return 0;
-            }
-
-            return substr_count($content, "\n") + (str_ends_with($content, "\n") ? 0 : 1);
+            return $this->countLinesInFile($repoPath.'/'.$path);
         }
 
         try {
@@ -358,6 +351,21 @@ class GitDiffService
             return null;
         }
 
+        return $this->countLinesInString($content);
+    }
+
+    /** Line count for a file on disk, or null if the file is missing. */
+    public function countLinesInFile(string $absolutePath): ?int
+    {
+        if (! File::isFile($absolutePath)) {
+            return null;
+        }
+
+        return $this->countLinesInString(File::get($absolutePath));
+    }
+
+    private function countLinesInString(string $content): int
+    {
         if ($content === '') {
             return 0;
         }

--- a/app/Services/GitFileContentService.php
+++ b/app/Services/GitFileContentService.php
@@ -43,6 +43,23 @@ class GitFileContentService
         return $this->hashCache[$key];
     }
 
+    /**
+     * Hash a file by its absolute on-disk path, sharing the same request-scoped
+     * memoization as `hashAt()`. Used for files that live outside any repo
+     * (see `GitRef::External` and `Project::external_paths`).
+     */
+    public function hashAtAbsolute(string $absolutePath): ?string
+    {
+        $key = "\0".GitRef::External->value."\0".$absolutePath;
+
+        if (! array_key_exists($key, $this->hashCache)) {
+            $hash = is_file($absolutePath) ? @hash_file('xxh128', $absolutePath) : false;
+            $this->hashCache[$key] = $hash === false ? null : $hash;
+        }
+
+        return $this->hashCache[$key];
+    }
+
     /** Drop every memoized hash. Call between requests under long-lived workers. */
     public function flushCache(): void
     {

--- a/app/View/DiffFileViewModel.php
+++ b/app/View/DiffFileViewModel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\View;
 
+use App\Enums\DiffSide;
 use Illuminate\Support\Collection;
 
 /**
@@ -23,7 +24,7 @@ final readonly class DiffFileViewModel
     {
         $byLine = [];
         foreach ($fileComments as $c) {
-            if (($c['side'] ?? null) === 'file') {
+            if (($c['side'] ?? null) === DiffSide::File->value) {
                 continue;
             }
             if (($c['anchorStatus'] ?? 'placed') === 'unplaced') {
@@ -46,7 +47,7 @@ final readonly class DiffFileViewModel
     public static function unplacedInlineComments(array $fileComments, array $visibleLineKeys): Collection
     {
         return collect($fileComments)
-            ->where('side', '!=', 'file')
+            ->where('side', '!=', DiffSide::File->value)
             ->filter(function ($c) use ($visibleLineKeys) {
                 if (($c['anchorStatus'] ?? null) === 'unplaced') {
                     return true;
@@ -62,7 +63,7 @@ final readonly class DiffFileViewModel
      */
     public static function anchorKeyFor(array $comment): string
     {
-        $side = $comment['side'] ?? 'right';
+        $side = $comment['side'] ?? DiffSide::Right->value;
         $line = $comment['endLine'] ?? $comment['startLine'] ?? 0;
 
         return $side.':'.$line;

--- a/database/migrations/2026_04_30_085826_add_external_paths_to_projects.php
+++ b/database/migrations/2026_04_30_085826_add_external_paths_to_projects.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->json('external_paths')->nullable()->after('default_base_branch');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dropColumn('external_paths');
+        });
+    }
+};

--- a/resources/views/livewire/⚡comments-drawer.blade.php
+++ b/resources/views/livewire/⚡comments-drawer.blade.php
@@ -172,7 +172,7 @@ class extends Component
                         <div class="group px-4 py-2.5 border-t border-gh-border/30 text-xs">
                             <div class="flex items-center gap-2 text-[10px] font-mono text-gh-muted mb-1">
                                 @if(! empty($c['origin_ref']))
-                                    <span>{{ $c['origin_ref'] === 'working' ? 'WD' : Str::limit($c['origin_ref'], 7, '') }}</span>
+                                    <span>{{ match($c['origin_ref']) { 'working' => 'WD', 'external' => 'EXT', default => Str::limit($c['origin_ref'], 7, '') } }}</span>
                                 @endif
                                 @if(! empty($c['start_line']))
                                     <span>&middot;</span>

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -73,6 +73,7 @@ new class extends Component {
             cacheKey: $this->diffCacheKey(),
             target: $this->buildDiffTarget(),
             oldPath: $this->file['oldPath'] ?? null,
+            externalAbsolutePath: $this->file['externalAbsolutePath'] ?? null,
         );
 
         $this->ensureCommentedLinesVisible();
@@ -107,6 +108,7 @@ new class extends Component {
             contextLines: 99999,
             target: $this->buildDiffTarget(),
             oldPath: $this->file['oldPath'] ?? null,
+            externalAbsolutePath: $this->file['externalAbsolutePath'] ?? null,
         );
     }
 
@@ -124,6 +126,7 @@ new class extends Component {
             contextLines: 99999,
             target: $this->buildDiffTarget(),
             oldPath: $this->file['oldPath'] ?? null,
+            externalAbsolutePath: $this->file['externalAbsolutePath'] ?? null,
         );
 
         if (empty($fullDiff['hunks'])) {

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -4,6 +4,7 @@ use App\Actions\ExpandDiffGapAction;
 use App\Actions\GetFileCopyContentAction;
 use App\Actions\LoadFileDiffAction;
 use App\DTOs\DiffTarget;
+use App\Enums\DiffSide;
 use App\Support\DiffCacheKey;
 use App\View\DiffFileViewModel;
 use Illuminate\Support\Facades\Cache;
@@ -154,7 +155,7 @@ new class extends Component {
             return;
         }
 
-        $inlineComments = array_filter($this->fileComments, fn ($c) => ($c['side'] ?? '') !== 'file');
+        $inlineComments = array_filter($this->fileComments, fn ($c) => ($c['side'] ?? '') !== DiffSide::File->value);
         if (empty($inlineComments)) {
             return;
         }
@@ -263,7 +264,7 @@ new class extends Component {
                 <x-comment-form save="submitComment" placeholder="File comment..." border-class="border-b" />
             </template>
             @foreach($fileComments as $comment)
-                @if($comment['side'] === 'file')
+                @if($comment['side'] === DiffSide::File->value)
                     <div x-data x-show="editingCommentId !== '{{ $comment['id'] }}'">
                         <x-comment-display :comment="$comment" border-class="border-b" />
                     </div>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -12,6 +12,7 @@ use App\Actions\GetCurrentHeadAction;
 use App\Actions\GetFileListAction;
 use App\Actions\GroupReviewFilesAction;
 use App\Actions\IsSinceBaseViewAction;
+use App\Actions\LinkExternalPathAction;
 use App\Actions\LoadCommitMetadataAction;
 use App\Actions\ResolveCommitAction;
 use App\Actions\ResolveProjectAction;
@@ -22,6 +23,7 @@ use App\Actions\RestoreDiscardedFileAction;
 use App\Actions\ScanReviewFilesAction;
 use App\Actions\SessionStateAction;
 use App\Actions\ToggleReviewedAction;
+use App\Actions\UnlinkExternalPathAction;
 use App\Actions\UpdateCommentAction;
 use App\Actions\UpdateProjectSettingAction;
 use App\Concerns\InteractsWithRemoteLinks;
@@ -100,6 +102,9 @@ new #[Layout('layouts.app')] class extends Component
 
     public string $defaultBaseBranch = '';
 
+    /** @var list<array{label: string, path: string}> */
+    public array $externalPaths = [];
+
     #[Locked]
     public string $diffFrom = 'HEAD';
 
@@ -161,6 +166,7 @@ new #[Layout('layouts.app')] class extends Component
         $this->respectGlobalGitignore = $project['respect_global_gitignore'] ?? true;
         $this->globalGitignorePath = $project['global_gitignore_path'] ?: null;
         $this->defaultBaseBranch = (string) ($project['default_base_branch'] ?? '');
+        $this->externalPaths = $this->normalizeExternalPathsForView($project['external_paths'] ?? []);
 
         // Commit mode: resolve hash to full SHA
         if ($hash !== null) {
@@ -291,6 +297,75 @@ new #[Layout('layouts.app')] class extends Component
         ]);
 
         $this->isSinceBaseView = $this->detectSinceBaseView();
+    }
+
+    public function addExternalPath(): void
+    {
+        $picked = app(\Native\Desktop\Dialog::class)
+            ->title('Link External Folder')
+            ->folders()
+            ->open();
+
+        if (! is_string($picked) || $picked === '') {
+            $this->skipRender();
+
+            return;
+        }
+
+        $updated = app(LinkExternalPathAction::class)->handle($this->projectId, $picked);
+        if ($updated === null) {
+            $this->skipRender();
+
+            return;
+        }
+
+        $this->externalPaths = $this->normalizeExternalPathsForView($updated);
+        $this->reloadAfterExternalPathsChange();
+    }
+
+    public function removeExternalPath(int $index): void
+    {
+        $updated = app(UnlinkExternalPathAction::class)->handle($this->projectId, $index);
+        if ($updated === null) {
+            $this->skipRender();
+
+            return;
+        }
+
+        $this->externalPaths = $this->normalizeExternalPathsForView($updated);
+        $this->reloadAfterExternalPathsChange();
+    }
+
+    private function reloadAfterExternalPathsChange(): void
+    {
+        $this->refreshFileList();
+
+        $target = $this->buildDiffTarget();
+        $session = app(SessionStateAction::class)->handle($this->repoPath, $this->files, $this->projectId, $target);
+        $this->comments = $session['comments'];
+        $this->reviewedFiles = $session['reviewedFiles'];
+
+        if (! empty($session['orphanedPaths'])) {
+            $this->injectOrphanedFiles($session['orphanedPaths']);
+        }
+    }
+
+    /**
+     * @param  array<int|string, mixed>  $rows
+     * @return list<array{label: string, path: string}>
+     */
+    private function normalizeExternalPathsForView(array $rows): array
+    {
+        return collect($rows)
+            ->filter(fn ($row): bool => is_array($row) && isset($row['path']) && is_string($row['path']))
+            ->map(fn (array $row): array => [
+                'label' => isset($row['label']) && is_string($row['label']) && trim($row['label']) !== ''
+                    ? $row['label']
+                    : basename((string) $row['path']),
+                'path' => (string) $row['path'],
+            ])
+            ->values()
+            ->all();
     }
 
     public function updatedRespectGlobalGitignore(): void
@@ -1494,6 +1569,50 @@ new #[Layout('layouts.app')] class extends Component
                                 <p class="text-[10px] font-mono text-gh-muted/80 leading-snug">
                                     Used by the "Since {base}" shortcut in the branch picker.
                                 </p>
+                            </div>
+                            <flux:menu.separator />
+                            <div class="px-3 py-2 w-72 space-y-2" wire:ignore.self>
+                                <label class="block text-[10px] font-display font-semibold uppercase tracking-brutal text-gh-muted">
+                                    Linked external paths
+                                </label>
+                                @if(count($externalPaths) === 0)
+                                    <p class="text-[10px] font-mono text-gh-muted/80 leading-snug">
+                                        Folders outside the repo that should appear as commentable files (e.g. design notes from external tools).
+                                    </p>
+                                @else
+                                    <ul class="space-y-1" data-testid="external-paths-list">
+                                        @foreach($externalPaths as $index => $row)
+                                            <li class="flex items-center gap-2 group" wire:key="external-path-{{ $index }}">
+                                                <div class="min-w-0 flex-1">
+                                                    <div class="text-xs font-display text-gh-text truncate" title="{{ $row['path'] }}">{{ $row['label'] }}</div>
+                                                    <div class="text-[10px] font-mono text-gh-muted/70 truncate" title="{{ $row['path'] }}">{{ $row['path'] }}</div>
+                                                </div>
+                                                <flux:tooltip content="Unlink">
+                                                    <flux:button
+                                                        size="xs"
+                                                        variant="ghost"
+                                                        icon="x-mark"
+                                                        icon:variant="outline"
+                                                        wire:click="removeExternalPath({{ $index }})"
+                                                        aria-label="Unlink {{ $row['label'] }}"
+                                                        data-testid="external-path-remove-{{ $index }}"
+                                                    />
+                                                </flux:tooltip>
+                                            </li>
+                                        @endforeach
+                                    </ul>
+                                @endif
+                                <flux:button
+                                    size="xs"
+                                    variant="ghost"
+                                    icon="plus"
+                                    icon:variant="outline"
+                                    wire:click="addExternalPath"
+                                    data-testid="external-path-add"
+                                    class="w-full"
+                                >
+                                    Link folder…
+                                </flux:button>
                             </div>
                         </flux:menu>
                     </flux:dropdown>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1538,6 +1538,9 @@ new #[Layout('layouts.app')] class extends Component
                             <flux:menu.item keep-open>
                                 <flux:checkbox wire:model.live="respectGlobalGitignore" label="Global .gitignore" class="text-xs whitespace-nowrap" />
                             </flux:menu.item>
+                            <p class="px-3 pb-2 text-[10px] font-mono text-gh-muted/80 leading-snug w-56">
+                                Hide files matched by your global .gitignore (e.g. ~/.gitignore_global).
+                            </p>
                             <flux:menu.separator />
                             <div class="px-3 py-2 w-56 space-y-1.5" wire:ignore.self>
                                 <label for="default-base-branch-input" class="block text-[10px] font-display font-semibold uppercase tracking-brutal text-gh-muted">
@@ -1553,7 +1556,14 @@ new #[Layout('layouts.app')] class extends Component
                                     class="!font-mono text-xs"
                                 />
                                 <p class="text-[10px] font-mono text-gh-muted/80 leading-snug">
-                                    Used by the "Since {base}" shortcut in the branch picker.
+                                    Default branch to compare against. Pre-fills the
+                                    @if($defaultBaseBranch !== '')
+                                        <span class="text-gh-text">Since {{ $defaultBaseBranch }}</span>
+                                        shortcut
+                                    @else
+                                        Since shortcut (e.g. <span class="text-gh-text">Since dev</span>)
+                                    @endif
+                                    in the branch picker.
                                 </p>
                             </div>
                             <flux:menu.separator />
@@ -1561,11 +1571,10 @@ new #[Layout('layouts.app')] class extends Component
                                 <label class="block text-[10px] font-display font-semibold uppercase tracking-brutal text-gh-muted">
                                     Linked external paths
                                 </label>
-                                @if(count($externalPaths) === 0)
-                                    <p class="text-[10px] font-mono text-gh-muted/80 leading-snug">
-                                        Folders outside the repo that should appear as commentable files (e.g. design notes from external tools).
-                                    </p>
-                                @else
+                                <p class="text-[10px] font-mono text-gh-muted/80 leading-snug">
+                                    Folders outside the repo that show up as commentable files (e.g. design notes from external tools).
+                                </p>
+                                @if(count($externalPaths) > 0)
                                     <ul class="space-y-1" data-testid="external-paths-list">
                                         @foreach($externalPaths as $index => $row)
                                             <li class="flex items-center gap-2 group" wire:key="external-path-{{ $index }}">

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -166,7 +166,9 @@ new #[Layout('layouts.app')] class extends Component
         $this->respectGlobalGitignore = $project['respect_global_gitignore'] ?? true;
         $this->globalGitignorePath = $project['global_gitignore_path'] ?: null;
         $this->defaultBaseBranch = (string) ($project['default_base_branch'] ?? '');
-        $this->externalPaths = $this->normalizeExternalPathsForView($project['external_paths'] ?? []);
+        // Stored shape is `[{label, path}]` because every write goes through
+        // Link/UnlinkExternalPathAction; trust it without re-normalizing.
+        $this->externalPaths = (array) ($project['external_paths'] ?? []);
 
         // Commit mode: resolve hash to full SHA
         if ($hash !== null) {
@@ -319,7 +321,7 @@ new #[Layout('layouts.app')] class extends Component
             return;
         }
 
-        $this->externalPaths = $this->normalizeExternalPathsForView($updated);
+        $this->externalPaths = $updated;
         $this->reloadAfterExternalPathsChange();
     }
 
@@ -332,7 +334,7 @@ new #[Layout('layouts.app')] class extends Component
             return;
         }
 
-        $this->externalPaths = $this->normalizeExternalPathsForView($updated);
+        $this->externalPaths = $updated;
         $this->reloadAfterExternalPathsChange();
     }
 
@@ -348,24 +350,6 @@ new #[Layout('layouts.app')] class extends Component
         if (! empty($session['orphanedPaths'])) {
             $this->injectOrphanedFiles($session['orphanedPaths']);
         }
-    }
-
-    /**
-     * @param  array<int|string, mixed>  $rows
-     * @return list<array{label: string, path: string}>
-     */
-    private function normalizeExternalPathsForView(array $rows): array
-    {
-        return collect($rows)
-            ->filter(fn ($row): bool => is_array($row) && isset($row['path']) && is_string($row['path']))
-            ->map(fn (array $row): array => [
-                'label' => isset($row['label']) && is_string($row['label']) && trim($row['label']) !== ''
-                    ? $row['label']
-                    : basename((string) $row['path']),
-                'path' => (string) $row['path'],
-            ])
-            ->values()
-            ->all();
     }
 
     public function updatedRespectGlobalGitignore(): void

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -30,7 +30,9 @@ use App\Concerns\InteractsWithRemoteLinks;
 use App\DTOs\CurrentHeadResult;
 use App\DTOs\DiffTarget;
 use App\DTOs\FileListEntry;
+use App\Enums\DiffSide;
 use App\Enums\DivergenceState;
+use App\Enums\GitRef;
 use App\Exceptions\GitCommandException;
 use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
@@ -700,9 +702,9 @@ new #[Layout('layouts.app')] class extends Component
                 [
                     'project_id' => $this->projectId ?: null,
                     'repo_path' => $this->repoPath,
-                    'origin_ref' => $c['originRef'] ?? 'working',
+                    'origin_ref' => $c['originRef'] ?? GitRef::Working->value,
                     'file_path' => $c['file'] ?? '',
-                    'side' => $c['side'] ?? 'right',
+                    'side' => $c['side'] ?? DiffSide::Right->value,
                     'start_line' => $c['startLine'] ?? null,
                     'end_line' => $c['endLine'] ?? null,
                     'file_content_hash' => $c['fileContentHash'] ?? null,

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1580,7 +1580,7 @@ new #[Layout('layouts.app')] class extends Component
                                             <li class="flex items-center gap-2 group" wire:key="external-path-{{ $index }}">
                                                 <div class="min-w-0 flex-1">
                                                     <div class="text-xs font-display text-gh-text truncate" title="{{ $row['path'] }}">{{ $row['label'] }}</div>
-                                                    <div class="text-[10px] font-mono text-gh-muted/70 truncate" title="{{ $row['path'] }}">{{ $row['path'] }}</div>
+                                                    <x-file-path :path="$row['path']" class="text-[10px] text-gh-muted/70" />
                                                 </div>
                                                 <flux:tooltip content="Unlink">
                                                     <flux:button

--- a/tests/Browser/SplitDiffViewTest.php
+++ b/tests/Browser/SplitDiffViewTest.php
@@ -44,6 +44,9 @@ test('view mode persists in localStorage across page reload', function () {
     expect(json_decode($stored, true))->toBe('split');
 
     $page->refresh();
+    // refresh() doesn't run visitAndLoad's networkidle wait, so the lazy
+    // diff-file children may not have rendered yet under parallel pressure.
+    $page->page()->waitForLoadState('networkidle');
 
     $page->page()->locator('[data-testid="diff-table"][data-view-mode="split"]')->first()->waitFor();
 });

--- a/tests/Feature/Console/LinkExternalPathCommandTest.php
+++ b/tests/Feature/Console/LinkExternalPathCommandTest.php
@@ -31,7 +31,7 @@ test('links a path by project id with a custom label', function () {
         ->assertSuccessful();
 
     $stored = $this->project->fresh()->external_paths;
-    expect($stored[0]['label'])->toBe('design notes');
+    expect($stored[0]['label'])->toBe('design-notes');
 });
 
 test('fails cleanly when the project cannot be found', function () {

--- a/tests/Feature/Console/LinkExternalPathCommandTest.php
+++ b/tests/Feature/Console/LinkExternalPathCommandTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Models\Project;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\Helpers\InteractsWithTestRepositories;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class, InteractsWithTestRepositories::class);
+
+beforeEach(function () {
+    $this->repoDir = $this->createTempDirectory('rfa_link_cmd_repo_');
+    $this->extDir = $this->createTempDirectory('rfa_link_cmd_ext_');
+
+    $this->project = Project::factory()->create([
+        'slug' => 'demo',
+        'name' => 'Demo',
+        'path' => $this->repoDir,
+        'git_common_dir' => $this->repoDir.'/.git',
+    ]);
+});
+
+test('links a path by project slug', function () {
+    $this->artisan('rfa:link-path', ['project' => 'demo', 'path' => $this->extDir])
+        ->assertSuccessful();
+
+    expect($this->project->fresh()->external_paths)->toHaveCount(1);
+});
+
+test('links a path by project id with a custom label', function () {
+    $this->artisan('rfa:link-path', ['project' => (string) $this->project->id, 'path' => $this->extDir, '--label' => 'design notes'])
+        ->assertSuccessful();
+
+    $stored = $this->project->fresh()->external_paths;
+    expect($stored[0]['label'])->toBe('design notes');
+});
+
+test('fails cleanly when the project cannot be found', function () {
+    $this->artisan('rfa:link-path', ['project' => 'nonexistent', 'path' => $this->extDir])
+        ->assertFailed();
+});
+
+test('fails cleanly when the path is not a directory', function () {
+    $this->artisan('rfa:link-path', ['project' => 'demo', 'path' => '/this/path/does/not/exist'])
+        ->assertFailed();
+});

--- a/tests/Unit/Actions/AddCommentActionTest.php
+++ b/tests/Unit/Actions/AddCommentActionTest.php
@@ -161,6 +161,29 @@ test('hashes right-side comments on renamed files using the post-rename path', f
     expect($result['fileContentHash'])->toBe('right-hash');
 });
 
+test('hashes external-file comments off disk and stamps origin_ref=external', function () {
+    $tmp = $this->createTempDirectory('rfa_addcomment_ext_');
+    $absolute = $tmp.'/note.md';
+    file_put_contents($absolute, "external content\n");
+
+    $action = app(AddCommentAction::class);
+    $files = [[
+        'id' => 'file-ext',
+        'path' => 'external/notes/note.md',
+        'isExternal' => true,
+        'externalAbsolutePath' => $absolute,
+    ]];
+
+    $result = $action->handle('/tmp/repo', null, DiffTarget::workingDirectory(), $files, 'file-ext', 'right', 1, 1, 'body');
+
+    expect($result['originRef'])->toBe('external');
+    expect($result['fileContentHash'])->toBe(hash_file('xxh128', $absolute));
+
+    $row = Comment::find($result['id']);
+    expect($row->origin_ref)->toBe('external');
+    expect($row->file_path)->toBe('external/notes/note.md');
+});
+
 test('file-level comments on renamed files hash the post-rename path at `to`', function () {
     $gitFileContent = Mockery::mock(GitFileContentService::class);
     $gitFileContent->shouldReceive('hashAt')

--- a/tests/Unit/Actions/AddCommentActionTest.php
+++ b/tests/Unit/Actions/AddCommentActionTest.php
@@ -166,6 +166,8 @@ test('hashes external-file comments off disk and stamps origin_ref=external', fu
     $absolute = $tmp.'/note.md';
     file_put_contents($absolute, "external content\n");
 
+    // Drop the beforeEach mock so we exercise the real hashAtAbsolute path.
+    app()->forgetInstance(GitFileContentService::class);
     $action = app(AddCommentAction::class);
     $files = [[
         'id' => 'file-ext',

--- a/tests/Unit/Actions/GetFileListActionTest.php
+++ b/tests/Unit/Actions/GetFileListActionTest.php
@@ -27,7 +27,7 @@ beforeEach(function () {
 test('returns files as arrays with id field', function () {
     File::put($this->tmpDir.'/file.txt', "changed\n");
 
-    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), new ExternalFilesService);
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class));
     $files = $action->handle($this->tmpDir);
 
     expect($files)->toHaveCount(1);
@@ -39,7 +39,7 @@ test('returns files as arrays with id field', function () {
 test('clears cache by default', function () {
     File::put($this->tmpDir.'/file.txt', "changed\n");
 
-    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), new ExternalFilesService);
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class));
     $files = $action->handle($this->tmpDir);
 
     $cacheKey = DiffCacheKey::for($this->tmpDir, $files[0]['id']);
@@ -53,7 +53,7 @@ test('clears cache by default', function () {
 test('preserves cache when clearCache is false', function () {
     File::put($this->tmpDir.'/file.txt', "changed\n");
 
-    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), new ExternalFilesService);
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class));
     $files = $action->handle($this->tmpDir, clearCache: false);
 
     $cacheKey = DiffCacheKey::for($this->tmpDir, $files[0]['id']);
@@ -76,7 +76,7 @@ test('appends entries from configured external paths in working-tree mode', func
         'external_paths' => [['label' => 'notes', 'path' => $extDir]],
     ]);
 
-    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), new ExternalFilesService);
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class));
     $files = $action->handle($this->tmpDir, projectId: $project->id);
 
     $paths = collect($files)->pluck('path')->all();
@@ -98,7 +98,7 @@ test('hides external entries when the diff target is an immutable commit range',
         'external_paths' => [['label' => 'notes', 'path' => $extDir]],
     ]);
 
-    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), new ExternalFilesService);
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class));
 
     $files = $action->handle(
         $this->tmpDir,

--- a/tests/Unit/Actions/GetFileListActionTest.php
+++ b/tests/Unit/Actions/GetFileListActionTest.php
@@ -1,15 +1,19 @@
 <?php
 
 use App\Actions\GetFileListAction;
+use App\DTOs\DiffTarget;
+use App\Models\Project;
+use App\Services\ExternalFilesService;
 use App\Services\GitDiffService;
 use App\Services\GitProcessService;
 use App\Services\IgnoreService;
 use App\Support\DiffCacheKey;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
 
-uses(TestCase::class);
+uses(TestCase::class, LazilyRefreshDatabase::class);
 
 beforeEach(function () {
     $this->tmpDir = $this->createTempDirectory('rfa_filelist_test_');
@@ -23,7 +27,7 @@ beforeEach(function () {
 test('returns files as arrays with id field', function () {
     File::put($this->tmpDir.'/file.txt', "changed\n");
 
-    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService));
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), new ExternalFilesService);
     $files = $action->handle($this->tmpDir);
 
     expect($files)->toHaveCount(1);
@@ -35,7 +39,7 @@ test('returns files as arrays with id field', function () {
 test('clears cache by default', function () {
     File::put($this->tmpDir.'/file.txt', "changed\n");
 
-    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService));
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), new ExternalFilesService);
     $files = $action->handle($this->tmpDir);
 
     $cacheKey = DiffCacheKey::for($this->tmpDir, $files[0]['id']);
@@ -49,7 +53,7 @@ test('clears cache by default', function () {
 test('preserves cache when clearCache is false', function () {
     File::put($this->tmpDir.'/file.txt', "changed\n");
 
-    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService));
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), new ExternalFilesService);
     $files = $action->handle($this->tmpDir, clearCache: false);
 
     $cacheKey = DiffCacheKey::for($this->tmpDir, $files[0]['id']);
@@ -58,4 +62,51 @@ test('preserves cache when clearCache is false', function () {
     $action->handle($this->tmpDir, clearCache: false);
 
     expect(Cache::get($cacheKey))->toBe('kept');
+});
+
+test('appends entries from configured external paths in working-tree mode', function () {
+    File::put($this->tmpDir.'/file.txt', "changed\n");
+
+    $extDir = $this->createTempDirectory('rfa_filelist_ext_');
+    File::put($extDir.'/note.md', "external content\n");
+
+    $project = Project::factory()->create([
+        'path' => $this->tmpDir,
+        'git_common_dir' => $this->tmpDir.'/.git',
+        'external_paths' => [['label' => 'notes', 'path' => $extDir]],
+    ]);
+
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), new ExternalFilesService);
+    $files = $action->handle($this->tmpDir, projectId: $project->id);
+
+    $paths = collect($files)->pluck('path')->all();
+    expect($paths)->toContain('file.txt');
+    expect($paths)->toContain('external/notes/note.md');
+
+    $external = collect($files)->firstWhere('path', 'external/notes/note.md');
+    expect($external['isExternal'])->toBeTrue();
+    expect($external['externalAbsolutePath'])->toEndWith('/note.md');
+});
+
+test('hides external entries when the diff target is an immutable commit range', function () {
+    $extDir = $this->createTempDirectory('rfa_filelist_ext_immut_');
+    File::put($extDir.'/note.md', "external\n");
+
+    $project = Project::factory()->create([
+        'path' => $this->tmpDir,
+        'git_common_dir' => $this->tmpDir.'/.git',
+        'external_paths' => [['label' => 'notes', 'path' => $extDir]],
+    ]);
+
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), new ExternalFilesService);
+
+    $files = $action->handle(
+        $this->tmpDir,
+        projectId: $project->id,
+        target: DiffTarget::range('HEAD', 'HEAD'),
+    );
+
+    foreach ($files as $file) {
+        expect($file['path'])->not->toStartWith('external/');
+    }
 });

--- a/tests/Unit/Actions/LinkExternalPathActionTest.php
+++ b/tests/Unit/Actions/LinkExternalPathActionTest.php
@@ -8,7 +8,7 @@ use Tests\TestCase;
 uses(TestCase::class, LazilyRefreshDatabase::class);
 
 beforeEach(function () {
-    $this->action = new LinkExternalPathAction;
+    $this->action = app(LinkExternalPathAction::class);
     $this->repoDir = $this->createTempDirectory('rfa_link_repo_');
     $this->extDir = $this->createTempDirectory('rfa_link_ext_');
 

--- a/tests/Unit/Actions/LinkExternalPathActionTest.php
+++ b/tests/Unit/Actions/LinkExternalPathActionTest.php
@@ -37,10 +37,10 @@ test('appends a new external path with a default label of the directory basename
     expect($this->project->fresh()->external_paths)->toEqual($updated);
 });
 
-test('honors a custom label override', function () {
+test('honors a custom label override and sanitizes it for the mount path', function () {
     $updated = $this->action->handle($this->project->id, $this->extDir, label: 'design notes');
 
-    expect($updated[0]['label'])->toBe('design notes');
+    expect($updated[0]['label'])->toBe('design-notes');
 });
 
 test('is idempotent on the same canonical path', function () {
@@ -61,4 +61,18 @@ test('appends a second distinct path', function () {
     expect(collect($updated)->pluck('path')->all())
         ->toContain(realpath($this->extDir))
         ->toContain(realpath($other));
+});
+
+test('disambiguates the label at write time when a sibling already uses the same basename', function () {
+    $a = $this->createTempDirectory('rfa_link_ext_collide_');
+    $b = $this->createTempDirectory('rfa_link_ext_collide_');
+    rename($a, $a.'_renamed');
+    rename($b, $b.'_renamed');
+    $a .= '_renamed';
+    $b .= '_renamed';
+
+    $this->action->handle($this->project->id, $a, label: 'notes');
+    $updated = $this->action->handle($this->project->id, $b, label: 'notes');
+
+    expect(collect($updated)->pluck('label')->all())->toBe(['notes', 'notes-2']);
 });

--- a/tests/Unit/Actions/LinkExternalPathActionTest.php
+++ b/tests/Unit/Actions/LinkExternalPathActionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Actions\LinkExternalPathAction;
+use App\Models\Project;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+beforeEach(function () {
+    $this->action = new LinkExternalPathAction;
+    $this->repoDir = $this->createTempDirectory('rfa_link_repo_');
+    $this->extDir = $this->createTempDirectory('rfa_link_ext_');
+
+    $this->project = Project::factory()->create([
+        'path' => $this->repoDir,
+        'git_common_dir' => $this->repoDir.'/.git',
+    ]);
+});
+
+test('returns null when the project does not exist', function () {
+    expect($this->action->handle(99_999, $this->extDir))->toBeNull();
+});
+
+test('returns null when the path is not a directory', function () {
+    expect($this->action->handle($this->project->id, '/this/path/is/not/real'))->toBeNull();
+});
+
+test('appends a new external path with a default label of the directory basename', function () {
+    $updated = $this->action->handle($this->project->id, $this->extDir);
+
+    expect($updated)->not->toBeNull();
+    expect($updated)->toHaveCount(1);
+    expect($updated[0]['label'])->toBe(basename(realpath($this->extDir)));
+    expect($updated[0]['path'])->toBe(realpath($this->extDir));
+
+    expect($this->project->fresh()->external_paths)->toEqual($updated);
+});
+
+test('honors a custom label override', function () {
+    $updated = $this->action->handle($this->project->id, $this->extDir, label: 'design notes');
+
+    expect($updated[0]['label'])->toBe('design notes');
+});
+
+test('is idempotent on the same canonical path', function () {
+    $first = $this->action->handle($this->project->id, $this->extDir);
+    $second = $this->action->handle($this->project->id, $this->extDir);
+
+    expect($first)->toEqual($second);
+    expect($this->project->fresh()->external_paths)->toHaveCount(1);
+});
+
+test('appends a second distinct path', function () {
+    $other = $this->createTempDirectory('rfa_link_ext_other_');
+
+    $this->action->handle($this->project->id, $this->extDir);
+    $updated = $this->action->handle($this->project->id, $other);
+
+    expect($updated)->toHaveCount(2);
+    expect(collect($updated)->pluck('path')->all())
+        ->toContain(realpath($this->extDir))
+        ->toContain(realpath($other));
+});

--- a/tests/Unit/Actions/LinkExternalPathActionTest.php
+++ b/tests/Unit/Actions/LinkExternalPathActionTest.php
@@ -63,6 +63,21 @@ test('appends a second distinct path', function () {
         ->toContain(realpath($other));
 });
 
+test('handleByReference prefers slug match over numeric id when the reference is digit-only', function () {
+    $numericSlug = (string) $this->project->id + 1; // ensure the slug is not the project's actual id
+    $other = Project::factory()->create([
+        'slug' => (string) ($this->project->id + 1000),
+        'path' => $this->createTempDirectory('rfa_link_other_repo_'),
+        'git_common_dir' => '/tmp/none/.git',
+    ]);
+
+    $updated = $this->action->handleByReference($other->slug, $this->extDir);
+
+    expect($updated)->not->toBeNull();
+    expect($other->fresh()->external_paths)->toHaveCount(1);
+    expect($this->project->fresh()->external_paths)->toBeNull();
+});
+
 test('disambiguates the label at write time when a sibling already uses the same basename', function () {
     $a = $this->createTempDirectory('rfa_link_ext_collide_');
     $b = $this->createTempDirectory('rfa_link_ext_collide_');

--- a/tests/Unit/Actions/LoadFileDiffActionTest.php
+++ b/tests/Unit/Actions/LoadFileDiffActionTest.php
@@ -29,7 +29,7 @@ beforeEach(function () {
 test('returns full DTO array for modified file', function () {
     File::put($this->tmpDir.'/hello.txt', "line1\nline2\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
     $result = $action->handle($this->tmpDir, 'hello.txt');
 
     expect($result)->toHaveKeys(['path', 'status', 'hunks', 'additions', 'deletions', 'isBinary', 'tooLarge'])
@@ -45,7 +45,7 @@ test('returns tooLarge true when diff exceeds limit', function () {
     // Use a very low maxBytes config
     config(['rfa.diff_max_bytes' => 100]);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
     $result = $action->handle($this->tmpDir, 'hello.txt');
 
     expect($result)->toHaveKeys(['path', 'status', 'oldPath', 'hunks', 'additions', 'deletions', 'isBinary', 'tooLarge'])
@@ -58,7 +58,7 @@ test('returns tooLarge true when diff exceeds limit', function () {
 });
 
 test('returns empty array for empty diff', function () {
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
     $result = $action->handle($this->tmpDir, 'nonexistent.txt', isUntracked: true);
 
     expect($result['hunks'])->toBe([])
@@ -68,7 +68,7 @@ test('returns empty array for empty diff', function () {
 test('handles untracked file', function () {
     File::put($this->tmpDir.'/newfile.txt', "hello\nworld\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
     $result = $action->handle($this->tmpDir, 'newfile.txt', isUntracked: true);
 
     expect($result)->not->toBeNull()
@@ -90,7 +90,7 @@ test('renamed file passes oldPath so rename detection finds the source', functio
     $modified = implode("\n", array_map(fn ($i) => "line {$i}", range(1, 19)))."\n";
     File::put($this->tmpDir.'/new.txt', $modified);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
     $result = $action->handle($this->tmpDir, 'new.txt', oldPath: 'old.txt');
 
     expect($result['status'])->toBe('renamed')
@@ -110,7 +110,7 @@ test('without oldPath the rename diff degrades to all additions', function () {
     $modified = implode("\n", array_map(fn ($i) => "line {$i}", range(1, 19)))."\n";
     File::put($this->tmpDir.'/new.txt', $modified);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
     $result = $action->handle($this->tmpDir, 'new.txt');
 
     expect($result['status'])->toBe('added')
@@ -126,7 +126,7 @@ test('adds highlightedContent for known file types', function () {
     $this->commitTestRepo($this->tmpDir, 'add php');
     File::put($this->tmpDir.'/hello.php', "<?php\necho 'hello';\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
     $result = $action->handle($this->tmpDir, 'hello.php');
 
     expect($result)->not->toBeNull()
@@ -143,7 +143,7 @@ test('result contains syntaxStyles CSS for known file types', function () {
     $this->commitTestRepo($this->tmpDir, 'add php styles');
     File::put($this->tmpDir.'/hello.php', "<?php\necho 'hello';\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
     $result = $action->handle($this->tmpDir, 'hello.php');
 
     expect($result)->toHaveKey('syntaxStyles')
@@ -157,7 +157,7 @@ test('no highlightedContent for unknown file types', function () {
     $this->commitTestRepo($this->tmpDir, 'add xyz');
     File::put($this->tmpDir.'/data.xyz', "updated content\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
     $result = $action->handle($this->tmpDir, 'data.xyz');
 
     expect($result)->not->toBeNull();
@@ -185,7 +185,7 @@ test('contextLines parameter produces single hunk for full context', function ()
         new MarkdownTableAlignerService,
         new CsvAlignerService,
         new MarkdownRegionService,
-        new ExternalFilesService,
+        app(ExternalFilesService::class),
     );
 
     $default = $action->handle($this->tmpDir, 'many.txt');
@@ -217,7 +217,7 @@ test('stale cache without syntaxStyles triggers re-computation', function () {
         'tooLarge' => false,
     ], 3600);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
     $result = $action->handle($this->tmpDir, 'hello.php', cacheKey: $cacheKey);
 
     expect($result)->toHaveKey('syntaxStyles')
@@ -230,7 +230,7 @@ test('class names in highlightedContent have matching selectors in syntaxStyles'
     $this->commitTestRepo($this->tmpDir, 'add php selectors');
     File::put($this->tmpDir.'/hello.php', "<?php\necho 'hello';\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
     $result = $action->handle($this->tmpDir, 'hello.php');
 
     $classNames = [];
@@ -259,7 +259,7 @@ test('result includes newFileLineCount for modified file', function () {
     // hello.txt starts as 1 line, modify to 3 lines
     File::put($this->tmpDir.'/hello.txt', "line1\nline2\nline3\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
     $result = $action->handle($this->tmpDir, 'hello.txt');
 
     expect($result)->toHaveKey('newFileLineCount')
@@ -275,7 +275,7 @@ test('newFileLineCount reflects actual file length beyond last hunk', function (
     $lines[0] = 'changed1';
     File::put($this->tmpDir.'/many.txt', implode("\n", $lines)."\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
     $result = $action->handle($this->tmpDir, 'many.txt');
 
     expect($result['newFileLineCount'])->toBe(20);
@@ -305,7 +305,7 @@ test('stale cache without newFileLineCount triggers re-computation', function ()
         'tableAligned' => true,
     ], 3600);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
     $result = $action->handle($this->tmpDir, 'hello.txt', cacheKey: $cacheKey);
 
     expect($result)->toHaveKey('newFileLineCount')
@@ -319,7 +319,7 @@ test('markdown files get heading metadata on hunk lines', function () {
     $this->commitTestRepo($this->tmpDir, 'add doc');
     File::put($this->tmpDir.'/doc.md', "# Title\n\nbody updated\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
     $result = $action->handle($this->tmpDir, 'doc.md');
 
     $hasHeading = collect($result['hunks'][0]['lines'])
@@ -334,7 +334,7 @@ test('non-markdown files do not get heading metadata', function () {
     $this->commitTestRepo($this->tmpDir, 'add php with hash');
     File::put($this->tmpDir.'/hello.php', "<?php\n# updated comment\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
     $result = $action->handle($this->tmpDir, 'hello.php');
 
     $hasHeading = collect($result['hunks'][0]['lines'])
@@ -365,7 +365,7 @@ test('stale cache without headingsAnnotated triggers re-computation', function (
         'newFileLineCount' => 1,
     ], 3600);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
     $result = $action->handle($this->tmpDir, 'doc.md', cacheKey: $cacheKey);
 
     expect($result)->toHaveKey('headingsAnnotated')
@@ -379,7 +379,7 @@ test('builds a synthetic whole-file diff for an external file via its absolute p
     $absolute = $extDir.'/note.md';
     File::put($absolute, "# title\n\nbody\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
 
     $result = $action->handle(
         $this->tmpDir,
@@ -396,12 +396,14 @@ test('does not shell out to git when an external file is requested', function ()
     $gitService = Mockery::mock(GitDiffService::class);
     $gitService->shouldNotReceive('getFileDiff');
     $gitService->shouldNotReceive('getNewFileLineCount');
+    // Pure file-ops on GitDiffService are allowed; only git shell-outs are forbidden.
+    $gitService->shouldReceive('countLinesInFile')->andReturn(1);
 
     $extDir = $this->createTempDirectory('rfa_load_ext_no_git_');
     $absolute = $extDir.'/note.md';
     File::put($absolute, "hello\n");
 
-    $action = new LoadFileDiffAction($gitService, new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction($gitService, new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
 
     $action->handle(
         $this->tmpDir,
@@ -417,7 +419,7 @@ test('returns error field when git command fails', function () {
     $gitService->shouldReceive('getFileDiff')
         ->andThrow(new GitCommandException('git diff', 'fatal: bad revision', 128));
 
-    $action = new LoadFileDiffAction($gitService, new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+    $action = new LoadFileDiffAction($gitService, new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
     $result = $action->handle($this->tmpDir, 'hello.txt');
 
     expect($result['error'])->toBe('Failed to load diff for this file.')

--- a/tests/Unit/Actions/LoadFileDiffActionTest.php
+++ b/tests/Unit/Actions/LoadFileDiffActionTest.php
@@ -4,6 +4,7 @@ use App\Actions\LoadFileDiffAction;
 use App\Exceptions\GitCommandException;
 use App\Services\CsvAlignerService;
 use App\Services\DiffParser;
+use App\Services\ExternalFilesService;
 use App\Services\GitDiffService;
 use App\Services\GitProcessService;
 use App\Services\IgnoreService;
@@ -28,7 +29,7 @@ beforeEach(function () {
 test('returns full DTO array for modified file', function () {
     File::put($this->tmpDir.'/hello.txt', "line1\nline2\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
     $result = $action->handle($this->tmpDir, 'hello.txt');
 
     expect($result)->toHaveKeys(['path', 'status', 'hunks', 'additions', 'deletions', 'isBinary', 'tooLarge'])
@@ -44,7 +45,7 @@ test('returns tooLarge true when diff exceeds limit', function () {
     // Use a very low maxBytes config
     config(['rfa.diff_max_bytes' => 100]);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
     $result = $action->handle($this->tmpDir, 'hello.txt');
 
     expect($result)->toHaveKeys(['path', 'status', 'oldPath', 'hunks', 'additions', 'deletions', 'isBinary', 'tooLarge'])
@@ -57,7 +58,7 @@ test('returns tooLarge true when diff exceeds limit', function () {
 });
 
 test('returns empty array for empty diff', function () {
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
     $result = $action->handle($this->tmpDir, 'nonexistent.txt', isUntracked: true);
 
     expect($result['hunks'])->toBe([])
@@ -67,7 +68,7 @@ test('returns empty array for empty diff', function () {
 test('handles untracked file', function () {
     File::put($this->tmpDir.'/newfile.txt', "hello\nworld\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
     $result = $action->handle($this->tmpDir, 'newfile.txt', isUntracked: true);
 
     expect($result)->not->toBeNull()
@@ -89,7 +90,7 @@ test('renamed file passes oldPath so rename detection finds the source', functio
     $modified = implode("\n", array_map(fn ($i) => "line {$i}", range(1, 19)))."\n";
     File::put($this->tmpDir.'/new.txt', $modified);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
     $result = $action->handle($this->tmpDir, 'new.txt', oldPath: 'old.txt');
 
     expect($result['status'])->toBe('renamed')
@@ -109,7 +110,7 @@ test('without oldPath the rename diff degrades to all additions', function () {
     $modified = implode("\n", array_map(fn ($i) => "line {$i}", range(1, 19)))."\n";
     File::put($this->tmpDir.'/new.txt', $modified);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
     $result = $action->handle($this->tmpDir, 'new.txt');
 
     expect($result['status'])->toBe('added')
@@ -125,7 +126,7 @@ test('adds highlightedContent for known file types', function () {
     $this->commitTestRepo($this->tmpDir, 'add php');
     File::put($this->tmpDir.'/hello.php', "<?php\necho 'hello';\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
     $result = $action->handle($this->tmpDir, 'hello.php');
 
     expect($result)->not->toBeNull()
@@ -142,7 +143,7 @@ test('result contains syntaxStyles CSS for known file types', function () {
     $this->commitTestRepo($this->tmpDir, 'add php styles');
     File::put($this->tmpDir.'/hello.php', "<?php\necho 'hello';\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
     $result = $action->handle($this->tmpDir, 'hello.php');
 
     expect($result)->toHaveKey('syntaxStyles')
@@ -156,7 +157,7 @@ test('no highlightedContent for unknown file types', function () {
     $this->commitTestRepo($this->tmpDir, 'add xyz');
     File::put($this->tmpDir.'/data.xyz', "updated content\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
     $result = $action->handle($this->tmpDir, 'data.xyz');
 
     expect($result)->not->toBeNull();
@@ -184,6 +185,7 @@ test('contextLines parameter produces single hunk for full context', function ()
         new MarkdownTableAlignerService,
         new CsvAlignerService,
         new MarkdownRegionService,
+        new ExternalFilesService,
     );
 
     $default = $action->handle($this->tmpDir, 'many.txt');
@@ -215,7 +217,7 @@ test('stale cache without syntaxStyles triggers re-computation', function () {
         'tooLarge' => false,
     ], 3600);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
     $result = $action->handle($this->tmpDir, 'hello.php', cacheKey: $cacheKey);
 
     expect($result)->toHaveKey('syntaxStyles')
@@ -228,7 +230,7 @@ test('class names in highlightedContent have matching selectors in syntaxStyles'
     $this->commitTestRepo($this->tmpDir, 'add php selectors');
     File::put($this->tmpDir.'/hello.php', "<?php\necho 'hello';\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
     $result = $action->handle($this->tmpDir, 'hello.php');
 
     $classNames = [];
@@ -257,7 +259,7 @@ test('result includes newFileLineCount for modified file', function () {
     // hello.txt starts as 1 line, modify to 3 lines
     File::put($this->tmpDir.'/hello.txt', "line1\nline2\nline3\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
     $result = $action->handle($this->tmpDir, 'hello.txt');
 
     expect($result)->toHaveKey('newFileLineCount')
@@ -273,7 +275,7 @@ test('newFileLineCount reflects actual file length beyond last hunk', function (
     $lines[0] = 'changed1';
     File::put($this->tmpDir.'/many.txt', implode("\n", $lines)."\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
     $result = $action->handle($this->tmpDir, 'many.txt');
 
     expect($result['newFileLineCount'])->toBe(20);
@@ -303,7 +305,7 @@ test('stale cache without newFileLineCount triggers re-computation', function ()
         'tableAligned' => true,
     ], 3600);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
     $result = $action->handle($this->tmpDir, 'hello.txt', cacheKey: $cacheKey);
 
     expect($result)->toHaveKey('newFileLineCount')
@@ -317,7 +319,7 @@ test('markdown files get heading metadata on hunk lines', function () {
     $this->commitTestRepo($this->tmpDir, 'add doc');
     File::put($this->tmpDir.'/doc.md', "# Title\n\nbody updated\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
     $result = $action->handle($this->tmpDir, 'doc.md');
 
     $hasHeading = collect($result['hunks'][0]['lines'])
@@ -332,7 +334,7 @@ test('non-markdown files do not get heading metadata', function () {
     $this->commitTestRepo($this->tmpDir, 'add php with hash');
     File::put($this->tmpDir.'/hello.php', "<?php\n# updated comment\n");
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
     $result = $action->handle($this->tmpDir, 'hello.php');
 
     $hasHeading = collect($result['hunks'][0]['lines'])
@@ -363,11 +365,49 @@ test('stale cache without headingsAnnotated triggers re-computation', function (
         'newFileLineCount' => 1,
     ], 3600);
 
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
     $result = $action->handle($this->tmpDir, 'doc.md', cacheKey: $cacheKey);
 
     expect($result)->toHaveKey('headingsAnnotated')
         ->and($result['hunks'])->not->toBeEmpty();
+});
+
+// -- external files --
+
+test('builds a synthetic whole-file diff for an external file via its absolute path', function () {
+    $extDir = $this->createTempDirectory('rfa_load_ext_');
+    $absolute = $extDir.'/note.md';
+    File::put($absolute, "# title\n\nbody\n");
+
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+
+    $result = $action->handle(
+        $this->tmpDir,
+        'external/notes/note.md',
+        externalAbsolutePath: $absolute,
+    );
+
+    expect($result['hunks'])->not->toBeEmpty();
+    expect($result['tooLarge'])->toBeFalse();
+    expect($result['additions'])->toBeGreaterThan(0);
+});
+
+test('does not shell out to git when an external file is requested', function () {
+    $gitService = Mockery::mock(GitDiffService::class);
+    $gitService->shouldNotReceive('getFileDiff');
+    $gitService->shouldNotReceive('getNewFileLineCount');
+
+    $extDir = $this->createTempDirectory('rfa_load_ext_no_git_');
+    $absolute = $extDir.'/note.md';
+    File::put($absolute, "hello\n");
+
+    $action = new LoadFileDiffAction($gitService, new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
+
+    $action->handle(
+        $this->tmpDir,
+        'external/notes/note.md',
+        externalAbsolutePath: $absolute,
+    );
 });
 
 // -- git error propagation --
@@ -377,7 +417,7 @@ test('returns error field when git command fails', function () {
     $gitService->shouldReceive('getFileDiff')
         ->andThrow(new GitCommandException('git diff', 'fatal: bad revision', 128));
 
-    $action = new LoadFileDiffAction($gitService, new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService);
+    $action = new LoadFileDiffAction($gitService, new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, new ExternalFilesService);
     $result = $action->handle($this->tmpDir, 'hello.txt');
 
     expect($result['error'])->toBe('Failed to load diff for this file.')

--- a/tests/Unit/Actions/ResolveCommentAnchorActionTest.php
+++ b/tests/Unit/Actions/ResolveCommentAnchorActionTest.php
@@ -222,7 +222,12 @@ test('places external comments when the on-disk hash matches the stored hash', f
     file_put_contents($absolute, "stable\n");
     $hash = hash_file('xxh128', $absolute);
 
-    $result = $this->action->handle(
+    // Use the real GitFileContentService for hashAtAbsolute; the beforeEach
+    // mock only stubs git-side hashAt() calls.
+    app()->forgetInstance(GitFileContentService::class);
+    $action = app(ResolveCommentAnchorAction::class);
+
+    $result = $action->handle(
         '/tmp/repo',
         [[
             'id' => 'c-ext',
@@ -252,7 +257,10 @@ test('marks external comments as unplaced when the on-disk content has changed',
     $absolute = $tmp.'/note.md';
     file_put_contents($absolute, "current\n");
 
-    $result = $this->action->handle(
+    app()->forgetInstance(GitFileContentService::class);
+    $action = app(ResolveCommentAnchorAction::class);
+
+    $result = $action->handle(
         '/tmp/repo',
         [[
             'id' => 'c-ext-stale',

--- a/tests/Unit/Actions/ResolveCommentAnchorActionTest.php
+++ b/tests/Unit/Actions/ResolveCommentAnchorActionTest.php
@@ -216,6 +216,65 @@ test('keeps stored side when stored hash matches that same side', function () {
     expect($result[0]['originalSide'])->toBe('left');
 });
 
+test('places external comments when the on-disk hash matches the stored hash', function () {
+    $tmp = $this->createTempDirectory('rfa_anchor_ext_');
+    $absolute = $tmp.'/note.md';
+    file_put_contents($absolute, "stable\n");
+    $hash = hash_file('xxh128', $absolute);
+
+    $result = $this->action->handle(
+        '/tmp/repo',
+        [[
+            'id' => 'c-ext',
+            'file_path' => 'external/notes/note.md',
+            'side' => 'right',
+            'start_line' => 1,
+            'file_content_hash' => $hash,
+            'body' => 'body',
+            'origin_ref' => 'external',
+        ]],
+        [[
+            'id' => 'file-ext',
+            'path' => 'external/notes/note.md',
+            'isExternal' => true,
+            'externalAbsolutePath' => $absolute,
+        ]],
+        DiffTarget::workingDirectory(),
+    );
+
+    expect($result[0]['anchorStatus'])->toBe('placed');
+    expect($result[0]['fileId'])->toBe('file-ext');
+    expect($result[0]['originRef'])->toBe('external');
+});
+
+test('marks external comments as unplaced when the on-disk content has changed', function () {
+    $tmp = $this->createTempDirectory('rfa_anchor_ext_stale_');
+    $absolute = $tmp.'/note.md';
+    file_put_contents($absolute, "current\n");
+
+    $result = $this->action->handle(
+        '/tmp/repo',
+        [[
+            'id' => 'c-ext-stale',
+            'file_path' => 'external/notes/note.md',
+            'side' => 'right',
+            'start_line' => 1,
+            'file_content_hash' => 'stale-hash',
+            'body' => 'body',
+            'origin_ref' => 'external',
+        ]],
+        [[
+            'id' => 'file-ext',
+            'path' => 'external/notes/note.md',
+            'isExternal' => true,
+            'externalAbsolutePath' => $absolute,
+        ]],
+        DiffTarget::workingDirectory(),
+    );
+
+    expect($result[0]['anchorStatus'])->toBe('unplaced');
+});
+
 test('uses the working copy as the right side when the target has no `to`', function () {
     $this->gitFileContent->shouldReceive('hashAt')->with('/tmp/repo', 'HEAD', 'f.php')->andReturn('old');
     $this->gitFileContent->shouldReceive('hashAt')

--- a/tests/Unit/Actions/SessionStateLoadTest.php
+++ b/tests/Unit/Actions/SessionStateLoadTest.php
@@ -213,6 +213,51 @@ test('marks comment as placed when content hash matches right side', function ()
     expect($result['comments'][0]['anchorStatus'])->toBe('placed');
 });
 
+test('rehydrates external reviewed files via on-disk hash, not git refs', function () {
+    // External files store an absolute-path hash. The session loader must
+    // compare the stored hash to the current on-disk hash; if it changes,
+    // the reviewed flag drops, matching the diff-anchor model.
+    $repoPath = '/tmp/'.$this->faker->word();
+    $tmp = sys_get_temp_dir().'/rfa_session_ext_'.getmypid().'_'.uniqid('', true);
+    mkdir($tmp);
+    $absolute = $tmp.'/note.md';
+    file_put_contents($absolute, "stable\n");
+    $hash = hash_file('xxh128', $absolute);
+
+    ReviewedFile::create([
+        'repo_path' => $repoPath,
+        'file_path' => 'external/notes/note.md',
+        'content_hash' => $hash,
+    ]);
+
+    $files = [[
+        'id' => 'file-ext',
+        'path' => 'external/notes/note.md',
+        'isUntracked' => false,
+        'isExternal' => true,
+        'externalAbsolutePath' => $absolute,
+    ]];
+
+    // Use the real hashAtAbsolute; mock the git-side hashAt as before.
+    $this->gitFileContentMock->shouldReceive('hashAtAbsolute')->andReturnUsing(
+        fn (string $p) => is_file($p) ? hash_file('xxh128', $p) : null,
+    );
+
+    $result = app(SessionStateAction::class)->handle($repoPath, $files);
+
+    expect($result['reviewedFiles'])->toBe(['external/notes/note.md' => $hash]);
+
+    // Mutate the file → reviewed state should drop on the next load.
+    file_put_contents($absolute, "changed\n");
+
+    $result = app(SessionStateAction::class)->handle($repoPath, $files);
+
+    expect($result['reviewedFiles'])->toBe([]);
+
+    unlink($absolute);
+    rmdir($tmp);
+});
+
 test('rehydrates reviewed files via left-side hash when the right ref has no content', function () {
     // ToggleReviewedAction explicitly stores the left-side hash for deleted /
     // left-only files. Without matching against the left ref too, those reviewed

--- a/tests/Unit/Actions/SessionStateLoadTest.php
+++ b/tests/Unit/Actions/SessionStateLoadTest.php
@@ -218,8 +218,7 @@ test('rehydrates external reviewed files via on-disk hash, not git refs', functi
     // compare the stored hash to the current on-disk hash; if it changes,
     // the reviewed flag drops, matching the diff-anchor model.
     $repoPath = '/tmp/'.$this->faker->word();
-    $tmp = sys_get_temp_dir().'/rfa_session_ext_'.getmypid().'_'.uniqid('', true);
-    mkdir($tmp);
+    $tmp = $this->createTempDirectory('rfa_session_ext_');
     $absolute = $tmp.'/note.md';
     file_put_contents($absolute, "stable\n");
     $hash = hash_file('xxh128', $absolute);
@@ -253,9 +252,6 @@ test('rehydrates external reviewed files via on-disk hash, not git refs', functi
     $result = app(SessionStateAction::class)->handle($repoPath, $files);
 
     expect($result['reviewedFiles'])->toBe([]);
-
-    unlink($absolute);
-    rmdir($tmp);
 });
 
 test('rehydrates reviewed files via left-side hash when the right ref has no content', function () {

--- a/tests/Unit/Actions/ToggleReviewedActionTest.php
+++ b/tests/Unit/Actions/ToggleReviewedActionTest.php
@@ -117,8 +117,7 @@ test('hashes external files off disk so a content edit un-reviews them', functio
     app()->forgetInstance(GitFileContentService::class);
     $action = app(ToggleReviewedAction::class);
 
-    $tmp = sys_get_temp_dir().'/rfa_toggle_ext_'.getmypid().'_'.uniqid('', true);
-    mkdir($tmp);
+    $tmp = $this->createTempDirectory('rfa_toggle_ext_');
     $absolute = $tmp.'/note.md';
     file_put_contents($absolute, "v1\n");
 
@@ -133,7 +132,4 @@ test('hashes external files off disk so a content edit un-reviews them', functio
 
     expect($result['external/notes/note.md'])->toBe(hash_file('xxh128', $absolute));
     expect($result['external/notes/note.md'])->not->toBe('');
-
-    unlink($absolute);
-    rmdir($tmp);
 });

--- a/tests/Unit/Actions/ToggleReviewedActionTest.php
+++ b/tests/Unit/Actions/ToggleReviewedActionTest.php
@@ -111,3 +111,29 @@ test('preserves other entries on toggle off', function () {
 
     expect($result)->toBe(['a.php' => 'h1', 'c.php' => 'h3']);
 });
+
+test('hashes external files off disk so a content edit un-reviews them', function () {
+    // Don't mock GitFileContentService here — we want the real hashAtAbsolute().
+    app()->forgetInstance(GitFileContentService::class);
+    $action = app(ToggleReviewedAction::class);
+
+    $tmp = sys_get_temp_dir().'/rfa_toggle_ext_'.getmypid().'_'.uniqid('', true);
+    mkdir($tmp);
+    $absolute = $tmp.'/note.md';
+    file_put_contents($absolute, "v1\n");
+
+    $files = [[
+        'id' => 'file-ext',
+        'path' => 'external/notes/note.md',
+        'isExternal' => true,
+        'externalAbsolutePath' => $absolute,
+    ]];
+
+    $result = $action->handle([], 'external/notes/note.md', $files, '/tmp/repo');
+
+    expect($result['external/notes/note.md'])->toBe(hash_file('xxh128', $absolute));
+    expect($result['external/notes/note.md'])->not->toBe('');
+
+    unlink($absolute);
+    rmdir($tmp);
+});

--- a/tests/Unit/Actions/UnlinkExternalPathActionTest.php
+++ b/tests/Unit/Actions/UnlinkExternalPathActionTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Actions\UnlinkExternalPathAction;
+use App\Models\Project;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+beforeEach(function () {
+    $this->action = new UnlinkExternalPathAction;
+    $this->repoDir = $this->createTempDirectory('rfa_unlink_repo_');
+
+    $this->project = Project::factory()->create([
+        'path' => $this->repoDir,
+        'git_common_dir' => $this->repoDir.'/.git',
+        'external_paths' => [
+            ['label' => 'a', 'path' => '/tmp/a'],
+            ['label' => 'b', 'path' => '/tmp/b'],
+            ['label' => 'c', 'path' => '/tmp/c'],
+        ],
+    ]);
+});
+
+test('returns null when the project does not exist', function () {
+    expect($this->action->handle(99_999, 0))->toBeNull();
+});
+
+test('removes the entry at the given index', function () {
+    $updated = $this->action->handle($this->project->id, 1);
+
+    expect($updated)->toHaveCount(2);
+    expect(collect($updated)->pluck('label')->all())->toBe(['a', 'c']);
+
+    expect($this->project->fresh()->external_paths)->toEqual($updated);
+});
+
+test('treats out-of-range indices as no-ops', function () {
+    $updated = $this->action->handle($this->project->id, 10);
+
+    expect($updated)->toHaveCount(3);
+    expect(collect($updated)->pluck('label')->all())->toBe(['a', 'b', 'c']);
+});

--- a/tests/Unit/Actions/UnlinkExternalPathActionTest.php
+++ b/tests/Unit/Actions/UnlinkExternalPathActionTest.php
@@ -8,7 +8,7 @@ use Tests\TestCase;
 uses(TestCase::class, LazilyRefreshDatabase::class);
 
 beforeEach(function () {
-    $this->action = new UnlinkExternalPathAction;
+    $this->action = app(UnlinkExternalPathAction::class);
     $this->repoDir = $this->createTempDirectory('rfa_unlink_repo_');
 
     $this->project = Project::factory()->create([

--- a/tests/Unit/FileListEntryTest.php
+++ b/tests/Unit/FileListEntryTest.php
@@ -52,6 +52,8 @@ test('toArray includes all properties and computed id', function () {
         'isSymlink' => false,
         'symlinkTarget' => null,
         'fileSize' => null,
+        'isExternal' => false,
+        'externalAbsolutePath' => null,
     ]);
 });
 

--- a/tests/Unit/Livewire/DiffFileTest.php
+++ b/tests/Unit/Livewire/DiffFileTest.php
@@ -23,7 +23,7 @@ beforeEach(function () {
     // Mock LoadFileDiffAction so it never touches git
     app()->bind(LoadFileDiffAction::class, fn () => new class
     {
-        public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, int $contextLines = 3, ?DiffTarget $target = null, ?string $oldPath = null): array
+        public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, int $contextLines = 3, ?DiffTarget $target = null, ?string $oldPath = null, ?string $externalAbsolutePath = null): array
         {
             return DiffFixtureFactory::diffData(path: $path);
         }
@@ -307,7 +307,7 @@ function mountMultiHunkDiffFile(array $diffData, array $file): Testable
     {
         public function __construct(private array $diffData) {}
 
-        public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, int $contextLines = 3, ?DiffTarget $target = null, ?string $oldPath = null): array
+        public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, int $contextLines = 3, ?DiffTarget $target = null, ?string $oldPath = null, ?string $externalAbsolutePath = null): array
         {
             return $this->diffData;
         }

--- a/tests/Unit/Services/ExternalFilesServiceTest.php
+++ b/tests/Unit/Services/ExternalFilesServiceTest.php
@@ -21,6 +21,22 @@ test('returns empty list when no configs are supplied', function () {
     expect($this->service->getEntries([]))->toBe([]);
 });
 
+test('does not follow symlinks out of the configured root', function () {
+    $secret = $this->createTempDirectory('rfa_ext_secret_');
+    File::put($secret.'/secret.md', "secret\n");
+
+    symlink($secret, $this->extDir.'/escape');
+
+    $paths = collect($this->service->getEntries($this->configs))->pluck('path')->all();
+
+    // The legitimate file is still listed.
+    expect($paths)->toContain('external/notes/note.md');
+    // But the symlink target's contents are NOT walked.
+    foreach ($paths as $p) {
+        expect($p)->not->toContain('secret.md');
+    }
+});
+
 test('caps recursion at MAX_DEPTH so a misconfigured root cannot pull in a huge subtree', function () {
     $deep = $this->createTempDirectory('rfa_ext_deep_');
     $segments = array_fill(0, ExternalFilesService::MAX_DEPTH + 3, 'd');

--- a/tests/Unit/Services/ExternalFilesServiceTest.php
+++ b/tests/Unit/Services/ExternalFilesServiceTest.php
@@ -21,6 +21,23 @@ test('returns empty list when no configs are supplied', function () {
     expect($this->service->getEntries([]))->toBe([]);
 });
 
+test('caps recursion at MAX_DEPTH so a misconfigured root cannot pull in a huge subtree', function () {
+    $deep = $this->createTempDirectory('rfa_ext_deep_');
+    $segments = array_fill(0, ExternalFilesService::MAX_DEPTH + 3, 'd');
+    File::ensureDirectoryExists($deep.'/'.implode('/', $segments));
+    File::put($deep.'/top.md', "shallow\n");
+    File::put($deep.'/'.implode('/', $segments).'/buried.md', "too deep\n");
+
+    $paths = collect($this->service->getEntries([['label' => 'deep', 'path' => $deep]]))
+        ->pluck('path')
+        ->all();
+
+    expect($paths)->toContain('external/deep/top.md');
+    foreach ($paths as $p) {
+        expect($p)->not->toContain('buried.md');
+    }
+});
+
 test('walks the configured directory recursively and mounts files under external/<label>', function () {
     $entries = $this->service->getEntries($this->configs);
 

--- a/tests/Unit/Services/ExternalFilesServiceTest.php
+++ b/tests/Unit/Services/ExternalFilesServiceTest.php
@@ -73,17 +73,31 @@ test('defaults the label to the directory basename when none is supplied', funct
     expect($entries[0]->path)->toStartWith('external/'.basename($this->extDir).'/');
 });
 
-test('disambiguates duplicate labels with a numeric suffix', function () {
+test('uniqueLabelFor picks a fresh suffix when the candidate clashes with existing labels', function () {
+    $existing = [
+        ['label' => 'notes', 'path' => '/tmp/a'],
+        ['label' => 'notes-2', 'path' => '/tmp/b'],
+    ];
+
+    expect($this->service->uniqueLabelFor($existing, 'notes'))->toBe('notes-3');
+    expect($this->service->uniqueLabelFor($existing, 'fresh'))->toBe('fresh');
+});
+
+test('uses stored labels literally at read time so unlinking a sibling cannot rename survivors', function () {
     $other = $this->createTempDirectory('rfa_ext_dir_b_');
     File::put($other.'/x.md', "x\n");
 
-    $paths = collect($this->service->getEntries([
+    // Stored shape after Link assigned the disambiguated label at write time.
+    $configs = [
         ['label' => 'notes', 'path' => $this->extDir],
-        ['label' => 'notes', 'path' => $other],
-    ]))->pluck('path')->all();
+        ['label' => 'notes-2', 'path' => $other],
+    ];
 
-    expect($paths)->toContain('external/notes/note.md');
-    expect($paths)->toContain('external/notes-2/x.md');
+    // Unlinking the first row leaves 'notes-2' alone; it must not collapse back to 'notes'.
+    $survivorOnly = [['label' => 'notes-2', 'path' => $other]];
+
+    expect(collect($this->service->getEntries($survivorOnly))->pluck('path')->all())
+        ->toContain('external/notes-2/x.md');
 });
 
 test('drops configs with non-existent paths', function () {

--- a/tests/Unit/Services/ExternalFilesServiceTest.php
+++ b/tests/Unit/Services/ExternalFilesServiceTest.php
@@ -7,7 +7,7 @@ use Tests\TestCase;
 uses(TestCase::class);
 
 beforeEach(function () {
-    $this->service = new ExternalFilesService;
+    $this->service = app(ExternalFilesService::class);
 
     $this->extDir = $this->createTempDirectory('rfa_ext_dir_');
     File::put($this->extDir.'/note.md', "# Title\n\nbody\n");

--- a/tests/Unit/Services/ExternalFilesServiceTest.php
+++ b/tests/Unit/Services/ExternalFilesServiceTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Services\ExternalFilesService;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    $this->service = new ExternalFilesService;
+
+    $this->extDir = $this->createTempDirectory('rfa_ext_dir_');
+    File::put($this->extDir.'/note.md', "# Title\n\nbody\n");
+    File::ensureDirectoryExists($this->extDir.'/sub');
+    File::put($this->extDir.'/sub/inner.md', "inner\n");
+
+    $this->configs = [['label' => 'notes', 'path' => $this->extDir]];
+});
+
+test('returns empty list when no configs are supplied', function () {
+    expect($this->service->getEntries([]))->toBe([]);
+});
+
+test('walks the configured directory recursively and mounts files under external/<label>', function () {
+    $entries = $this->service->getEntries($this->configs);
+
+    expect($entries)->toHaveCount(2);
+
+    $paths = collect($entries)->pluck('path')->all();
+    expect($paths)->toContain('external/notes/note.md');
+    expect($paths)->toContain('external/notes/sub/inner.md');
+});
+
+test('marks every entry as external/added/non-binary with an absolute path back to disk', function () {
+    [$entry] = $this->service->getEntries($this->configs);
+
+    expect($entry->isExternal)->toBeTrue();
+    expect($entry->isUntracked)->toBeFalse();
+    expect($entry->isBinary)->toBeFalse();
+    expect($entry->status)->toBe('added');
+    expect($entry->externalAbsolutePath)->not->toBeNull();
+    expect(file_exists($entry->externalAbsolutePath))->toBeTrue();
+});
+
+test('skips binary files', function () {
+    File::put($this->extDir.'/binary.bin', "ok\0bytes\0here\n");
+
+    $paths = collect($this->service->getEntries($this->configs))->pluck('path')->all();
+
+    expect($paths)->not->toContain('external/notes/binary.bin');
+});
+
+test('defaults the label to the directory basename when none is supplied', function () {
+    $entries = $this->service->getEntries([['path' => $this->extDir]]);
+
+    expect($entries[0]->path)->toStartWith('external/'.basename($this->extDir).'/');
+});
+
+test('disambiguates duplicate labels with a numeric suffix', function () {
+    $other = $this->createTempDirectory('rfa_ext_dir_b_');
+    File::put($other.'/x.md', "x\n");
+
+    $paths = collect($this->service->getEntries([
+        ['label' => 'notes', 'path' => $this->extDir],
+        ['label' => 'notes', 'path' => $other],
+    ]))->pluck('path')->all();
+
+    expect($paths)->toContain('external/notes/note.md');
+    expect($paths)->toContain('external/notes-2/x.md');
+});
+
+test('drops configs with non-existent paths', function () {
+    $paths = collect($this->service->getEntries([
+        ['label' => 'good', 'path' => $this->extDir],
+        ['label' => 'gone', 'path' => '/this/path/does/not/exist'],
+    ]))->pluck('path')->all();
+
+    expect($paths)->toContain('external/good/note.md');
+    foreach ($paths as $p) {
+        expect($p)->not->toStartWith('external/gone');
+    }
+});
+
+test('resolveAbsolutePath round-trips a mount path back to its on-disk file', function () {
+    $absolute = $this->service->resolveAbsolutePath($this->configs, 'external/notes/note.md');
+
+    expect($absolute)->toBe(realpath($this->extDir.'/note.md'));
+});
+
+test('resolveAbsolutePath returns null for unknown mounts', function () {
+    expect($this->service->resolveAbsolutePath($this->configs, 'external/notes/missing.md'))->toBeNull();
+    expect($this->service->resolveAbsolutePath($this->configs, 'src/anything.php'))->toBeNull();
+});
+
+test('resolveAbsolutePath rejects path traversal escapes', function () {
+    $escape = 'external/notes/../../../etc/passwd';
+
+    expect($this->service->resolveAbsolutePath($this->configs, $escape))->toBeNull();
+});
+
+test('buildDiff emits a synthetic /dev/null whole-file diff', function () {
+    $absolute = $this->extDir.'/note.md';
+    $diff = $this->service->buildDiff($absolute, 'external/notes/note.md');
+
+    expect($diff)->toContain('diff --git a/external/notes/note.md b/external/notes/note.md');
+    expect($diff)->toContain('--- /dev/null');
+    expect($diff)->toContain('+++ b/external/notes/note.md');
+    expect($diff)->toContain('+# Title');
+    expect($diff)->toContain('+body');
+});
+
+test('buildDiff returns null for files larger than the configured cap', function () {
+    $absolute = $this->extDir.'/note.md';
+
+    expect($this->service->buildDiff($absolute, 'external/notes/note.md', maxBytes: 1))->toBeNull();
+});
+
+test('buildDiff returns empty string when the file no longer exists on disk', function () {
+    expect($this->service->buildDiff($this->extDir.'/missing.md', 'external/notes/missing.md'))->toBe('');
+});


### PR DESCRIPTION
## Summary
This PR adds the ability to link external directories (outside the git repository) to projects, allowing their files to appear in the review interface as commentable entries. External files are mounted under a synthetic `external/<label>/<path>` namespace and treated as "added" files in diffs.

## Key Changes

- **ExternalFilesService**: New service that manages external directory configuration, file discovery, and diff generation
  - Recursively walks configured directories (capped at 8 levels deep to prevent pathological walks)
  - Generates synthetic `FileListEntry` objects for each file
  - Builds unified diffs for external files (whole-file "added" view against `/dev/null`)
  - Handles binary file detection and path normalization
  - Provides path resolution from mount paths back to absolute filesystem paths with symlink/traversal protection

- **LinkExternalPathAction & UnlinkExternalPathAction**: Actions to manage external path configuration
  - `LinkExternalPathAction`: Appends external directories to a project (idempotent on canonical paths)
  - `UnlinkExternalPathAction`: Removes external paths by index
  - Both support label customization and validation

- **LinkExternalPathCommand**: CLI command to link external directories without UI
  - Accepts project reference (slug, name, or ID) and directory path
  - Optional `--label` flag for custom display names

- **Database migration**: Adds `external_paths` JSON column to projects table
  - Stores normalized `{label, path}` entries

- **Integration with existing systems**:
  - `GetFileListAction` now appends external file entries to the file list when viewing working directory
  - `LoadFileDiffAction` uses `ExternalFilesService` to build diffs for external files
  - `ResolveCommentAnchorAction` supports placing/validating comments on external files using content hashing
  - `AddCommentAction` stamps external file comments with `origin_ref=external`
  - `GitFileContentService` adds `hashAtAbsolute()` for hashing files outside the repo

- **UI integration** (review page):
  - New `addExternalPath()` and `removeExternalPath()` methods
  - Reloads file list and session state after external paths change
  - Stores external paths in component state

- **Enums & DTOs**:
  - Added `GitRef::External` sentinel for external file references
  - Extended `FileListEntry` with `isExternal` and `externalAbsolutePath` fields
  - Used `DiffSide` enum in place of string literals for type safety

## Notable Implementation Details

- External files are detected as binary by checking for NUL bytes in the first chunk during a single streaming pass
- Path traversal attacks are prevented by validating that resolved paths stay within the configured root using `realpath()`
- Duplicate labels are disambiguated with numeric suffixes (e.g., `notes-2`, `notes-3`)
- Comments on external files are anchored using file content hashing (xxh128) rather than git refs
- The synthetic mount path structure (`external/<label>/<relative>`) ensures stable file IDs across sessions

https://claude.ai/code/session_01Ps2Cmuacuxcm8oYWY8ZrHu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for linking external directories to projects; files in linked directories now appear in the review alongside git-tracked files and can receive comments.
  * Added UI controls in review page settings to manage linked external paths.
  * Added `rfa:link-path` console command for linking external directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->