### PR TITLE
fix: hide discard-changes button for external files

### DIFF
--- a/resources/views/components/diff/file-header.blade.php
+++ b/resources/views/components/diff/file-header.blade.php
@@ -70,7 +70,7 @@
                 </flux:dropdown>
             @endif
 
-            @if($diffTo === null && ($file['status'] ?? '') !== 'commented')
+            @if($diffTo === null && ($file['status'] ?? '') !== 'commented' && ! ($file['isExternal'] ?? false))
                 <flux:button
                     tooltip="Discard changes"
                     aria-label="Discard changes"

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -931,7 +931,7 @@ new #[Layout('layouts.app')] class extends Component
         }
 
         $file = collect($this->files)->firstWhere('id', $fileId);
-        if (! $file || $file['status'] === 'commented') {
+        if (! $file || $file['status'] === 'commented' || ($file['isExternal'] ?? false)) {
             return;
         }
 
@@ -2058,7 +2058,7 @@ new #[Layout('layouts.app')] class extends Component
                             </flux:tooltip.content>
                         </flux:tooltip>
                         <span class="shrink-0 size-3.5 flex items-center justify-center">
-                            @if(! $this->isCommitMode() && $file['status'] !== 'commented')
+                            @if(! $this->isCommitMode() && $file['status'] !== 'commented' && ! ($file['isExternal'] ?? false))
                                 <flux:tooltip content="Discard changes">
                                     <button
                                         class="opacity-0 group-hover:opacity-100 transition-opacity text-gh-muted hover:text-gh-text data-loading:pointer-events-none data-loading:opacity-50"

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -96,9 +96,30 @@ install_node_dependencies() {
   fi
 
   # npm install is intentional here: it heals stale cached node_modules without
-  # the full wipe that npm ci performs on every cloud session.
+  # the full wipe that npm ci performs on every cloud session. The trade-off
+  # is that npm may rewrite the lockfile when the running npm version
+  # normalizes fields differently than the version that generated it
+  # (e.g. `libc` on platform-specific optional deps). Snapshot beforehand
+  # and revert that drift so the working tree stays clean — but only when
+  # the lockfile was already clean, so we don't clobber a real user change.
+  local lockfile_was_clean=0
+  if [ -f package-lock.json ] \
+    && git -C "$(pwd)" diff --quiet -- package-lock.json 2>/dev/null \
+    && git -C "$(pwd)" diff --cached --quiet -- package-lock.json 2>/dev/null; then
+    lockfile_was_clean=1
+    cp package-lock.json package-lock.json.predrift
+  fi
+
   log "Installing npm dependencies..."
   npm install --no-audit --no-fund
+
+  if [ "$lockfile_was_clean" = "1" ] && [ -f package-lock.json.predrift ]; then
+    if ! cmp -s package-lock.json package-lock.json.predrift; then
+      mv package-lock.json.predrift package-lock.json
+    else
+      rm -f package-lock.json.predrift
+    fi
+  fi
 }
 
 install_playwright_browser() {

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -101,11 +101,12 @@ install_node_dependencies() {
   # normalizes fields differently than the version that generated it
   # (e.g. `libc` on platform-specific optional deps). Snapshot beforehand
   # and revert that drift so the working tree stays clean — but only when
-  # the lockfile was already clean, so we don't clobber a real user change.
+  # both files were already clean, so an in-progress package.json edit can
+  # still produce a matching lockfile update.
   local lockfile_was_clean=0
   if [ -f package-lock.json ] \
-    && git -C "$(pwd)" diff --quiet -- package-lock.json 2>/dev/null \
-    && git -C "$(pwd)" diff --cached --quiet -- package-lock.json 2>/dev/null; then
+    && git -C "$(pwd)" diff --quiet -- package.json package-lock.json 2>/dev/null \
+    && git -C "$(pwd)" diff --cached --quiet -- package.json package-lock.json 2>/dev/null; then
     lockfile_was_clean=1
     cp package-lock.json package-lock.json.predrift
   fi

--- a/tests/Unit/Livewire/ReviewPageTest.php
+++ b/tests/Unit/Livewire/ReviewPageTest.php
@@ -492,24 +492,17 @@ test('discardFileChanges is a no-op for external files', function () {
         }
     });
 
-    $actionCalled = false;
-    app()->bind(DiscardFileChangesAction::class, fn () => new class($actionCalled)
+    app()->bind(DiscardFileChangesAction::class, fn () => new class
     {
-        public function __construct(public bool &$called) {}
-
         public function handle(string $repoPath, string $path, string $status, int $projectId, ?string $oldPath = null, bool $isUntracked = false, bool $isSymlink = false, array $comments = []): TrashedFile
         {
-            $this->called = true;
-
             throw new RuntimeException('DiscardFileChangesAction should not be called for external files');
         }
     });
 
-    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
-        ->dispatch('discard-file', fileId: 'ext789');
-
-    expect($actionCalled)->toBeFalse();
-    $component->assertNotDispatched('undo-available');
+    Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('discard-file', fileId: 'ext789')
+        ->assertNotDispatched('undo-available');
 });
 
 test('mount writes the project id to the active-project-id cache key for the menu handler', function () {

--- a/tests/Unit/Livewire/ReviewPageTest.php
+++ b/tests/Unit/Livewire/ReviewPageTest.php
@@ -477,6 +477,41 @@ test('discardFileChanges includes comment count in undo message', function () {
     );
 });
 
+test('discardFileChanges is a no-op for external files', function () {
+    $externalFiles = [
+        ['id' => 'ext789', 'path' => 'external/notes/draft.md', 'status' => 'added', 'oldPath' => null, 'additions' => 10, 'deletions' => 0, 'isBinary' => false, 'isUntracked' => false, 'isExternal' => true, 'externalAbsolutePath' => '/tmp/notes/draft.md'],
+    ];
+
+    app()->bind(GetFileListAction::class, fn () => new class($externalFiles)
+    {
+        public function __construct(private array $files) {}
+
+        public function handle(string $repoPath, bool $clearCache = true, ?int $projectId = null, ?string $globalGitignorePath = null, ?DiffTarget $target = null): array
+        {
+            return $this->files;
+        }
+    });
+
+    $actionCalled = false;
+    app()->bind(DiscardFileChangesAction::class, fn () => new class($actionCalled)
+    {
+        public function __construct(public bool &$called) {}
+
+        public function handle(string $repoPath, string $path, string $status, int $projectId, ?string $oldPath = null, bool $isUntracked = false, bool $isSymlink = false, array $comments = []): TrashedFile
+        {
+            $this->called = true;
+
+            throw new RuntimeException('DiscardFileChangesAction should not be called for external files');
+        }
+    });
+
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('discard-file', fileId: 'ext789');
+
+    expect($actionCalled)->toBeFalse();
+    $component->assertNotDispatched('undo-available');
+});
+
 test('mount writes the project id to the active-project-id cache key for the menu handler', function () {
     Cache::forget('rfa.active-project-id');
 


### PR DESCRIPTION
External-files entries are synthetic diffs mounted under `external/<label>/...`
and not present in the git working tree. Running the discard action on one
would shell out to `git rm`/`git restore` against a path git doesn't know
about. Hide the affordance in both the file header and sidebar, and
short-circuit the action so a stale event can't bypass the UI gate.

https://claude.ai/code/session_01Tf2TrN27jmuqogg4WPUUvv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * External files can no longer be discarded, matching the behavior for already-commented files.

* **Chores**
  * Improved npm dependency installation process to maintain lockfile integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fgilio/rfa/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->