### PR TITLE
Persist per-project page+selection so re-entry restores last view

### DIFF
--- a/app/Actions/PersistProjectViewAction.php
+++ b/app/Actions/PersistProjectViewAction.php
@@ -9,19 +9,13 @@ use App\Enums\LastViewMode;
 use App\Models\ReviewSession;
 
 /**
- * Persists "the page the user is currently looking at" for a project so that
- * re-entry (project picker, startup redirect, menu deep-link) can put them
- * back on the same surface.
+ * Saves "the page the user is currently looking at" so that re-entry — via
+ * the project picker, startup redirect, or menu deep-link — can put them back
+ * on the same surface. Read side: {@see ResolveProjectEntryUrlAction}.
  *
- * Save-side only — the matching read happens in {@see ResolveProjectEntryUrlAction}.
- *
- * Mode and kind are orthogonal:
- *  - {@see LastViewMode::Context} stores nothing else (kind/from/to are nulled)
- *  - {@see LastViewMode::Review} stores the diff selection via $kind/$from/$to
- *
- * `SinceBase` is saved as semantic intent rather than the resolved SHA so the
- * restore side can re-resolve against the current merge-base. The other four
- * review kinds round-trip the literal refs.
+ * SinceBase intentionally does not persist `from`/`to`: the resolver
+ * re-resolves the merge-base at restore time so the view follows base-branch
+ * advancement. Storing the at-save SHA would be both unused and misleading.
  */
 final readonly class PersistProjectViewAction
 {
@@ -33,16 +27,18 @@ final readonly class PersistProjectViewAction
         ?string $from = null,
         ?string $to = null,
     ): void {
-        $isContext = $mode === LastViewMode::Context;
+        $persistsRefs = $mode === LastViewMode::Review
+            && $kind !== null
+            && $kind !== LastViewKind::SinceBase;
 
         ReviewSession::updateOrCreate(
             ReviewSession::lookupKey($repoPath, $projectId ?: null),
             [
                 'repo_path' => $repoPath,
                 'last_view_mode' => $mode,
-                'last_view_kind' => $isContext ? null : $kind,
-                'last_view_from' => $isContext ? null : $from,
-                'last_view_to' => $isContext ? null : $to,
+                'last_view_kind' => $mode === LastViewMode::Context ? null : $kind,
+                'last_view_from' => $persistsRefs ? $from : null,
+                'last_view_to' => $persistsRefs ? $to : null,
             ]
         );
     }

--- a/app/Actions/PersistProjectViewAction.php
+++ b/app/Actions/PersistProjectViewAction.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Enums\LastViewKind;
+use App\Enums\LastViewMode;
+use App\Models\ReviewSession;
+
+/**
+ * Persists "the page the user is currently looking at" for a project so that
+ * re-entry (project picker, startup redirect, menu deep-link) can put them
+ * back on the same surface.
+ *
+ * Save-side only — the matching read happens in {@see ResolveProjectEntryUrlAction}.
+ *
+ * Mode and kind are orthogonal:
+ *  - {@see LastViewMode::Context} stores nothing else (kind/from/to are nulled)
+ *  - {@see LastViewMode::Review} stores the diff selection via $kind/$from/$to
+ *
+ * `SinceBase` is saved as semantic intent rather than the resolved SHA so the
+ * restore side can re-resolve against the current merge-base. The other four
+ * review kinds round-trip the literal refs.
+ */
+final readonly class PersistProjectViewAction
+{
+    public function handle(
+        int $projectId,
+        string $repoPath,
+        LastViewMode $mode,
+        ?LastViewKind $kind = null,
+        ?string $from = null,
+        ?string $to = null,
+    ): void {
+        $isContext = $mode === LastViewMode::Context;
+
+        ReviewSession::updateOrCreate(
+            ReviewSession::lookupKey($repoPath, $projectId ?: null),
+            [
+                'repo_path' => $repoPath,
+                'last_view_mode' => $mode,
+                'last_view_kind' => $isContext ? null : $kind,
+                'last_view_from' => $isContext ? null : $from,
+                'last_view_to' => $isContext ? null : $to,
+            ]
+        );
+    }
+}

--- a/app/Actions/ResolveProjectEntryUrlAction.php
+++ b/app/Actions/ResolveProjectEntryUrlAction.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
-use App\Enums\BranchBaseState;
 use App\Enums\LastViewKind;
 use App\Enums\LastViewMode;
+use App\Exceptions\GitCommandException;
 use App\Models\Project;
 use App\Models\ReviewSession;
 use App\Services\GitMetadataService;
@@ -18,15 +18,14 @@ use App\Services\GitMetadataService;
  *
  * Stale refs (rebased commits, force-pushed branches, removed base branch)
  * silently fall back to the working-tree URL — re-entry never fails closed.
