### PR TITLE
Fix stale diff detection in softRefresh using raw mtime/byteSize

### DIFF
--- a/app/DTOs/FileListEntry.php
+++ b/app/DTOs/FileListEntry.php
@@ -23,6 +23,12 @@ class FileListEntry
         public readonly ?string $fileSize = null,
         public readonly bool $isExternal = false,
         public readonly ?string $externalAbsolutePath = null,
+        // Raw mtime + byte size used by the review page's softRefresh
+        // change-detection. Kept separate from the human-readable
+        // `lastModified` / `fileSize` because those bucket aggressively
+        // (e.g. `diffForHumans` short-form) and miss rapid in-place edits.
+        public readonly ?int $mtime = null,
+        public readonly ?int $byteSize = null,
     ) {}
 
     public static function idForPath(string $path): string
@@ -61,6 +67,8 @@ class FileListEntry
             'fileSize' => $this->fileSize,
             'isExternal' => $this->isExternal,
             'externalAbsolutePath' => $this->externalAbsolutePath,
+            'mtime' => $this->mtime,
+            'byteSize' => $this->byteSize,
         ];
     }
 }

--- a/app/Services/ExternalFilesService.php
+++ b/app/Services/ExternalFilesService.php
@@ -177,6 +177,7 @@ class ExternalFilesService
             );
 
             $size = $file->getSize();
+            $mtime = $file->getMTime();
 
             $entries[] = new FileListEntry(
                 path: self::MOUNT_PREFIX.'/'.$config['label'].'/'.$relative,
@@ -186,12 +187,14 @@ class ExternalFilesService
                 deletions: 0,
                 isBinary: false,
                 isUntracked: false,
-                lastModified: Carbon::createFromTimestamp($file->getMTime())->diffForHumans(short: true),
+                lastModified: Carbon::createFromTimestamp($mtime)->diffForHumans(short: true),
                 isSymlink: false,
                 symlinkTarget: null,
                 fileSize: Number::fileSize($size, precision: 1),
                 isExternal: true,
                 externalAbsolutePath: $absolutePath,
+                mtime: $mtime,
+                byteSize: $size,
             );
         }
 

--- a/app/Services/GitDiffService.php
+++ b/app/Services/GitDiffService.php
@@ -99,6 +99,8 @@ class GitDiffService
                     ? $this->symlinkTarget($repoPath.'/'.$path)
                     : null;
 
+                $isWorkingDir = $target->isWorkingDirectory();
+
                 return new FileListEntry(
                     path: $path,
                     status: $status,
@@ -107,10 +109,12 @@ class GitDiffService
                     deletions: $stats['deletions'],
                     isBinary: $isBinary,
                     isUntracked: false,
-                    lastModified: $target->isWorkingDirectory() ? $this->getLastModified($repoPath, $path) : null,
+                    lastModified: $isWorkingDir ? $this->getLastModified($repoPath, $path) : null,
                     isSymlink: $symlinkTarget !== null,
                     symlinkTarget: $symlinkTarget,
-                    fileSize: $target->isWorkingDirectory() ? $this->getHumanFileSize($repoPath, $path) : null,
+                    fileSize: $isWorkingDir ? $this->getHumanFileSize($repoPath, $path) : null,
+                    mtime: $isWorkingDir ? $this->getRawMtime($repoPath, $path) : null,
+                    byteSize: $isWorkingDir ? $this->getRawByteSize($repoPath, $path) : null,
                 );
             })
             ->values()
@@ -169,6 +173,8 @@ class GitDiffService
                             isUntracked: true,
                             lastModified: $this->getLastModified($repoPath, $file),
                             fileSize: $this->getHumanFileSize($repoPath, $file),
+                            mtime: $this->getRawMtime($repoPath, $file),
+                            byteSize: $this->getRawByteSize($repoPath, $file),
                         );
 
                         continue;
@@ -186,6 +192,8 @@ class GitDiffService
                         isBinary: false,
                         isUntracked: true,
                         lastModified: $this->getLastModified($repoPath, $file),
+                        mtime: $this->getRawMtime($repoPath, $file),
+                        byteSize: $this->getRawByteSize($repoPath, $file),
                     );
                 }
             }
@@ -393,6 +401,20 @@ class GitDiffService
         }
 
         return Number::fileSize(File::size($fullPath), precision: 1);
