### PR TITLE
Use absolute paths in clipboard text instead of @.rfa prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Auto-updates work normally after that (handled by Electron, independent of code 
 The exported `.md` file is ready to paste into AI tools:
 
 ```
-address my comments on these changes in @.rfa/{timestamp}_comments_{hash}.md
+address my comments on these changes in /absolute/path/to/repo/.rfa/{timestamp}_comments_{hash}.md
 ```
 
 ## Terminal Helper

--- a/app/Services/CommentExporter.php
+++ b/app/Services/CommentExporter.php
@@ -35,15 +35,15 @@ class CommentExporter
 
         return [
             'md' => $path,
-            'clipboard' => $this->clipboardText($kind, $basename),
+            'clipboard' => $this->clipboardText($kind, $path),
         ];
     }
 
-    private function clipboardText(CommentExportKind $kind, string $basename): string
+    private function clipboardText(CommentExportKind $kind, string $path): string
     {
         return match ($kind) {
-            CommentExportKind::ContextFile => "improve the agent context files based on my comments in @.rfa/{$basename}.md",
-            CommentExportKind::Review => "address my comments on these changes in @.rfa/{$basename}.md",
+            CommentExportKind::ContextFile => "improve the agent context files based on my comments in {$path}",
+            CommentExportKind::Review => "address my comments on these changes in {$path}",
         };
     }
 }

--- a/tests/Unit/CommentExporterTest.php
+++ b/tests/Unit/CommentExporterTest.php
@@ -53,7 +53,9 @@ test('exports Markdown with file grouping', function () {
 test('returns clipboard text', function () {
     $result = $this->exporter->export($this->tmpDir, [], 'test');
 
-    expect($result['clipboard'])->toMatch('/^address my comments on these changes in @\.rfa\/\d{8}_\d{6}_comments_.*\.md$/');
+    $expectedPrefix = 'address my comments on these changes in '.$this->tmpDir.'/.rfa/';
+    expect($result['clipboard'])->toStartWith($expectedPrefix)
+        ->and(substr($result['clipboard'], strlen($expectedPrefix)))->toMatch('/^\d{8}_\d{6}_comments_[a-zA-Z0-9]{8}\.md$/');
 });
 
 test('creates .rfa directory if missing', function () {
@@ -145,7 +147,7 @@ test('default review kind keeps the existing intro and clipboard text', function
     $md = File::get($result['md']);
     expect($md)->toContain('# Code Review Comments');
     expect($md)->not->toContain('# Agent Context Feedback');
-    expect($result['clipboard'])->toMatch('/^address my comments on these changes in @\.rfa\//');
+    expect($result['clipboard'])->toStartWith('address my comments on these changes in '.$this->tmpDir.'/.rfa/');
 });
 
 test('context-file kind swaps intro, outro and clipboard prose', function () {
@@ -161,7 +163,7 @@ test('context-file kind swaps intro, outro and clipboard prose', function () {
     expect($md)->toContain('## `CLAUDE.md`');
     expect($md)->toContain('tighten this');
 
-    expect($result['clipboard'])->toMatch('/^improve the agent context files based on my comments in @\.rfa\//');
+    expect($result['clipboard'])->toStartWith('improve the agent context files based on my comments in '.$this->tmpDir.'/.rfa/');
 });
 
 test('handles an empty comment body without truncating later comments', function () {


### PR DESCRIPTION
## Summary
Changed the clipboard text generation to use absolute file paths instead of the `@.rfa/` prefix notation. This makes the exported paths more explicit and easier to work with in various contexts.

## Key Changes
- Modified `clipboardText()` method to accept the full file path instead of just the basename
- Updated clipboard text templates to use the complete path directly rather than constructing `@.rfa/{basename}`
- Updated all test assertions to verify the new absolute path format
- Updated README documentation to reflect the new path format in examples

## Implementation Details
- The `export()` method now passes the full `$path` to `clipboardText()` instead of `$basename`
- Clipboard text now includes the complete absolute path to the exported markdown file
- Tests were refactored to be more maintainable by checking the prefix separately from the filename pattern, making them less brittle to path changes

https://claude.ai/code/session_01QsSDogBG9br2K8wUnsHjZN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed exported review markdown paths to use absolute repository paths instead of relative references for improved clarity and consistency.

* **Documentation**
  * Updated example instructions in README to reflect absolute path usage in export functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->