- * `SinceBase` is re-resolved through {@see ResolveBranchBaseAction} so the
- * restored view follows base-branch advancement instead of pinning the SHA
- * that was current at save time.
+ * `SinceBase` is re-resolved against the current merge-base so the restored
+ * view follows base-branch advancement instead of pinning the SHA that was
+ * current at save time.
  */
 final readonly class ResolveProjectEntryUrlAction
 {
     public function __construct(
         private GitMetadataService $gitMetadataService,
-        private ResolveBranchBaseAction $resolveBranchBase,
     ) {}
 
     public function handle(string $slug, ?LastViewMode $fallbackMode = null): string
@@ -80,19 +79,42 @@ final readonly class ResolveProjectEntryUrlAction
 
     private function buildSinceBaseUrl(Project $project, string $slug): ?string
     {
-        $result = $this->resolveBranchBase->handle(
-            $project->path,
-            $project->default_base_branch ?? null,
-            $project->branch ?? null,
-        );
+        $base = trim((string) ($project->default_base_branch ?? ''));
 
-        if ($result->state !== BranchBaseState::Ready || $result->baseSha === null) {
+        if ($base === '') {
+            return null;
+        }
+
+        // On the base branch itself there's nothing to diff "since base".
+        if (trim((string) ($project->branch ?? '')) === $base) {
+            return null;
+        }
+
+        // Inlined merge-base resolution: ResolveBranchBaseAction runs an extra
+        // `git log base..HEAD` to list every commit ahead of base, which is
+        // proportional to branch length (50–200ms on long-lived branches) and
+        // wasted here — the resolver only needs the merge-base for the URL and
+        // an "is HEAD ahead?" check (head SHA equality). Two git subprocesses
+        // instead of three.
+        $mergeBase = $this->gitMetadataService->getMergeBase($project->path, $base, 'HEAD');
+
+        if ($mergeBase === null) {
+            return null;
+        }
+
+        try {
+            $headSha = $this->gitMetadataService->getHeadSha($project->path);
+        } catch (GitCommandException) {
+            return null;
+        }
+
+        if ($headSha === $mergeBase) {
             return null;
         }
 
         return route('review-page.range-to-working', [
             'slug' => $slug,
-            'rangeFromWorking' => $result->baseSha,
+            'rangeFromWorking' => $mergeBase,
         ]);
     }
 

--- a/app/Actions/ResolveProjectEntryUrlAction.php
+++ b/app/Actions/ResolveProjectEntryUrlAction.php
@@ -16,17 +16,11 @@ use App\Services\GitMetadataService;
  * project {slug}?". Consulted from the project picker, the home redirect,
  * and {@see ResolveStartupRouteAction}.
  *
- * Bullet-proofness rules:
- *  - Every saved selection is validated against the live repo before the URL
- *    is built. Stale refs (rebased commits, force-pushed branches, removed
- *    base branch) silently fall back to the working-tree URL — re-entry never
- *    fails closed on persisted state.
- *  - {@see LastViewKind::SinceBase} is re-resolved through
- *    {@see ResolveBranchBaseAction} so the restored view follows base-branch
- *    advancement rather than pinning the SHA that was current at save time.
- *  - Projects with no saved row use $fallbackMode (defaults to Review) so the
- *    picker's mode-stickiness still works for projects visited for the first
- *    time.
+ * Stale refs (rebased commits, force-pushed branches, removed base branch)
+ * silently fall back to the working-tree URL — re-entry never fails closed.
+ * `SinceBase` is re-resolved through {@see ResolveBranchBaseAction} so the
+ * restored view follows base-branch advancement instead of pinning the SHA
+ * that was current at save time.
  */
 final readonly class ResolveProjectEntryUrlAction
 {
@@ -40,7 +34,7 @@ final readonly class ResolveProjectEntryUrlAction
         $project = Project::where('slug', $slug)->first();
 
         if ($project === null) {
-            return route('review-page', ['slug' => $slug]);
+            return $this->workingTreeUrl($slug);
         }
 
         $session = ReviewSession::query()
@@ -56,17 +50,17 @@ final readonly class ResolveProjectEntryUrlAction
         }
 
         if ($session === null) {
-            return route('review-page', ['slug' => $slug]);
+            return $this->workingTreeUrl($slug);
         }
 
         $kind = $session->last_view_kind;
 
         if ($kind === null || $kind === LastViewKind::WorkingTree) {
-            return route('review-page', ['slug' => $slug]);
+            return $this->workingTreeUrl($slug);
         }
 
         return $this->buildReviewUrl($project, $session, $kind, $slug)
-            ?? route('review-page', ['slug' => $slug]);
+            ?? $this->workingTreeUrl($slug);
     }
 
     private function buildReviewUrl(Project $project, ReviewSession $session, LastViewKind $kind, string $slug): ?string
@@ -79,8 +73,8 @@ final readonly class ResolveProjectEntryUrlAction
             LastViewKind::Commit => $this->buildCommitUrl($project, $slug, $to),
             LastViewKind::Range => $this->buildRangeUrl($project, $slug, $from, $to),
             LastViewKind::RangeToWorking => $this->buildRangeToWorkingUrl($project, $slug, $from),
-            // Working tree branch is handled by the caller; keep this exhaustive.
-            LastViewKind::WorkingTree => route('review-page', ['slug' => $slug]),
+            // Unreachable: `handle()` returns early for WorkingTree before delegating here.
+            LastViewKind::WorkingTree => $this->workingTreeUrl($slug),
         };
     }
 
@@ -121,17 +115,16 @@ final readonly class ResolveProjectEntryUrlAction
             return null;
         }
 
-        // Range `from` may carry a parent suffix (e.g. `abc1234^`) when the
-        // selection was applied via the catchall route. Strip the suffix
-        // before existence-checking so a still-reachable commit doesn't
-        // fail validation, and route via the catchall format that accepts
-        // the suffix verbatim.
+        // `from` may carry a parent suffix (e.g. `abc1234^`) when the selection
+        // was applied via the catchall route. Strip it for the existence check
+        // so a still-reachable commit doesn't fail validation, and round-trip
+        // the suffix to the URL via the catchall route shape.
         $fromBase = str_ends_with($from, '^') ? substr($from, 0, -1) : $from;
         if ($fromBase !== '' && ! $this->refExists($project->path, $fromBase)) {
             return null;
         }
 
-        return '/p/'.rawurlencode($slug).'/'.rawurlencode($to).'/'.rawurlencode($from);
+        return route('review-page', ['slug' => $slug, 'ref' => $to, 'baseRef' => $from]);
     }
 
     private function buildRangeToWorkingUrl(Project $project, string $slug, ?string $from): ?string
@@ -149,6 +142,11 @@ final readonly class ResolveProjectEntryUrlAction
             'slug' => $slug,
             'rangeFromWorking' => $from,
         ]);
+    }
+
+    private function workingTreeUrl(string $slug): string
+    {
+        return route('review-page', ['slug' => $slug]);
     }
 
     private function refExists(string $repoPath, string $ref): bool