+    }
+
+    private function getRawMtime(string $repoPath, string $path): ?int
+    {
+        $fullPath = $repoPath.'/'.$path;
+
+        return File::isFile($fullPath) ? File::lastModified($fullPath) : null;
+    }
+
+    private function getRawByteSize(string $repoPath, string $path): ?int
+    {
+        $fullPath = $repoPath.'/'.$path;
+
+        return File::isFile($fullPath) ? File::size($fullPath) : null;
     }
 
     private function symlinkTarget(string $fullPath): ?string

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -436,12 +436,21 @@ new #[Layout('layouts.app')] class extends Component
         }
     }
 
+    /**
+     * User-initiated refresh (⌘R, click the refresh affordance, head-advance
+     * auto-refresh). Always re-renders. We compute `changedCount` for the
+     * "Up to date" / "N files updated" toast, but we do NOT use it to gate
+     * rendering: the cost of a needless morph on cmd+r is bounded; the cost
+     * of a false negative is silently stale UI. The cache-invalidation done
+     * by `rehydrateForTarget` only takes effect when children rehydrate,
+     * which requires a render.
+     */
     public function softRefresh(): void
     {
         $before = $this->fileFingerprints($this->files);
 
         $this->rehydrateForTarget();
-        $divergenceChanged = $this->refreshDivergenceState();
+        $this->refreshDivergenceState();
 
         $after = $this->fileFingerprints($this->files);
         $changedCount = count(array_diff_assoc($after, $before))
@@ -449,25 +458,20 @@ new #[Layout('layouts.app')] class extends Component
 
         $this->dispatch('fingerprint-reset');
         $this->dispatch('refresh-completed', changedCount: $changedCount);
-
-        if ($changedCount === 0 && ! $divergenceChanged) {
-            $this->skipRender();
-        }
     }
 
     /**
-     * Per-file change signature for softRefresh's skipRender heuristic.
+     * Per-file change signature used to compute `changedCount` for the
+     * post-refresh toast ("Up to date" vs "N files updated"). It does NOT
+     * gate rendering — see `softRefresh`.
      *
-     * Uses raw mtime + byte size — not the human-readable `lastModified` /
-     * `fileSize` strings, because those bucket aggressively (`diffForHumans`
-     * short-form rounds to whole seconds against an ever-advancing "now",
-     * `Number::fileSize` rounds to a precision-1 unit). With those, two
-     * rapid in-place WC edits of the same byte count produce identical
-     * fingerprints — softRefresh thinks nothing changed, latches
-     * skipRender, and the diff stays stale despite the cache being cleared
-     * upstream. `additions/deletions` from numstat are also too coarse on
-     * their own in 1commit+WC mode: an in-place edit on a line already
-     * modified by the pinned commit doesn't change either count.
+     * Uses raw mtime + byte size (not the human-readable `lastModified` /
+     * `fileSize` strings), because those bucket aggressively
+     * (`diffForHumans` short-form rounds to whole seconds against an
+     * ever-advancing "now"; `Number::fileSize` rounds to a precision-1
+     * unit) and `additions/deletions` from numstat are also too coarse on
+     * their own — in 1commit+WC and Since-base modes an in-place edit on
+     * a line already changed by some pinned commit moves neither count.
      *
      * @param  array<int, array<string, mixed>>  $files
      * @return array<string, string>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -456,6 +456,19 @@ new #[Layout('layouts.app')] class extends Component
     }
 
     /**
+     * Per-file change signature for softRefresh's skipRender heuristic.
+     *
+     * Uses raw mtime + byte size — not the human-readable `lastModified` /
+     * `fileSize` strings, because those bucket aggressively (`diffForHumans`
+     * short-form rounds to whole seconds against an ever-advancing "now",
+     * `Number::fileSize` rounds to a precision-1 unit). With those, two
+     * rapid in-place WC edits of the same byte count produce identical
+     * fingerprints — softRefresh thinks nothing changed, latches
+     * skipRender, and the diff stays stale despite the cache being cleared
+     * upstream. `additions/deletions` from numstat are also too coarse on
+     * their own in 1commit+WC mode: an in-place edit on a line already
+     * modified by the pinned commit doesn't change either count.
+     *
      * @param  array<int, array<string, mixed>>  $files
      * @return array<string, string>
      */
