### PR TITLE
Fix Since-mode auto-update on commit and restore on reopen

### DIFF
--- a/resources/views/livewire/head-divergence-poller.blade.php
+++ b/resources/views/livewire/head-divergence-poller.blade.php
@@ -14,18 +14,24 @@ new class extends Component
     #[Locked]
     public string $target = '';
 
+    /** Branch + detached + targetExists. Changes here flip a banner. */
     #[Locked]
-    public string $fingerprint = '';
+    public string $identity = '';
+
+    /** Empty until first successful prime; doubles as the "primed" flag. */
+    #[Locked]
+    public string $sha = '';
 
     public function mount(): void
     {
-        // Prime the fingerprint so the first poll after mount does not dispatch
-        // unless HEAD actually moves. The parent's own mount() already ran
+        // Prime so the first poll after mount does not dispatch unless HEAD
+        // actually moves. The parent's own mount() already ran
         // checkHeadDivergence once; we don't need to force a second round-trip.
         $head = app(GetCurrentHeadAction::class)->handle($this->repoPath, $this->target !== '' ? $this->target : null);
 
         if ($head->sha !== '') {
-            $this->fingerprint = $this->fingerprintOf($head);
+            $this->identity = $this->identityOf($head);
+            $this->sha = $head->sha;
         }
     }
 
@@ -41,25 +47,42 @@ new class extends Component
             return;
         }
 
-        $next = $this->fingerprintOf($head);
+        $nextIdentity = $this->identityOf($head);
+        $identityChanged = $nextIdentity !== $this->identity;
+        $shaChanged = $head->sha !== $this->sha;
 
-        if ($next === $this->fingerprint) {
+        if (! $identityChanged && ! $shaChanged) {
             return;
         }
 
-        $this->fingerprint = $next;
-        $this->dispatch('head-divergence-transitioned');
+        $primed = $this->sha !== '';
+        $this->identity = $nextIdentity;
+        $this->sha = $head->sha;
+
+        // A primed identity transition (branch switch, detach, target gone)
+        // is a banner-only concern — recompute divergence without re-reading
+        // the file list. Everything else (sha-only advance OR a post-recovery
+        // first prime where we don't know what mount-time HEAD was) leaves
+        // the file list potentially stale; route it through softRefresh,
+        // which re-reads files AND recomputes divergence.
+        if ($primed && $identityChanged) {
+            $this->dispatch('head-divergence-transitioned');
+
+            return;
+        }
+
+        $this->dispatch('head-advanced-on-branch');
     }
 
