### PR TITLE
fix: center find-in-page badge & kill phantom pills on token-crossing matches

### DIFF
--- a/public/js/page-search.js
+++ b/public/js/page-search.js
@@ -40,16 +40,131 @@
         return cursor;
     }
 
+    // Walk every visible text node under `root` and bucket it by nearest
+    // block-level ancestor. Each block becomes one searchable string, so a
+    // query can cross sibling token spans inside a line but never hop between
+    // lines, cells, or paragraphs. Returns Map<blockElement, Text[]>.
+    function groupTextNodesByBlock(root) {
+        // Sibling text nodes share a parent (very common in diff rows), so
+        // memoize the per-walk visibility answer instead of re-walking the
+        // style chain for each one.
+        const visibility = new WeakMap();
+        const blockCache = new WeakMap();
+        const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+            acceptNode(node) {
+                if (!node.nodeValue || !node.nodeValue.length) {
+                    return NodeFilter.FILTER_REJECT;
+                }
+                const parent = node.parentElement;
+                if (!parent || parent.closest(SKIP_SELECTOR)) {
+                    return NodeFilter.FILTER_REJECT;
+                }
+                // Skip collapsed/hidden sections (x-show, [hidden],
+                // display:none, visibility:hidden, opacity:0) so the counter
+                // and next/prev navigation only target visible matches.
+                let visible = visibility.get(parent);
+                if (visible === undefined) {
+                    visible = parent.checkVisibility({
+                        checkOpacity: true,
+                        checkVisibilityCSS: true,
+                    });
+                    visibility.set(parent, visible);
+                }
+                return visible ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+            },
+        });
+
+        const blocks = new Map();
+        let node;
+        while ((node = walker.nextNode())) {
+            const block = findBlockAncestor(node.parentElement, blockCache);
+            let bucket = blocks.get(block);
+            if (!bucket) {
+                bucket = [];
+                blocks.set(block, bucket);
+            }
+            bucket.push(node);
+        }
+        return blocks;
+    }
+
+    // Join a block's text nodes into one string, recording where each node's
+    // text lands in the joined string so a match offset can be mapped back to
+    // the right node and its local range.
+    function buildSegments(textNodes) {
+        const segments = [];
+        let joined = '';
+        textNodes.forEach(node => {
+            const value = node.nodeValue;
+            segments.push({ node, start: joined.length, length: value.length });
+            joined += value;
+        });
+        return { segments, joined };
+    }
+
+    // Find every occurrence of `pattern` in `joined` as [start, end) offset
+    // pairs. `needle` is the lowercased query for a cheap pre-check: the regex
+    // is just an escaped literal, so if the needle isn't present the regex
+    // can't match either and we skip the scan entirely.
+    function findRanges(joined, pattern, needle) {
+        if (joined.length === 0) return [];
+        if (!joined.toLowerCase().includes(needle)) return [];
+        pattern.lastIndex = 0;
+        const ranges = [];
+        let m;
+        while ((m = pattern.exec(joined)) !== null) {
+            if (m[0].length === 0) {
+                pattern.lastIndex++;
+                continue;
+            }
+            ranges.push([m.index, m.index + m[0].length]);
+        }
+        return ranges;
+    }
+
+    // Wrap each match's text in its own `.rfa-search-match` span(s), returning
+    // one group of pieces per match. A match that crosses sibling text nodes
+    // wraps each piece separately. Matches and segments are processed
+    // back-to-front so each DOM split only invalidates offsets already handled.
+    function wrapRanges(ranges, segments) {
+        const wrapped = new Array(ranges.length);
+        for (let i = ranges.length - 1; i >= 0; i--) {
+            const [matchStart, matchEnd] = ranges[i];
+            const pieces = [];
+            for (let s = segments.length - 1; s >= 0; s--) {
+                const seg = segments[s];
+                const segEnd = seg.start + seg.length;
+                if (segEnd <= matchStart || seg.start >= matchEnd) continue;
+                const localStart = Math.max(0, matchStart - seg.start);
+                const localEnd = Math.min(seg.length, matchEnd - seg.start);
+                if (localStart >= localEnd) continue;
+                const range = document.createRange();
+                range.setStart(seg.node, localStart);
+                range.setEnd(seg.node, localEnd);
+                const span = document.createElement('span');
+                span.className = MATCH_CLASS;
+                range.surroundContents(span);
+                pieces.unshift(span);
+            }
+            wrapped[i] = pieces;
+        }
+        return wrapped;
+    }
+
     function createPageSearch() {
         return {
             open: false,
             query: '',
             currentMatch: 0,
-            // Each entry is one logical match: an array of one or more spans.
-            // A query that crosses sibling text nodes wraps each piece in its
-            // own `.rfa-search-match` span, all grouped under a single entry.
+            // Each entry is one match's pieces: a single `.rfa-search-match`
+            // span, or several when the match crosses sibling token spans.
             matches: [],
 
+            // Cmd/Ctrl+F is handled here, not through the global keymap store,
+            // because find must fire while focus is inside its own search input
+            // (to re-select and re-run the query) — the very case the store
+            // suppresses via its editable-target guard. It also owns local
+            // open/refresh/$refs state the store can't reach.
             handleKeydown(e) {
                 if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
                     e.preventDefault();
@@ -99,20 +214,44 @@
             updateCurrent(scroll) {
                 const total = this.matches.length;
                 const badge = `${this.currentMatch} of ${total}`;
-                this.matches.forEach((spans, i) => {
+                this.matches.forEach((pieces, i) => {
                     const isCurrent = (i + 1) === this.currentMatch;
-                    spans.forEach((el, j) => {
-                        el.classList.toggle(CURRENT_CLASS, isCurrent);
+                    pieces.forEach((piece, j) => {
+                        piece.classList.toggle(CURRENT_CLASS, isCurrent);
                         if (isCurrent && j === 0) {
-                            el.setAttribute('data-match-number', badge);
+                            piece.setAttribute('data-match-number', badge);
                         } else {
-                            el.removeAttribute('data-match-number');
+                            piece.removeAttribute('data-match-number');
+                            piece.style.removeProperty('--rfa-match-center');
                         }
                     });
-                    if (isCurrent && scroll && spans[0]) {
-                        spans[0].scrollIntoView({ block: 'center', behavior: 'smooth' });
+                    if (isCurrent) {
+                        this.centerBadge(pieces);
+                        if (scroll && pieces[0]) {
+                            pieces[0].scrollIntoView({ block: 'center', behavior: 'smooth' });
+                        }
                     }
                 });
+            },
+
+            // Center the "X of Y" pill on the horizontal midpoint of the whole
+            // match. The pill renders via ::after on the first piece only, but a
+            // match can cross several token spans — without this it sits under
+            // the first piece and reads as off-center. We hand CSS the offset
+            // (measured from the first piece's left edge) via --rfa-match-center
+            // and fall back to `left: 50%` for single-piece matches and any case
+            // we can't measure (a wrapped match, or zero-size rects in tests).
+            centerBadge(pieces) {
+                const anchor = pieces[0];
+                if (!anchor) return;
+                anchor.style.removeProperty('--rfa-match-center');
+                if (pieces.length < 2) return;
+                const first = anchor.getBoundingClientRect();
+                const last = pieces[pieces.length - 1].getBoundingClientRect();
+                const sameLine = Math.abs(last.top - first.top) < 1;
+                const width = last.right - first.left;
+                if (!sameLine || width <= 0) return;
+                anchor.style.setProperty('--rfa-match-center', `${width / 2}px`);
             },
 
             close() {
@@ -138,114 +277,14 @@
             markMatches(query) {
                 const pattern = new RegExp(escapeRegex(query), 'gi');
                 const needle = query.toLowerCase();
-                // Sibling text nodes share a parent (very common in diff rows),
-                // so memoize the per-walk visibility answer to avoid re-walking
-                // the style chain for each one.
-                const visibility = new WeakMap();
-                const blockCache = new WeakMap();
-                const walker = document.createTreeWalker(
-                    document.body,
-                    NodeFilter.SHOW_TEXT,
-                    {
-                        acceptNode(node) {
-                            if (!node.nodeValue || !node.nodeValue.length) {
-                                return NodeFilter.FILTER_REJECT;
-                            }
-                            const parent = node.parentElement;
-                            if (!parent || parent.closest(SKIP_SELECTOR)) {
-                                return NodeFilter.FILTER_REJECT;
-                            }
-                            // Skip collapsed/hidden sections (x-show, [hidden],
-                            // display:none, visibility:hidden, opacity:0) so
-                            // the counter and next/prev navigation only target
-                            // visible matches.
-                            let visible = visibility.get(parent);
-                            if (visible === undefined) {
-                                visible = parent.checkVisibility({
-                                    checkOpacity: true,
-                                    checkVisibilityCSS: true,
-                                });
-                                visibility.set(parent, visible);
-                            }
-                            return visible ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
-                        },
-                    }
-                );
-
-                // Group accepted text nodes by their nearest block-level
-                // ancestor. Each block becomes one searchable string, so a
-                // query can cross sibling token spans inside a line but not
-                // hop between lines/cells/paragraphs.
-                const groups = new Map();
-                let node;
-                while ((node = walker.nextNode())) {
-                    const block = findBlockAncestor(node.parentElement, blockCache);
-                    let bucket = groups.get(block);
-                    if (!bucket) {
-                        bucket = [];
-                        groups.set(block, bucket);
-                    }
-                    bucket.push(node);
-                }
-
                 const matches = [];
-                groups.forEach(textNodes => {
-                    const segments = [];
-                    let joined = '';
-                    textNodes.forEach(n => {
-                        const value = n.nodeValue;
-                        segments.push({ node: n, start: joined.length, length: value.length });
-                        joined += value;
-                    });
-                    if (joined.length === 0) return;
-                    // Cheap substring pre-check: the regex is just an escaped
-                    // literal, so if the lowercased needle isn't in the joined
-                    // string the regex can't match either.
-                    if (!joined.toLowerCase().includes(needle)) return;
-
-                    pattern.lastIndex = 0;
-                    const ranges = [];
-                    let m;
-                    while ((m = pattern.exec(joined)) !== null) {
-                        if (m[0].length === 0) {
-                            pattern.lastIndex++;
-                            continue;
-                        }
-                        ranges.push([m.index, m.index + m[0].length]);
-                    }
-                    if (ranges.length === 0) return;
-
-                    // Wrap each match's text-node ranges in their own
-                    // `.rfa-search-match` span. Process matches back-to-front
-                    // and segments back-to-front within a match so each DOM
-                    // split only invalidates offsets we've already handled.
-                    const wrapped = new Array(ranges.length);
-                    for (let i = ranges.length - 1; i >= 0; i--) {
-                        const [matchStart, matchEnd] = ranges[i];
-                        const spans = [];
-                        for (let s = segments.length - 1; s >= 0; s--) {
-                            const seg = segments[s];
-                            const segEnd = seg.start + seg.length;
-                            if (segEnd <= matchStart || seg.start >= matchEnd) continue;
-                            const localStart = Math.max(0, matchStart - seg.start);
-                            const localEnd = Math.min(seg.length, matchEnd - seg.start);
-                            if (localStart >= localEnd) continue;
-                            const range = document.createRange();
-                            range.setStart(seg.node, localStart);
-                            range.setEnd(seg.node, localEnd);
-                            const span = document.createElement('span');
-                            span.className = MATCH_CLASS;
-                            range.surroundContents(span);
-                            spans.unshift(span);
-                        }
-                        wrapped[i] = spans;
-                    }
-
-                    wrapped.forEach(spans => {
-                        if (spans && spans.length > 0) matches.push(spans);
+                groupTextNodesByBlock(document.body).forEach(textNodes => {
+                    const { segments, joined } = buildSegments(textNodes);
+                    const ranges = findRanges(joined, pattern, needle);
+                    wrapRanges(ranges, segments).forEach(pieces => {
+                        if (pieces.length > 0) matches.push(pieces);
                     });
                 });
-
                 return matches;
             },
         };

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -202,11 +202,17 @@
             position: relative;
             z-index: 1;
         }
-        .rfa-search-match--current::after {
+        /* Render the "X of Y" pill only on the piece that carries the number.
+           A match that crosses a token boundary wraps each piece in its own
+           --current span; gating on [data-match-number] stops the other pieces
+           from painting empty phantom pills. `left` is centered across the
+           whole match via the JS-measured --rfa-match-center offset, falling
+           back to the first piece's center for single-piece matches. */
+        .rfa-search-match--current[data-match-number]::after {
             content: attr(data-match-number);
             position: absolute;
             top: 100%;
-            left: 50%;
+            left: var(--rfa-match-center, 50%);
             transform: translate(-50%, 6px);
             background: rgb(var(--gh-accent));
             color: rgb(var(--gh-bg));
@@ -215,10 +221,10 @@
             font-weight: 500;
             line-height: 1;
             padding: 3px 6px;
-            border-radius: 4px;
+            border-radius: 2px;
             white-space: nowrap;
             pointer-events: none;
-            box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+            box-shadow: 0 0 0 1px rgb(var(--gh-border));
             z-index: 2;
         }
     </style>
@@ -233,7 +239,11 @@
         }).catch(() => {});
     "
 >
-    {{-- Find-in-page search bar (Cmd/Ctrl+F) --}}
+    {{-- Find-in-page search bar (Cmd/Ctrl+F).
+         @keydown.window (not a plain @keydown) is deliberate: the listener
+         lives on window, so Cmd+F still fires while this bar is x-show-hidden
+         (display:none). Move it onto the element and the shortcut can no longer
+         open the bar. --}}
     <div x-data="pageSearch" x-show="open" x-cloak data-search-ignore
          x-transition:enter="transition ease-out duration-150"
          x-transition:enter-start="opacity-0 -translate-y-1"

--- a/tests/Browser/PageSearchTest.php
+++ b/tests/Browser/PageSearchTest.php
@@ -332,3 +332,58 @@ test('current match badge text tracks navigation', function () {
     expect($result['afterNext'])->toBe('2 of 3');
     expect($result['afterPrev'])->toBe('1 of 3');
 });
+
+test('a match crossing a token boundary paints the pill once, centered, with no phantom box', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $result = $page->script(<<<'JS'
+        (() => {
+            const host = document.createElement('div');
+            host.id = '__search_sandbox_phantom';
+            // Two inline spans on one line, so "aaaaaabbbbbb" matches across the
+            // boundary — the same shape as a query straddling syntax-highlight
+            // tokens in a diff (e.g. "workflow (`Aoi").
+            host.innerHTML = '<span>aaaaaa</span><span>bbbbbb</span>';
+            document.body.appendChild(host);
+
+            const root = document.querySelector('[x-data="pageSearch"]');
+            const data = Alpine.$data(root);
+
+            data.query = 'aaaaaabbbbbb';
+            data.refresh();
+
+            const spans = host.querySelectorAll('.rfa-search-match');
+            const first = spans[0].getBoundingClientRect();
+            const last = spans[spans.length - 1].getBoundingClientRect();
+
+            const afterFirst = getComputedStyle(spans[0], '::after').content;
+            const afterSecond = getComputedStyle(spans[spans.length - 1], '::after').content;
+            const center = parseFloat(spans[0].style.getPropertyValue('--rfa-match-center'));
+
+            data.close();
+            host.remove();
+
+            return {
+                pieces: spans.length,
+                afterFirst,
+                afterSecond,
+                center,
+                expectedCenter: (last.right - first.left) / 2,
+                firstHalf: first.width / 2,
+            };
+        })()
+    JS);
+
+    // The match really does cross the boundary into a second piece.
+    expect($result['pieces'])->toBe(2);
+
+    // The numbered piece paints the pill; the crossed piece renders no ::after
+    // box at all (pre-fix it painted an empty `""` phantom pill).
+    expect($result['afterFirst'])->not->toBe('none')
+        ->and($result['afterFirst'])->not->toBe('""')
+        ->and($result['afterSecond'])->toBe('none');
+
+    // The pill anchors to the midpoint of the whole match, not the first piece.
+    expect($result['center'])->toEqualWithDelta($result['expectedCenter'], 1.0)
+        ->and($result['center'])->toBeGreaterThan($result['firstHalf']);
+});

--- a/tests/Js/page-search.test.js
+++ b/tests/Js/page-search.test.js
@@ -369,6 +369,42 @@ describe('updateCurrent', () => {
         expect(spans[1].hasAttribute('data-match-number')).toBe(false);
         expect(spans[2].hasAttribute('data-match-number')).toBe(false);
     });
+
+    it('centers the badge across a multi-piece match via --rfa-match-center', () => {
+        document.body.innerHTML = "<p><span>'</span><span>local</span><span>'</span></p>";
+        data.query = "'local'";
+        data.refresh();
+
+        const [spans] = data.matches;
+        expect(spans).toHaveLength(3);
+
+        // happy-dom reports zero-size rects, so stub the pieces onto one line
+        // laid left-to-right: 0–10, 10–60, 60–70 (px). The whole match spans
+        // 0..70, so the center offset from the first piece's left edge is 35px.
+        const lefts = [0, 10, 60];
+        const rights = [10, 60, 70];
+        spans.forEach((span, i) => {
+            span.getBoundingClientRect = () => ({
+                top: 0, bottom: 10, left: lefts[i], right: rights[i],
+                width: rights[i] - lefts[i], height: 10,
+            });
+        });
+        data.updateCurrent(false);
+
+        // 35px is past the first piece's own center (5px) — proving the badge
+        // anchors to the whole match, not just the first token span.
+        expect(spans[0].style.getPropertyValue('--rfa-match-center')).toBe('35px');
+    });
+
+    it('leaves --rfa-match-center unset for a single-piece match so CSS falls back to 50%', () => {
+        data.query = 'cat';
+        data.refresh();
+
+        // Each "cat" is a single text node, so centerBadge sees one span and
+        // sets no offset; CSS centers on the piece itself via `left: 50%`.
+        expect(data.matches[0]).toHaveLength(1);
+        expect(data.matches[0][0].style.getPropertyValue('--rfa-match-center')).toBe('');
+    });
 });
 
 describe('install', () => {


### PR DESCRIPTION
## What

Polish pass on the find-in-page (Cmd/Ctrl+F) feature, fixing two visual bugs and decomposing the core matcher.

### Bugs fixed
When a match straddles sibling syntax-highlight token spans (e.g. searching ``workflow (`Aoi`` or `215) (merged` in a diff), the match wraps into several `.rfa-search-match` pieces. Previously **every** current piece painted the `"X of Y"` `::after` pill:

- the non-numbered pieces painted an empty **phantom pill**, and
- the real pill sat under the *first* piece, reading **off-center** for the whole match.

Fixes:
- Gate the pill on `[data-match-number]` so only the numbered piece paints `::after`; crossed pieces render no box.
- `centerBadge()` measures the full match width and hands CSS the midpoint via `--rfa-match-center`, with a `left: 50%` fallback for single-piece matches and any unmeasurable case.
- Swap the soft Material drop-shadow for a hard `1px` `gh-border` ring (brutalist system consistency) + tighten the pill radius to match `.rfa-search-match`.

### Refactor (no behavior change)
- Decompose the ~110-line `markMatches` into four named pipeline phases: `groupTextNodesByBlock` → `buildSegments` → `findRanges` → `wrapRanges`.
- Rename inner span arrays to `pieces`; tighten the data-shape comment.
- Add load-bearing comments: why Cmd+F is handled locally (not via the keymap store) and why the search-bar listener is `@keydown.window`-scoped.

## Tests
- New JS unit tests: badge centering via `--rfa-match-center`, single-piece fallback.
- New browser test: token-crossing match paints the pill once, centered, no phantom box.
- Refactor pinned by existing JS / browser / arch suites (all green: 257 JS, 12 browser, 86 arch, Pint clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search match detection when matches span multiple text elements.
  * Enhanced match indicator positioning to better center on the entire matched text.

* **Style**
  * Refined visual styling of search match indicators with updated appearance and positioning.

* **Tests**
  * Added tests for cross-boundary match handling and match indicator centering accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->