@@ -468,8 +481,8 @@ new #[Layout('layouts.app')] class extends Component
                     $f['status'] ?? '',
                     $f['additions'] ?? 0,
                     $f['deletions'] ?? 0,
-                    $f['lastModified'] ?? '',
-                    $f['fileSize'] ?? '',
+                    $f['mtime'] ?? '',
+                    $f['byteSize'] ?? '',
                 ),
             ])
             ->all();

--- a/tests/Arch/BladeConventionsTest.php
+++ b/tests/Arch/BladeConventionsTest.php
@@ -129,8 +129,9 @@ test('review-page fileFingerprints uses raw mtime and byteSize, not formatted st
 
     $body = $m[1];
 
-    expect($body)->toContain("'mtime'");
-    expect($body)->toContain("'byteSize'");
-    expect($body)->not->toContain("'lastModified'");
-    expect($body)->not->toContain("'fileSize'");
+    expect($body)
+        ->toContain("'mtime'")
+        ->toContain("'byteSize'")
+        ->not->toContain("'lastModified'")
+        ->not->toContain("'fileSize'");
 });

--- a/tests/Arch/BladeConventionsTest.php
+++ b/tests/Arch/BladeConventionsTest.php
@@ -110,3 +110,27 @@ test('alpine event names do not collide with blade directives', function () {
     }
     expect($violations)->toBeEmpty();
 });
+
+/**
+ * Pins the design intent of the review-page softRefresh fingerprint:
+ * change-detection must use the raw `mtime` / `byteSize` fields, not
+ * the formatted `lastModified` / `fileSize` strings. The latter bucket
+ * (`diffForHumans` short-form, `Number::fileSize` precision-1) and
+ * caused the 1commit+WC stale-diff bug. If a future refactor reverts
+ * the keys, this test fires before the toast count silently degrades.
+ */
+test('review-page fileFingerprints uses raw mtime and byteSize, not formatted strings', function () {
+    $page = dirname(__DIR__, 2).'/resources/views/pages/⚡review-page.blade.php';
+    $content = file_get_contents($page);
+
+    if (! preg_match('/private function fileFingerprints\([^)]*\): array\s*\{(.*?)^    \}/sm', $content, $m)) {
+        test()->fail('Could not locate fileFingerprints method body');
+    }
+
+    $body = $m[1];
+
+    expect($body)->toContain("'mtime'");
+    expect($body)->toContain("'byteSize'");
+    expect($body)->not->toContain("'lastModified'");
+    expect($body)->not->toContain("'fileSize'");
+});

--- a/tests/Unit/FileListEntryTest.php
+++ b/tests/Unit/FileListEntryTest.php
@@ -54,6 +54,8 @@ test('toArray includes all properties and computed id', function () {
         'fileSize' => null,
         'isExternal' => false,
         'externalAbsolutePath' => null,
+        'mtime' => null,
+        'byteSize' => null,
     ]);
 });
 

--- a/tests/Unit/GitDiffServiceTest.php
+++ b/tests/Unit/GitDiffServiceTest.php
@@ -178,6 +178,103 @@ test('getFileList returns empty for clean repo', function () {
     expect($entries)->toBeEmpty();
 });
 
