### PR TITLE
Allow linking single external files alongside folders

### DIFF
--- a/app/Actions/LinkExternalPathAction.php
+++ b/app/Actions/LinkExternalPathAction.php
@@ -14,10 +14,11 @@ final readonly class LinkExternalPathAction
     ) {}
 
     /**
-     * Append an external directory link to a project. Idempotent on the
-     * canonical path: the same directory is never linked twice. Returns the
-     * project's updated `external_paths` value, or null if the project does
-     * not exist or the path is not a directory.
+     * Append an external path link to a project. The path may be a directory
+     * (whose contents are walked) or a single file (mounted as one entry).
+     * Idempotent on the canonical path: the same path is never linked twice.
+     * Returns the project's updated `external_paths` value, or null if the
+     * project does not exist or the path is neither a file nor a directory.
      *
      * @return list<array{label: string, path: string}>|null
      */
@@ -53,7 +54,7 @@ final readonly class LinkExternalPathAction
         }
 
         $real = realpath($path);
-        if ($real === false || ! is_dir($real)) {
+        if ($real === false || (! is_dir($real) && ! is_file($real))) {
             return null;
         }
 

--- a/app/Console/Commands/LinkExternalPathCommand.php
+++ b/app/Console/Commands/LinkExternalPathCommand.php
@@ -9,9 +9,9 @@ use Illuminate\Console\Command;
 
 class LinkExternalPathCommand extends Command
 {
-    protected $signature = 'rfa:link-path {project : Project slug, name, or id} {path : Absolute directory path to link} {--label= : Optional display label (defaults to directory basename)}';
+    protected $signature = 'rfa:link-path {project : Project slug, name, or id} {path : Absolute path to a directory or single file to link} {--label= : Optional display label (defaults to the path basename)}';
 
-    protected $description = 'Link an external directory to a project so its files appear in review as commentable entries';
+    protected $description = 'Link an external directory or single file to a project so it appears in review as a commentable entry';
 
     public function handle(LinkExternalPathAction $action): int
     {
@@ -22,7 +22,7 @@ class LinkExternalPathCommand extends Command
         $updated = $action->handleByReference($reference, $path, is_string($label) ? $label : null);
 
         if ($updated === null) {
-            $this->error("Could not link path: project {$reference} not found, or path {$path} is not a directory.");
+            $this->error("Could not link path: project {$reference} not found, or path {$path} is not a file or directory.");
 
             return self::FAILURE;
         }

--- a/app/Services/ExternalFilesService.php
+++ b/app/Services/ExternalFilesService.php
@@ -73,7 +73,7 @@ class ExternalFilesService
                     continue;
                 }
 
-                return File::isFile($config['root']) ? $config['root'] : null;
+                return $config['root'];
             }
 
             $prefix = $config['label'].'/';
@@ -141,9 +141,7 @@ class ExternalFilesService
     private function entriesForConfig(array $config): array
     {
         if ($config['is_file']) {
-            $entry = $this->entryForFile($config);
-
-            return $entry === null ? [] : [$entry];
+            return [$this->entryForFile($config)];
         }
 
         $root = $config['root'];
@@ -192,25 +190,13 @@ class ExternalFilesService
                 ltrim(substr($absolutePath, strlen($root)), DIRECTORY_SEPARATOR),
             );
 
-            $size = $file->getSize();
-            $mtime = $file->getMTime();
-
-            $entries[] = new FileListEntry(
-                path: self::MOUNT_PREFIX.'/'.$config['label'].'/'.$relative,
-                status: 'added',
-                oldPath: null,
+            $entries[] = $this->buildFileListEntry(
+                mountPath: self::MOUNT_PREFIX.'/'.$config['label'].'/'.$relative,
+                absolutePath: $absolutePath,
                 additions: $additions,
-                deletions: 0,
                 isBinary: false,
-                isUntracked: false,
-                lastModified: Carbon::createFromTimestamp($mtime)->diffForHumans(short: true),
-                isSymlink: false,
-                symlinkTarget: null,
-                fileSize: Number::fileSize($size, precision: 1),
-                isExternal: true,
-                externalAbsolutePath: $absolutePath,
-                mtime: $mtime,
-                byteSize: $size,
+                size: $file->getSize(),
+                mtime: $file->getMTime(),
             );
         }
 
@@ -257,13 +243,9 @@ class ExternalFilesService
     /**
      * @param  array{label: string, root: string, is_file: bool}  $config
      */
-    private function entryForFile(array $config): ?FileListEntry
+    private function entryForFile(array $config): FileListEntry
     {
         $absolutePath = $config['root'];
-
-        if (! is_file($absolutePath)) {
-            return null;
-        }
 
         // Single-file mounts are explicit user choices — surface binaries (with
         // a header-only diff) rather than silently dropping them the way folder
@@ -272,14 +254,30 @@ class ExternalFilesService
         $isBinary = $additions === null;
 
         $info = new SplFileInfo($absolutePath);
-        $size = $info->getSize();
-        $mtime = $info->getMTime();
 
+        return $this->buildFileListEntry(
+            mountPath: self::MOUNT_PREFIX.'/'.$config['label'],
+            absolutePath: $absolutePath,
+            additions: $isBinary ? 0 : $additions,
+            isBinary: $isBinary,
+            size: $info->getSize(),
+            mtime: $info->getMTime(),
+        );
+    }
+
+    private function buildFileListEntry(
+        string $mountPath,
+        string $absolutePath,
+        int $additions,
+        bool $isBinary,
+        int $size,
+        int $mtime,
+    ): FileListEntry {
         return new FileListEntry(
-            path: self::MOUNT_PREFIX.'/'.$config['label'],
+            path: $mountPath,
             status: 'added',
             oldPath: null,
-            additions: $isBinary ? 0 : $additions,
+            additions: $additions,
             deletions: 0,
             isBinary: $isBinary,
             isUntracked: false,

--- a/app/Services/ExternalFilesService.php
+++ b/app/Services/ExternalFilesService.php
@@ -29,9 +29,11 @@ class ExternalFilesService
     ) {}
 
     /**
-     * Build synthetic FileListEntry rows for every configured external directory.
-     * Each file is mounted under `external/<label>/<relative>` so the synthetic
-     * path stays stable across sessions and yields the same file id.
+     * Build synthetic FileListEntry rows for every configured external path.
+     * Directory configs are walked and each file mounted under
+     * `external/<label>/<relative>`. Single-file configs produce one entry at
+     * `external/<label>`. The synthetic path stays stable across sessions and
+     * yields the same file id.
      *
      * @param  array<int, mixed>  $rawConfigs  Raw rows from `Project::external_paths`.
      * @return list<FileListEntry>
@@ -66,6 +68,14 @@ class ExternalFilesService
         $remainder = substr($mountPath, strlen(self::MOUNT_PREFIX) + 1);
 
         foreach ($configs as $config) {
+            if ($config['is_file']) {
+                if ($remainder !== $config['label']) {
+                    continue;
+                }
+
+                return File::isFile($config['root']) ? $config['root'] : null;
+            }
+
             $prefix = $config['label'].'/';
 
             if (! str_starts_with($remainder, $prefix)) {
@@ -125,11 +135,17 @@ class ExternalFilesService
     }
 
     /**
-     * @param  array{label: string, root: string}  $config
+     * @param  array{label: string, root: string, is_file: bool}  $config
      * @return list<FileListEntry>
      */
     private function entriesForConfig(array $config): array
     {
+        if ($config['is_file']) {
+            $entry = $this->entryForFile($config);
+
+            return $entry === null ? [] : [$entry];
+        }
+
         $root = $config['root'];
 
         if (! is_dir($root)) {
@@ -204,28 +220,78 @@ class ExternalFilesService
     }
 
     /**
-     * Resolve normalized rows to absolute roots ready for filesystem walking.
-     * Drops rows whose path no longer exists. Stored labels are used as-is
+     * Resolve normalized rows to absolute roots ready for filesystem walking
+     * (directories) or direct mounting (single files). Drops rows whose path
+     * no longer exists or has changed type. Stored labels are used as-is
      * (only sanitized) — disambiguation happens at link time so unlinking a
      * sibling never renames a surviving mount.
      *
      * @param  array<int, mixed>  $raw
-     * @return list<array{label: string, root: string}>
+     * @return list<array{label: string, root: string, is_file: bool}>
      */
     private function resolvedConfigs(array $raw): array
     {
         return collect($this->normalizeForStorage($raw))
             ->map(function (array $row): ?array {
                 $root = realpath($row['path']);
-                if ($root === false || ! is_dir($root)) {
+                if ($root === false) {
                     return null;
                 }
 
-                return ['label' => $this->sanitizeLabel($row['label']), 'root' => $root];
+                $isFile = is_file($root);
+                if (! $isFile && ! is_dir($root)) {
+                    return null;
+                }
+
+                return [
+                    'label' => $this->sanitizeLabel($row['label']),
+                    'root' => $root,
+                    'is_file' => $isFile,
+                ];
             })
             ->filter()
             ->values()
             ->all();
+    }
+
+    /**
+     * @param  array{label: string, root: string, is_file: bool}  $config
+     */
+    private function entryForFile(array $config): ?FileListEntry
+    {
+        $absolutePath = $config['root'];
+
+        if (! is_file($absolutePath)) {
+            return null;
+        }
+
+        // Single-file mounts are explicit user choices — surface binaries (with
+        // a header-only diff) rather than silently dropping them the way folder
+        // walks do.
+        $additions = $this->streamCountLines($absolutePath);
+        $isBinary = $additions === null;
+
+        $info = new SplFileInfo($absolutePath);
+        $size = $info->getSize();
+        $mtime = $info->getMTime();
+
+        return new FileListEntry(
+            path: self::MOUNT_PREFIX.'/'.$config['label'],
+            status: 'added',
+            oldPath: null,
+            additions: $isBinary ? 0 : $additions,
+            deletions: 0,
+            isBinary: $isBinary,
+            isUntracked: false,
+            lastModified: Carbon::createFromTimestamp($mtime)->diffForHumans(short: true),
+            isSymlink: false,
+            symlinkTarget: null,
+            fileSize: Number::fileSize($size, precision: 1),
+            isExternal: true,
+            externalAbsolutePath: $absolutePath,
+            mtime: $mtime,
+            byteSize: $size,
+        );
     }
 
     /**

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -353,10 +353,21 @@ new #[Layout('layouts.app')] class extends Component
 
     public function addExternalPath(): void
     {
-        $picked = app(\Native\Desktop\Dialog::class)
-            ->title('Link External Folder')
-            ->folders()
-            ->open();
+        $this->pickAndLinkExternalPath(isFile: false);
+    }
+
+    public function addExternalFile(): void
+    {
+        $this->pickAndLinkExternalPath(isFile: true);
+    }
+
+    private function pickAndLinkExternalPath(bool $isFile): void
+    {
+        $kind = $isFile ? 'file' : 'folder';
+
+        $dialog = app(\Native\Desktop\Dialog::class)
+            ->title($isFile ? 'Link External File' : 'Link External Folder');
+        $picked = ($isFile ? $dialog->files() : $dialog->folders())->open();
 
         if (! is_string($picked) || $picked === '') {
             $this->skipRender();
@@ -367,7 +378,7 @@ new #[Layout('layouts.app')] class extends Component
         $previousCount = count($this->externalPaths);
         $updated = app(LinkExternalPathAction::class)->handle($this->projectId, $picked);
         if ($updated === null) {
-            Flux::toast(variant: 'danger', text: 'Could not link folder: '.basename($picked));
+            Flux::toast(variant: 'danger', text: "Could not link {$kind}: ".basename($picked));
             $this->skipRender();
 
             return;
@@ -1657,7 +1668,7 @@ new #[Layout('layouts.app')] class extends Component
                                     Linked external paths
                                 </label>
                                 <p class="text-[10px] font-mono text-gh-muted/80 leading-snug">
-                                    Folders outside the repo that show up as commentable files (e.g. design notes from external tools).
+                                    Folders or single files outside the repo that show up as commentable files (e.g. design notes, a Claude Code plan).
                                 </p>
                                 @if(count($externalPaths) > 0)
                                     <ul class="space-y-1" data-testid="external-paths-list">
@@ -1682,20 +1693,36 @@ new #[Layout('layouts.app')] class extends Component
                                         @endforeach
                                     </ul>
                                 @endif
-                                <flux:button
-                                    size="xs"
-                                    variant="ghost"
-                                    icon="plus"
-                                    icon:variant="outline"
-                                    wire:click="addExternalPath"
-                                    wire:loading.attr="disabled"
-                                    wire:target="addExternalPath"
-                                    data-testid="external-path-add"
-                                    class="w-full"
-                                >
-                                    <span wire:loading.remove wire:target="addExternalPath">Link folder…</span>
-                                    <span wire:loading wire:target="addExternalPath">Opening…</span>
-                                </flux:button>
+                                <div class="flex gap-1">
+                                    <flux:button
+                                        size="xs"
+                                        variant="ghost"
+                                        icon="folder-plus"
+                                        icon:variant="outline"
+                                        wire:click="addExternalPath"
+                                        wire:loading.attr="disabled"
+                                        wire:target="addExternalPath"
+                                        data-testid="external-path-add"
+                                        class="flex-1"
+                                    >
+                                        <span wire:loading.remove wire:target="addExternalPath">Link folder…</span>
+                                        <span wire:loading wire:target="addExternalPath">Opening…</span>
+                                    </flux:button>
+                                    <flux:button
+                                        size="xs"
+                                        variant="ghost"
+                                        icon="document-plus"
+                                        icon:variant="outline"
+                                        wire:click="addExternalFile"
+                                        wire:loading.attr="disabled"
+                                        wire:target="addExternalFile"
+                                        data-testid="external-file-add"
+                                        class="flex-1"
+                                    >
+                                        <span wire:loading.remove wire:target="addExternalFile">Link file…</span>
+                                        <span wire:loading wire:target="addExternalFile">Opening…</span>
+                                    </flux:button>
+                                </div>
                             </div>
                         </flux:menu>
                     </flux:dropdown>

--- a/tests/Feature/Console/LinkExternalPathCommandTest.php
+++ b/tests/Feature/Console/LinkExternalPathCommandTest.php
@@ -39,7 +39,20 @@ test('fails cleanly when the project cannot be found', function () {
         ->assertFailed();
 });
 
-test('fails cleanly when the path is not a directory', function () {
+test('fails cleanly when the path is neither a file nor a directory', function () {
     $this->artisan('rfa:link-path', ['project' => 'demo', 'path' => '/this/path/does/not/exist'])
         ->assertFailed();
+});
+
+test('links a single file', function () {
+    $file = $this->extDir.'/plan.md';
+    file_put_contents($file, "# plan\n");
+
+    $this->artisan('rfa:link-path', ['project' => 'demo', 'path' => $file])
+        ->assertSuccessful();
+
+    $stored = $this->project->fresh()->external_paths;
+    expect($stored)->toHaveCount(1);
+    expect($stored[0]['path'])->toBe(realpath($file));
+    expect($stored[0]['label'])->toBe('plan.md');
 });

--- a/tests/Unit/Actions/LinkExternalPathActionTest.php
+++ b/tests/Unit/Actions/LinkExternalPathActionTest.php
@@ -22,8 +22,31 @@ test('returns null when the project does not exist', function () {
     expect($this->action->handle(99_999, $this->extDir))->toBeNull();
 });
 
-test('returns null when the path is not a directory', function () {
+test('returns null when the path is neither a file nor a directory', function () {
     expect($this->action->handle($this->project->id, '/this/path/is/not/real'))->toBeNull();
+});
+
+test('links a single file with the file basename as default label', function () {
+    $file = $this->extDir.'/plan.md';
+    file_put_contents($file, "# plan\n");
+
+    $updated = $this->action->handle($this->project->id, $file);
+
+    expect($updated)->not->toBeNull();
+    expect($updated)->toHaveCount(1);
+    expect($updated[0]['label'])->toBe('plan.md');
+    expect($updated[0]['path'])->toBe(realpath($file));
+});
+
+test('is idempotent when the same file is linked twice', function () {
+    $file = $this->extDir.'/plan.md';
+    file_put_contents($file, "# plan\n");
+
+    $first = $this->action->handle($this->project->id, $file);
+    $second = $this->action->handle($this->project->id, $file);
+
+    expect($first)->toEqual($second);
+    expect($this->project->fresh()->external_paths)->toHaveCount(1);
 });
 
 test('appends a new external path with a default label of the directory basename', function () {

--- a/tests/Unit/Services/ExternalFilesServiceTest.php
+++ b/tests/Unit/Services/ExternalFilesServiceTest.php
@@ -165,3 +165,58 @@ test('buildDiff returns null for files larger than the configured cap', function
 test('buildDiff returns empty string when the file no longer exists on disk', function () {
     expect($this->service->buildDiff($this->extDir.'/missing.md', 'external/notes/missing.md'))->toBe('');
 });
+
+// -- single-file configs --
+
+test('mounts a single-file config as one entry at external/<label> with no subpath', function () {
+    $file = $this->extDir.'/plan.md';
+    File::put($file, "# plan\n");
+
+    $entries = $this->service->getEntries([['label' => 'plan.md', 'path' => $file]]);
+
+    expect($entries)->toHaveCount(1);
+    expect($entries[0]->path)->toBe('external/plan.md');
+    expect($entries[0]->isExternal)->toBeTrue();
+    expect($entries[0]->externalAbsolutePath)->toBe(realpath($file));
+});
+
+test('resolveAbsolutePath round-trips a single-file mount back to its on-disk file', function () {
+    $file = $this->extDir.'/plan.md';
+    File::put($file, "# plan\n");
+    $configs = [['label' => 'plan.md', 'path' => $file]];
+
+    expect($this->service->resolveAbsolutePath($configs, 'external/plan.md'))->toBe(realpath($file));
+});
+
+test('resolveAbsolutePath returns null when a single-file mount is queried with a child path', function () {
+    $file = $this->extDir.'/plan.md';
+    File::put($file, "# plan\n");
+    $configs = [['label' => 'plan.md', 'path' => $file]];
+
+    expect($this->service->resolveAbsolutePath($configs, 'external/plan.md/anything'))->toBeNull();
+});
+
+test('surfaces a single-file binary as a binary entry rather than dropping it', function () {
+    $bin = $this->extDir.'/blob.bin';
+    file_put_contents($bin, "ok\0bytes\0here\n");
+
+    $entries = $this->service->getEntries([['label' => 'blob.bin', 'path' => $bin]]);
+
+    expect($entries)->toHaveCount(1);
+    expect($entries[0]->isBinary)->toBeTrue();
+    expect($entries[0]->additions)->toBe(0);
+});
+
+test('directory and single-file configs coexist on the same project', function () {
+    $file = $this->createTempDirectory('rfa_ext_file_').'/plan.md';
+    File::put($file, "# plan\n");
+
+    $entries = $this->service->getEntries([
+        ['label' => 'notes', 'path' => $this->extDir],
+        ['label' => 'plan.md', 'path' => $file],
+    ]);
+
+    $paths = collect($entries)->pluck('path')->all();
+    expect($paths)->toContain('external/notes/note.md');
+    expect($paths)->toContain('external/plan.md');
+});


### PR DESCRIPTION
Previously LINKED EXTERNAL PATHS only accepted directories, which made
the feature awkward for review use cases like a single Claude Code plan
file. Now `is_file($real) || is_dir($real)` passes the gate; single-file
configs surface as one entry at `external/<label>` (no walk), while
folder configs keep their existing recursive mount.

https://claude.ai/code/session_01N3F9gT2fCc26iSwyKC5Huk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now link individual external files as commentable entries in addition to directories
  * Updated UI with separate controls for linking folders versus single files, including dedicated icons and loading states

* **Documentation**
  * Updated command help text and error messages to reflect support for both file and directory paths

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fgilio/rfa/pull/90)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->