### PR TITLE
Support search queries spanning multiple inline elements

### DIFF
--- a/public/js/page-search.js
+++ b/public/js/page-search.js
@@ -235,14 +235,8 @@
                             range.setEnd(seg.node, localEnd);
                             const span = document.createElement('span');
                             span.className = MATCH_CLASS;
-                            try {
-                                range.surroundContents(span);
-                                spans.unshift(span);
-                            } catch (_) {
-                                // surroundContents only throws when the range
-                                // partially selects a non-text node, which our
-                                // text-only ranges never do.
-                            }
+                            range.surroundContents(span);
+                            spans.unshift(span);
                         }
                         wrapped[i] = spans;
                     }

--- a/public/js/page-search.js
+++ b/public/js/page-search.js
@@ -12,8 +12,32 @@
     const CURRENT_CLASS = 'rfa-search-match--current';
     const SKIP_SELECTOR = 'script,style,noscript,iframe,input,textarea,[data-search-ignore]';
 
+    // Tag whitelist used to find the nearest block-level ancestor of a text
+    // node. Anything outside this set ends the walk; sibling text nodes
+    // sharing a block ancestor get joined for matching, so a query can span
+    // adjacent syntax-highlighter token spans (e.g. `'`, `local`, `'`)
+    // without bleeding across rows, cells, or paragraphs. Tag-based instead
+    // of getComputedStyle to keep the walker O(1) on big diffs.
+    const INLINE_TAGS = new Set([
+        'A', 'ABBR', 'B', 'BDI', 'BDO', 'BIG', 'CITE', 'CODE', 'DEL', 'DFN',
+        'EM', 'FONT', 'I', 'INS', 'KBD', 'MARK', 'OUTPUT', 'Q', 'RP', 'RT',
+        'RUBY', 'S', 'SAMP', 'SMALL', 'SPAN', 'STRONG', 'SUB', 'SUP', 'TIME',
+        'TT', 'U', 'VAR', 'WBR',
+    ]);
+
     function escapeRegex(value) {
         return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+
+    function findBlockAncestor(el, cache) {
+        const cached = cache.get(el);
+        if (cached) return cached;
+        let cursor = el;
+        while (cursor.parentElement && INLINE_TAGS.has(cursor.tagName)) {
+            cursor = cursor.parentElement;
+        }
+        cache.set(el, cursor);
+        return cursor;
     }
 
     function createPageSearch() {
@@ -21,7 +45,10 @@
             open: false,
             query: '',
             currentMatch: 0,
-            matchElements: [],
+            // Each entry is one logical match: an array of one or more spans.
+            // A query that crosses sibling text nodes wraps each piece in its
+            // own `.rfa-search-match` span, all grouped under a single entry.
+            matches: [],
 
             handleKeydown(e) {
                 if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
@@ -48,13 +75,13 @@
                     this.currentMatch = 0;
                     return;
                 }
-                this.matchElements = this.markMatches(this.query);
-                this.currentMatch = this.matchElements.length > 0 ? 1 : 0;
+                this.matches = this.markMatches(this.query);
+                this.currentMatch = this.matches.length > 0 ? 1 : 0;
                 this.updateCurrent(true);
             },
 
             find(backwards) {
-                const total = this.matchElements.length;
+                const total = this.matches.length;
                 if (total === 0) {
                     if (this.query) {
                         this.refresh();
@@ -70,17 +97,20 @@
             },
 
             updateCurrent(scroll) {
-                const badge = `${this.currentMatch} of ${this.matchElements.length}`;
-                this.matchElements.forEach((el, i) => {
+                const total = this.matches.length;
+                const badge = `${this.currentMatch} of ${total}`;
+                this.matches.forEach((spans, i) => {
                     const isCurrent = (i + 1) === this.currentMatch;
-                    el.classList.toggle(CURRENT_CLASS, isCurrent);
-                    if (isCurrent) {
-                        el.setAttribute('data-match-number', badge);
-                        if (scroll) {
-                            el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+                    spans.forEach((el, j) => {
+                        el.classList.toggle(CURRENT_CLASS, isCurrent);
+                        if (isCurrent && j === 0) {
+                            el.setAttribute('data-match-number', badge);
+                        } else {
+                            el.removeAttribute('data-match-number');
                         }
-                    } else {
-                        el.removeAttribute('data-match-number');
+                    });
+                    if (isCurrent && scroll && spans[0]) {
+                        spans[0].scrollIntoView({ block: 'center', behavior: 'smooth' });
                     }
                 });
             },
@@ -102,7 +132,7 @@
                     parents.add(parent);
                 });
                 parents.forEach(parent => parent.normalize());
-                this.matchElements = [];
+                this.matches = [];
             },
 
             markMatches(query) {
@@ -112,6 +142,7 @@
                 // so memoize the per-walk visibility answer to avoid re-walking
                 // the style chain for each one.
                 const visibility = new WeakMap();
+                const blockCache = new WeakMap();
                 const walker = document.createTreeWalker(
                     document.body,
                     NodeFilter.SHOW_TEXT,
@@ -136,51 +167,91 @@
                                 });
                                 visibility.set(parent, visible);
                             }
-                            if (!visible) return NodeFilter.FILTER_REJECT;
-                            // Substring check (not pattern.test) avoids
-                            // mutating the shared regex's lastIndex.
-                            return node.nodeValue.toLowerCase().includes(needle)
-                                ? NodeFilter.FILTER_ACCEPT
-                                : NodeFilter.FILTER_REJECT;
+                            return visible ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
                         },
                     }
                 );
 