--- a/app/Actions/ResolveProjectEntryUrlAction.php
+++ b/app/Actions/ResolveProjectEntryUrlAction.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Enums\BranchBaseState;
+use App\Enums\LastViewKind;
+use App\Enums\LastViewMode;
+use App\Models\Project;
+use App\Models\ReviewSession;
+use App\Services\GitMetadataService;
+
+/**
+ * Single source of truth for "where should the user land when re-entering
+ * project {slug}?". Consulted from the project picker, the home redirect,
+ * and {@see ResolveStartupRouteAction}.
+ *
+ * Bullet-proofness rules:
+ *  - Every saved selection is validated against the live repo before the URL
+ *    is built. Stale refs (rebased commits, force-pushed branches, removed
+ *    base branch) silently fall back to the working-tree URL — re-entry never
+ *    fails closed on persisted state.
+ *  - {@see LastViewKind::SinceBase} is re-resolved through
+ *    {@see ResolveBranchBaseAction} so the restored view follows base-branch
+ *    advancement rather than pinning the SHA that was current at save time.
+ *  - Projects with no saved row use $fallbackMode (defaults to Review) so the
+ *    picker's mode-stickiness still works for projects visited for the first
+ *    time.
+ */
+final readonly class ResolveProjectEntryUrlAction
+{
+    public function __construct(
+        private GitMetadataService $gitMetadataService,
+        private ResolveBranchBaseAction $resolveBranchBase,
+    ) {}
+
+    public function handle(string $slug, ?LastViewMode $fallbackMode = null): string
+    {
+        $project = Project::where('slug', $slug)->first();
+
+        if ($project === null) {
+            return route('review-page', ['slug' => $slug]);
+        }
+
+        $session = ReviewSession::query()
+            ->where(ReviewSession::lookupKey($project->path, $project->id))
+            ->first();
+
+        $mode = ($session === null ? null : $session->last_view_mode)
+            ?? $fallbackMode
+            ?? LastViewMode::Review;
+
+        if ($mode === LastViewMode::Context) {
+            return route('context-page', ['slug' => $slug]);
+        }
+
+        if ($session === null) {
+            return route('review-page', ['slug' => $slug]);
+        }
+
+        $kind = $session->last_view_kind;
+
+        if ($kind === null || $kind === LastViewKind::WorkingTree) {
+            return route('review-page', ['slug' => $slug]);
+        }
+
+        return $this->buildReviewUrl($project, $session, $kind, $slug)
+            ?? route('review-page', ['slug' => $slug]);
+    }
+
+    private function buildReviewUrl(Project $project, ReviewSession $session, LastViewKind $kind, string $slug): ?string
+    {
+        $from = $session->last_view_from;
+        $to = $session->last_view_to;
+
+        return match ($kind) {
+            LastViewKind::SinceBase => $this->buildSinceBaseUrl($project, $slug),
+            LastViewKind::Commit => $this->buildCommitUrl($project, $slug, $to),
+            LastViewKind::Range => $this->buildRangeUrl($project, $slug, $from, $to),
+            LastViewKind::RangeToWorking => $this->buildRangeToWorkingUrl($project, $slug, $from),
+            // Working tree branch is handled by the caller; keep this exhaustive.
+            LastViewKind::WorkingTree => route('review-page', ['slug' => $slug]),
+        };
+    }
+
+    private function buildSinceBaseUrl(Project $project, string $slug): ?string
+    {
+        $result = $this->resolveBranchBase->handle(
+            $project->path,
+            $project->default_base_branch ?? null,
+            $project->branch ?? null,
+        );
+
+        if ($result->state !== BranchBaseState::Ready || $result->baseSha === null) {
+            return null;
+        }
+
+        return route('review-page.range-to-working', [
+            'slug' => $slug,
+            'rangeFromWorking' => $result->baseSha,
+        ]);
+    }
+
+    private function buildCommitUrl(Project $project, string $slug, ?string $to): ?string
+    {
+        if ($to === null || ! $this->refExists($project->path, $to)) {
+            return null;
+        }
+
+        return route('review-page.commit', ['slug' => $slug, 'hash' => $to]);
+    }
+
+    private function buildRangeUrl(Project $project, string $slug, ?string $from, ?string $to): ?string
+    {
+        if ($from === null || $to === null) {
+            return null;
+        }
+
+        if (! $this->refExists($project->path, $to)) {
+            return null;
+        }
+
+        // Range `from` may carry a parent suffix (e.g. `abc1234^`) when the
+        // selection was applied via the catchall route. Strip the suffix
+        // before existence-checking so a still-reachable commit doesn't
+        // fail validation, and route via the catchall format that accepts
+        // the suffix verbatim.
+        $fromBase = str_ends_with($from, '^') ? substr($from, 0, -1) : $from;
+        if ($fromBase !== '' && ! $this->refExists($project->path, $fromBase)) {
+            return null;
+        }
+
+        return '/p/'.rawurlencode($slug).'/'.rawurlencode($to).'/'.rawurlencode($from);
+    }
+
+    private function buildRangeToWorkingUrl(Project $project, string $slug, ?string $from): ?string
+    {
+        if ($from === null) {
+            return null;
+        }
+
+        $fromBase = str_ends_with($from, '^') ? substr($from, 0, -1) : $from;
+        if ($fromBase !== '' && ! $this->refExists($project->path, $fromBase)) {
+            return null;
+        }
+
+        return route('review-page.range-to-working', [
+            'slug' => $slug,
+            'rangeFromWorking' => $from,
+        ]);
+    }
+
+    private function refExists(string $repoPath, string $ref): bool
+    {
+        return $this->gitMetadataService->resolveRef($repoPath, $ref) !== null;
+    }
+}

