### PR TITLE
Display remote branch names without prefix in branch picker

### DIFF
--- a/app/Services/GitMetadataService.php
+++ b/app/Services/GitMetadataService.php
@@ -287,7 +287,11 @@ class GitMetadataService
         $local = collect(explode("\n", $localOutput))
             ->filter()
             ->map(fn (string $line): BranchEntry => new BranchEntry(
-                name: trim(ltrim($line, '* ')),
+                // `git branch --list` uses a fixed two-column marker: `* ` for the
+                // current branch, `+ ` for a branch checked out in a linked worktree,
+                // two spaces otherwise. Strip those columns rather than only the `* `,
+                // so a worktree branch doesn't become an unresolvable "+ name" ref.
+                name: trim(substr($line, 2)),
                 isCurrent: str_starts_with($line, '* '),
                 isRemote: false,
             ))

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -200,10 +200,7 @@
              * from `upstream/x`.
              */
             get hasMultipleRemotes() {
-                const remotes = new Set();
-                for (const branch of (this.allBranches.remote || [])) {
-                    if (branch.remote) remotes.add(branch.remote);
-                }
+                const remotes = new Set((this.allBranches.remote || []).map(b => b.remote).filter(Boolean));
                 return remotes.size > 1;
             },
 

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -78,6 +78,23 @@
         return matches.length === 1 ? matches[0] : -1;
     }
 
