### PR TITLE
Remove unused RFA_GITHUB_REPO config entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Always excluded: `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lock`,
 
 ## Development
 
-Prerequisites: PHP 8.3+, Composer, Node.js 22+, git.
+Prerequisites: PHP 8.4+, Composer, Node.js 22+, git.
 
 ```bash
 composer install
@@ -97,7 +97,7 @@ composer test        # Pest
 
 ## Tech Stack
 
-Laravel 12, Livewire 4, Flux UI, Alpine.js, Tailwind CSS, NativePHP Desktop (Electron).
+Laravel 13, Livewire 4, Flux UI, Alpine.js, Tailwind CSS, NativePHP Desktop (Electron).
 
 ## License
 

--- a/app/Listeners/HandleMenuItemClicked.php
+++ b/app/Listeners/HandleMenuItemClicked.php
@@ -14,6 +14,13 @@ use Native\Desktop\Facades\Window;
 
 final readonly class HandleMenuItemClicked
 {
+    /**
+     * Cross-process channel: the renderer page's mount() writes the active
+     * project id here so the main-process menu listener can resolve which
+     * project the user is on when "Show Context" fires.
+     */
+    public const string ACTIVE_PROJECT_CACHE_KEY = 'rfa.active-project-id';
+
     public function handle(MenuItemClicked $event): void
     {
         $id = $event->item['id'] ?? null;
@@ -54,7 +61,7 @@ final readonly class HandleMenuItemClicked
      */
     private function handleShowContext(): void
     {
-        $cachedId = Cache::get('rfa.active-project-id');
+        $cachedId = Cache::get(self::ACTIVE_PROJECT_CACHE_KEY);
         $project = is_int($cachedId) ? app(ResolveProjectByIdAction::class)->handle($cachedId) : null;
 
         if (! $project) {

--- a/config/rfa.php
+++ b/config/rfa.php
@@ -3,7 +3,6 @@
 return [
     'diff_max_bytes' => env('RFA_DIFF_MAX_BYTES', 512_000),
     'cache_ttl_hours' => env('RFA_CACHE_TTL_HOURS', 24),
-    'github_repo' => env('RFA_GITHUB_REPO', 'fgilio/rfa'),
 
     /*
     | Path prefixes (from repo root) the AgentContextFileScanner skips when

--- a/resources/views/pages/⚡context-page.blade.php
+++ b/resources/views/pages/⚡context-page.blade.php
@@ -9,6 +9,7 @@ use App\Actions\PersistProjectViewAction;
 use App\Actions\ResolveProjectAction;
 use App\DTOs\AgentContextFile;
 use App\Enums\LastViewMode;
+use App\Listeners\HandleMenuItemClicked;
 use Illuminate\Support\Facades\Cache;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
@@ -73,7 +74,7 @@ new #[Layout('layouts.app')] class extends Component
         $this->projectBranch = $project['branch'] ?? '';
         $this->hasRemote = ! empty($project['remote_url']);
 
-        Cache::put('rfa.active-project-id', $this->projectId, now()->addDay());
+        Cache::put(HandleMenuItemClicked::ACTIVE_PROJECT_CACHE_KEY, $this->projectId, now()->addDay());
 
         $projectId = $this->projectId;
         $repoPath = $this->repoPath;

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -37,6 +37,7 @@ use App\Enums\GitRef;
 use App\Enums\LastViewKind;
 use App\Enums\LastViewMode;
 use App\Exceptions\GitCommandException;
+use App\Listeners\HandleMenuItemClicked;
 use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
 use Livewire\Attributes\Computed;
@@ -166,7 +167,7 @@ new #[Layout('layouts.app')] class extends Component
 
         app(ResolveStartupRouteAction::class)->rememberLastOpened($slug);
 
-        Cache::put('rfa.active-project-id', $this->projectId, now()->addDay());
+        Cache::put(HandleMenuItemClicked::ACTIVE_PROJECT_CACHE_KEY, $this->projectId, now()->addDay());
 
         if (config('nativephp-internal.running')) {
             \Native\Desktop\Facades\Window::get('main')->title("rfa - {$this->projectName}");

--- a/resources/views/pages/⚡select-repo-page.blade.php
+++ b/resources/views/pages/⚡select-repo-page.blade.php
@@ -4,6 +4,7 @@ use App\Actions\ListProjectsAction;
 use App\Actions\RemoveProjectAction;
 use App\Actions\ResolveStartupRouteAction;
 use App\Concerns\InteractsWithRemoteLinks;
+use App\Listeners\HandleMenuItemClicked;
 use Illuminate\Support\Facades\Cache;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\On;
@@ -36,7 +37,7 @@ new #[Layout('layouts.app')] class extends Component
 
         // Without this, ⌘⇧K from the repo picker would ambush the user with
         // the last project they had open via the menu-handler's cache lookup.
-        Cache::forget('rfa.active-project-id');
+        Cache::forget(HandleMenuItemClicked::ACTIVE_PROJECT_CACHE_KEY);
 
         if (config('nativephp-internal.running')) {
             \Native\Desktop\Facades\Window::get('main')->title('rfa');


### PR DESCRIPTION
config('rfa.github_repo') is never read anywhere in the codebase. The
real GitHub repo for the auto-updater is configured in
config/nativephp.php under a different env var (GITHUB_REPO), as noted
in .github/CLAUDE.md. Leaving this entry around suggested the variable
controlled the updater and made it harder to reason about release
configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated PHP minimum requirement to 8.4+
  * Upgraded Laravel framework to version 13

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fgilio/rfa/pull/89)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->