--- a/app/Actions/ResolveStartupRouteAction.php
+++ b/app/Actions/ResolveStartupRouteAction.php
@@ -11,12 +11,16 @@ final readonly class ResolveStartupRouteAction
 {
     private const string CACHE_KEY = 'last-opened-project-slug';
 
+    public function __construct(
+        private ResolveProjectEntryUrlAction $resolveProjectEntryUrl,
+    ) {}
+
     public function handle(): string
     {
         $lastSlug = Cache::get(self::CACHE_KEY);
 
         if ($lastSlug && Project::where('slug', $lastSlug)->exists()) {
-            return route('review-page', ['slug' => $lastSlug]);
+            return $this->resolveProjectEntryUrl->handle($lastSlug);
         }
 
         if ($lastSlug) {

--- a/app/Enums/LastViewKind.php
+++ b/app/Enums/LastViewKind.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Shape of the review-page diff selection persisted alongside {@see LastViewMode::Review}.
+ *
+ * `SinceBase` is stored as semantic intent (not a frozen SHA): the entry-URL
+ * resolver re-resolves the merge-base against the current state of the repo
+ * so the restored view follows base-branch advancement instead of pinning a
+ * stale commit.
+ *
+ * The other four kinds round-trip the literal `from` / `to` refs and validate
+ * them at restore time. Anything that no longer resolves falls back to the
+ * working-tree default.
+ */
+enum LastViewKind: string
+{
+    case WorkingTree = 'working_tree';
+    case SinceBase = 'since_base';
+    case Commit = 'commit';
+    case Range = 'range';
+    case RangeToWorking = 'range_to_working';
+
+    public static function fromNullable(?string $value): ?self
+    {
+        return $value === null ? null : self::tryFrom($value);
+    }
+}

--- a/app/Enums/LastViewKind.php
+++ b/app/Enums/LastViewKind.php
@@ -5,16 +5,10 @@ declare(strict_types=1);
 namespace App\Enums;
 
 /**
- * Shape of the review-page diff selection persisted alongside {@see LastViewMode::Review}.
- *
- * `SinceBase` is stored as semantic intent (not a frozen SHA): the entry-URL
- * resolver re-resolves the merge-base against the current state of the repo
- * so the restored view follows base-branch advancement instead of pinning a
- * stale commit.
- *
- * The other four kinds round-trip the literal `from` / `to` refs and validate
- * them at restore time. Anything that no longer resolves falls back to the
- * working-tree default.
+ * `SinceBase` is stored as semantic intent: the entry-URL resolver re-resolves
+ * the merge-base at restore time so the view follows base-branch advancement
+ * instead of pinning a stale commit. The other four kinds round-trip the
+ * literal `from` / `to` refs and validate them against the live repo.
  */
 enum LastViewKind: string
 {
@@ -23,9 +17,4 @@ enum LastViewKind: string
     case Commit = 'commit';
     case Range = 'range';
     case RangeToWorking = 'range_to_working';
-
-    public static function fromNullable(?string $value): ?self
-    {
-        return $value === null ? null : self::tryFrom($value);
-    }
 }

--- a/app/Enums/LastViewMode.php
+++ b/app/Enums/LastViewMode.php
@@ -4,18 +4,8 @@ declare(strict_types=1);
 
 namespace App\Enums;
 
-/**
- * Per-project sticky page selection. Saved on every page mount; consulted
- * from project-picker, startup-route, and the home redirect so re-entering
- * a project lands the user on whichever page they last had open.
- */
 enum LastViewMode: string
 {
     case Review = 'review';
     case Context = 'context';
-
-    public static function fromNullable(?string $value): ?self
-    {
-        return $value === null ? null : self::tryFrom($value);
-    }
 }

--- a/app/Enums/LastViewMode.php
+++ b/app/Enums/LastViewMode.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Per-project sticky page selection. Saved on every page mount; consulted
+ * from project-picker, startup-route, and the home redirect so re-entering
+ * a project lands the user on whichever page they last had open.
+ */
+enum LastViewMode: string
+{
+    case Review = 'review';
+    case Context = 'context';
+
+    public static function fromNullable(?string $value): ?self
+    {
+        return $value === null ? null : self::tryFrom($value);
+    }
+}

--- a/app/Models/ReviewSession.php
+++ b/app/Models/ReviewSession.php
@@ -4,17 +4,41 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Enums\LastViewKind;
+use App\Enums\LastViewMode;
 use Database\Factories\ReviewSessionFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @property ?LastViewMode $last_view_mode
+ * @property ?LastViewKind $last_view_kind
+ * @property ?string $last_view_from
+ * @property ?string $last_view_to
+ */
 class ReviewSession extends Model
 {
     /** @use HasFactory<ReviewSessionFactory> */
     use HasFactory;
 
-    protected $fillable = ['repo_path', 'project_id', 'global_comment'];
+    protected $fillable = [
+        'repo_path',
+        'project_id',
+        'global_comment',
+        'last_view_mode',
+        'last_view_kind',
+        'last_view_from',
+        'last_view_to',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'last_view_mode' => LastViewMode::class,
+            'last_view_kind' => LastViewKind::class,
+        ];
+    }
 
     /** @return array<string, int|string|null> */
     public static function lookupKey(string $repoPath, ?int $projectId): array

--- a/database/migrations/2026_05_01_171623_add_last_view_to_review_sessions.php
+++ b/database/migrations/2026_05_01_171623_add_last_view_to_review_sessions.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('review_sessions', function (Blueprint $table) {
+            $table->string('last_view_mode')->nullable()->after('global_comment');
+            $table->string('last_view_kind')->nullable()->after('last_view_mode');
+            $table->string('last_view_from')->nullable()->after('last_view_kind');
+            $table->string('last_view_to')->nullable()->after('last_view_from');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('review_sessions', function (Blueprint $table) {
+            $table->dropColumn(['last_view_mode', 'last_view_kind', 'last_view_from', 'last_view_to']);
+        });
+    }
+};

--- a/resources/views/livewire/⚡project-picker.blade.php
+++ b/resources/views/livewire/⚡project-picker.blade.php
@@ -2,7 +2,9 @@
 
 use App\Actions\ListProjectsAction;
 use App\Actions\RemoveProjectAction;
+use App\Actions\ResolveProjectEntryUrlAction;
 use App\Concerns\InteractsWithRemoteLinks;
+use App\Enums\LastViewMode;
 use Livewire\Attributes\Lazy;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
@@ -21,7 +23,12 @@ class extends Component
     #[Locked]
     public string $projectName = '';
 
-    /** Mode the host page is in. 'review' or 'context'. Picker preserves it on switch. */
+    /**
+     * Mode the host page is in. 'review' or 'context'. Used as the *fallback*
+     * for projects with no saved selection — projects the user has visited
+     * before restore through {@see ResolveProjectEntryUrlAction} and may land
+     * on the other mode.
+     */
     #[Locked]
     public string $mode = 'review';
 
@@ -63,9 +70,12 @@ class extends Component
 
     public function selectProject(string $slug): void
     {
-        $routeName = $this->mode === 'context' ? 'context-page' : 'review-page';
+        $url = app(ResolveProjectEntryUrlAction::class)->handle(
+            $slug,
+            LastViewMode::tryFrom($this->mode),
+        );
 
-        $this->redirect(route($routeName, ['slug' => $slug]), navigate: true);
+        $this->redirect($url, navigate: true);
     }
 
     public function removeProject(int $projectId): void

--- a/resources/views/pages/⚡context-page.blade.php
+++ b/resources/views/pages/⚡context-page.blade.php
@@ -5,8 +5,10 @@ use App\Actions\ContextCommentWorkflowAction;
 use App\Actions\DiscoverAgentContextFilesAction;
 use App\Actions\ExportContextFeedbackAction;
 use App\Actions\LoadContextCommentsAction;
+use App\Actions\PersistProjectViewAction;
 use App\Actions\ResolveProjectAction;
 use App\DTOs\AgentContextFile;
+use App\Enums\LastViewMode;
 use Illuminate\Support\Facades\Cache;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
@@ -70,6 +72,12 @@ new #[Layout('layouts.app')] class extends Component
         $this->hasRemote = ! empty($project['remote_url']);
 
         Cache::put('rfa.active-project-id', $this->projectId, now()->addDay());
+
+        app(PersistProjectViewAction::class)->handle(
+            $this->projectId,
+            $this->repoPath,
+            LastViewMode::Context,
+        );
 
         if (config('nativephp-internal.running')) {
             \Native\Desktop\Facades\Window::get('main')->title("rfa - {$this->projectName} · context");

--- a/resources/views/pages/⚡context-page.blade.php
+++ b/resources/views/pages/⚡context-page.blade.php
@@ -16,6 +16,8 @@ use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
+use function Illuminate\Support\defer;
+
 /**
  * Context page: inventory + line-level review of every CLAUDE.md / AGENTS.md
  * in the current repo. Sibling to ⚡review-page; intentionally does not share
@@ -73,11 +75,19 @@ new #[Layout('layouts.app')] class extends Component
 
         Cache::put('rfa.active-project-id', $this->projectId, now()->addDay());
 
-        app(PersistProjectViewAction::class)->handle(
-            $this->projectId,
-            $this->repoPath,
-            LastViewMode::Context,
-        );
+        $projectId = $this->projectId;
+        $repoPath = $this->repoPath;
+
+        // Run after the response is sent: the persisted view is only consumed
+        // on the next navigation, so making the user wait for the UPSERT here
+        // would be needless mount latency.
+        defer(static function () use ($projectId, $repoPath) {
+            app(PersistProjectViewAction::class)->handle(
+                $projectId,
+                $repoPath,
+                LastViewMode::Context,
+            );
+        });
 
         if (config('nativephp-internal.running')) {
             \Native\Desktop\Facades\Window::get('main')->title("rfa - {$this->projectName} · context");

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -14,6 +14,7 @@ use App\Actions\GroupReviewFilesAction;
 use App\Actions\IsSinceBaseViewAction;
 use App\Actions\LinkExternalPathAction;
 use App\Actions\LoadCommitMetadataAction;
+use App\Actions\PersistProjectViewAction;
 use App\Actions\ResolveCommitAction;
 use App\Actions\ResolveProjectAction;
 use App\Actions\ResolveRangeAction;
@@ -33,6 +34,8 @@ use App\DTOs\FileListEntry;
 use App\Enums\DiffSide;
 use App\Enums\DivergenceState;
 use App\Enums\GitRef;
+use App\Enums\LastViewKind;
+use App\Enums\LastViewMode;
 use App\Exceptions\GitCommandException;
 use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
@@ -213,6 +216,42 @@ new #[Layout('layouts.app')] class extends Component
 
         $this->rehydrateForTarget();
         $this->checkHeadDivergence();
+
+        $this->persistCurrentView($hash, $from, $to, $ref, $rangeFromWorking);
+    }
+
+    /**
+     * Persist the (mode, kind, from, to) shape of the diff currently being
+     * viewed so that re-entering this project via the picker, the home
+     * redirect, or a deep-link puts the user back on the same surface.
+     *
+     * Kind is derived from the arrival shape — which mount branch was taken
+     * — rather than recomputed from `$diffFrom`/`$diffTo`, because resolved
+     * SHAs lose the original "single commit vs explicit range" distinction.
+     *
+     * `since_base` is saved as semantic intent rather than the resolved SHA
+     * so the restore side re-resolves the merge-base. Base-branch advance
+     * after this save carries the user forward instead of pinning a stale
+     * commit.
+     */
+    private function persistCurrentView(?string $hash, ?string $from, ?string $to, ?string $ref, ?string $rangeFromWorking): void
+    {
+        $kind = match (true) {
+            $hash !== null => LastViewKind::Commit,
+            $from !== null && $to !== null => LastViewKind::Range,
+            $rangeFromWorking !== null => $this->isSinceBaseView ? LastViewKind::SinceBase : LastViewKind::RangeToWorking,
+            $ref !== null => LastViewKind::Range,
+            default => LastViewKind::WorkingTree,
+        };
+
+        app(PersistProjectViewAction::class)->handle(
+            $this->projectId,
+            $this->repoPath,
+            LastViewMode::Review,
+            $kind,
+            $kind === LastViewKind::WorkingTree || $kind === LastViewKind::Commit ? null : $this->diffFrom,
+            $kind === LastViewKind::WorkingTree ? null : $this->diffTo,
+        );
     }
 
     private function rehydrateForTarget(): void

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -45,6 +45,8 @@ use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
+use function Illuminate\Support\defer;
+
 new #[Layout('layouts.app')] class extends Component
 {
     use InteractsWithRemoteLinks;
@@ -239,14 +241,24 @@ new #[Layout('layouts.app')] class extends Component
             default => LastViewKind::WorkingTree,
         };
 
-        app(PersistProjectViewAction::class)->handle(
-            $this->projectId,
-            $this->repoPath,
-            LastViewMode::Review,
-            $kind,
-            $kind === LastViewKind::WorkingTree || $kind === LastViewKind::Commit ? null : $this->diffFrom,
-            $kind === LastViewKind::WorkingTree ? null : $this->diffTo,
-        );
+        $projectId = $this->projectId;
+        $repoPath = $this->repoPath;
+        $diffFrom = $this->diffFrom;
+        $diffTo = $this->diffTo;
+
+        // Run after the response is sent: the persisted view is only consumed
+        // on the next navigation, so making the user wait for the UPSERT here
+        // would be needless mount latency.
+        defer(static function () use ($projectId, $repoPath, $kind, $diffFrom, $diffTo) {
+            app(PersistProjectViewAction::class)->handle(
+                $projectId,
+                $repoPath,
+                LastViewMode::Review,
+                $kind,
+                $kind === LastViewKind::WorkingTree || $kind === LastViewKind::Commit ? null : $diffFrom,
+                $kind === LastViewKind::WorkingTree ? null : $diffTo,
+            );
+        });
     }
 
     private function rehydrateForTarget(): void

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -217,30 +217,25 @@ new #[Layout('layouts.app')] class extends Component
         $this->rehydrateForTarget();
         $this->checkHeadDivergence();
 
-        $this->persistCurrentView($hash, $from, $to, $ref, $rangeFromWorking);
+        $this->persistCurrentView($hash, $from, $to, $ref, $baseRef, $rangeFromWorking);
     }
 
     /**
-     * Persist the (mode, kind, from, to) shape of the diff currently being
-     * viewed so that re-entering this project via the picker, the home
-     * redirect, or a deep-link puts the user back on the same surface.
+     * Persist the (mode, kind, from, to) shape so that re-entering this
+     * project — via the picker, the home redirect, or a deep-link — puts
+     * the user back on the same surface.
      *
-     * Kind is derived from the arrival shape — which mount branch was taken
-     * — rather than recomputed from `$diffFrom`/`$diffTo`, because resolved
-     * SHAs lose the original "single commit vs explicit range" distinction.
-     *
-     * `since_base` is saved as semantic intent rather than the resolved SHA
-     * so the restore side re-resolves the merge-base. Base-branch advance
-     * after this save carries the user forward instead of pinning a stale
-     * commit.
+     * Kind is derived from the arrival shape (which mount branch fired)
+     * rather than from `$diffFrom`/`$diffTo`, because resolved SHAs lose
+     * the original "single commit vs explicit range" distinction.
      */
-    private function persistCurrentView(?string $hash, ?string $from, ?string $to, ?string $ref, ?string $rangeFromWorking): void
+    private function persistCurrentView(?string $hash, ?string $from, ?string $to, ?string $ref, ?string $baseRef, ?string $rangeFromWorking): void
     {
         $kind = match (true) {
             $hash !== null => LastViewKind::Commit,
             $from !== null && $to !== null => LastViewKind::Range,
             $rangeFromWorking !== null => $this->isSinceBaseView ? LastViewKind::SinceBase : LastViewKind::RangeToWorking,
-            $ref !== null => LastViewKind::Range,
+            $ref !== null && $baseRef !== null => LastViewKind::Range,
             default => LastViewKind::WorkingTree,
         };
 

--- a/tests/Unit/Actions/PersistProjectViewActionTest.php
+++ b/tests/Unit/Actions/PersistProjectViewActionTest.php
@@ -1,0 +1,107 @@
+<?php
+
+use App\Actions\PersistProjectViewAction;
+use App\Enums\LastViewKind;
+use App\Enums\LastViewMode;
+use App\Models\Project;
+use App\Models\ReviewSession;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+beforeEach(function () {
+    $this->project = Project::factory()->create(['slug' => 'persist-test', 'path' => '/tmp/persist-test']);
+    $this->action = app(PersistProjectViewAction::class);
+});
+
+test('creates a review_session row on first save', function () {
+    $this->action->handle($this->project->id, $this->project->path, LastViewMode::Review, LastViewKind::WorkingTree);
+
+    $row = ReviewSession::where('project_id', $this->project->id)->first();
+
+    expect($row)->not->toBeNull()
+        ->and($row->last_view_mode)->toBe(LastViewMode::Review)
+        ->and($row->last_view_kind)->toBe(LastViewKind::WorkingTree)
+        ->and($row->last_view_from)->toBeNull()
+        ->and($row->last_view_to)->toBeNull();
+});
+
+test('persists range refs on a Range save', function () {
+    $this->action->handle(
+        $this->project->id,
+        $this->project->path,
+        LastViewMode::Review,
+        LastViewKind::Range,
+        from: 'aaaa1111',
+        to: 'bbbb2222',
+    );
+
+    $row = ReviewSession::where('project_id', $this->project->id)->first();
+
+    expect($row->last_view_kind)->toBe(LastViewKind::Range)
+        ->and($row->last_view_from)->toBe('aaaa1111')
+        ->and($row->last_view_to)->toBe('bbbb2222');
+});
+
+test('persists since_base intent without freezing the SHA', function () {
+    $this->action->handle(
+        $this->project->id,
+        $this->project->path,
+        LastViewMode::Review,
+        LastViewKind::SinceBase,
+        from: 'merge-base-sha',
+    );
+
+    $row = ReviewSession::where('project_id', $this->project->id)->first();
+
+    expect($row->last_view_kind)->toBe(LastViewKind::SinceBase)
+        ->and($row->last_view_from)->toBe('merge-base-sha');
+});
+
+test('clears review-only columns when saving Context mode', function () {
+    $this->action->handle(
+        $this->project->id,
+        $this->project->path,
+        LastViewMode::Review,
+        LastViewKind::Range,
+        from: 'aaaa',
+        to: 'bbbb',
+    );
+
+    $this->action->handle(
+        $this->project->id,
+        $this->project->path,
+        LastViewMode::Context,
+    );
+
+    $row = ReviewSession::where('project_id', $this->project->id)->first();
+
+    expect($row->last_view_mode)->toBe(LastViewMode::Context)
+        ->and($row->last_view_kind)->toBeNull()
+        ->and($row->last_view_from)->toBeNull()
+        ->and($row->last_view_to)->toBeNull();
+});
+
+test('overwrites the same row across multiple saves', function () {
+    $this->action->handle($this->project->id, $this->project->path, LastViewMode::Review, LastViewKind::WorkingTree);
+    $this->action->handle($this->project->id, $this->project->path, LastViewMode::Review, LastViewKind::Commit, to: 'cafe1234');
+    $this->action->handle($this->project->id, $this->project->path, LastViewMode::Context);
+
+    expect(ReviewSession::where('project_id', $this->project->id)->count())->toBe(1);
+});
+
+test('preserves existing global_comment on save', function () {
+    ReviewSession::create([
+        'project_id' => $this->project->id,
+        'repo_path' => $this->project->path,
+        'global_comment' => 'do not lose me',
+    ]);
+
+    $this->action->handle($this->project->id, $this->project->path, LastViewMode::Review, LastViewKind::WorkingTree);
+
+    $row = ReviewSession::where('project_id', $this->project->id)->first();
+
+    expect($row->global_comment)->toBe('do not lose me')
+        ->and($row->last_view_mode)->toBe(LastViewMode::Review);
+});

--- a/tests/Unit/Actions/PersistProjectViewActionTest.php
+++ b/tests/Unit/Actions/PersistProjectViewActionTest.php
@@ -44,7 +44,7 @@ test('persists range refs on a Range save', function () {
         ->and($row->last_view_to)->toBe('bbbb2222');
 });
 
-test('persists since_base intent without freezing the SHA', function () {
+test('persists since_base as semantic intent and discards the at-save SHA', function () {
     $this->action->handle(
         $this->project->id,
         $this->project->path,
@@ -56,7 +56,8 @@ test('persists since_base intent without freezing the SHA', function () {
     $row = ReviewSession::where('project_id', $this->project->id)->first();
 
     expect($row->last_view_kind)->toBe(LastViewKind::SinceBase)
-        ->and($row->last_view_from)->toBe('merge-base-sha');
+        ->and($row->last_view_from)->toBeNull()
+        ->and($row->last_view_to)->toBeNull();
 });
 
 test('clears review-only columns when saving Context mode', function () {

--- a/tests/Unit/Actions/ResolveProjectEntryUrlActionTest.php
+++ b/tests/Unit/Actions/ResolveProjectEntryUrlActionTest.php
@@ -1,0 +1,231 @@
+<?php
+
+use App\Actions\ResolveProjectEntryUrlAction;
+use App\Enums\LastViewKind;
+use App\Enums\LastViewMode;
+use App\Models\Project;
+use App\Models\ReviewSession;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Tests\Helpers\InteractsWithTestRepositories;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class, InteractsWithTestRepositories::class);
+
+afterEach(function () {
+    $this->cleanupTrackedTempDirectories();
+});
+
+beforeEach(function () {
+    $this->repoPath = $this->createTempDirectory('rfa_entry_url_test_');
+    $this->initTestRepo($this->repoPath);
+
+    File::put($this->repoPath.'/file.txt', "line\n");
+    $this->commitTestRepo($this->repoPath, 'first');
+    $this->firstSha = trim($this->runTestRepoCommand($this->repoPath, 'git rev-parse HEAD'));
+
+    File::put($this->repoPath.'/file.txt', "line\nline2\n");
+    $this->commitTestRepo($this->repoPath, 'second');
+    $this->secondSha = trim($this->runTestRepoCommand($this->repoPath, 'git rev-parse HEAD'));
+
+    $this->project = Project::factory()->create([
+        'slug' => 'entry-test',
+        'path' => $this->repoPath,
+        'branch' => 'main',
+        'default_base_branch' => 'main',
+    ]);
+
+    $this->action = app(ResolveProjectEntryUrlAction::class);
+});
+
+// -- empty / fallback cases --
+
+test('returns review-page when project does not exist', function () {
+    expect($this->action->handle('does-not-exist'))
+        ->toBe(route('review-page', ['slug' => 'does-not-exist']));
+});
+
+test('returns review-page for a project with no saved selection', function () {
+    expect($this->action->handle($this->project->slug))
+        ->toBe(route('review-page', ['slug' => 'entry-test']));
+});
+
+test('uses the supplied fallback mode when no row exists', function () {
+    expect($this->action->handle($this->project->slug, LastViewMode::Context))
+        ->toBe(route('context-page', ['slug' => 'entry-test']));
+});
+
+// -- mode dimension --
+
+test('routes to context-page when last_view_mode is Context', function () {
+    ReviewSession::create([
+        'project_id' => $this->project->id,
+        'repo_path' => $this->repoPath,
+        'last_view_mode' => LastViewMode::Context,
+    ]);
+
+    expect($this->action->handle($this->project->slug, LastViewMode::Review))
+        ->toBe(route('context-page', ['slug' => 'entry-test']));
+});
+
+test('saved Review mode beats fallback Context', function () {
+    ReviewSession::create([
+        'project_id' => $this->project->id,
+        'repo_path' => $this->repoPath,
+        'last_view_mode' => LastViewMode::Review,
+        'last_view_kind' => LastViewKind::WorkingTree,
+    ]);
+
+    expect($this->action->handle($this->project->slug, LastViewMode::Context))
+        ->toBe(route('review-page', ['slug' => 'entry-test']));
+});
+
+// -- review kinds --
+
+test('builds the working-tree URL for WorkingTree kind', function () {
+    ReviewSession::create([
+        'project_id' => $this->project->id,
+        'repo_path' => $this->repoPath,
+        'last_view_mode' => LastViewMode::Review,
+        'last_view_kind' => LastViewKind::WorkingTree,
+    ]);
+
+    expect($this->action->handle($this->project->slug))
+        ->toBe(route('review-page', ['slug' => 'entry-test']));
+});
+
+test('builds the commit URL when the saved sha still resolves', function () {
+    ReviewSession::create([
+        'project_id' => $this->project->id,
+        'repo_path' => $this->repoPath,
+        'last_view_mode' => LastViewMode::Review,
+        'last_view_kind' => LastViewKind::Commit,
+        'last_view_to' => $this->secondSha,
+    ]);
+
+    expect($this->action->handle($this->project->slug))
+        ->toBe(route('review-page.commit', ['slug' => 'entry-test', 'hash' => $this->secondSha]));
+});
+
+test('falls back to working tree when the saved commit no longer resolves', function () {
+    ReviewSession::create([
+        'project_id' => $this->project->id,
+        'repo_path' => $this->repoPath,
+        'last_view_mode' => LastViewMode::Review,
+        'last_view_kind' => LastViewKind::Commit,
+        'last_view_to' => str_repeat('0', 40),
+    ]);
+
+    expect($this->action->handle($this->project->slug))
+        ->toBe(route('review-page', ['slug' => 'entry-test']));
+});
+
+test('builds the range URL via the catchall format', function () {
+    ReviewSession::create([
+        'project_id' => $this->project->id,
+        'repo_path' => $this->repoPath,
+        'last_view_mode' => LastViewMode::Review,
+        'last_view_kind' => LastViewKind::Range,
+        'last_view_from' => $this->firstSha,
+        'last_view_to' => $this->secondSha,
+    ]);
+
+    expect($this->action->handle($this->project->slug))
+        ->toBe('/p/entry-test/'.$this->secondSha.'/'.$this->firstSha);
+});
+
+test('preserves a parent-suffix on the range from', function () {
+    $fromWithSuffix = $this->firstSha.'^';
+
+    ReviewSession::create([
+        'project_id' => $this->project->id,
+        'repo_path' => $this->repoPath,
+        'last_view_mode' => LastViewMode::Review,
+        'last_view_kind' => LastViewKind::Range,
+        'last_view_from' => $fromWithSuffix,
+        'last_view_to' => $this->secondSha,
+    ]);
+
+    expect($this->action->handle($this->project->slug))
+        ->toBe('/p/entry-test/'.$this->secondSha.'/'.rawurlencode($fromWithSuffix));
+});
+
+test('builds the range-to-working URL', function () {
+    ReviewSession::create([
+        'project_id' => $this->project->id,
+        'repo_path' => $this->repoPath,
+        'last_view_mode' => LastViewMode::Review,
+        'last_view_kind' => LastViewKind::RangeToWorking,
+        'last_view_from' => $this->firstSha,
+    ]);
+
+    expect($this->action->handle($this->project->slug))
+        ->toBe(route('review-page.range-to-working', ['slug' => 'entry-test', 'rangeFromWorking' => $this->firstSha]));
+});
+
+test('falls back to working tree when range-to-working from no longer resolves', function () {
+    ReviewSession::create([
+        'project_id' => $this->project->id,
+        'repo_path' => $this->repoPath,
+        'last_view_mode' => LastViewMode::Review,
+        'last_view_kind' => LastViewKind::RangeToWorking,
+        'last_view_from' => str_repeat('0', 40),
+    ]);
+
+    expect($this->action->handle($this->project->slug))
+        ->toBe(route('review-page', ['slug' => 'entry-test']));
+});
+
+// -- since_base re-resolution --
+
+test('since_base re-resolves against the current merge-base', function () {
+    // Branch off main, advance feature.
+    $this->runTestRepoCommand($this->repoPath, 'git checkout -b feature');
+    File::put($this->repoPath.'/feature.txt', "f\n");
+    $this->commitTestRepo($this->repoPath, 'feature commit');
+
+    $this->project->update(['branch' => 'feature']);
+
+    ReviewSession::create([
+        'project_id' => $this->project->id,
+        'repo_path' => $this->repoPath,
+        'last_view_mode' => LastViewMode::Review,
+        'last_view_kind' => LastViewKind::SinceBase,
+        // Stale from-value: re-resolution should ignore it and recompute.
+        'last_view_from' => str_repeat('0', 40),
+    ]);
+
+    $expected = route('review-page.range-to-working', [
+        'slug' => 'entry-test',
+        'rangeFromWorking' => $this->secondSha,
+    ]);
+
+    expect($this->action->handle($this->project->slug))->toBe($expected);
+});
+
+test('since_base falls back to working tree when base is not configured', function () {
+    $this->project->update(['default_base_branch' => null]);
+
+    ReviewSession::create([
+        'project_id' => $this->project->id,
+        'repo_path' => $this->repoPath,
+        'last_view_mode' => LastViewMode::Review,
+        'last_view_kind' => LastViewKind::SinceBase,
+    ]);
+
+    expect($this->action->handle($this->project->slug))
+        ->toBe(route('review-page', ['slug' => 'entry-test']));
+});
+
+test('since_base falls back to working tree when on the base branch itself', function () {
+    // Project still on `main`, base is `main` — no commits ahead of itself.
+    ReviewSession::create([
+        'project_id' => $this->project->id,
+        'repo_path' => $this->repoPath,
+        'last_view_mode' => LastViewMode::Review,
+        'last_view_kind' => LastViewKind::SinceBase,
+    ]);
+
+    expect($this->action->handle($this->project->slug))
+        ->toBe(route('review-page', ['slug' => 'entry-test']));
+});

--- a/tests/Unit/Actions/ResolveProjectEntryUrlActionTest.php
+++ b/tests/Unit/Actions/ResolveProjectEntryUrlActionTest.php
@@ -131,7 +131,7 @@ test('builds the range URL via the catchall format', function () {
     ]);
 
     expect($this->action->handle($this->project->slug))
-        ->toBe('/p/entry-test/'.$this->secondSha.'/'.$this->firstSha);
+        ->toBe(route('review-page', ['slug' => 'entry-test', 'ref' => $this->secondSha, 'baseRef' => $this->firstSha]));
 });
 
 test('preserves a parent-suffix on the range from', function () {
@@ -147,7 +147,7 @@ test('preserves a parent-suffix on the range from', function () {
     ]);
 
     expect($this->action->handle($this->project->slug))
-        ->toBe('/p/entry-test/'.$this->secondSha.'/'.rawurlencode($fromWithSuffix));
+        ->toBe(route('review-page', ['slug' => 'entry-test', 'ref' => $this->secondSha, 'baseRef' => $fromWithSuffix]));
 });
 
 test('builds the range-to-working URL', function () {

--- a/tests/Unit/Actions/ResolveStartupRouteActionTest.php
+++ b/tests/Unit/Actions/ResolveStartupRouteActionTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Actions\ResolveStartupRouteAction;
+use App\Enums\LastViewMode;
 use App\Models\Project;
+use App\Models\ReviewSession;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Tests\TestCase;
 
@@ -54,4 +56,19 @@ test('rememberLastOpened is a no-op when slug already cached', function () {
     $action->rememberLastOpened('foo');
 
     expect($action->lastOpenedSlug())->toBe('foo');
+});
+
+test('handle restores the saved Context mode for the last-opened project', function () {
+    $project = Project::factory()->create(['slug' => 'has-context']);
+    ReviewSession::create([
+        'project_id' => $project->id,
+        'repo_path' => $project->path,
+        'last_view_mode' => LastViewMode::Context,
+    ]);
+
+    $action = app(ResolveStartupRouteAction::class);
+    $action->rememberLastOpened('has-context');
+
+    expect($action->handle())
+        ->toBe(route('context-page', ['slug' => 'has-context']));
 });

--- a/tests/Unit/Livewire/ProjectPickerTest.php
+++ b/tests/Unit/Livewire/ProjectPickerTest.php
@@ -1,8 +1,11 @@
 <?php
 
 use App\Actions\ResolveStartupRouteAction;
+use App\Enums\LastViewKind;
+use App\Enums\LastViewMode;
 use App\Models\Comment;
 use App\Models\Project;
+use App\Models\ReviewSession;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -55,6 +58,37 @@ test('selectProject defaults to review-page when mode is unrecognized', function
     Project::factory()->create(['slug' => 'other']);
 
     Livewire::test('project-picker', ['currentSlug' => 'current', 'projectName' => 'Current', 'mode' => 'whatever'])
+        ->call('selectProject', 'other')
+        ->assertRedirect(route('review-page', ['slug' => 'other']));
+});
+
+test('selectProject restores the target project saved Context mode regardless of host mode', function () {
+    Project::factory()->create(['slug' => 'current']);
+    $other = Project::factory()->create(['slug' => 'other']);
+
+    ReviewSession::create([
+        'project_id' => $other->id,
+        'repo_path' => $other->path,
+        'last_view_mode' => LastViewMode::Context,
+    ]);
+
+    Livewire::test('project-picker', ['currentSlug' => 'current', 'projectName' => 'Current', 'mode' => 'review'])
+        ->call('selectProject', 'other')
+        ->assertRedirect(route('context-page', ['slug' => 'other']));
+});
+
+test('selectProject restores the target project saved Review WT when host is on Context', function () {
+    Project::factory()->create(['slug' => 'current']);
+    $other = Project::factory()->create(['slug' => 'other']);
+
+    ReviewSession::create([
+        'project_id' => $other->id,
+        'repo_path' => $other->path,
+        'last_view_mode' => LastViewMode::Review,
+        'last_view_kind' => LastViewKind::WorkingTree,
+    ]);
+
+    Livewire::test('project-picker', ['currentSlug' => 'current', 'projectName' => 'Current', 'mode' => 'context'])
         ->call('selectProject', 'other')
         ->assertRedirect(route('review-page', ['slug' => 'other']));
 });


### PR DESCRIPTION
Each project remembers which page it was last on (review or context) and,
for review, which diff selection (working tree, since-base, single commit,
range, or range-to-working). The picker, home redirect, and startup-route
all consult the saved row and rebuild the entry URL from it.

Mode-stickiness from #79's picker becomes the *fallback* for projects with
no saved row, so first-time visits still inherit the host page's mode.

since_base is saved as semantic intent and re-resolved through
ResolveBranchBaseAction at restore time so base-branch advancement carries
the user forward instead of pinning a stale SHA. The other four review
kinds round-trip the literal refs and silently fall back to working tree
when validation against the live repo fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now remembers your view preferences when navigating between projects.
  * Your current view mode and diff context (specific commits, ranges, or comparisons) are automatically preserved.
  * When you return to a project, your previous view state is restored, ensuring a seamless workflow across project switches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->