-                const textNodes = [];
+                // Group accepted text nodes by their nearest block-level
+                // ancestor. Each block becomes one searchable string, so a
+                // query can cross sibling token spans inside a line but not
+                // hop between lines/cells/paragraphs.
+                const groups = new Map();
                 let node;
                 while ((node = walker.nextNode())) {
-                    textNodes.push(node);
+                    const block = findBlockAncestor(node.parentElement, blockCache);
+                    let bucket = groups.get(block);
+                    if (!bucket) {
+                        bucket = [];
+                        groups.set(block, bucket);
+                    }
+                    bucket.push(node);
                 }
 
                 const matches = [];
-                textNodes.forEach(textNode => {
-                    const text = textNode.nodeValue;
+                groups.forEach(textNodes => {
+                    const segments = [];
+                    let joined = '';
+                    textNodes.forEach(n => {
+                        const value = n.nodeValue;
+                        segments.push({ node: n, start: joined.length, length: value.length });
+                        joined += value;
+                    });
+                    if (joined.length === 0) return;
+                    // Cheap substring pre-check: the regex is just an escaped
+                    // literal, so if the lowercased needle isn't in the joined
+                    // string the regex can't match either.
+                    if (!joined.toLowerCase().includes(needle)) return;
+
                     pattern.lastIndex = 0;
-                    const fragments = [];
-                    let cursor = 0;
-                    let match;
-                    while ((match = pattern.exec(text)) !== null) {
-                        if (match.index > cursor) {
-                            fragments.push(document.createTextNode(text.slice(cursor, match.index)));
-                        }
-                        const span = document.createElement('span');
-                        span.className = MATCH_CLASS;
-                        span.textContent = match[0];
-                        fragments.push(span);
-                        matches.push(span);
-                        cursor = match.index + match[0].length;
-                        if (match[0].length === 0) {
+                    const ranges = [];
+                    let m;
+                    while ((m = pattern.exec(joined)) !== null) {
+                        if (m[0].length === 0) {
                             pattern.lastIndex++;
+                            continue;
                         }
+                        ranges.push([m.index, m.index + m[0].length]);
                     }
-                    if (fragments.length === 0) return;
-                    if (cursor < text.length) {
-                        fragments.push(document.createTextNode(text.slice(cursor)));
+                    if (ranges.length === 0) return;
+
+                    // Wrap each match's text-node ranges in their own
+                    // `.rfa-search-match` span. Process matches back-to-front
+                    // and segments back-to-front within a match so each DOM
+                    // split only invalidates offsets we've already handled.
+                    const wrapped = new Array(ranges.length);
+                    for (let i = ranges.length - 1; i >= 0; i--) {
+                        const [matchStart, matchEnd] = ranges[i];
+                        const spans = [];
+                        for (let s = segments.length - 1; s >= 0; s--) {
+                            const seg = segments[s];
+                            const segEnd = seg.start + seg.length;
+                            if (segEnd <= matchStart || seg.start >= matchEnd) continue;
+                            const localStart = Math.max(0, matchStart - seg.start);
+                            const localEnd = Math.min(seg.length, matchEnd - seg.start);
+                            if (localStart >= localEnd) continue;
+                            const range = document.createRange();
+                            range.setStart(seg.node, localStart);
+                            range.setEnd(seg.node, localEnd);
+                            const span = document.createElement('span');
+                            span.className = MATCH_CLASS;
+                            try {
+                                range.surroundContents(span);
+                                spans.unshift(span);
+                            } catch (_) {
+                                // surroundContents only throws when the range
+                                // partially selects a non-text node, which our
+                                // text-only ranges never do.
+                            }
+                        }
+                        wrapped[i] = spans;
                     }
-                    const parent = textNode.parentNode;
-                    fragments.forEach(fragment => parent.insertBefore(fragment, textNode));
-                    parent.removeChild(textNode);
+
+                    wrapped.forEach(spans => {
+                        if (spans && spans.length > 0) matches.push(spans);
+                    });
                 });
+
                 return matches;
             },
         };

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -260,7 +260,7 @@
                @keydown.escape.prevent="close()">
         <span x-show="query" role="status" aria-live="polite" aria-atomic="true"
               class="text-gh-muted text-xs font-mono tabular-nums shrink-0 min-w-[3rem] text-right"
-              x-text="matchElements.length === 0 ? 'No results' : currentMatch + ' of ' + matchElements.length"></span>
+              x-text="matches.length === 0 ? 'No results' : currentMatch + ' of ' + matches.length"></span>
         <button @click="find(true)" class="text-gh-muted hover:text-gh-text p-0.5" title="Previous (Shift+Enter)">
             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />

--- a/tests/Js/page-search.test.js
+++ b/tests/Js/page-search.test.js
@@ -60,16 +60,17 @@ describe('markMatches', () => {
         document.body.innerHTML = '';
     });
 
-    it('returns one span per match, wrapped with the match class', () => {
+    it('returns one group per match, each group is an array of one or more spans', () => {
         document.body.innerHTML = '<p>the cat sat on the cat mat</p>';
 
         const matches = data.markMatches('cat');
 
         expect(matches).toHaveLength(2);
-        matches.forEach((span) => {
-            expect(span.tagName).toBe('SPAN');
-            expect(span.classList.contains('rfa-search-match')).toBe(true);
-            expect(span.textContent).toBe('cat');
+        matches.forEach((spans) => {
+            expect(spans).toHaveLength(1);
+            expect(spans[0].tagName).toBe('SPAN');
+            expect(spans[0].classList.contains('rfa-search-match')).toBe(true);
+            expect(spans[0].textContent).toBe('cat');
         });
         expect(document.querySelectorAll('.rfa-search-match')).toHaveLength(2);
     });
@@ -80,7 +81,7 @@ describe('markMatches', () => {
         const matches = data.markMatches('Cat');
 
         expect(matches).toHaveLength(3);
-        expect(matches.map((m) => m.textContent)).toEqual(['Cat', 'cat', 'CAT']);
+        expect(matches.map(([span]) => span.textContent)).toEqual(['Cat', 'cat', 'CAT']);
     });
 
     it('skips text inside script, style, input, textarea, and [data-search-ignore]', () => {
@@ -98,8 +99,8 @@ describe('markMatches', () => {
 
         // Only the two visible <p> matches should be wrapped.
         expect(matches).toHaveLength(2);
-        expect(matches[0].closest('p').textContent).toBe('visible cat one');
-        expect(matches[1].closest('p').textContent).toBe('visible cat two');
+        expect(matches[0][0].closest('p').textContent).toBe('visible cat one');
+        expect(matches[1][0].closest('p').textContent).toBe('visible cat two');
     });
 
     it('skips text inside elements with display:none', () => {
@@ -111,7 +112,7 @@ describe('markMatches', () => {
         const matches = data.markMatches('cat');
 
         expect(matches).toHaveLength(1);
-        expect(matches[0].closest('p').textContent).toBe('visible cat');
+        expect(matches[0][0].closest('p').textContent).toBe('visible cat');
     });
 
     it('escapes special regex chars in the query', () => {
@@ -121,7 +122,32 @@ describe('markMatches', () => {
 
         // Only the literal period matches; '.' as a regex would match every char.
         expect(matches).toHaveLength(1);
-        expect(matches[0].textContent).toBe('.');
+        expect(matches[0][0].textContent).toBe('.');
+    });
+
+    it('matches a query that spans sibling syntax-highlighter token spans', () => {
+        // Phiki renders `'local'` as three sibling token spans, each with its
+        // own text node. The old per-text-node search couldn't match across
+        // that boundary; this guards against regressing.
+        document.body.innerHTML = "<p><span>'</span><span>local</span><span>'</span></p>";
+
+        const matches = data.markMatches("'local'");
+
+        expect(matches).toHaveLength(1);
+        expect(matches[0]).toHaveLength(3);
+        expect(matches[0].map((s) => s.textContent).join('')).toBe("'local'");
+        // One logical match, but rendered as three pieces (one per crossed text node).
+        expect(document.querySelectorAll('.rfa-search-match')).toHaveLength(3);
+    });
+
+    it('does not match across block-level boundaries', () => {
+        // Joining text across separate <p>s would let "ab" match across lines.
+        document.body.innerHTML = '<p>a</p><p>b</p>';
+
+        const matches = data.markMatches('ab');
+
+        expect(matches).toHaveLength(0);
+        expect(document.querySelectorAll('.rfa-search-match')).toHaveLength(0);
     });
 });
 
@@ -142,7 +168,7 @@ describe('refresh', () => {
 
         data.refresh();
 
-        expect(data.matchElements).toHaveLength(0);
+        expect(data.matches).toHaveLength(0);
         expect(data.currentMatch).toBe(0);
         expect(document.querySelectorAll('.rfa-search-match')).toHaveLength(0);
     });
@@ -164,7 +190,7 @@ describe('find', () => {
         data.query = 'cat';
         data.refresh();
 
-        expect(data.matchElements).toHaveLength(3);
+        expect(data.matches).toHaveLength(3);
         expect(data.currentMatch).toBe(1);
 
         data.find(false);
@@ -185,23 +211,23 @@ describe('find', () => {
         expect(data.currentMatch).toBe(2);
     });
 
-    it('triggers a refresh when matchElements is empty but query is set', () => {
+    it('triggers a refresh when matches is empty but query is set', () => {
         data.query = 'cat';
-        // Note: no refresh() call before find(). matchElements starts as [].
-        expect(data.matchElements).toHaveLength(0);
+        // Note: no refresh() call before find(). matches starts as [].
+        expect(data.matches).toHaveLength(0);
 
         data.find(false);
 
-        expect(data.matchElements).toHaveLength(3);
+        expect(data.matches).toHaveLength(3);
         expect(data.currentMatch).toBe(1);
     });
 
-    it('is a no-op when query is empty and matchElements is empty', () => {
+    it('is a no-op when query is empty and matches is empty', () => {
         data.query = '';
 
         data.find(false);
 
-        expect(data.matchElements).toHaveLength(0);
+        expect(data.matches).toHaveLength(0);
         expect(data.currentMatch).toBe(0);
         expect(document.querySelectorAll('.rfa-search-match')).toHaveLength(0);
     });
@@ -236,7 +262,20 @@ describe('clearMarks', () => {
         expect(p.textContent).toBe(originalText);
         // normalize() should merge adjacent text nodes back into a single text node.
         expect(p.childNodes.length).toBe(originalChildCount);
-        expect(data.matchElements).toEqual([]);
+        expect(data.matches).toEqual([]);
+    });
+
+    it('round-trips a cross-text-node match without leaving stray spans', () => {
+        const original = "<span>'</span><span>local</span><span>'</span>";
+        document.body.innerHTML = `<p>${original}</p>`;
+
+        data.markMatches("'local'");
+        expect(document.querySelectorAll('.rfa-search-match')).toHaveLength(3);
+
+        data.clearMarks();
+
+        expect(document.querySelectorAll('.rfa-search-match')).toHaveLength(0);
+        expect(document.querySelector('p').innerHTML).toBe(original);
     });
 });
 
@@ -257,7 +296,7 @@ describe('close', () => {
         data.query = 'cat';
         data.refresh();
 
-        expect(data.matchElements.length).toBeGreaterThan(0);
+        expect(data.matches.length).toBeGreaterThan(0);
         expect(data.currentMatch).toBe(1);
 
         data.close();
@@ -288,28 +327,47 @@ describe('updateCurrent', () => {
         data.refresh();
 
         // After refresh, currentMatch === 1; badge should be on the first match.
-        expect(data.matchElements[0].getAttribute('data-match-number')).toBe('1 of 3');
-        expect(data.matchElements[1].hasAttribute('data-match-number')).toBe(false);
-        expect(data.matchElements[2].hasAttribute('data-match-number')).toBe(false);
+        expect(data.matches[0][0].getAttribute('data-match-number')).toBe('1 of 3');
+        expect(data.matches[1][0].hasAttribute('data-match-number')).toBe(false);
+        expect(data.matches[2][0].hasAttribute('data-match-number')).toBe(false);
 
         data.find(false);
 
-        expect(data.matchElements[0].hasAttribute('data-match-number')).toBe(false);
-        expect(data.matchElements[1].getAttribute('data-match-number')).toBe('2 of 3');
-        expect(data.matchElements[2].hasAttribute('data-match-number')).toBe(false);
+        expect(data.matches[0][0].hasAttribute('data-match-number')).toBe(false);
+        expect(data.matches[1][0].getAttribute('data-match-number')).toBe('2 of 3');
+        expect(data.matches[2][0].hasAttribute('data-match-number')).toBe(false);
     });
 
     it('toggles the rfa-search-match--current class to track the current match', () => {
         data.query = 'cat';
         data.refresh();
 
-        expect(data.matchElements[0].classList.contains('rfa-search-match--current')).toBe(true);
-        expect(data.matchElements[1].classList.contains('rfa-search-match--current')).toBe(false);
+        expect(data.matches[0][0].classList.contains('rfa-search-match--current')).toBe(true);
+        expect(data.matches[1][0].classList.contains('rfa-search-match--current')).toBe(false);
 
         data.find(false);
 
-        expect(data.matchElements[0].classList.contains('rfa-search-match--current')).toBe(false);
-        expect(data.matchElements[1].classList.contains('rfa-search-match--current')).toBe(true);
+        expect(data.matches[0][0].classList.contains('rfa-search-match--current')).toBe(false);
+        expect(data.matches[1][0].classList.contains('rfa-search-match--current')).toBe(true);
+    });
+
+    it('toggles the current class on every span of a multi-piece match', () => {
+        document.body.innerHTML = "<p><span>'</span><span>local</span><span>'</span></p>";
+        data.query = "'local'";
+        data.refresh();
+
+        expect(data.matches).toHaveLength(1);
+        const [spans] = data.matches;
+        expect(spans).toHaveLength(3);
+
+        spans.forEach((span) => {
+            expect(span.classList.contains('rfa-search-match--current')).toBe(true);
+        });
+        // Badge sits on the first piece only so the "X of Y" indicator
+        // doesn't render once per crossed token span.
+        expect(spans[0].getAttribute('data-match-number')).toBe('1 of 1');
+        expect(spans[1].hasAttribute('data-match-number')).toBe(false);
+        expect(spans[2].hasAttribute('data-match-number')).toBe(false);
     });
 });
 


### PR DESCRIPTION
## Summary
Enhanced the page search functionality to match queries that span across sibling inline elements (such as syntax-highlighter token spans), while preventing matches from crossing block-level boundaries (paragraphs, table cells, etc.).

## Key Changes

- **Added `INLINE_TAGS` whitelist**: Defines which HTML tags are considered inline, used to identify block-level ancestors for grouping text nodes.

- **Introduced `findBlockAncestor()` function**: Walks up the DOM tree to find the nearest block-level ancestor of a text node, with caching to optimize performance on large diffs.

- **Refactored match storage structure**: Changed `matchElements` to `matches`, where each entry is now an array of one or more spans representing a single logical match. This allows a single query match to be rendered across multiple DOM nodes.

- **Rewrote `markMatches()` algorithm**:
  - Groups text nodes by their block-level ancestor before searching
  - Joins text within each block group to enable cross-sibling matching
  - Processes matches back-to-front to avoid invalidating DOM offsets during wrapping
  - Creates separate `<span>` elements for each text node piece of a multi-node match

- **Updated `updateCurrent()` logic**: Now iterates through all spans in a match group, applying the current class to all pieces while placing the badge only on the first span to avoid duplicate indicators.

- **Enhanced test coverage**: Added tests for cross-text-node matching, block-boundary enforcement, and round-trip clearing of complex matches.

## Implementation Details

The key insight is grouping text nodes by block-level ancestor before regex matching. This allows queries like `'local'` (rendered as three sibling spans: `'`, `local`, `'`) to match as a single logical unit, while preventing matches from spanning across `<p>`, `<td>`, or other block elements. The back-to-front processing of matches ensures DOM mutations don't affect offset calculations for subsequent matches.

https://claude.ai/code/session_01RDHJSeDrihB1U6rHYZtKFs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced search to properly detect and highlight matches spanning adjacent text segments within the same document block.
  * Corrected match counter to display accurate result count.
  * Improved search result navigation for multi-segment matches.
  * Search now respects document structure boundaries when identifying results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->