+// -- mtime / byteSize fingerprint fields --
+
+/**
+ * Producer-side regression for the 1commit+WC / Since-base stale-diff
+ * bug: the review page's softRefresh fingerprint depends on `mtime` and
+ * `byteSize` being populated from the live filesystem in working-tree
+ * mode. If `getFileList` ever stops setting them, the toast count
+ * silently degrades to "always zero" and the bug is back.
+ */
+test('getFileList populates raw mtime and byteSize for working-tree entries', function () {
+    $this->initTestRepo($this->tmpDir);
+    File::put($this->tmpDir.'/hello.txt', "v1\n");
+    $this->commitTestRepo($this->tmpDir, 'initial');
+    File::put($this->tmpDir.'/hello.txt', "v2 longer\n");
+
+    $entries = $this->service->getFileList($this->tmpDir);
+
+    expect($entries)->toHaveCount(1);
+    $entry = $entries[0];
+    expect($entry->mtime)->toBe(File::lastModified($this->tmpDir.'/hello.txt'));
+    expect($entry->byteSize)->toBe(File::size($this->tmpDir.'/hello.txt'));
+});
+
+test('getFileList populates raw mtime and byteSize for untracked text entries', function () {
+    $this->initTestRepo($this->tmpDir);
+    File::put($this->tmpDir.'/seed.txt', "ok\n");
+    $this->commitTestRepo($this->tmpDir, 'initial');
+    File::put($this->tmpDir.'/new.txt', "fresh\n");
+
+    $entries = $this->service->getFileList($this->tmpDir);
+
+    expect($entries)->toHaveCount(1);
+    $entry = $entries[0];
+    expect($entry->isUntracked)->toBeTrue();
+    expect($entry->mtime)->toBe(File::lastModified($this->tmpDir.'/new.txt'));
+    expect($entry->byteSize)->toBe(File::size($this->tmpDir.'/new.txt'));
+});
+
+test('getFileList mtime advances after rewriting a working-tree file', function () {
+    $this->initTestRepo($this->tmpDir);
+    File::put($this->tmpDir.'/hello.txt', "before\n");
+    $this->commitTestRepo($this->tmpDir, 'initial');
+
+    File::put($this->tmpDir.'/hello.txt', "edit-1\n");
+    clearstatcache(true, $this->tmpDir.'/hello.txt');
+    $first = $this->service->getFileList($this->tmpDir)[0];
+
+    // Bump mtime explicitly so the test isn't a same-second flake.
+    touch($this->tmpDir.'/hello.txt', $first->mtime + 5);
+    File::put($this->tmpDir.'/hello.txt', "edit-2\n");
+    touch($this->tmpDir.'/hello.txt', $first->mtime + 5);
+    clearstatcache(true, $this->tmpDir.'/hello.txt');
+    $second = $this->service->getFileList($this->tmpDir)[0];
+
+    expect($second->mtime)->toBeGreaterThan($first->mtime);
+});
+
+/**
+ * 1commit+WC and Since-base are both `rangeToWorking` targets. Same
+ * branch as plain WT for `isWorkingDirectory()`, so mtime/byteSize must
+ * still be populated — the fix relies on this.
+ */
+test('getFileList populates mtime/byteSize in rangeToWorking (1commit+WC / Since-base) mode', function () {
+    $this->initTestRepo($this->tmpDir);
+    File::put($this->tmpDir.'/file.txt', "v1\n");
+    $this->commitTestRepo($this->tmpDir, 'c1');
+    File::put($this->tmpDir.'/file.txt', "v2\n");
+    $this->commitTestRepo($this->tmpDir, 'c2');
+    File::put($this->tmpDir.'/file.txt', "v3 wc\n");
+
+    $entries = $this->service->getFileList(
+        $this->tmpDir,
+        target: DiffTarget::rangeToWorking('HEAD~1'),
+    );
+
+    expect($entries)->toHaveCount(1);
+    expect($entries[0]->mtime)->toBe(File::lastModified($this->tmpDir.'/file.txt'));
+    expect($entries[0]->byteSize)->toBe(File::size($this->tmpDir.'/file.txt'));
+});
+
+test('getFileList leaves mtime/byteSize null for immutable (commit-to-commit) targets', function () {
+    $this->initTestRepo($this->tmpDir);
+    File::put($this->tmpDir.'/file.txt', "v1\n");
+    $this->commitTestRepo($this->tmpDir, 'c1');
+    File::put($this->tmpDir.'/file.txt', "v2\n");
+    $this->commitTestRepo($this->tmpDir, 'c2');
+
+    $entries = $this->service->getFileList(
+        $this->tmpDir,
+        target: DiffTarget::range('HEAD~1', 'HEAD'),
+    );
+
+    expect($entries)->toHaveCount(1);
+    expect($entries[0]->mtime)->toBeNull();
+    expect($entries[0]->byteSize)->toBeNull();
+});
+
 // -- getFileDiff tests --
 
 test('getFileDiff returns raw diff for tracked file', function () {

--- a/tests/Unit/GitDiffServiceTest.php
+++ b/tests/Unit/GitDiffServiceTest.php
@@ -225,8 +225,7 @@ test('getFileList mtime advances after rewriting a working-tree file', function 
     clearstatcache(true, $this->tmpDir.'/hello.txt');
     $first = $this->service->getFileList($this->tmpDir)[0];
 
-    // Bump mtime explicitly so the test isn't a same-second flake.
-    touch($this->tmpDir.'/hello.txt', $first->mtime + 5);
+    // Write, then pin mtime so the assertion isn't a same-second flake.
     File::put($this->tmpDir.'/hello.txt', "edit-2\n");
     touch($this->tmpDir.'/hello.txt', $first->mtime + 5);
     clearstatcache(true, $this->tmpDir.'/hello.txt');

--- a/tests/Unit/Livewire/ReviewPageSoftRefreshTest.php
+++ b/tests/Unit/Livewire/ReviewPageSoftRefreshTest.php
@@ -43,7 +43,7 @@ beforeEach(function () {
     {
         /** @var array<int, array<string, mixed>> */
         public array $files = [
-            ['id' => 'abc123', 'path' => 'src/Foo.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 5, 'deletions' => 2, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T00:00:00Z', 'fileSize' => '100'],
+            ['id' => 'abc123', 'path' => 'src/Foo.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 5, 'deletions' => 2, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T00:00:00Z', 'fileSize' => '100', 'mtime' => 1714000000, 'byteSize' => 100],
         ];
 
         public int $callCount = 0;
@@ -105,8 +105,8 @@ test('softRefresh reports changedCount when files differ', function () {
     $component = Livewire::test('pages::review-page', ['slug' => 'soft-refresh-test']);
 
     $this->fileListFake->files = [
-        ['id' => 'abc123', 'path' => 'src/Foo.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 7, 'deletions' => 2, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T01:00:00Z', 'fileSize' => '120'],
-        ['id' => 'def456', 'path' => 'src/Bar.php', 'status' => 'added', 'oldPath' => null, 'additions' => 10, 'deletions' => 0, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T01:00:00Z', 'fileSize' => '200'],
+        ['id' => 'abc123', 'path' => 'src/Foo.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 7, 'deletions' => 2, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T01:00:00Z', 'fileSize' => '120', 'mtime' => 1714000100, 'byteSize' => 120],
+        ['id' => 'def456', 'path' => 'src/Bar.php', 'status' => 'added', 'oldPath' => null, 'additions' => 10, 'deletions' => 0, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T01:00:00Z', 'fileSize' => '200', 'mtime' => 1714000100, 'byteSize' => 200],
     ];
 
     $component->call('softRefresh')
@@ -136,8 +136,8 @@ test('softRefresh with file changes renders the new file list despite stable div
     expect($component->get('divergenceChecked'))->toBeTrue();
 
     $this->fileListFake->files = [
-        ['id' => 'abc123', 'path' => 'src/Foo.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 5, 'deletions' => 2, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T00:00:00Z', 'fileSize' => '100'],
-        ['id' => 'def456', 'path' => 'src/NewlyAdded.php', 'status' => 'added', 'oldPath' => null, 'additions' => 10, 'deletions' => 0, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T01:00:00Z', 'fileSize' => '200'],
+        ['id' => 'abc123', 'path' => 'src/Foo.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 5, 'deletions' => 2, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T00:00:00Z', 'fileSize' => '100', 'mtime' => 1714000000, 'byteSize' => 100],
+        ['id' => 'def456', 'path' => 'src/NewlyAdded.php', 'status' => 'added', 'oldPath' => null, 'additions' => 10, 'deletions' => 0, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T01:00:00Z', 'fileSize' => '200', 'mtime' => 1714000100, 'byteSize' => 200],
     ];
 
     $component->call('softRefresh')
@@ -153,14 +153,39 @@ test('softRefresh with no file changes and stable divergence skips the render', 
     expect($component->effects['html'] ?? null)->toBeNull();
 });
 
+/**
+ * Regression: in 1commit+WC mode, an in-place WC edit can leave numstat
+ * additions/deletions unchanged (the line was already counted by the
+ * pinned commit), and the human-readable `lastModified` / `fileSize`
+ * strings can bucket identically across two rapid refreshes. softRefresh
+ * must still detect the edit via raw mtime / byte size — otherwise it
+ * latches `skipRender()` and the diff stays stale despite the cache
+ * being cleared upstream.
+ */
+test('softRefresh detects in-place WC edits via raw mtime even when status/additions/lastModified are stable', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'soft-refresh-test']);
+
+    // Same id, status, additions, deletions, and human-readable
+    // lastModified/fileSize as the mount fixture — only the raw mtime
+    // bumps, simulating an in-place edit between two refreshes.
+    $this->fileListFake->files = [
+        ['id' => 'abc123', 'path' => 'src/Foo.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 5, 'deletions' => 2, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T00:00:00Z', 'fileSize' => '100', 'mtime' => 1714000042, 'byteSize' => 100],
+    ];
+
+    $component->call('softRefresh')
+        ->assertDispatched('refresh-completed', changedCount: 1);
+
+    expect($component->effects['html'] ?? null)->not->toBeNull();
+});
+
 test('head-advanced-on-branch triggers softRefresh and dispatches refresh-completed', function () {
     $component = Livewire::test('pages::review-page', ['slug' => 'soft-refresh-test']);
 
     // Simulate a new commit landing on the branch the user is reviewing —
     // the file list now reflects post-commit state.
     $this->fileListFake->files = [
-        ['id' => 'abc123', 'path' => 'src/Foo.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 12, 'deletions' => 3, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T02:00:00Z', 'fileSize' => '150'],
-        ['id' => 'new789', 'path' => 'src/JustCommitted.php', 'status' => 'added', 'oldPath' => null, 'additions' => 20, 'deletions' => 0, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T02:00:00Z', 'fileSize' => '300'],
+        ['id' => 'abc123', 'path' => 'src/Foo.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 12, 'deletions' => 3, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T02:00:00Z', 'fileSize' => '150', 'mtime' => 1714000200, 'byteSize' => 150],
+        ['id' => 'new789', 'path' => 'src/JustCommitted.php', 'status' => 'added', 'oldPath' => null, 'additions' => 20, 'deletions' => 0, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T02:00:00Z', 'fileSize' => '300', 'mtime' => 1714000200, 'byteSize' => 300],
     ];
 
     $component->call('refreshAfterHeadAdvance')

--- a/tests/Unit/Livewire/ReviewPageSoftRefreshTest.php
+++ b/tests/Unit/Livewire/ReviewPageSoftRefreshTest.php
@@ -123,17 +123,8 @@ test('softRefresh preserves activeFileId across the call', function () {
     expect($component->get('activeFileId'))->toBe('abc123');
 });
 
-/**
- * Regression: after mount, `divergenceChecked` is true, so an unchanged
- * divergence poll inside softRefresh would latch `skipRender()` onto the
- * response. If files also changed, the toast fires but the Blade never
- * morphs and the UI stays stale until a hard reload. softRefresh must
- * still render when `changedCount > 0`, even with stable divergence.
- */
-test('softRefresh with file changes renders the new file list despite stable divergence', function () {
+test('softRefresh renders the new file list when files change', function () {
     $component = Livewire::test('pages::review-page', ['slug' => 'soft-refresh-test']);
-
-    expect($component->get('divergenceChecked'))->toBeTrue();
 
     $this->fileListFake->files = [
         ['id' => 'abc123', 'path' => 'src/Foo.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 5, 'deletions' => 2, 'isBinary' => false, 'isUntracked' => false, 'lastModified' => '2026-04-24T00:00:00Z', 'fileSize' => '100', 'mtime' => 1714000000, 'byteSize' => 100],
@@ -145,24 +136,36 @@ test('softRefresh with file changes renders the new file list despite stable div
         ->assertSee('src/NewlyAdded.php');
 });
 
-test('softRefresh with no file changes and stable divergence skips the render', function () {
+/**
+ * Contract: softRefresh always renders, even when nothing visible changed.
+ * The previous implementation called `skipRender()` based on a
+ * fingerprint heuristic; that was the root cause of the 1commit+WC
+ * stale-diff bug, because a fingerprint false-negative latched the
+ * response into a no-op morph and children never re-hydrated from the
+ * (already-cleared) cache. softRefresh is user-initiated (⌘R or click),
+ * so the cost of an idempotent render is acceptable; the cost of a
+ * silently stale UI is not.
+ */
+test('softRefresh always renders even when no files changed', function () {
     $component = Livewire::test('pages::review-page', ['slug' => 'soft-refresh-test']);
 
-    $component->call('softRefresh');
+    $component->call('softRefresh')
+        ->assertDispatched('refresh-completed', changedCount: 0);
 
-    expect($component->effects['html'] ?? null)->toBeNull();
+    expect($component->effects['html'] ?? null)->not->toBeNull();
 });
 
 /**
- * Regression: in 1commit+WC mode, an in-place WC edit can leave numstat
- * additions/deletions unchanged (the line was already counted by the
- * pinned commit), and the human-readable `lastModified` / `fileSize`
- * strings can bucket identically across two rapid refreshes. softRefresh
- * must still detect the edit via raw mtime / byte size — otherwise it
- * latches `skipRender()` and the diff stays stale despite the cache
- * being cleared upstream.
+ * Toast accuracy regression: in 1commit+WC and Since-base modes an
+ * in-place WC edit can leave numstat additions/deletions unchanged (the
+ * line was already counted by some pinned commit) and the human-readable
+ * `lastModified` / `fileSize` strings can bucket identically across two
+ * rapid refreshes. The fingerprint must still detect the edit via raw
+ * mtime / byte size — otherwise the toast says "Up to date" while the
+ * diff did, in fact, change. (The render itself no longer depends on
+ * this signal, but the toast text does.)
  */
-test('softRefresh detects in-place WC edits via raw mtime even when status/additions/lastModified are stable', function () {
+test('softRefresh changedCount catches in-place edits via raw mtime when status/additions/lastModified are stable', function () {
     $component = Livewire::test('pages::review-page', ['slug' => 'soft-refresh-test']);
 
     // Same id, status, additions, deletions, and human-readable


### PR DESCRIPTION
## Summary

Fixes a bug where the review page's softRefresh would fail to detect in-place file edits in "1commit+WC" and "Since-base" diff modes, causing the toast to incorrectly show "Up to date" while the diff had actually changed. The root cause was relying on formatted `lastModified` and `fileSize` strings for change detection, which bucket too aggressively to catch rapid edits.

## Key Changes

- **Added raw mtime and byteSize fields to FileListEntry**: New `mtime` (Unix timestamp) and `byteSize` (byte count) fields capture the raw filesystem state, separate from the human-readable formatted strings.

- **Updated GitDiffService.getFileList()**: Now populates `mtime` and `byteSize` for all working-directory targets (plain WT, 1commit+WC, Since-base modes) via new helper methods `getRawMtime()` and `getRawByteSize()`.

- **Updated ExternalFilesService**: Also populates the new raw fields for external file entries.

- **Fixed softRefresh fingerprinting**: Changed `fileFingerprints()` to use raw `mtime` and `byteSize` instead of formatted `lastModified` and `fileSize` strings. This catches in-place edits where line counts and human-readable timestamps haven't changed.

- **Removed conditional skipRender()**: softRefresh now always renders, even when `changedCount === 0`. The previous heuristic-based skip was the root cause of the stale-diff bug—a false-negative fingerprint would latch the response into a no-op morph, preventing child components from rehydrating. User-initiated refreshes (⌘R, click, head-advance) have acceptable morph cost; silently stale UI does not.

- **Added comprehensive test coverage**: New tests in GitDiffServiceTest verify mtime/byteSize population across all scenarios (tracked, untracked, rangeToWorking, commit-to-commit). New tests in ReviewPageSoftRefreshTest verify the toast accuracy fix and that renders always occur.

- **Added architectural test**: BladeConventionsTest now pins the design intent that fileFingerprints must use raw fields, preventing future regressions.

## Implementation Details

- Raw fields are only populated for working-directory targets; commit-to-commit diffs leave them null (immutable state).
- The fingerprint now uses a hash of `[id, status, additions, deletions, mtime, byteSize]` instead of including formatted strings.
- All test fixtures updated to include the new `mtime` and `byteSize` fields in mock file lists.

https://claude.ai/code/session_019WzLy3s8FXh2gCXy5WoFQr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced file metadata tracking with modification time and byte size information for improved change detection.
  * Improved review page refresh behavior for more reliable UI updates.

* **Tests**
  * Added comprehensive test coverage for file metadata population and change detection.
  * Added tests validating refresh behavior and file state fingerprinting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->