-    private function fingerprintOf(CurrentHeadResult $head): string
+    private function identityOf(CurrentHeadResult $head): string
     {
-        $targetExists = match ($head->targetExists) {
+        $exists = match ($head->targetExists) {
             true => '1',
             false => '0',
             null => 'n',
         };
 
-        return ($head->branch ?? '').'|'.$head->sha.'|'.($head->detached ? '1' : '0').'|'.$targetExists;
+        return ($head->branch ?? '').'|'.($head->detached ? '1' : '0').'|'.$exists;
     }
 };
 ?>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -426,6 +426,24 @@ new #[Layout('layouts.app')] class extends Component
     }
 
     /**
+     * HEAD advanced on the same branch the user is reviewing — typically
+     * because they just committed. Reload the file list so the diff reflects
+     * the new commit. Commit/range modes pin both endpoints, so a HEAD move
+     * cannot affect what's shown; skip render in that case.
+     */
+    #[On('head-advanced-on-branch')]
+    public function refreshAfterHeadAdvance(): void
+    {
+        if ($this->isCommitMode()) {
+            $this->skipRender();
+
+            return;
+        }
+
+        $this->softRefresh();
+    }
+
+    /**
      * Recompute divergence state. Returns true if state changed since the last
      * check (i.e. the caller should render), false when the caller can skip.
      * Kept separate from `checkHeadDivergence()` so callers like `softRefresh`

--- a/tests/Unit/Livewire/HeadDivergencePollerTest.php
+++ b/tests/Unit/Livewire/HeadDivergencePollerTest.php
@@ -30,7 +30,8 @@ test('mount primes the fingerprint without dispatching', function () {
     $poller = Livewire::test('head-divergence-poller', ['repoPath' => '/tmp/repo', 'target' => 'main']);
 
     $poller->assertNotDispatched('head-divergence-transitioned');
-    expect($poller->get('fingerprint'))->not->toBe('');
+    expect($poller->get('sha'))->not->toBe('');
+    expect($poller->get('identity'))->not->toBe('');
 });
 
 test('poll after mount on an unchanged HEAD does not dispatch', function () {
@@ -46,10 +47,11 @@ test('mount does not prime when git is transiently failing', function () {
 
     $poller = Livewire::test('head-divergence-poller', ['repoPath' => '/tmp/repo', 'target' => 'main']);
 
-    expect($poller->get('fingerprint'))->toBe('');
+    expect($poller->get('sha'))->toBe('');
+    expect($poller->get('identity'))->toBe('');
 });
 
-test('poll dispatches again when SHA changes', function () {
+test('poll dispatches head-advanced-on-branch when only the SHA changes', function () {
     $fake = bindFakeHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
 
     $poller = Livewire::test('head-divergence-poller', ['repoPath' => '/tmp/repo', 'target' => 'main']);
@@ -57,7 +59,9 @@ test('poll dispatches again when SHA changes', function () {
 
     $fake->result = new CurrentHeadResult(branch: 'main', sha: 'b'.str_repeat('0', 39), detached: false, targetExists: true);
 
-    $poller->call('poll')->assertDispatched('head-divergence-transitioned');
+    $poller->call('poll')
+        ->assertDispatched('head-advanced-on-branch')
+        ->assertNotDispatched('head-divergence-transitioned');
 });
 
 test('poll dispatches again when branch changes', function () {
@@ -68,7 +72,22 @@ test('poll dispatches again when branch changes', function () {
 
     $fake->result = new CurrentHeadResult(branch: 'feature-x', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true);
 
-    $poller->call('poll')->assertDispatched('head-divergence-transitioned');
+    $poller->call('poll')
+        ->assertDispatched('head-divergence-transitioned')
+        ->assertNotDispatched('head-advanced-on-branch');
+});
+
+test('poll dispatches divergence (not advance) when branch and SHA both change', function () {
+    $fake = bindFakeHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
+
+    $poller = Livewire::test('head-divergence-poller', ['repoPath' => '/tmp/repo', 'target' => 'main']);
+    $poller->call('poll');
+
+    $fake->result = new CurrentHeadResult(branch: 'feature-x', sha: 'b'.str_repeat('0', 39), detached: false, targetExists: true);
+
+    $poller->call('poll')
+        ->assertDispatched('head-divergence-transitioned')
+        ->assertNotDispatched('head-advanced-on-branch');
 });
 
 test('poll dispatches again when detached flag flips', function () {
@@ -93,17 +112,39 @@ test('poll dispatches again when targetExists flips', function () {
     $poller->call('poll')->assertDispatched('head-divergence-transitioned');
 });
 
+test('first successful poll after a sentinel mount dispatches head-advanced-on-branch', function () {
+    // Scenario: GetCurrentHeadAction returns the sentinel during mount (mid-rebase
+    // or lock contention). A commit may have landed during the transient window,
+    // so the file list captured at mount is potentially stale. Surfacing this as
+    // head-advanced-on-branch routes through softRefresh, which re-reads files
+    // AND recomputes divergence. Dispatching only head-divergence-transitioned
+    // would leave the diff stuck at the pre-recovery snapshot for same-branch
+    // HEADs (the page sees no banner change and skipRenders).
+    $fake = bindFakeHeadAction(new CurrentHeadResult(branch: null, sha: '', detached: false));
+
+    $poller = Livewire::test('head-divergence-poller', ['repoPath' => '/tmp/repo', 'target' => 'main']);
+    expect($poller->get('sha'))->toBe('');
+
+    $fake->result = new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true);
+
+    $poller->call('poll')
+        ->assertDispatched('head-advanced-on-branch')
+        ->assertNotDispatched('head-divergence-transitioned');
+});
+
 test('sentinel result (empty sha) does not dispatch and does not advance fingerprint', function () {
     $fake = bindFakeHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
 
     $poller = Livewire::test('head-divergence-poller', ['repoPath' => '/tmp/repo', 'target' => 'main']);
     $poller->call('poll');
 
-    $established = $poller->get('fingerprint');
+    $establishedSha = $poller->get('sha');
+    $establishedIdentity = $poller->get('identity');
 
     // Simulate transient git failure (mid-rebase, lock contention).
     $fake->result = new CurrentHeadResult(branch: null, sha: '', detached: false);
     $poller->call('poll')->assertNotDispatched('head-divergence-transitioned');
 
-    expect($poller->get('fingerprint'))->toBe($established);
+    expect($poller->get('sha'))->toBe($establishedSha);
+    expect($poller->get('identity'))->toBe($establishedIdentity);
 });

--- a/tests/Unit/Livewire/ReviewPageSoftRefreshTest.php
+++ b/tests/Unit/Livewire/ReviewPageSoftRefreshTest.php
@@ -152,3 +152,31 @@ test('softRefresh with no file changes and stable divergence skips the render', 
 
     expect($component->effects['html'] ?? null)->toBeNull();
 });
+
+test('head-advanced-on-branch triggers softRefresh and dispatches refresh-completed', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'soft-refresh-test']);
+
+    // Simulate a new commit landing on the branch the user is reviewing —
+    // the file list now reflects post-commit state.
+    $this->fileListFake->files = [
+        ['id' => 'abc123', 'path' => 'src/Foo.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 12, 'deletions' => 3, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T02:00:00Z', 'fileSize' => '150'],
+        ['id' => 'new789', 'path' => 'src/JustCommitted.php', 'status' => 'added', 'oldPath' => null, 'additions' => 20, 'deletions' => 0, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T02:00:00Z', 'fileSize' => '300'],
+    ];
+
+    $component->call('refreshAfterHeadAdvance')
+        ->assertDispatched('fingerprint-reset')
+        ->assertDispatched('refresh-completed')
+        ->assertSee('src/JustCommitted.php');
+});
+
+test('head-advanced-on-branch is a no-op in commit/range mode', function () {
+    $component = Livewire::test('pages::review-page', [
+        'slug' => 'soft-refresh-test',
+        'from' => 'aaaa111',
+        'to' => 'bbbb222',
+    ]);
+
+    $component->call('refreshAfterHeadAdvance')
+        ->assertNotDispatched('fingerprint-reset')
+        ->assertNotDispatched('refresh-completed');
+});


### PR DESCRIPTION
Two related bugs in the Since-{branch} review flow:

- The page never refreshed when the user committed on the branch they
  were reviewing. head-divergence-poller detected the HEAD move but
  resolveDivergenceState short-circuited to markAligned() for same-branch
  advances, so files stayed pinned to the pre-commit diff. Split the
  fingerprint into identity (branch + detached + targetExists) and SHA;
  same-branch SHA-only advances now dispatch a new
  head-advanced-on-branch event that the page handles by calling
  softRefresh(). Identity changes still go through the existing
  divergence pathway.

- Reopening the app always landed on the bare working-tree URL because
  ResolveStartupRouteAction only cached the slug. Cache the matched
  route name + params alongside the slug, and reconstruct the URL on
  startup. Restorable routes are gated to review-page* and the cached
  view is dropped when the slug changes or route() throws.

https://claude.ai/code/session_01VwemDrKMWxXnDc56p7zRED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The app now remembers the exact page and view parameters when you reopen a project, restoring you to your previous location (e.g., specific commit or range view).

* **Improvements**
  * Enhanced repository state detection to distinguish between branch switches, detached HEAD states, and new commits.
  * Improved refresh behavior when the repository HEAD changes during your work session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->