+    /**
+     * Strip a remote-tracking branch's `<remote>/` prefix for display. The full
+     * ref (e.g. `origin/feature/x`) is what git needs to resolve the branch, but
+     * under the picker's "Remote" header the remote is implied, so the list shows
+     * just `feature/x` - keeping the distinguishing tail visible in a narrow pane.
+     *
+     * @param {string}  name    full branch name, e.g. `origin/feature/x`
+     * @param {?string} remote  remote name, e.g. `origin`
+     */
+    function stripRemotePrefix(name, remote) {
+        const value = String(name || '');
+        if (remote && value.startsWith(remote + '/')) {
+            return value.slice(remote.length + 1);
+        }
+        return value;
+    }
+
     function createBranchExplorer({ currentBranch, activeCommitHash, activeDiffFrom, projectSlug, branches }) {
         return {
             open: false,
@@ -170,6 +187,25 @@
             get filteredLocal() { return this._filterBranches('local'); },
             get filteredRemote() { return this._filterBranches('remote'); },
             get allFiltered() { return [...this.filteredLocal, ...this.filteredRemote]; },
+
+            /** Display label for a remote branch row - the `<remote>/` prefix dropped. */
+            remoteBranchLabel(branch) {
+                return stripRemotePrefix(branch.name, branch.remote);
+            },
+
+            /**
+             * True when the repo tracks more than one remote (e.g. origin +
+             * upstream). With a single remote the dropped `<remote>/` prefix is
+             * pure noise; with several, a muted tag keeps `origin/x` distinct
+             * from `upstream/x`.
+             */
+            get hasMultipleRemotes() {
+                const remotes = new Set();
+                for (const branch of (this.allBranches.remote || [])) {
+                    if (branch.remote) remotes.add(branch.remote);
+                }
+                return remotes.size > 1;
+            },
 
             async openPanel() {
                 this.open = true;
@@ -647,5 +683,5 @@
         }
     }
 
-    return { BranchBaseState, isSinceBaseExactly, violatesTipAnchor, createBranchExplorer, install, autoInstall };
+    return { BranchBaseState, isSinceBaseExactly, violatesTipAnchor, stripRemotePrefix, createBranchExplorer, install, autoInstall };
 });

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -269,7 +269,7 @@ new class extends Component {
                                         @if($hasRemote)
                                             data-remote-context
                                             data-remote-type="branch"
-                                            :data-remote-params="JSON.stringify({ name: branch.remote && branch.name.startsWith(branch.remote + '/') ? branch.name.slice(branch.remote.length + 1) : branch.name })"
+                                            :data-remote-params="JSON.stringify({ name: remoteBranchLabel(branch) })"
                                             :data-remote-label="'branch ' + branch.name"
                                         @endif
                                     >

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -281,7 +281,10 @@ new class extends Component {
                                             :title="branch.name"
                                         >
                                             <span class="shrink-0 w-3"></span>
-                                            <span class="truncate" x-text="branch.name"></span>
+                                            <span class="truncate min-w-0 flex-1" x-text="remoteBranchLabel(branch)"></span>
+                                            <template x-if="hasMultipleRemotes">
+                                                <span class="shrink-0 text-[10px] text-gh-muted/70" x-text="branch.remote"></span>
+                                            </template>
                                         </button>
                                     </div>
                                 </template>

--- a/tests/Browser/SplitDiffViewTest.php
+++ b/tests/Browser/SplitDiffViewTest.php
@@ -92,7 +92,11 @@ test('split view pairs a remove with its add on the same row', function () {
     // split mode, blocking grid-auto-flow:dense from packing rem+add together.
     $page = $this->visitAndLoad($this->projectUrl());
     $page->page()->getByLabel('Switch to split view')->click();
-    $page->page()->locator('[data-testid="diff-table"][data-view-mode="split"]')->first()->waitFor();
+    // Wait for the split table that already has *both* a remove and an add line,
+    // not just the table shell: the diff lines arrive via a lazy x-intersect
+    // round-trip and can lag under load, and the evaluate() below assumes this
+    // compound table exists (otherwise querySelector returns null and throws).
+    $page->page()->locator('[data-testid="diff-table"][data-view-mode="split"]:has(.diff-line[data-type="remove"]):has(.diff-line[data-type="add"])')->first()->waitFor();
 
     $rect = $page->page()->evaluate(<<<'JS'
         () => {

--- a/tests/Js/branch-explorer.test.js
+++ b/tests/Js/branch-explorer.test.js
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import branchExplorer from '../../public/js/branch-explorer.js';
 
-const { BranchBaseState, isSinceBaseExactly, createBranchExplorer, install } = branchExplorer;
+const { BranchBaseState, isSinceBaseExactly, stripRemotePrefix, createBranchExplorer, install } = branchExplorer;
 
 /** Minimal factory wrapper for tests that exercise the Alpine state machine
  *  directly. Provides a stub `$wire` that the production code reads from. */
@@ -832,5 +832,57 @@ describe('install', () => {
         window.Alpine = { data };
         expect(install(window)).toBe(true);
         expect(data).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('stripRemotePrefix', () => {
+    it('drops the matching remote prefix for display', () => {
+        expect(stripRemotePrefix('origin/feature/laravel-cloud-migration', 'origin'))
+            .toBe('feature/laravel-cloud-migration');
+    });
+
+    it('leaves the name untouched when it does not start with the remote', () => {
+        expect(stripRemotePrefix('feature/x', 'origin')).toBe('feature/x');
+    });
+
+    it('leaves the name untouched when the remote is null', () => {
+        expect(stripRemotePrefix('origin/feature/x', null)).toBe('origin/feature/x');
+    });
+
+    it('only strips the leading remote segment, not later collisions', () => {
+        expect(stripRemotePrefix('origin/origin/x', 'origin')).toBe('origin/x');
+    });
+});
+
+describe('remote branch display', () => {
+    function withRemotes(remote) {
+        return createBranchExplorer({
+            currentBranch: 'main',
+            activeCommitHash: null,
+            activeDiffFrom: 'HEAD',
+            projectSlug: 'p',
+            branches: { local: [], remote },
+        });
+    }
+
+    it('remoteBranchLabel drops the prefix for the row', () => {
+        const a = withRemotes([{ name: 'origin/feature/x', remote: 'origin' }]);
+        expect(a.remoteBranchLabel({ name: 'origin/feature/x', remote: 'origin' })).toBe('feature/x');
+    });
+
+    it('hasMultipleRemotes is false when every branch shares one remote', () => {
+        const a = withRemotes([
+            { name: 'origin/main', remote: 'origin' },
+            { name: 'origin/dev', remote: 'origin' },
+        ]);
+        expect(a.hasMultipleRemotes).toBe(false);
+    });
+
+    it('hasMultipleRemotes is true when branches span more than one remote', () => {
+        const a = withRemotes([
+            { name: 'origin/main', remote: 'origin' },
+            { name: 'upstream/main', remote: 'upstream' },
+        ]);
+        expect(a.hasMultipleRemotes).toBe(true);
     });
 });

--- a/tests/Unit/GitMetadataServiceTest.php
+++ b/tests/Unit/GitMetadataServiceTest.php
@@ -319,6 +319,31 @@ test('getBranches returns multiple local branches', function () {
     expect(array_values($current)[0]->name)->toBe('main');
 });
 
+test('getBranches strips the worktree marker from branches checked out elsewhere', function () {
+    $this->initTestRepo($this->tmpDir);
+    File::put($this->tmpDir.'/file.txt', "ok\n");
+    $this->commitTestRepo($this->tmpDir, 'initial');
+
+    // A branch checked out in a linked worktree is prefixed with `+ ` by
+    // `git branch --list`, just as the current branch is prefixed with `* `.
+    $linkedWorktree = $this->createTempDirectory('rfa_test_wt_').'/linked';
+    $this->runTestRepoCommand($this->tmpDir, [
+        'git branch feature-x',
+        'git worktree add '.escapeshellarg($linkedWorktree).' feature-x',
+    ]);
+
+    $result = $this->service->getBranches($this->tmpDir);
+    $names = array_map(fn ($b) => $b->name, $result['local']);
+
+    expect($names)->toContain('feature-x')
+        ->and($names)->not->toContain('+ feature-x')
+        ->and($names)->toContain('main');
+
+    $featureX = array_values(array_filter($result['local'], fn ($b) => $b->name === 'feature-x'))[0];
+    expect($featureX->isCurrent)->toBeFalse()
+        ->and($featureX->isRemote)->toBeFalse();
+});
+
 test('getBranches returns empty remote list when no remotes', function () {
     $this->initTestRepo($this->tmpDir);
     File::put($this->tmpDir.'/file.txt', "ok\n");


### PR DESCRIPTION
## Summary
Improves the remote branch display in the branch picker by stripping the `<remote>/` prefix from branch names, making them more readable in narrow panes while optionally showing the remote name when multiple remotes are tracked.

## Key Changes

- **New `stripRemotePrefix()` utility** — Extracts the logic to remove a remote-tracking branch's `<remote>/` prefix (e.g., `origin/feature/x` → `feature/x`) for cleaner display while preserving the full ref for git operations.

- **Remote branch label method** — Added `remoteBranchLabel(branch)` to the branch explorer state to consistently apply the prefix stripping across the UI.

- **Multiple remotes detection** — Added `hasMultipleRemotes` computed property that returns `true` when branches span more than one remote, enabling conditional display of remote tags to disambiguate branches with the same name across different remotes.

- **Updated Blade template** — Refactored remote branch row rendering to:
  - Use `remoteBranchLabel(branch)` instead of inline prefix-stripping logic
  - Display a muted remote tag (e.g., `origin`, `upstream`) only when `hasMultipleRemotes` is true
  - Improved layout with proper flex sizing to prevent truncation issues

- **Git worktree marker handling** — Fixed `GitMetadataService::getBranches()` to correctly strip the two-column marker (`* `, `+ `, or two spaces) that `git branch --list` uses, preventing branches checked out in linked worktrees from becoming unresolvable refs like `+ feature-x`.

## Testing
- Added comprehensive test suite for `stripRemotePrefix()` covering edge cases (missing prefix, null remote, nested collisions)
- Added tests for `remoteBranchLabel()` and `hasMultipleRemotes` behavior
- Added test for worktree branch marker stripping in `GitMetadataServiceTest`

https://claude.ai/code/session_019odPeGHUDPoAzcxUdeinc3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect display of branches checked out in git worktrees.

* **Improvements**
  * Enhanced remote branch display with cleaner labels by removing remote prefixes.
  * When multiple remotes are configured, the remote name is now displayed alongside the branch label for clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fgilio/rfa/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->