### PR TITLE
[codex] Stabilize reviewed state and terminal helper recovery

### DIFF
--- a/app/Actions/ToggleReviewedAction.php
+++ b/app/Actions/ToggleReviewedAction.php
@@ -44,9 +44,8 @@ final readonly class ToggleReviewedAction
                 ->forProjectOrRepo($projectId, $repoPath)
                 ->where('file_path', $filePath)
                 ->delete();
-            unset($reviewedFiles[$filePath]);
 
-            return $reviewedFiles;
+            return $this->reviewedFilesFromStorage($knownFiles, $repoPath, $projectId);
         }
 
         ReviewedFile::updateOrCreate(
@@ -58,9 +57,33 @@ final readonly class ToggleReviewedAction
             ['content_hash' => $contentHash],
         );
 
-        $reviewedFiles[$filePath] = $contentHash;
+        return $this->reviewedFilesFromStorage($knownFiles, $repoPath, $projectId);
+    }
 
-        return $reviewedFiles;
+    /**
+     * Reload reviewed state from persisted rows so overlapping Livewire
+     * requests cannot replace the page with a partial snapshot.
+     *
+     * @param  array<int, array{path: string}>  $knownFiles
+     * @return array<string, string>
+     */
+    private function reviewedFilesFromStorage(array $knownFiles, string $repoPath, ?int $projectId): array
+    {
+        $paths = collect($knownFiles)
+            ->pluck('path')
+            ->map(fn (mixed $path): string => (string) $path)
+            ->filter()
+            ->values();
+
+        $hashesByPath = ReviewedFile::query()
+            ->forProjectOrRepo($projectId, $repoPath)
+            ->whereIn('file_path', $paths)
+            ->pluck('content_hash', 'file_path');
+
+        return $paths
+            ->filter(fn (string $path): bool => $hashesByPath->has($path))
+            ->mapWithKeys(fn (string $path): array => [$path => (string) $hashesByPath->get($path)])
+            ->all();
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ namespace App\Providers;
 
 use App\Services\GitFileContentService;
 use App\Services\ReviewConfigService;
+use App\Support\LocalAsset;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
@@ -39,6 +40,11 @@ class AppServiceProvider extends ServiceProvider
 
         Blade::if('native', fn () => (bool) config('nativephp-internal.running'));
         Blade::if('browser', fn () => ! config('nativephp-internal.running'));
+        Blade::directive('localScript', fn (string $expression): string => sprintf(
+            '<?php echo %s::script(%s); ?>',
+            LocalAsset::class,
+            $expression,
+        ));
 
         RateLimiter::for('diagnostics', fn (Request $request): Limit => Limit::perMinute(120)
             ->by($request->ip() ?: 'local'));

--- a/app/Support/LocalAsset.php
+++ b/app/Support/LocalAsset.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
+
+final class LocalAsset
+{
+    public static function script(string $path): HtmlString
+    {
+        return new HtmlString('<script src="'.e(self::url($path)).'"></script>');
+    }
+
+    public static function url(string $path): string
+    {
+        $normalizedPath = Str::of($path)
+            ->replace('\\', '/')
+            ->ltrim('/')
+            ->toString();
+
+        $absolutePath = public_path($normalizedPath);
+        $version = is_file($absolutePath)
+            ? (string) filemtime($absolutePath)
+            : app()->version();
+
+        return '/'.$normalizedPath.'?v='.$version;
+    }
+}

--- a/public/js/CLAUDE.md
+++ b/public/js/CLAUDE.md
@@ -5,7 +5,7 @@ custom directives, and global wiring (find-in-page, session recovery, etc.).
 
 ## No build process
 
-Scripts here are loaded directly via `<script src="/js/foo.js">` from `resources/views/layouts/app.blade.php`. There is no bundler — no Vite, no esbuild, no transpile.
+Scripts here are loaded directly through Blade's versioned `@localScript('js/foo.js')` helper. There is no bundler — no Vite, no esbuild, no transpile.
 
 - Don't `import` from npm packages. Write what runs natively in the target Chromium (Electron 38+).
 - Don't use TypeScript.
@@ -27,9 +27,11 @@ window.Alpine ? init() : document.addEventListener('alpine:init', init);
 
 For scripts that touch Livewire (custom directives, request interceptors), use `livewire:init` instead.
 
-## Guard against SPA-navigation re-execution
+## Guard singleton listeners against SPA-navigation re-execution
 
-Livewire's `wire:navigate` swaps the body and re-runs head scripts. Without a guard, listeners stack and stores get re-registered on every navigation. Pattern (see `keymap-store.js`):
+Livewire's `wire:navigate` swaps the body and re-runs head scripts. Singleton
+listeners and stores need a guard so they do not stack on every navigation.
+Pattern (see `keymap-store.js`):
 
 ```js
 if (window.__fooAttached) return;
@@ -37,6 +39,10 @@ window.__fooAttached = true;
 ```
 
 If the script keeps per-page state that doesn't survive navigation (e.g. registered keymap bindings), clear it on `livewire:navigating`.
+
+Alpine factory scripts (`Alpine.data(...)`) should re-register without a
+one-shot guard so an updated, cache-busted script replaces stale factories after
+an app update.
 
 ## Testable scripts use the UMD shape
 

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -561,7 +561,7 @@
             onReviewedChange() {
                 this.collapsed = this.reviewed;
                 this.$dispatch('file-reviewed-changed', { id: this.fileId, reviewed: this.reviewed });
-                this.$wire.dispatch('toggle-reviewed', { filePath: this.filePath });
+                this.$dispatch('rfa-toggle-reviewed', { filePath: this.filePath });
             },
         };
     }

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -567,8 +567,7 @@
     }
 
     function install(root) {
-        if (typeof root.Alpine === 'undefined' || root.__diffFileAttached) return false;
-        root.__diffFileAttached = true;
+        if (typeof root.Alpine === 'undefined') return false;
         root.Alpine.data('diffFile', createDiffFile);
         return true;
     }

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -557,12 +557,6 @@
 
                 return rowContainsLinePoint(rowSide, oldLineNum, newLineNum, this.formEndPoint);
             },
-
-            onReviewedChange() {
-                this.collapsed = this.reviewed;
-                this.$dispatch('file-reviewed-changed', { id: this.fileId, reviewed: this.reviewed });
-                this.$dispatch('rfa-toggle-reviewed', { filePath: this.filePath });
-            },
         };
     }
 

--- a/public/js/review-page.js
+++ b/public/js/review-page.js
@@ -81,6 +81,12 @@
         };
     }
 
+    const reviewedQueueKey = '__rfaReviewedActionQueue';
+
+    function reviewedQueueRoot() {
+        return typeof window !== 'undefined' ? window : globalThis;
+    }
+
     function createReviewPage(config = {}) {
         return {
             config,
@@ -136,6 +142,29 @@
             },
             get visibleFileCount() {
                 return this.visibleFileEntries.length;
+            },
+            queueReviewedAction(action) {
+                const root = reviewedQueueRoot();
+
+                root[reviewedQueueKey] = (root[reviewedQueueKey] || Promise.resolve())
+                    .catch(() => {})
+                    .then(action);
+
+                return root[reviewedQueueKey];
+            },
+            toggleReviewed(filePath) {
+                if (!filePath) return Promise.resolve();
+
+                return this.queueReviewedAction(() => this.$wire.toggleReviewed(filePath));
+            },
+            hideReviewedFiles() {
+                return this.queueReviewedAction(() => this.$wire.hideReviewedFiles());
+            },
+            showAllFiles() {
+                return this.queueReviewedAction(() => this.$wire.showAllFiles());
+            },
+            clearRecentlyReviewed() {
+                return this.queueReviewedAction(() => this.$wire.clearRecentlyReviewed());
             },
             buildFullPath(path) {
                 const repo = this.repoPath || '';
@@ -276,8 +305,7 @@
     }
 
     function install(root) {
-        if (typeof root.Alpine === 'undefined' || root.__reviewPageAttached) return false;
-        root.__reviewPageAttached = true;
+        if (typeof root.Alpine === 'undefined') return false;
         root.Alpine.data('reviewPage', createReviewPage);
         root.Alpine.data('reviewChangePoller', createChangePoller);
         return true;

--- a/resources/CLAUDE.md
+++ b/resources/CLAUDE.md
@@ -178,8 +178,8 @@ ReviewPage (`resources/views/pages/⚡review-page.blade.php`) renders N DiffFile
 | `clearAllComments` | Yes | Dispatches comment-updated + undo-available events |
 | `restoreComments` | Yes | Dispatches comment-updated events to affected files |
 | `updatedGlobalComment` | Yes | No UI change needed server-side |
-| `toggleReviewed` | Yes | Always skips the parent render; refreshes the `reviewed-summary` + `file-list` islands, plus the visibility islands (`source-diff-list`, `file-count`, `file-list-header`) in Hide-reviewed mode where the toggle drops the file from the visible set. |
-| `hideReviewedFiles` / `showAllFiles` | Yes | Skip the parent render; refresh `reviewed-summary` + `file-list` + the visibility islands as files drop in/out of the visible set. |
+| `toggleReviewed` | Yes | Always skips the parent render; refreshes the `reviewed-toggle`, `reviewed-counter`, and `file-list` islands, plus the visibility islands (`source-diff-list`, `file-count`, `file-list-header`, `status-strip-copy-paths`) in Hide-reviewed mode where the toggle drops the file from the visible set. |
+| `hideReviewedFiles` / `showAllFiles` | Yes | Skip the parent render; refresh `reviewed-toggle`, `reviewed-counter`, `file-list`, and the visibility islands as files drop in/out of the visible set. |
 | `clearRecentlyReviewed` | Yes | Skip the parent render; refresh `file-list` only in Hide-reviewed mode (where the Recently-reviewed group shows). |
 | `submitReview` | No | Replaces entire submit bar UI (submitted state) |
 | `discardFileChanges` | No | Structural change: file removed from list, trash updated |
@@ -194,9 +194,9 @@ ReviewPage (`resources/views/pages/⚡review-page.blade.php`) renders N DiffFile
 | `delete-comment` | DiffFile Alpine -> parent | ReviewPage `#[On]` | `{commentId}` |
 | `toggle-reviewed` | Livewire event — unit tests only; runtime goes via the `rfa-toggle-reviewed` bridge below | ReviewPage `#[On]` -> `toggleReviewed` | `{filePath}` |
 | `rfa-toggle-reviewed` | DiffFile Alpine + sidebar / Recently-reviewed buttons `$dispatch` (bubbles to window) | ReviewPage root Alpine `@window` -> `$wire.toggleReviewed` | `{filePath}` |
-| `rfa-hide-reviewed` | `reviewed-summary` island button `$dispatch` (window) | ReviewPage root Alpine `@window` -> `$wire.hideReviewedFiles` | none |
-| `rfa-show-all-files` | `reviewed-summary` island button `$dispatch` (window) | ReviewPage root Alpine `@window` -> `$wire.showAllFiles` | none |
-| `rfa-clear-recently-reviewed` | Recently-reviewed "Clear" button `$dispatch` (window) | ReviewPage root Alpine `@window` -> `$wire.clearRecentlyReviewed` | none |
+| `rfa-hide-reviewed` | `reviewed-toggle` island button `$dispatch` (window) | ReviewPage root Alpine `@window` -> queued `$wire.hideReviewedFiles` | none |
+| `rfa-show-all-files` | `reviewed-toggle` island button `$dispatch` (window) | ReviewPage root Alpine `@window` -> queued `$wire.showAllFiles` | none |
+| `rfa-clear-recently-reviewed` | Recently-reviewed "Clear" button `$dispatch` (window) | ReviewPage root Alpine `@window` -> queued `$wire.clearRecentlyReviewed` | none |
 | `comment-updated` | ReviewPage PHP dispatch | DiffFile Alpine `@window` | `{fileId, comments}` |
 | `copy-to-clipboard` | DiffFile Alpine/PHP, ReviewPage PHP, comment-display, comments-drawer, branch-explorer | layout `<body>` Alpine `@window` | `{text, toast?}` (if `toast` string is set, a success toast with that text shows on success) |
 | `file-reviewed-changed` | DiffFile Alpine `$dispatch`, sidebar reviewed button | DiffFile Alpine `@window` (targeted by `id`) | `{id, reviewed}` |

--- a/resources/CLAUDE.md
+++ b/resources/CLAUDE.md
@@ -178,7 +178,9 @@ ReviewPage (`resources/views/pages/⚡review-page.blade.php`) renders N DiffFile
 | `clearAllComments` | Yes | Dispatches comment-updated + undo-available events |
 | `restoreComments` | Yes | Dispatches comment-updated events to affected files |
 | `updatedGlobalComment` | Yes | No UI change needed server-side |
-| `toggleReviewed` | Conditional | Renders only in Hide-reviewed mode (only then does a toggle change the server-visible list). A path filter is reviewed-independent, so filter-only stays a skipRender. |
+| `toggleReviewed` | Yes | Always skips the parent render; refreshes the `reviewed-summary` + `file-list` islands, plus the visibility islands (`source-diff-list`, `file-count`, `file-list-header`) in Hide-reviewed mode where the toggle drops the file from the visible set. |
+| `hideReviewedFiles` / `showAllFiles` | Yes | Skip the parent render; refresh `reviewed-summary` + `file-list` + the visibility islands as files drop in/out of the visible set. |
+| `clearRecentlyReviewed` | Yes | Skip the parent render; refresh `file-list` only in Hide-reviewed mode (where the Recently-reviewed group shows). |
 | `submitReview` | No | Replaces entire submit bar UI (submitted state) |
 | `discardFileChanges` | No | Structural change: file removed from list, trash updated |
 | `restoreDiscardedFile` | No | Structural change: file reappears in list |
@@ -190,7 +192,11 @@ ReviewPage (`resources/views/pages/⚡review-page.blade.php`) renders N DiffFile
 |---|---|---|---|
 | `add-comment` | DiffFile Alpine -> parent | ReviewPage `#[On]` | `{fileId, side, startLine, endLine, body}` |
 | `delete-comment` | DiffFile Alpine -> parent | ReviewPage `#[On]` | `{commentId}` |
-| `toggle-reviewed` | DiffFile Alpine -> parent | ReviewPage `#[On]` | `{filePath}` |
+| `toggle-reviewed` | Livewire event — unit tests only; runtime goes via the `rfa-toggle-reviewed` bridge below | ReviewPage `#[On]` -> `toggleReviewed` | `{filePath}` |
+| `rfa-toggle-reviewed` | DiffFile Alpine + sidebar / Recently-reviewed buttons `$dispatch` (bubbles to window) | ReviewPage root Alpine `@window` -> `$wire.toggleReviewed` | `{filePath}` |
+| `rfa-hide-reviewed` | `reviewed-summary` island button `$dispatch` (window) | ReviewPage root Alpine `@window` -> `$wire.hideReviewedFiles` | none |
+| `rfa-show-all-files` | `reviewed-summary` island button `$dispatch` (window) | ReviewPage root Alpine `@window` -> `$wire.showAllFiles` | none |
+| `rfa-clear-recently-reviewed` | Recently-reviewed "Clear" button `$dispatch` (window) | ReviewPage root Alpine `@window` -> `$wire.clearRecentlyReviewed` | none |
 | `comment-updated` | ReviewPage PHP dispatch | DiffFile Alpine `@window` | `{fileId, comments}` |
 | `copy-to-clipboard` | DiffFile Alpine/PHP, ReviewPage PHP, comment-display, comments-drawer, branch-explorer | layout `<body>` Alpine `@window` | `{text, toast?}` (if `toast` string is set, a success toast with that text shows on success) |
 | `file-reviewed-changed` | DiffFile Alpine `$dispatch`, sidebar reviewed button | DiffFile Alpine `@window` (targeted by `id`) | `{id, reviewed}` |
@@ -204,6 +210,13 @@ ReviewPage (`resources/views/pages/⚡review-page.blade.php`) renders N DiffFile
 | `open-remote-menu` | DiffFile Alpine `$dispatch` | ReviewPage Alpine `@window` | `{target: 'file'\|'line', fileId, filePath, oldPath, status, side?, start?, end?, clientX, clientY}` |
 | `scroll-to-comment` | comments-drawer Alpine `$dispatch` | ReviewPage Alpine `@window` | `{commentId, filePath}` |
 | `unfold-for-comment` | ReviewPage Alpine `$dispatch` | DiffFile Alpine `@window` | `{fileId}` |
+
+The `rfa-*` events are a deliberate bridge: a `wire:click` or `$wire.dispatch()`
+fired from inside a Livewire island scopes the action to that island, so a
+reviewed control nested in an island could only refresh its own island. The
+controls instead `$dispatch` a bubbling window event that the page-root Alpine
+catches and forwards to `$wire`, letting the action run outside island scope and
+settle every affected island (see the skipRender table).
 
 ### Known Debt
 

--- a/resources/views/components/copy-paths-button.blade.php
+++ b/resources/views/components/copy-paths-button.blade.php
@@ -63,5 +63,5 @@
 </div>
 
 @once
-    <script src="/js/copy-paths-button.js"></script>
+    @localScript('js/copy-paths-button.js')
 @endonce

--- a/resources/views/components/diff/file-header.blade.php
+++ b/resources/views/components/diff/file-header.blade.php
@@ -110,7 +110,17 @@
         </div>
 
         <flux:tooltip content="Mark as reviewed">
-            <flux:checkbox x-model="reviewed" @change="onReviewedChange()" aria-label="Reviewed" class="cursor-pointer" />
+            <flux:checkbox
+                x-model="reviewed"
+                @change="
+                    reviewed = $event.target.checked;
+                    collapsed = reviewed;
+                    $dispatch('file-reviewed-changed', { id: fileId, reviewed });
+                    $dispatch('rfa-toggle-reviewed', { filePath });
+                "
+                aria-label="Reviewed"
+                class="cursor-pointer"
+            />
         </flux:tooltip>
     </div>
 </div>

--- a/resources/views/components/diff/file-header.blade.php
+++ b/resources/views/components/diff/file-header.blade.php
@@ -1,5 +1,5 @@
 {{-- Parent Alpine scope contract: fileId, filePath, oldPath, status, reviewed, collapsed,
-     toggleCollapse(), openFileComment(), onReviewedChange(), $wire.fileComments,
+     toggleCollapse(), openFileComment(), $wire.fileComments,
      $wire.copyContent(), $dispatch('open-remote-menu' | 'discard-file' | 'copy-to-clipboard') --}}
 @props([
     'file',

--- a/resources/views/components/remote-link-menu.blade.php
+++ b/resources/views/components/remote-link-menu.blade.php
@@ -43,7 +43,7 @@
 @endphp
 
 @assets
-<script src="/js/context-menu.js"></script>
+@localScript('js/context-menu.js')
 @endassets
 
 <template x-teleport="body">

--- a/resources/views/components/status-strip.blade.php
+++ b/resources/views/components/status-strip.blade.php
@@ -15,10 +15,10 @@
 {{-- State band under the page header: file count, +/- totals, review count, and
      a copy-paths affordance. Pure state, no actions. Visibility is derived
      server-side by ReviewState. The reviewed-progress summary and the file count
-     are injected via the $reviewedSummary / $fileCount slots so the page can
-     render them inside Livewire islands (the @island directive needs the Livewire
-     view's scope) — the count must refresh when Hide-reviewed changes the visible
-     set even though the strip itself isn't re-rendered on that skipRender path. --}}
+     are injected via slots so the page can render them inside Livewire islands
+     (the @island directive needs the Livewire view's scope) — visible-count
+     surfaces must refresh when Hide-reviewed changes the visible set even though
+     the strip itself isn't re-rendered on that skipRender path. --}}
 <div data-testid="status-strip" class="bg-gh-bg/60 border-b border-gh-border px-5 py-1 flex items-center gap-3 font-mono text-[11px] text-gh-muted">
     @isset($fileCount)
         {{ $fileCount }}
@@ -40,11 +40,15 @@
 
     <div class="ml-auto flex items-center gap-2">
         {{ $reviewedSummary ?? '' }}
-        @if($visibleFileCount > 0)
-            <x-copy-paths-button
-                testid-prefix="status-strip-copy-paths"
-                :visible-count="$visibleFileCount"
-            />
-        @endif
+        @isset($copyPaths)
+            {{ $copyPaths }}
+        @else
+            @if($visibleFileCount > 0)
+                <x-copy-paths-button
+                    testid-prefix="status-strip-copy-paths"
+                    :visible-count="$visibleFileCount"
+                />
+            @endif
+        @endisset
     </div>
 </div>

--- a/resources/views/components/status-strip.blade.php
+++ b/resources/views/components/status-strip.blade.php
@@ -2,6 +2,7 @@
     'sourceFiles',
     'reviewPairs',
     'reviewState' => null,
+    'fileCount' => null,
 ])
 
 @php
@@ -13,17 +14,23 @@
 
 {{-- State band under the page header: file count, +/- totals, review count, and
      a copy-paths affordance. Pure state, no actions. Visibility is derived
-     server-side by ReviewState. The reviewed-progress summary is injected via
-     the $reviewedSummary slot so the page can render it inside a Livewire
-     island (the @island directive needs the Livewire view's scope). --}}
+     server-side by ReviewState. The reviewed-progress summary and the file count
+     are injected via the $reviewedSummary / $fileCount slots so the page can
+     render them inside Livewire islands (the @island directive needs the Livewire
+     view's scope) — the count must refresh when Hide-reviewed changes the visible
+     set even though the strip itself isn't re-rendered on that skipRender path. --}}
 <div data-testid="status-strip" class="bg-gh-bg/60 border-b border-gh-border px-5 py-1 flex items-center gap-3 font-mono text-[11px] text-gh-muted">
-    <span>
-        @if($visibleFileCount === $totalFileCount)
-            {{ $totalFileCount }} {{ Str::plural('file', $totalFileCount) }}
-        @else
-            {{ $visibleFileCount }}/{{ $totalFileCount }} {{ Str::plural('file', $totalFileCount) }}
-        @endif
-    </span>
+    @isset($fileCount)
+        {{ $fileCount }}
+    @else
+        <span>
+            @if($visibleFileCount === $totalFileCount)
+                {{ $totalFileCount }} {{ Str::plural('file', $totalFileCount) }}
+            @else
+                {{ $visibleFileCount }}/{{ $totalFileCount }} {{ Str::plural('file', $totalFileCount) }}
+            @endif
+        </span>
+    @endisset
     <span class="text-gh-green">+{{ $totalAdditions }}</span>
     <span class="text-gh-red">-{{ $totalDeletions }}</span>
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -181,7 +181,7 @@
             border-color: rgb(var(--gh-border));
         }
         .dark [data-flux-checkbox-indicator] svg {
-            color: white;
+            color: var(--color-accent-foreground);
         }
 
         /* Override Flux heading to use display font */

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -16,14 +16,14 @@
             processSampleIntervalMs: @js((int) config('rfa.diagnostics.process_sample_interval_ms')),
         };
     </script>
-    <script src="/js/runtime-diagnostics.js"></script>
-    <script src="/js/settings-store.js"></script>
-    <script src="/js/overlays-store.js"></script>
-    <script src="/js/keymap-store.js"></script>
-    <script src="/js/page-search.js"></script>
-    <script src="/js/session-recovery.js"></script>
-    <script src="/js/smart-poll.js"></script>
-    <script src="/js/pending-saves.js"></script>
+    @localScript('js/runtime-diagnostics.js')
+    @localScript('js/settings-store.js')
+    @localScript('js/overlays-store.js')
+    @localScript('js/keymap-store.js')
+    @localScript('js/page-search.js')
+    @localScript('js/session-recovery.js')
+    @localScript('js/smart-poll.js')
+    @localScript('js/pending-saves.js')
     <style>
         @font-face {
             font-family: 'Space Grotesk';

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -150,7 +150,7 @@ new class extends Component {
 ?>
 
 @assets
-<script src="/js/branch-explorer.js"></script>
+@localScript('js/branch-explorer.js')
 @endassets
 
 <div

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -379,7 +379,7 @@ HTML;
 ?>
 
 @assets
-<script src="/js/diff-file.js"></script>
+@localScript('js/diff-file.js')
 @endassets
 
 {{-- Single file diff rendering --}}

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -946,8 +946,7 @@ new #[Layout('layouts.app')] class extends Component
         $this->forgetReviewState();
 
         $this->skipRender();
-        $this->renderIsland('reviewed-summary');
-        $this->renderIsland('file-list');
+        $this->renderReviewedStateIslands();
 
         // Only Hide-reviewed mode lets a reviewed toggle change the server-visible
         // list. A path filter is reviewed-independent (ReviewStateService only
@@ -964,8 +963,7 @@ new #[Layout('layouts.app')] class extends Component
         $this->forgetReviewState();
 
         $this->skipRender();
-        $this->renderIsland('reviewed-summary');
-        $this->renderIsland('file-list');
+        $this->renderReviewedStateIslands();
         $this->renderVisibilityIslands();
     }
 
@@ -982,6 +980,13 @@ new #[Layout('layouts.app')] class extends Component
         }
     }
 
+    private function renderReviewedStateIslands(): void
+    {
+        $this->renderIsland('reviewed-toggle');
+        $this->renderIsland('reviewed-counter');
+        $this->renderIsland('file-list');
+    }
+
     /**
      * Refresh every island that reflects which files are currently visible.
      *
@@ -996,6 +1001,7 @@ new #[Layout('layouts.app')] class extends Component
         $this->renderIsland('source-diff-list');
         $this->renderIsland('file-count');
         $this->renderIsland('file-list-header');
+        $this->renderIsland('status-strip-copy-paths');
     }
 
     private function forgetReviewState(): void
@@ -1137,8 +1143,8 @@ new #[Layout('layouts.app')] class extends Component
 ?>
 
 @assets
-<script src="/js/diff-file.js"></script>
-<script src="/js/review-page.js"></script>
+@localScript('js/diff-file.js')
+@localScript('js/review-page.js')
 @endassets
 
 <div
@@ -1163,10 +1169,10 @@ new #[Layout('layouts.app')] class extends Component
     })"
     @scroll-to-comment.window="scrollToComment($event.detail.commentId, $event.detail.filePath)"
     @open-remote-menu.window="showRemoteMenu($event)"
-    x-on:rfa-toggle-reviewed.window="$wire.toggleReviewed($event.detail.filePath)"
-    x-on:rfa-hide-reviewed.window="$wire.hideReviewedFiles()"
-    x-on:rfa-show-all-files.window="$wire.showAllFiles()"
-    x-on:rfa-clear-recently-reviewed.window="$wire.clearRecentlyReviewed()"
+    x-on:rfa-toggle-reviewed.window="toggleReviewed($event.detail?.filePath)"
+    x-on:rfa-hide-reviewed.window="hideReviewedFiles()"
+    x-on:rfa-show-all-files.window="showAllFiles()"
+    x-on:rfa-clear-recently-reviewed.window="clearRecentlyReviewed()"
     @keydown.window="
         if ($event.target.tagName === 'TEXTAREA' || $event.target.tagName === 'INPUT') {
             if ($event.key === 'Escape' && !$event.target.closest('[data-comment-form]')) { $wire.clearFileFilter(); $event.target.blur(); $event.preventDefault(); }
@@ -1295,11 +1301,9 @@ new #[Layout('layouts.app')] class extends Component
                 <livewire:comments-drawer :repo-path="$repoPath" :project-id="$projectId ?: null" />
             </div>
             <div class="flex items-center gap-2 text-xs">
-                {{-- Hide reviewed toggle. Same-named island as the counter, so
-                     renderIsland('reviewed-summary') flips its visibility in step
-                     with the count on a mark/un-mark. always:true keeps it in sync
-                     on full renders too. --}}
-                @island(name: 'reviewed-summary', always: true)
+                {{-- Hide reviewed toggle. Separate from the counter island so
+                     each reviewed-state fragment has one DOM target. --}}
+                @island(name: 'reviewed-toggle', always: true)
                     @if ($this->reviewState->reviewedFileCount > 0)
                         <div class="grid place-items-center">
                             {{-- Bridge through the page root so island children don't
@@ -1407,7 +1411,7 @@ new #[Layout('layouts.app')] class extends Component
                         </span>
                     @endisland
                 </x-slot:fileCount>
-                {{-- Reviewed-progress summary. Wrapped in a Livewire island so a
+                {{-- Reviewed-progress counter. Wrapped in a Livewire island so a
                      mark/un-mark re-renders just this counter and meter, not the
                      2200-line review page. Reads only $this state (island scope
                      can't see template locals). --}}
@@ -1415,7 +1419,7 @@ new #[Layout('layouts.app')] class extends Component
                     {{-- always:true so a full render (e.g. hide-reviewed mode,
                          filtering) re-renders the counter inline instead of
                          skipping it; renderIsland still scopes the latency path. --}}
-                    @island(name: 'reviewed-summary', always: true)
+                    @island(name: 'reviewed-counter', always: true)
                         @if ($this->reviewState->reviewedFileCount > 0)
                             <div class="flex items-center gap-2">
                                 <span data-testid="reviewed-counter">{{ $this->reviewState->reviewedFileCount }}/{{ $this->reviewState->totalFileCount }} reviewed</span>
@@ -1426,6 +1430,16 @@ new #[Layout('layouts.app')] class extends Component
                         @endif
                     @endisland
                 </x-slot:reviewedSummary>
+                <x-slot:copyPaths>
+                    @island(name: 'status-strip-copy-paths', always: true)
+                        @if($this->reviewState->visibleFileCount > 0)
+                            <x-copy-paths-button
+                                testid-prefix="status-strip-copy-paths"
+                                :visible-count="$this->reviewState->visibleFileCount"
+                            />
+                        @endif
+                    @endisland
+                </x-slot:copyPaths>
             </x-status-strip>
         </x-slot:below>
     </x-page-header>
@@ -1737,7 +1751,7 @@ new #[Layout('layouts.app')] class extends Component
                 @endif
 
                 {{-- Source Files --}}
-                {{-- Source diffs are isolated from reviewed-summary/sidebar islands
+                {{-- Source diffs are isolated from reviewed-state/sidebar islands
                      so hide-reviewed mode can remove mounted lazy diff-file children
                      without morphing the entire review page. --}}
                 @island(name: 'source-diff-list', always: true)

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -835,24 +835,23 @@ new #[Layout('layouts.app')] class extends Component
     public function clearRecentlyReviewed(): void
     {
         $this->recentlyReviewedIds = [];
-        $this->forgetReviewState();
 
-        if (! $this->hideReviewed) {
-            $this->skipRender();
-        }
+        $this->settleRecentlyReviewedRender();
     }
 
     public function hideReviewedFiles(): void
     {
         $this->hideReviewed = true;
-        $this->forgetReviewState();
+
+        $this->settleReviewedVisibilityRender();
     }
 
     public function showAllFiles(): void
     {
         $this->hideReviewed = false;
         $this->recentlyReviewedIds = [];
-        $this->forgetReviewState();
+
+        $this->settleReviewedVisibilityRender();
     }
 
     public function clearFileFilter(): void
@@ -934,40 +933,55 @@ new #[Layout('layouts.app')] class extends Component
             ->all();
     }
 
-    private function reviewedChangeNeedsParentRender(): bool
+    private function reviewedChangeNeedsSourceDiffListRender(): bool
     {
         // Only Hide-reviewed mode lets a reviewed toggle change the server-visible
         // list. A path filter is reviewed-independent (ReviewStateService only
-        // drops files for reviewed-ness when hideReviewed is on), so re-rendering
-        // the parent — and re-hydrating every mounted diff-file child — on a
-        // filter-only toggle is wasted work on a latency-sensitive path.
+        // drops files for reviewed-ness when hideReviewed is on), so refreshing
+        // the source diff list on a filter-only toggle is wasted work on a
+        // latency-sensitive path.
         return $this->hideReviewed;
     }
 
     /**
-     * Settle the response after a reviewed-state change. Hide-reviewed mode needs
-     * a full parent render because the toggle drops the file from the visible
-     * list. Every other mode re-renders only the reviewed-summary island, so the
-     * counter and meter update without re-rendering the page or re-hydrating the
-     * mounted diff-file children.
+     * Settle the response after a reviewed-state change.
+     *
+     * The affected regions are intentionally islands: summary controls, sidebar
+     * file list, and (only while hiding reviewed files) the source diff list.
      */
     private function settleReviewedRender(): void
     {
         $this->forgetReviewState();
 
-        // Hide-reviewed mode does a full render because the toggle drops the
-        // newly-reviewed file from the visible list. The reviewed-summary island
-        // is declared always:true, so it re-renders inline as part of that full
-        // render rather than emitting a skip marker.
-        if ($this->reviewedChangeNeedsParentRender()) {
+        $this->skipRender();
+        $this->renderIsland('reviewed-summary');
+        $this->renderIsland('file-list');
+
+        if ($this->reviewedChangeNeedsSourceDiffListRender()) {
+            $this->renderIsland('source-diff-list');
+        }
+    }
+
+    private function settleReviewedVisibilityRender(): void
+    {
+        $this->forgetReviewState();
+        $this->skipRender();
+        $this->renderIsland('reviewed-summary');
+        $this->renderIsland('file-list');
+        $this->renderIsland('source-diff-list');
+    }
+
+    private function settleRecentlyReviewedRender(): void
+    {
+        $this->forgetReviewState();
+
+        if (! $this->hideReviewed) {
+            $this->skipRender();
+
             return;
         }
 
-        // Other modes skip the full render for latency and refresh just the
-        // islands. The computed cache has already been busted so they reflect the
-        // reviewedFiles change just made rather than a value memoized earlier.
         $this->skipRender();
-        $this->renderIsland('reviewed-summary');
         $this->renderIsland('file-list');
     }
 
@@ -1136,6 +1150,10 @@ new #[Layout('layouts.app')] class extends Component
     })"
     @scroll-to-comment.window="scrollToComment($event.detail.commentId, $event.detail.filePath)"
     @open-remote-menu.window="showRemoteMenu($event)"
+    x-on:rfa-toggle-reviewed.window="$wire.toggleReviewed($event.detail.filePath)"
+    x-on:rfa-hide-reviewed.window="$wire.hideReviewedFiles()"
+    x-on:rfa-show-all-files.window="$wire.showAllFiles()"
+    x-on:rfa-clear-recently-reviewed.window="$wire.clearRecentlyReviewed()"
     @keydown.window="
         if ($event.target.tagName === 'TEXTAREA' || $event.target.tagName === 'INPUT') {
             if ($event.key === 'Escape' && !$event.target.closest('[data-comment-form]')) { $wire.clearFileFilter(); $event.target.blur(); $event.preventDefault(); }
@@ -1271,18 +1289,20 @@ new #[Layout('layouts.app')] class extends Component
                 @island(name: 'reviewed-summary', always: true)
                     @if ($this->reviewState->reviewedFileCount > 0)
                         <div class="grid place-items-center">
+                            {{-- Bridge through the page root so island children don't
+                                 scope reviewed-state actions to their own island. --}}
                             @if($hideReviewed)
                                 <flux:button variant="ghost" size="sm" icon="eye" icon:variant="outline"
                                     tooltip="Show all files"
                                     aria-label="Show all files"
                                     class="col-start-1 row-start-1"
-                                    wire:click="showAllFiles" />
+                                    @click="$dispatch('rfa-show-all-files')" />
                             @else
                                 <flux:button variant="ghost" size="sm" icon="eye-slash" icon:variant="outline"
                                     tooltip="Hide reviewed"
                                     aria-label="Hide reviewed"
                                     class="col-start-1 row-start-1"
-                                    wire:click="hideReviewedFiles" />
+                                    @click="$dispatch('rfa-hide-reviewed')" />
                             @endif
                         </div>
                     @endif
@@ -1460,13 +1480,18 @@ new #[Layout('layouts.app')] class extends Component
                     x-ref="fileFilterInput"
                     @keydown.escape="$wire.clearFileFilter(); $el.blur()"
                 />
+                {{-- File list as an island so a reviewed mark/un-mark refreshes the
+                     sidebar checkmarks and recovery group without a full page render.
+                     always:true keeps it current on full renders too (filtering,
+                     discard, hide-reviewed mode). --}}
+                @island(name: 'file-list', always: true)
                 {{-- Recently reviewed: surfaces just-marked files in Hide-reviewed mode so the user can un-mark in place --}}
                 @if($hideReviewed && count($this->recentlyReviewedFiles) > 0)
                     <div data-testid="recently-reviewed-group" class="mb-3">
                         <div class="flex items-center justify-between mb-2">
                             <span class="section-label text-gh-muted">Recently reviewed</span>
                             <button type="button"
-                                wire:click="clearRecentlyReviewed"
+                                @click="$dispatch('rfa-clear-recently-reviewed')"
                                 class="text-[10px] uppercase tracking-wider text-gh-muted hover:text-gh-text transition-colors"
                                 title="Clear recently reviewed list"
                                 aria-label="Clear recently reviewed list">Clear</button>
@@ -1483,7 +1508,7 @@ new #[Layout('layouts.app')] class extends Component
                                 </button>
                                 <flux:tooltip content="Un-mark as reviewed">
                                     <button type="button"
-                                        wire:click="toggleReviewed(@js($recentlyReviewedFile['path']))"
+                                        @click.stop="$dispatch('rfa-toggle-reviewed', { filePath: @js($recentlyReviewedFile['path']) })"
                                         class="shrink-0 size-3.5 flex items-center justify-center text-gh-green hover:text-gh-text transition-colors"
                                         aria-label="Un-mark as reviewed">
                                         <flux:icon icon="check" variant="outline" class="!size-3.5" />
@@ -1494,11 +1519,6 @@ new #[Layout('layouts.app')] class extends Component
                         <div class="border-b border-gh-border my-3"></div>
                     </div>
                 @endif
-                {{-- File list as an island so a reviewed mark/un-mark refreshes the
-                     sidebar checkmarks via renderIsland('file-list') without a full
-                     page render. always:true keeps it current on full renders too
-                     (filtering, discard, hide-reviewed mode). --}}
-                @island(name: 'file-list', always: true)
                 @foreach($this->reviewState->visibleFiles as $file)
                     @php
                         // Badge label and color come from ReviewState so this list and the
@@ -1554,11 +1574,11 @@ new #[Layout('layouts.app')] class extends Component
                         <flux:tooltip>
                             {{-- Reviewed state is server-rendered inside the file-list island.
                                  The click tells DiffFile's checkbox mirror the new state and
-                                 asks the parent to toggle, which refreshes this island. --}}
+                                 asks the parent to toggle, which refreshes affected islands. --}}
                             <button type="button"
                                 @click.stop="
                                     $dispatch('file-reviewed-changed', { id: '{{ $file['id'] }}', reviewed: {{ $isReviewed ? 'false' : 'true' }} });
-                                    $wire.dispatch('toggle-reviewed', { filePath: @js($file['path']) });
+                                    $dispatch('rfa-toggle-reviewed', { filePath: @js($file['path']) });
                                 "
                                 class="shrink-0 size-3.5 flex items-center justify-center transition-[opacity,colors] {{ $isReviewed ? 'text-gh-green hover:text-gh-text' : 'text-gh-muted/40 opacity-0 group-hover:opacity-100 hover:text-gh-text' }}"
                                 aria-label="{{ $isReviewed ? 'Un-mark as reviewed' : 'Mark as reviewed' }}"
@@ -1680,44 +1700,50 @@ new #[Layout('layouts.app')] class extends Component
                 @endif
 
                 {{-- Source Files --}}
-                {{-- Filter-independent: singleFile is read once at a diff-file child's
-                     Alpine init and its :key has no filter component, so a filtered
-                     1-of-N view can't re-init an already-mounted child. Key off the
-                     total source count so the value is stable across filtering. --}}
-                @php $singleFile = $this->reviewState->totalFileCount === 1 && count($reviewPairs) === 0; @endphp
-                @forelse($this->reviewState->visibleFiles as $file)
-                    <div id="{{ $file['id'] }}"
-                         class="border-b border-gh-border transition-opacity duration-150 ease-out">
-                        <livewire:diff-file
-                            lazy
-                            :key="$file['id'].'-'.$file['refreshFingerprint']"
-                            :file="$file"
-                            :load-delay="(int) (floor($loop->index / 15) * 100)"
-                            :file-comments="$this->groupedComments[$file['id']] ?? []"
-                            :is-reviewed="array_key_exists($file['path'], $reviewedFiles)"
-                            :single-file="$singleFile"
-                            :repo-path="$repoPath"
-                            :project-id="$projectId"
-                            :has-remote="$hasRemote"
-                            :diff-from="$diffFrom"
-                            :diff-to="$diffTo"
-                        />
-                    </div>
-                @empty
-                    @if(count($reviewPairs) === 0)
-                        @if($this->reviewState->emptyStateReason === \App\DTOs\ReviewState::EMPTY_FILTER)
-                            <x-empty-state>
-                                <x-slot:heading>No files match</x-slot:heading>
-                                <p class="text-sm text-gh-muted">Clear the filter to show all changed files</p>
-                            </x-empty-state>
-                        @elseif($this->reviewState->emptyStateReason === \App\DTOs\ReviewState::EMPTY_ALL_REVIEWED)
-                            <x-empty-state>
-                                <x-slot:heading>All files reviewed</x-slot:heading>
-                                <p class="text-sm text-gh-muted">Show all files to revisit reviewed changes</p>
-                            </x-empty-state>
+                {{-- Source diffs are isolated from reviewed-summary/sidebar islands
+                     so hide-reviewed mode can remove mounted lazy diff-file children
+                     without morphing the entire review page. --}}
+                @island(name: 'source-diff-list', always: true)
+                    {{-- Filter-independent: singleFile is read once at a diff-file child's
+                         Alpine init and its :key has no filter component, so a filtered
+                         1-of-N view can't re-init an already-mounted child. Key off the
+                         total source count so the value is stable across filtering. --}}
+                    @php $singleFile = $this->reviewState->totalFileCount === 1 && count($reviewPairs) === 0; @endphp
+                    @forelse($this->reviewState->visibleFiles as $file)
+                        <div id="{{ $file['id'] }}"
+                             wire:key="source-file-shell-{{ $file['id'] }}-{{ $file['refreshFingerprint'] }}"
+                             class="border-b border-gh-border transition-opacity duration-150 ease-out">
+                            <livewire:diff-file
+                                lazy
+                                :key="$file['id'].'-'.$file['refreshFingerprint']"
+                                :file="$file"
+                                :load-delay="(int) (floor($loop->index / 15) * 100)"
+                                :file-comments="$this->groupedComments[$file['id']] ?? []"
+                                :is-reviewed="array_key_exists($file['path'], $reviewedFiles)"
+                                :single-file="$singleFile"
+                                :repo-path="$repoPath"
+                                :project-id="$projectId"
+                                :has-remote="$hasRemote"
+                                :diff-from="$diffFrom"
+                                :diff-to="$diffTo"
+                            />
+                        </div>
+                    @empty
+                        @if(count($reviewPairs) === 0)
+                            @if($this->reviewState->emptyStateReason === \App\DTOs\ReviewState::EMPTY_FILTER)
+                                <x-empty-state>
+                                    <x-slot:heading>No files match</x-slot:heading>
+                                    <p class="text-sm text-gh-muted">Clear the filter to show all changed files</p>
+                                </x-empty-state>
+                            @elseif($this->reviewState->emptyStateReason === \App\DTOs\ReviewState::EMPTY_ALL_REVIEWED)
+                                <x-empty-state>
+                                    <x-slot:heading>All files reviewed</x-slot:heading>
+                                    <p class="text-sm text-gh-muted">Show all files to revisit reviewed changes</p>
+                                </x-empty-state>
+                            @endif
                         @endif
-                    @endif
-                @endforelse
+                    @endforelse
+                @endisland
             @endif
     </x-resizable-sidebar-shell>
 

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -933,21 +933,13 @@ new #[Layout('layouts.app')] class extends Component
             ->all();
     }
 
-    private function reviewedChangeNeedsSourceDiffListRender(): bool
-    {
-        // Only Hide-reviewed mode lets a reviewed toggle change the server-visible
-        // list. A path filter is reviewed-independent (ReviewStateService only
-        // drops files for reviewed-ness when hideReviewed is on), so refreshing
-        // the source diff list on a filter-only toggle is wasted work on a
-        // latency-sensitive path.
-        return $this->hideReviewed;
-    }
-
     /**
      * Settle the response after a reviewed-state change.
      *
-     * The affected regions are intentionally islands: summary controls, sidebar
-     * file list, and (only while hiding reviewed files) the source diff list.
+     * The affected regions are intentionally islands: summary controls and the
+     * sidebar file list always; the visibility islands (source diff list and the
+     * visible-file counts) only while hiding reviewed files, since that is the
+     * only mode where a toggle drops a file from the visible set.
      */
     private function settleReviewedRender(): void
     {
@@ -957,32 +949,53 @@ new #[Layout('layouts.app')] class extends Component
         $this->renderIsland('reviewed-summary');
         $this->renderIsland('file-list');
 
-        if ($this->reviewedChangeNeedsSourceDiffListRender()) {
-            $this->renderIsland('source-diff-list');
+        // Only Hide-reviewed mode lets a reviewed toggle change the server-visible
+        // list. A path filter is reviewed-independent (ReviewStateService only
+        // drops files for reviewed-ness when hideReviewed is on), so refreshing
+        // the visibility islands on a filter-only toggle is wasted work on a
+        // latency-sensitive path.
+        if ($this->hideReviewed) {
+            $this->renderVisibilityIslands();
         }
     }
 
     private function settleReviewedVisibilityRender(): void
     {
         $this->forgetReviewState();
+
         $this->skipRender();
         $this->renderIsland('reviewed-summary');
         $this->renderIsland('file-list');
-        $this->renderIsland('source-diff-list');
+        $this->renderVisibilityIslands();
     }
 
     private function settleRecentlyReviewedRender(): void
     {
         $this->forgetReviewState();
 
-        if (! $this->hideReviewed) {
-            $this->skipRender();
-
-            return;
-        }
-
         $this->skipRender();
-        $this->renderIsland('file-list');
+
+        // The Recently-reviewed group lives inside the file-list island and only
+        // shows in Hide-reviewed mode, so nothing else needs refreshing here.
+        if ($this->hideReviewed) {
+            $this->renderIsland('file-list');
+        }
+    }
+
+    /**
+     * Refresh every island that reflects which files are currently visible.
+     *
+     * Dropping a file in/out of the visible set changes the source diff list and
+     * the visible-file counts that live OUTSIDE the sidebar file list: the
+     * status-strip count band and the sidebar "Files" header (the j/k hint and
+     * copy-paths trigger). Each is its own island so a skipRender() reviewed
+     * toggle keeps them in step instead of leaving a stale "N files" behind.
+     */
+    private function renderVisibilityIslands(): void
+    {
+        $this->renderIsland('source-diff-list');
+        $this->renderIsland('file-count');
+        $this->renderIsland('file-list-header');
     }
 
     private function forgetReviewState(): void
@@ -1377,6 +1390,23 @@ new #[Layout('layouts.app')] class extends Component
 
         <x-slot:below>
             <x-status-strip :source-files="$sourceFiles" :review-pairs="$reviewPairs" :review-state="$this->reviewState">
+                {{-- File count band. Its own island so Hide-reviewed (a skipRender
+                     path that re-renders islands, not the strip) keeps "N files" /
+                     "X/N files" in step with the visible set instead of leaving a
+                     stale total behind. always:true keeps it current on full
+                     renders too. Reads only $this state (island scope can't see
+                     template locals). --}}
+                <x-slot:fileCount>
+                    @island(name: 'file-count', always: true)
+                        <span>
+                            @if ($this->reviewState->visibleFileCount === $this->reviewState->totalFileCount)
+                                {{ $this->reviewState->totalFileCount }} {{ Str::plural('file', $this->reviewState->totalFileCount) }}
+                            @else
+                                {{ $this->reviewState->visibleFileCount }}/{{ $this->reviewState->totalFileCount }} {{ Str::plural('file', $this->reviewState->totalFileCount) }}
+                            @endif
+                        </span>
+                    @endisland
+                </x-slot:fileCount>
                 {{-- Reviewed-progress summary. Wrapped in a Livewire island so a
                      mark/un-mark re-renders just this counter and meter, not the
                      2200-line review page. Reads only $this state (island scope
@@ -1448,6 +1478,12 @@ new #[Layout('layouts.app')] class extends Component
                     <div class="border-b border-gh-border my-3"></div>
                 @endif
 
+                {{-- Header island: the j/k hint and copy-paths trigger both read
+                     visibleFileCount, which Hide-reviewed changes. Kept separate
+                     from the file-list island below so it can refresh on the
+                     skipRender visibility path without re-rendering (and stealing
+                     focus from) the filter input that sits between them. --}}
+                @island(name: 'file-list-header', always: true)
                 <div class="flex items-center justify-between mb-3">
                     <div class="flex items-center gap-2">
                         <span class="section-label text-gh-muted">Files</span>
@@ -1467,6 +1503,7 @@ new #[Layout('layouts.app')] class extends Component
                         />
                     @endif
                 </div>
+                @endisland
                 <flux:input
                     wire:model.live.debounce.150ms="fileFilter"
                     placeholder="Filter files..."

--- a/rfa
+++ b/rfa
@@ -32,11 +32,45 @@ else
     INBOX_DIR="$HOME/.local/share/com.fgilio.rfa/inbox"
 fi
 INBOX_PARENT="${INBOX_DIR%/*}"
-mkdir -p "$INBOX_PARENT"
-if [ -e "$INBOX_DIR" ] && [ ! -d "$INBOX_DIR" ]; then
-    mv "$INBOX_DIR" "$INBOX_DIR.$(date +%s)-$$.bak"
-fi
-mkdir -p "$INBOX_DIR"
+
+ensure_dir_path() {
+    local path="$1"
+    local current=""
+    local segment=""
+
+    if [ "${path#/}" != "$path" ]; then
+        current="/"
+        path="${path#/}"
+    fi
+
+    while [ -n "$path" ]; do
+        segment="${path%%/*}"
+        if [ "$path" = "$segment" ]; then
+            path=""
+        else
+            path="${path#*/}"
+        fi
+
+        [ -z "$segment" ] && continue
+
+        if [ "$current" = "/" ]; then
+            current="/$segment"
+        elif [ -z "$current" ]; then
+            current="$segment"
+        else
+            current="$current/$segment"
+        fi
+
+        if [ -e "$current" ] && [ ! -d "$current" ]; then
+            mv "$current" "$current.$(date +%s)-$$.bak"
+        fi
+
+        mkdir -p "$current"
+    done
+}
+
+ensure_dir_path "$INBOX_PARENT"
+ensure_dir_path "$INBOX_DIR"
 INBOX_FILE="$INBOX_DIR/$(date +%s%N)-$$.path"
 INBOX_TMP="$INBOX_FILE.tmp"
 if [ -n "$MODE" ]; then

--- a/rfa
+++ b/rfa
@@ -31,6 +31,11 @@ if [ "$(uname)" = "Darwin" ]; then
 else
     INBOX_DIR="$HOME/.local/share/com.fgilio.rfa/inbox"
 fi
+INBOX_PARENT="${INBOX_DIR%/*}"
+mkdir -p "$INBOX_PARENT"
+if [ -e "$INBOX_DIR" ] && [ ! -d "$INBOX_DIR" ]; then
+    mv "$INBOX_DIR" "$INBOX_DIR.$(date +%s)-$$.bak"
+fi
 mkdir -p "$INBOX_DIR"
 INBOX_FILE="$INBOX_DIR/$(date +%s%N)-$$.path"
 INBOX_TMP="$INBOX_FILE.tmp"

--- a/tests/Arch/BladeConventionsTest.php
+++ b/tests/Arch/BladeConventionsTest.php
@@ -201,6 +201,22 @@ test('blade templates do not attach pending-save Livewire hooks inline', functio
     expect($violations)->toBeEmpty();
 });
 
+test('blade templates version first-party javascript assets', function () {
+    $violations = [];
+
+    foreach (bladeFiles() as $file) {
+        $content = file_get_contents($file);
+
+        if (preg_match_all('/<script\s+[^>]*src=["\']\/js\/[^"\']+["\'][^>]*>/i', $content, $matches)) {
+            foreach ($matches[0] as $tag) {
+                $violations[] = bladeRelativePath($file).': '.$tag;
+            }
+        }
+    }
+
+    expect($violations)->toBeEmpty();
+});
+
 test('inline alpine timers clear themselves on destroy', function () {
     $violations = [];
 

--- a/tests/Arch/SessionRecoveryTest.php
+++ b/tests/Arch/SessionRecoveryTest.php
@@ -23,7 +23,7 @@ test('.env.example sets a session lifetime of at least 1 week', function () {
 test('app layout loads session-recovery.js', function () {
     $layout = file_get_contents(dirname(__DIR__, 2).'/resources/views/layouts/app.blade.php');
 
-    expect($layout)->toContain('/js/session-recovery.js');
+    expect($layout)->toContain("@localScript('js/session-recovery.js')");
 });
 
 test('session-recovery.js intercepts 419 responses and reloads', function () {

--- a/tests/Browser/FileInteractionTest.php
+++ b/tests/Browser/FileInteractionTest.php
@@ -24,6 +24,72 @@ function waitForCopiedText($page, float $timeoutSec = 5.0): ?string
     return null;
 }
 
+function cssRgbChannelValues(string $rgb): array
+{
+    preg_match_all('/[\d.]+/', $rgb, $matches);
+
+    return array_map('floatval', array_slice($matches[0], 0, 3));
+}
+
+function cssContrastRatio(string $firstColor, string $secondColor): float
+{
+    $relativeLuminance = function (string $color): float {
+        $channels = array_map(
+            fn (float $channel): float => $channel / 255,
+            cssRgbChannelValues($color),
+        );
+
+        $linear = array_map(
+            fn (float $channel): float => $channel <= 0.03928
+                ? $channel / 12.92
+                : (($channel + 0.055) / 1.055) ** 2.4,
+            $channels,
+        );
+
+        return 0.2126 * $linear[0] + 0.7152 * $linear[1] + 0.0722 * $linear[2];
+    };
+
+    $first = $relativeLuminance($firstColor);
+    $second = $relativeLuminance($secondColor);
+
+    return (max($first, $second) + 0.05) / (min($first, $second) + 0.05);
+}
+
+function renderedDiffFiles($page): array
+{
+    return $page->script("
+        [...document.querySelectorAll('[data-rfa-diff-file]')].map((element) => {
+            const data = window.Alpine?.\$data(element) ?? {};
+            const checkbox = element.querySelector('ui-checkbox');
+
+            return {
+                id: element.getAttribute('data-file-id'),
+                path: data.filePath ?? null,
+                checked: checkbox?.checked ?? null,
+                dataChecked: checkbox?.hasAttribute('data-checked') ?? null,
+            };
+        })
+    ");
+}
+
+function waitForRenderedDiffFileCount($page, int $expectedCount, float $timeoutSec = 5.0): array
+{
+    $deadline = microtime(true) + $timeoutSec;
+    $diffFiles = [];
+
+    while (microtime(true) < $deadline) {
+        $diffFiles = renderedDiffFiles($page);
+
+        if (count($diffFiles) === $expectedCount) {
+            return $diffFiles;
+        }
+
+        usleep(100_000);
+    }
+
+    return $diffFiles;
+}
+
 test('clicking file name collapses and expands file diff', function () {
     $page = $this->visit($this->projectUrl());
 
@@ -251,6 +317,63 @@ test('marking a file reveals the Hide reviewed toggle', function () {
 
     // The mark refreshes the island, which renders the toggle into view.
     $page->page()->getByRole('button', ['name' => 'Hide reviewed'])->waitFor(['state' => 'visible']);
+});
+
+test('checked reviewed checkbox keeps its check glyph visible in dark mode', function () {
+    $page = $this->visitAndLoad($this->projectUrl());
+
+    $page->script("
+        document.documentElement.classList.add('dark');
+        if (window.Flux) window.Flux.dark = true;
+    ");
+
+    $page->page()->getByRole('checkbox', ['name' => 'Reviewed'])->first()->click();
+    $page->assertSee('1/3 reviewed');
+
+    $styles = $page->script("
+        (() => {
+            const checkboxes = [...document.querySelectorAll('ui-checkbox')];
+            const checkbox = checkboxes.find((candidate) => candidate.checked);
+            const indicator = checkbox?.querySelector('[data-flux-checkbox-indicator]');
+            const icon = indicator?.querySelector('svg');
+
+            return {
+                checked: Boolean(checkbox),
+                hasCheckedAttribute: checkbox?.hasAttribute('data-checked') ?? false,
+                display: icon ? getComputedStyle(icon).display : null,
+                iconColor: icon ? getComputedStyle(icon).color : null,
+                backgroundColor: indicator ? getComputedStyle(indicator).backgroundColor : null,
+            };
+        })()
+    ");
+
+    expect($styles['checked'])->toBeTrue()
+        ->and($styles['hasCheckedAttribute'])->toBeTrue()
+        ->and($styles['display'])->toBe('block')
+        ->and(cssContrastRatio($styles['iconColor'], $styles['backgroundColor']))->toBeGreaterThan(3.0);
+});
+
+test('hide reviewed removes checked diff files from the rendered page', function () {
+    $page = $this->visitAndLoad($this->projectUrl());
+
+    $markedPath = waitForRenderedDiffFileCount($page, 3)[0]['path'];
+
+    $page->page()->getByRole('checkbox', ['name' => 'Reviewed'])->first()->click();
+    $page->page()->getByRole('button', ['name' => 'Hide reviewed'])->waitFor(['state' => 'visible']);
+    $page->page()->getByRole('button', ['name' => 'Hide reviewed'])->click();
+
+    $page->page()->getByRole('button', ['name' => 'Show all files'])->waitFor(['state' => 'visible']);
+    $diffFiles = waitForRenderedDiffFileCount($page, 2);
+
+    expect($diffFiles)->toHaveCount(2);
+    expect(collect($diffFiles)->pluck('path')->all())->not->toContain($markedPath);
+    expect($page->page()->getByRole('checkbox', ['name' => 'Reviewed'])->count())->toBe(2);
+
+    $page->page()->getByRole('button', ['name' => 'Show all files'])->click();
+    $diffFiles = waitForRenderedDiffFileCount($page, 3);
+
+    expect($diffFiles)->toHaveCount(3);
+    expect(collect($diffFiles)->pluck('path')->all())->toContain($markedPath);
 });
 
 test('clicking sidebar file scrolls to it', function () {

--- a/tests/Browser/FileInteractionTest.php
+++ b/tests/Browser/FileInteractionTest.php
@@ -24,6 +24,23 @@ function waitForCopiedText($page, float $timeoutSec = 5.0): ?string
     return null;
 }
 
+function waitForReviewedCounter($page, string $text): void
+{
+    $counter = $page->page()->getByTestId('reviewed-counter');
+
+    $counter->getByText($text)->waitFor(['state' => 'visible']);
+
+    expect($counter->innerText())->toContain($text);
+}
+
+function clickFirstUncheckedReviewedCheckbox($page): void
+{
+    $page->page()
+        ->locator('[data-rfa-diff-file] ui-checkbox:not([data-checked])')
+        ->first()
+        ->click();
+}
+
 function cssRgbChannelValues(string $rgb): array
 {
     preg_match_all('/[\d.]+/', $rgb, $matches);
@@ -278,22 +295,22 @@ test('checking reviewed updates sidebar indicator', function () {
 
     $page->page()->getByRole('checkbox', ['name' => 'Reviewed'])->first()->click();
 
-    $page->assertSee('1/3 reviewed');
+    waitForReviewedCounter($page, '1/3 reviewed');
 });
 
 test('a second mark in normal mode advances the status-strip counter via the slot island', function () {
     $page = $this->visitAndLoad($this->projectUrl());
 
     // First mark: 1/3. Second mark: 2/3. The counter lives in the
-    // reviewed-summary island nested inside the x-status-strip slot, refreshed
+    // reviewed-counter island nested inside the x-status-strip slot, refreshed
     // by renderIsland on the skipRender path. This guards that the slot-scoped
     // island actually re-renders (not just the first mark or the hide-mode
     // full render).
-    $page->page()->getByRole('checkbox', ['name' => 'Reviewed'])->first()->click();
-    $page->assertSee('1/3 reviewed');
+    clickFirstUncheckedReviewedCheckbox($page);
+    waitForReviewedCounter($page, '1/3 reviewed');
 
-    $page->page()->getByRole('checkbox', ['name' => 'Reviewed'])->nth(1)->click();
-    $page->assertSee('2/3 reviewed');
+    clickFirstUncheckedReviewedCheckbox($page);
+    waitForReviewedCounter($page, '2/3 reviewed');
 });
 
 test('marking a file flips its sidebar button to the reviewed state via the island', function () {
@@ -309,7 +326,7 @@ test('marking a file flips its sidebar button to the reviewed state via the isla
 test('marking a file reveals the Hide reviewed toggle', function () {
     $page = $this->visitAndLoad($this->projectUrl());
 
-    // The toggle lives in the reviewed-summary island and is absent until at
+    // The toggle lives in the reviewed-toggle island and is absent until at
     // least one file is reviewed.
     $page->page()->getByRole('button', ['name' => 'Hide reviewed'])->waitFor(['state' => 'hidden']);
 
@@ -328,7 +345,7 @@ test('checked reviewed checkbox keeps its check glyph visible in dark mode', fun
     ");
 
     $page->page()->getByRole('checkbox', ['name' => 'Reviewed'])->first()->click();
-    $page->assertSee('1/3 reviewed');
+    waitForReviewedCounter($page, '1/3 reviewed');
 
     $styles = $page->script("
         (() => {
@@ -382,6 +399,21 @@ test('hide reviewed removes checked diff files from the rendered page', function
 
     // Showing all files clears the partial-visibility count.
     $page->page()->getByTestId('status-strip')->getByText('2/3 files')->waitFor(['state' => 'hidden']);
+});
+
+test('status strip copy menu hides when hide-reviewed removes every file', function () {
+    $page = $this->visitAndLoad($this->projectUrl());
+
+    foreach (range(0, 2) as $index) {
+        clickFirstUncheckedReviewedCheckbox($page);
+        waitForReviewedCounter($page, ($index + 1).'/3 reviewed');
+    }
+
+    $page->page()->getByRole('button', ['name' => 'Hide reviewed'])->click();
+
+    $page->page()->getByTestId('status-strip-copy-paths')->waitFor(['state' => 'hidden']);
+
+    expect($page->page()->getByTestId('status-strip-copy-paths')->isHidden())->toBeTrue();
 });
 
 test('clicking sidebar file scrolls to it', function () {

--- a/tests/Browser/FileInteractionTest.php
+++ b/tests/Browser/FileInteractionTest.php
@@ -369,11 +369,19 @@ test('hide reviewed removes checked diff files from the rendered page', function
     expect(collect($diffFiles)->pluck('path')->all())->not->toContain($markedPath);
     expect($page->page()->getByRole('checkbox', ['name' => 'Reviewed'])->count())->toBe(2);
 
+    // The status-strip count band renders outside the islands the toggle
+    // refreshes, so it must drop to the visible total via its own island rather
+    // than stay stale at "3 files".
+    $page->page()->getByTestId('status-strip')->getByText('2/3 files')->waitFor(['state' => 'visible']);
+
     $page->page()->getByRole('button', ['name' => 'Show all files'])->click();
     $diffFiles = waitForRenderedDiffFileCount($page, 3);
 
     expect($diffFiles)->toHaveCount(3);
     expect(collect($diffFiles)->pluck('path')->all())->toContain($markedPath);
+
+    // Showing all files clears the partial-visibility count.
+    $page->page()->getByTestId('status-strip')->getByText('2/3 files')->waitFor(['state' => 'hidden']);
 });
 
 test('clicking sidebar file scrolls to it', function () {

--- a/tests/Browser/SessionPersistenceTest.php
+++ b/tests/Browser/SessionPersistenceTest.php
@@ -87,7 +87,7 @@ test('reviewed files persist after page reload', function () {
     JS);
 
     $page->page()->getByRole('checkbox', ['name' => 'Reviewed'])->first()->click();
-    // The reviewed-summary island re-renders the counter on the toggle round-trip;
+    // The reviewed-counter island re-renders on the toggle round-trip;
     // poll until it renders.
     $page->page()->waitForFunction("document.querySelector('[data-testid=\"reviewed-counter\"]')?.textContent?.includes('1/3 reviewed')");
     $page->page()->waitForFunction('window.__reviewedPersisted === true && window.__reviewedPendingCommits === 0');

--- a/tests/Js/diff-file.test.js
+++ b/tests/Js/diff-file.test.js
@@ -253,10 +253,9 @@ describe('line comment anchors', () => {
 describe('install', () => {
     afterEach(() => {
         delete window.Alpine;
-        delete window.__diffFileAttached;
     });
 
-    it('registers the diffFile Alpine factory and is idempotent', () => {
+    it('registers the latest diffFile Alpine factory every time it loads', () => {
         const data = vi.fn();
         window.Alpine = { data };
 
@@ -264,19 +263,16 @@ describe('install', () => {
         expect(data).toHaveBeenCalledTimes(1);
         expect(data).toHaveBeenCalledWith('diffFile', expect.any(Function));
 
-        expect(install(window)).toBe(false);
-        expect(data).toHaveBeenCalledTimes(1);
+        expect(install(window)).toBe(true);
+        expect(data).toHaveBeenCalledTimes(2);
     });
 
     it('returns false when Alpine is not present', () => {
         expect(install(window)).toBe(false);
     });
 
-    it('does not poison the attached flag when called before Alpine loads', () => {
-        // First attempt with no Alpine must NOT set the flag, otherwise a
-        // later attempt would silently no-op.
+    it('returns false before Alpine loads and registers once Alpine is available', () => {
         expect(install(window)).toBe(false);
-        expect(window.__diffFileAttached).toBeUndefined();
 
         const data = vi.fn();
         window.Alpine = { data };
@@ -568,7 +564,6 @@ describe('pending comment form cleared on SPA navigation', () => {
     afterEach(() => {
         delete globalThis.Alpine;
         delete window.Alpine;
-        delete window.__diffFileAttached;
         delete window.__diffFilePendingFormsCleanup;
     });
 

--- a/tests/Js/review-page.test.js
+++ b/tests/Js/review-page.test.js
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import reviewPage from '../../public/js/review-page.js';
 
-const { computeRemoteMenu, createReviewPage, createChangePoller } = reviewPage;
+const { computeRemoteMenu, createReviewPage, createChangePoller, install } = reviewPage;
 
 // A roomy viewport so the clamp never trims the requested click position;
 // clamping itself is covered by its own test.
@@ -235,7 +235,31 @@ describe('createChangePoller', () => {
     });
 });
 
+describe('install', () => {
+    afterEach(() => {
+        delete window.Alpine;
+    });
+
+    it('registers the latest review-page Alpine factories every time it loads', () => {
+        const data = vi.fn();
+        window.Alpine = { data };
+
+        expect(install(window)).toBe(true);
+        expect(install(window)).toBe(true);
+
+        expect(data).toHaveBeenCalledTimes(4);
+        expect(data).toHaveBeenNthCalledWith(1, 'reviewPage', expect.any(Function));
+        expect(data).toHaveBeenNthCalledWith(2, 'reviewChangePoller', expect.any(Function));
+        expect(data).toHaveBeenNthCalledWith(3, 'reviewPage', expect.any(Function));
+        expect(data).toHaveBeenNthCalledWith(4, 'reviewChangePoller', expect.any(Function));
+    });
+});
+
 describe('createReviewPage path helpers', () => {
+    afterEach(() => {
+        delete window.__rfaReviewedActionQueue;
+    });
+
     it('splits a path into directory and basename', () => {
         const page = createReviewPage(config);
         expect(page.pathDir('src/app/Foo.php')).toBe('src/app/');
@@ -254,5 +278,82 @@ describe('createReviewPage path helpers', () => {
     it('seeds activeFile from config', () => {
         expect(createReviewPage({ activeFile: 'file-7' }).activeFile).toBe('file-7');
         expect(createReviewPage({}).activeFile).toBeNull();
+    });
+
+    it('serializes reviewed actions so rapid toggles use settled Livewire state', async () => {
+        let releaseFirst;
+        const first = new Promise(resolve => {
+            releaseFirst = resolve;
+        });
+        const calls = [];
+        const page = createReviewPage({});
+        page.$wire = {
+            toggleReviewed: vi.fn((path) => {
+                calls.push(path);
+
+                return path === 'src/Foo.php' ? first : Promise.resolve();
+            }),
+        };
+
+        const firstToggle = page.toggleReviewed('src/Foo.php');
+        const secondToggle = page.toggleReviewed('src/Bar.php');
+
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(calls).toEqual(['src/Foo.php']);
+
+        releaseFirst();
+        await firstToggle;
+        await secondToggle;
+
+        expect(calls).toEqual(['src/Foo.php', 'src/Bar.php']);
+    });
+
+    it('keeps reviewed actions serialized across remounted page instances', async () => {
+        let releaseFirst;
+        const first = new Promise(resolve => {
+            releaseFirst = resolve;
+        });
+        const calls = [];
+        const firstPage = createReviewPage({});
+        const remountedPage = createReviewPage({});
+        firstPage.$wire = {
+            toggleReviewed: vi.fn((path) => {
+                calls.push(path);
+
+                return first;
+            }),
+        };
+        remountedPage.$wire = {
+            toggleReviewed: vi.fn((path) => {
+                calls.push(path);
+
+                return Promise.resolve();
+            }),
+        };
+
+        const firstToggle = firstPage.toggleReviewed('src/Foo.php');
+        const secondToggle = remountedPage.toggleReviewed('src/Bar.php');
+
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(calls).toEqual(['src/Foo.php']);
+
+        releaseFirst();
+        await firstToggle;
+        await secondToggle;
+
+        expect(calls).toEqual(['src/Foo.php', 'src/Bar.php']);
+    });
+
+    it('ignores reviewed toggle events without a file path', async () => {
+        const page = createReviewPage({});
+        page.$wire = { toggleReviewed: vi.fn() };
+
+        await page.toggleReviewed(undefined);
+
+        expect(page.$wire.toggleReviewed).not.toHaveBeenCalled();
     });
 });

--- a/tests/Unit/Actions/ToggleReviewedActionTest.php
+++ b/tests/Unit/Actions/ToggleReviewedActionTest.php
@@ -36,6 +36,7 @@ test('adds file to reviewed list with content hash', function () {
 
 test('removes file from reviewed list', function () {
     ReviewedFile::create(['repo_path' => '/tmp/repo', 'file_path' => 'a.php', 'content_hash' => 'hash1']);
+    ReviewedFile::create(['repo_path' => '/tmp/repo', 'file_path' => 'b.php', 'content_hash' => 'hash2']);
 
     $result = $this->action->handle(['a.php' => 'hash1', 'b.php' => 'hash2'], 'a.php', $this->knownFiles, '/tmp/repo');
 
@@ -105,11 +106,24 @@ test('updates content_hash in place instead of inserting a new row when the file
 });
 
 test('preserves other entries on toggle off', function () {
+    ReviewedFile::create(['repo_path' => '/tmp/repo', 'file_path' => 'a.php', 'content_hash' => 'h1']);
     ReviewedFile::create(['repo_path' => '/tmp/repo', 'file_path' => 'b.php', 'content_hash' => 'h2']);
+    ReviewedFile::create(['repo_path' => '/tmp/repo', 'file_path' => 'c.php', 'content_hash' => 'h3']);
 
     $result = $this->action->handle(['a.php' => 'h1', 'b.php' => 'h2', 'c.php' => 'h3'], 'b.php', $this->knownFiles, '/tmp/repo');
 
     expect($result)->toBe(['a.php' => 'h1', 'c.php' => 'h3']);
+});
+
+test('rebuilds returned state from persisted rows when the component snapshot is stale', function () {
+    ReviewedFile::create(['repo_path' => '/tmp/repo', 'file_path' => 'a.php', 'content_hash' => 'hash-a']);
+
+    $result = $this->action->handle([], 'b.php', $this->knownFiles, '/tmp/repo');
+
+    expect($result)->toBe([
+        'a.php' => 'hash-a',
+        'b.php' => 'mock-hash',
+    ]);
 });
 
 test('hashes external files off disk so a content edit un-reviews them', function () {

--- a/tests/Unit/Livewire/ReviewPageReviewedUndoTest.php
+++ b/tests/Unit/Livewire/ReviewPageReviewedUndoTest.php
@@ -233,7 +233,11 @@ test('toggleReviewed renders source diff list island when hide-reviewed visibili
         ->and($component->instance()->reviewState()->isFileVisible('id-foo'))->toBeFalse()
         ->and($component->instance()->reviewState()->isFileVisible('id-bar'))->toBeTrue()
         ->and(renderedIslandFragments($component, 'source-diff-list'))->toContain('wire:key="id-bar-')
-        ->and(renderedIslandFragments($component, 'source-diff-list'))->not->toContain('wire:key="id-foo-');
+        ->and(renderedIslandFragments($component, 'source-diff-list'))->not->toContain('wire:key="id-foo-')
+        // The visible-file counts live outside the sidebar list, so a skipRender
+        // toggle must refresh them through their own islands or they go stale.
+        ->and(renderedIslandFragments($component, 'file-count'))->toContain('5/6 files')
+        ->and(renderedIslandFragments($component, 'file-list-header'))->toContain('Files');
 });
 
 test('hide-reviewed actions render diff-file children from fresh review state', function () {
@@ -247,14 +251,16 @@ test('hide-reviewed actions render diff-file children from fresh review state', 
     expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue()
         ->and(renderedIslandFragments($component, 'reviewed-summary'))->toContain('aria-label="Show all files"')
         ->and(renderedIslandFragments($component, 'source-diff-list'))->not->toContain('wire:key="id-foo-')
-        ->and(renderedIslandFragments($component, 'source-diff-list'))->toContain('wire:key="id-bar-');
+        ->and(renderedIslandFragments($component, 'source-diff-list'))->toContain('wire:key="id-bar-')
+        ->and(renderedIslandFragments($component, 'file-count'))->toContain('5/6 files');
 
     $component->call('showAllFiles');
 
     expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue()
         ->and(renderedIslandFragments($component, 'reviewed-summary'))->toContain('aria-label="Hide reviewed"')
         ->and(renderedIslandFragments($component, 'source-diff-list'))->toContain('wire:key="id-foo-')
-        ->and(renderedIslandFragments($component, 'source-diff-list'))->toContain('wire:key="id-bar-');
+        ->and(renderedIslandFragments($component, 'source-diff-list'))->toContain('wire:key="id-bar-')
+        ->and(renderedIslandFragments($component, 'file-count'))->toContain('6 files');
 });
 
 test('the reviewed counter reflects new marks in hide-reviewed mode', function () {
@@ -267,6 +273,23 @@ test('the reviewed counter reflects new marks in hide-reviewed mode', function (
 
     expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue()
         ->and(renderedIslandFragments($component, 'reviewed-summary'))->toContain('2/6 reviewed');
+});
+
+test('hide-reviewed keeps the visible-file count band in step instead of going stale', function () {
+    // The status-strip count ("N files" / "X/N files") and the sidebar "Files"
+    // header read visibleFileCount but render OUTSIDE the file-list island. On
+    // the skipRender visibility path they must refresh through file-count /
+    // file-list-header islands, otherwise the band keeps showing the pre-hide
+    // total while the sidebar and diff list correctly drop the reviewed file.
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
+        ->call('hideReviewedFiles')
+        ->dispatch('toggle-reviewed', filePath: 'src/Bar.php');
+
+    expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue()
+        ->and($component->instance()->reviewState()->visibleFileCount)->toBe(4)
+        ->and(renderedIslandFragments($component, 'file-count'))->toContain('4/6 files')
+        ->and(renderedIslandFragments($component, 'file-list-header'))->toContain('Files');
 });
 
 test('marking a file broadcasts an authoritative file-reviewed-changed so DiffFile converges to the server state', function () {

--- a/tests/Unit/Livewire/ReviewPageReviewedUndoTest.php
+++ b/tests/Unit/Livewire/ReviewPageReviewedUndoTest.php
@@ -219,7 +219,8 @@ test('toggleReviewed still skips parent re-render after these changes', function
         ->dispatch('toggle-reviewed', filePath: 'src/Foo.php');
 
     expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue()
-        ->and(renderedIslandFragments($component, 'reviewed-summary'))->toContain('1/6 reviewed')
+        ->and(renderedIslandFragments($component, 'reviewed-counter'))->toContain('1/6 reviewed')
+        ->and(renderedIslandFragments($component, 'reviewed-toggle'))->toContain('aria-label="Hide reviewed"')
         ->and(renderedIslandFragments($component, 'file-list'))->toContain('Un-mark as reviewed')
         ->and(renderedIslandFragments($component, 'source-diff-list'))->toBe('');
 });
@@ -249,7 +250,7 @@ test('hide-reviewed actions render diff-file children from fresh review state', 
     $component->call('hideReviewedFiles');
 
     expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue()
-        ->and(renderedIslandFragments($component, 'reviewed-summary'))->toContain('aria-label="Show all files"')
+        ->and(renderedIslandFragments($component, 'reviewed-toggle'))->toContain('aria-label="Show all files"')
         ->and(renderedIslandFragments($component, 'source-diff-list'))->not->toContain('wire:key="id-foo-')
         ->and(renderedIslandFragments($component, 'source-diff-list'))->toContain('wire:key="id-bar-')
         ->and(renderedIslandFragments($component, 'file-count'))->toContain('5/6 files');
@@ -257,7 +258,7 @@ test('hide-reviewed actions render diff-file children from fresh review state', 
     $component->call('showAllFiles');
 
     expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue()
-        ->and(renderedIslandFragments($component, 'reviewed-summary'))->toContain('aria-label="Hide reviewed"')
+        ->and(renderedIslandFragments($component, 'reviewed-toggle'))->toContain('aria-label="Hide reviewed"')
         ->and(renderedIslandFragments($component, 'source-diff-list'))->toContain('wire:key="id-foo-')
         ->and(renderedIslandFragments($component, 'source-diff-list'))->toContain('wire:key="id-bar-')
         ->and(renderedIslandFragments($component, 'file-count'))->toContain('6 files');
@@ -265,14 +266,14 @@ test('hide-reviewed actions render diff-file children from fresh review state', 
 
 test('the reviewed counter reflects new marks in hide-reviewed mode', function () {
     // Hide-reviewed mode renders reviewed-state surfaces as explicit islands.
-    // The reviewed-summary island must advance to 2/6, not stick at 1/6.
+    // The reviewed-counter island must advance to 2/6, not stick at 1/6.
     $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
         ->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
         ->call('hideReviewedFiles')
         ->dispatch('toggle-reviewed', filePath: 'src/Bar.php');
 
     expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue()
-        ->and(renderedIslandFragments($component, 'reviewed-summary'))->toContain('2/6 reviewed');
+        ->and(renderedIslandFragments($component, 'reviewed-counter'))->toContain('2/6 reviewed');
 });
 
 test('hide-reviewed keeps the visible-file count band in step instead of going stale', function () {
@@ -290,6 +291,20 @@ test('hide-reviewed keeps the visible-file count band in step instead of going s
         ->and($component->instance()->reviewState()->visibleFileCount)->toBe(4)
         ->and(renderedIslandFragments($component, 'file-count'))->toContain('4/6 files')
         ->and(renderedIslandFragments($component, 'file-list-header'))->toContain('Files');
+});
+
+test('hide-reviewed refreshes the status-strip copy-paths trigger visibility', function () {
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project']);
+
+    collect($this->files)
+        ->pluck('path')
+        ->each(fn (string $path) => $component->dispatch('toggle-reviewed', filePath: $path));
+
+    $component->call('hideReviewedFiles');
+
+    expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue()
+        ->and($component->instance()->reviewState()->visibleFileCount)->toBe(0)
+        ->and(renderedIslandFragments($component, 'status-strip-copy-paths'))->not->toContain('status-strip-copy-paths-trigger');
 });
 
 test('marking a file broadcasts an authoritative file-reviewed-changed so DiffFile converges to the server state', function () {

--- a/tests/Unit/Livewire/ReviewPageReviewedUndoTest.php
+++ b/tests/Unit/Livewire/ReviewPageReviewedUndoTest.php
@@ -17,6 +17,13 @@ use Tests\TestCase;
 
 uses(TestCase::class, LazilyRefreshDatabase::class);
 
+function renderedIslandFragments(mixed $component, string $name): string
+{
+    return collect($component->effects['islandFragments'] ?? [])
+        ->filter(fn (string $fragment): bool => str_contains($fragment, "name={$name}|"))
+        ->implode("\n");
+}
+
 beforeEach(function () {
     $this->files = [
         ['id' => 'id-foo', 'path' => 'src/Foo.php', 'status' => 'modified', 'oldPath' => null, 'additions' => 5, 'deletions' => 2, 'isBinary' => false, 'isUntracked' => false],
@@ -211,17 +218,22 @@ test('toggleReviewed still skips parent re-render after these changes', function
     $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
         ->dispatch('toggle-reviewed', filePath: 'src/Foo.php');
 
-    expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue();
+    expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue()
+        ->and(renderedIslandFragments($component, 'reviewed-summary'))->toContain('1/6 reviewed')
+        ->and(renderedIslandFragments($component, 'file-list'))->toContain('Un-mark as reviewed')
+        ->and(renderedIslandFragments($component, 'source-diff-list'))->toBe('');
 });
 
-test('toggleReviewed renders when hide-reviewed visibility changes', function () {
+test('toggleReviewed renders source diff list island when hide-reviewed visibility changes', function () {
     $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
         ->call('hideReviewedFiles')
         ->dispatch('toggle-reviewed', filePath: 'src/Foo.php');
 
-    expect(\Livewire\store($component->instance())->get('skipRender'))->toBeFalsy()
+    expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue()
         ->and($component->instance()->reviewState()->isFileVisible('id-foo'))->toBeFalse()
-        ->and($component->instance()->reviewState()->isFileVisible('id-bar'))->toBeTrue();
+        ->and($component->instance()->reviewState()->isFileVisible('id-bar'))->toBeTrue()
+        ->and(renderedIslandFragments($component, 'source-diff-list'))->toContain('wire:key="id-bar-')
+        ->and(renderedIslandFragments($component, 'source-diff-list'))->not->toContain('wire:key="id-foo-');
 });
 
 test('hide-reviewed actions render diff-file children from fresh review state', function () {
@@ -230,28 +242,31 @@ test('hide-reviewed actions render diff-file children from fresh review state', 
         ->assertSeeHtml('wire:key="id-foo-')
         ->assertSeeHtml('wire:key="id-bar-');
 
-    $component->call('hideReviewedFiles')
-        ->assertSeeHtml('aria-label="Show all files"')
-        ->assertDontSeeHtml('wire:key="id-foo-')
-        ->assertSeeHtml('wire:key="id-bar-');
+    $component->call('hideReviewedFiles');
 
-    $component->call('showAllFiles')
-        ->assertSeeHtml('aria-label="Hide reviewed"')
-        ->assertSeeHtml('wire:key="id-foo-')
-        ->assertSeeHtml('wire:key="id-bar-');
+    expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue()
+        ->and(renderedIslandFragments($component, 'reviewed-summary'))->toContain('aria-label="Show all files"')
+        ->and(renderedIslandFragments($component, 'source-diff-list'))->not->toContain('wire:key="id-foo-')
+        ->and(renderedIslandFragments($component, 'source-diff-list'))->toContain('wire:key="id-bar-');
+
+    $component->call('showAllFiles');
+
+    expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue()
+        ->and(renderedIslandFragments($component, 'reviewed-summary'))->toContain('aria-label="Hide reviewed"')
+        ->and(renderedIslandFragments($component, 'source-diff-list'))->toContain('wire:key="id-foo-')
+        ->and(renderedIslandFragments($component, 'source-diff-list'))->toContain('wire:key="id-bar-');
 });
 
 test('the reviewed counter reflects new marks in hide-reviewed mode', function () {
-    // Hide-reviewed mode does a full render, which emits only skip markers for
-    // islands. The reviewed-summary island is declared always:true so it
-    // re-renders inline rather than going stale: marking a second file while
-    // hidden must advance the counter to 2/6, not stick at 1/6.
+    // Hide-reviewed mode renders reviewed-state surfaces as explicit islands.
+    // The reviewed-summary island must advance to 2/6, not stick at 1/6.
     $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
         ->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
         ->call('hideReviewedFiles')
         ->dispatch('toggle-reviewed', filePath: 'src/Bar.php');
 
-    $component->assertSee('2/6 reviewed');
+    expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue()
+        ->and(renderedIslandFragments($component, 'reviewed-summary'))->toContain('2/6 reviewed');
 });
 
 test('marking a file broadcasts an authoritative file-reviewed-changed so DiffFile converges to the server state', function () {
@@ -285,14 +300,15 @@ test('clearRecentlyReviewed skips parent re-render', function () {
     expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue();
 });
 
-test('clearRecentlyReviewed renders while hide-reviewed group is visible', function () {
+test('clearRecentlyReviewed renders sidebar file-list island while hide-reviewed group is visible', function () {
     $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
         ->dispatch('toggle-reviewed', filePath: 'src/Foo.php')
         ->call('hideReviewedFiles')
         ->call('clearRecentlyReviewed');
 
-    expect(\Livewire\store($component->instance())->get('skipRender'))->toBeFalsy()
-        ->and($component->get('recentlyReviewedIds'))->toBe([]);
+    expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue()
+        ->and($component->get('recentlyReviewedIds'))->toBe([])
+        ->and(renderedIslandFragments($component, 'file-list'))->not->toContain('data-testid="recently-reviewed-group"');
 });
 
 test('unmarkReviewed skips parent re-render to avoid 1+N child hydration', function () {

--- a/tests/Unit/LocalAssetTest.php
+++ b/tests/Unit/LocalAssetTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Support\LocalAsset;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+test('local asset urls include the public file modification time', function () {
+    $mtime = filemtime(public_path('js/diff-file.js'));
+
+    expect(LocalAsset::url('/js/diff-file.js'))->toBe("/js/diff-file.js?v={$mtime}");
+});
+
+test('local script renders a versioned script tag', function () {
+    $mtime = filemtime(public_path('js/diff-file.js'));
+
+    expect((string) LocalAsset::script('js/diff-file.js'))
+        ->toBe('<script src="/js/diff-file.js?v='.$mtime.'"></script>');
+});

--- a/tests/Unit/Scripts/RfaTerminalHelperTest.php
+++ b/tests/Unit/Scripts/RfaTerminalHelperTest.php
@@ -23,7 +23,12 @@ SH);
 });
 
 test('terminal helper replaces a stale inbox file with the inbox directory', function () {
-    $appSupportPath = $this->homePath.'/Library/Application Support/com.fgilio.rfa';
+    // Mirror the script's own `uname` branch so the test targets the same inbox
+    // base the helper actually writes to: macOS uses Application Support, every
+    // other platform (e.g. the Linux CI runner) uses the XDG data dir.
+    $appSupportPath = PHP_OS_FAMILY === 'Darwin'
+        ? $this->homePath.'/Library/Application Support/com.fgilio.rfa'
+        : $this->homePath.'/.local/share/com.fgilio.rfa';
 
     File::makeDirectory($appSupportPath, 0755, true);
     File::put($appSupportPath.'/inbox', "/stale/repo\n");

--- a/tests/Unit/Scripts/RfaTerminalHelperTest.php
+++ b/tests/Unit/Scripts/RfaTerminalHelperTest.php
@@ -7,6 +7,16 @@ use Tests\TestCase;
 
 uses(TestCase::class, InteractsWithTestRepositories::class);
 
+function rfaTerminalHelperDataPath(string $homePath): string
+{
+    // Mirror the script's own `uname` branch so the test targets the same inbox
+    // base the helper actually writes to: macOS uses Application Support, every
+    // other platform (e.g. the Linux CI runner) uses the XDG data dir.
+    return PHP_OS_FAMILY === 'Darwin'
+        ? $homePath.'/Library/Application Support/com.fgilio.rfa'
+        : $homePath.'/.local/share/com.fgilio.rfa';
+}
+
 beforeEach(function () {
     $this->repoPath = $this->createTempDirectory('rfa_terminal_helper_repo_');
     $this->homePath = $this->createTempDirectory('rfa_terminal_helper_home_');
@@ -23,13 +33,7 @@ SH);
 });
 
 test('terminal helper replaces a stale inbox file with the inbox directory', function () {
-    // Mirror the script's own `uname` branch so the test targets the same inbox
-    // base the helper actually writes to: macOS uses Application Support, every
-    // other platform (e.g. the Linux CI runner) uses the XDG data dir.
-    $appSupportPath = PHP_OS_FAMILY === 'Darwin'
-        ? $this->homePath.'/Library/Application Support/com.fgilio.rfa'
-        : $this->homePath.'/.local/share/com.fgilio.rfa';
-
+    $appSupportPath = rfaTerminalHelperDataPath($this->homePath);
     File::makeDirectory($appSupportPath, 0755, true);
     File::put($appSupportPath.'/inbox', "/stale/repo\n");
 
@@ -49,5 +53,31 @@ test('terminal helper replaces a stale inbox file with the inbox directory', fun
         ->and(File::get($inboxFiles[0]))->toBe(realpath($this->repoPath)."\n")
         ->and($backupFiles)->toHaveCount(1)
         ->and(File::get($backupFiles[0]))->toBe("/stale/repo\n")
+        ->and(File::get($this->openCapturePath))->toStartWith('rfa://open?path=');
+});
+
+test('terminal helper replaces a stale app data file with the app data directory', function () {
+    $appSupportPath = rfaTerminalHelperDataPath($this->homePath);
+
+    File::makeDirectory(dirname($appSupportPath), 0755, true);
+    File::put($appSupportPath, "/stale/app-data\n");
+
+    $process = new Process([base_path('rfa'), $this->repoPath], base_path(), [
+        'HOME' => $this->homePath,
+        'PATH' => $this->fakeBinPath.':'.getenv('PATH'),
+        'RFA_OPEN_CAPTURE' => $this->openCapturePath,
+    ]);
+    $process->mustRun();
+
+    $inboxPath = $appSupportPath.'/inbox';
+    $inboxFiles = File::glob($inboxPath.'/*.path');
+    $backupFiles = File::glob($appSupportPath.'.*.bak');
+
+    expect(File::isDirectory($appSupportPath))->toBeTrue()
+        ->and(File::isDirectory($inboxPath))->toBeTrue()
+        ->and($inboxFiles)->toHaveCount(1)
+        ->and(File::get($inboxFiles[0]))->toBe(realpath($this->repoPath)."\n")
+        ->and($backupFiles)->toHaveCount(1)
+        ->and(File::get($backupFiles[0]))->toBe("/stale/app-data\n")
         ->and(File::get($this->openCapturePath))->toStartWith('rfa://open?path=');
 });

--- a/tests/Unit/Scripts/RfaTerminalHelperTest.php
+++ b/tests/Unit/Scripts/RfaTerminalHelperTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Process\Process;
+use Tests\Helpers\InteractsWithTestRepositories;
+use Tests\TestCase;
+
+uses(TestCase::class, InteractsWithTestRepositories::class);
+
+beforeEach(function () {
+    $this->repoPath = $this->createTempDirectory('rfa_terminal_helper_repo_');
+    $this->homePath = $this->createTempDirectory('rfa_terminal_helper_home_');
+    $this->fakeBinPath = $this->createTempDirectory('rfa_terminal_helper_bin_');
+    $this->openCapturePath = $this->createTempDirectory('rfa_terminal_helper_capture_').'/open.txt';
+
+    $this->initTestRepo($this->repoPath);
+
+    File::put($this->fakeBinPath.'/open', <<<'SH'
+#!/bin/sh
+printf '%s\n' "$1" > "$RFA_OPEN_CAPTURE"
+SH);
+    chmod($this->fakeBinPath.'/open', 0755);
+});
+
+test('terminal helper replaces a stale inbox file with the inbox directory', function () {
+    $appSupportPath = $this->homePath.'/Library/Application Support/com.fgilio.rfa';
+
+    File::makeDirectory($appSupportPath, 0755, true);
+    File::put($appSupportPath.'/inbox', "/stale/repo\n");
+
+    $process = new Process([base_path('rfa'), $this->repoPath], base_path(), [
+        'HOME' => $this->homePath,
+        'PATH' => $this->fakeBinPath.':'.getenv('PATH'),
+        'RFA_OPEN_CAPTURE' => $this->openCapturePath,
+    ]);
+    $process->mustRun();
+
+    $inboxPath = $appSupportPath.'/inbox';
+    $inboxFiles = File::glob($inboxPath.'/*.path');
+    $backupFiles = File::glob($appSupportPath.'/inbox.*.bak');
+
+    expect(File::isDirectory($inboxPath))->toBeTrue()
+        ->and($inboxFiles)->toHaveCount(1)
+        ->and(File::get($inboxFiles[0]))->toBe(realpath($this->repoPath)."\n")
+        ->and($backupFiles)->toHaveCount(1)
+        ->and(File::get($backupFiles[0]))->toBe("/stale/repo\n")
+        ->and(File::get($this->openCapturePath))->toStartWith('rfa://open?path=');
+});


### PR DESCRIPTION
Closes: none

Related: none

## Summary
Stabilizes the reviewed-file UI path that regressed in the packaged app, refreshes every visible-count surface touched by Hide reviewed, and includes the terminal-helper inbox recovery fixes from the parallel session.

## Root Cause
The reviewed controls had three overlapping failure modes:

- First-party `/js/*.js` assets were loaded with stable URLs in Electron, so a released app could keep stale Alpine factories after an update.
- The reviewed-state bridge queued Livewire calls on a remountable Alpine page instance. Livewire island morphs could replace that instance while reviewed actions were in flight, allowing stale snapshots to win.
- Several visible-count surfaces lived outside the refreshed islands. Hide reviewed updated the sidebar/diff list but could leave status-strip counts or the status-strip copy trigger stale.

The terminal helper also only repaired a stale `inbox` leaf file. If the app data directory itself was a file, `mkdir -p` aborted before the helper could write the cold-start inbox path.

## Solution
- Add `@localScript` / `LocalAsset` so local JS gets a filemtime cache-busting query string.
- Re-register Alpine factories on repeated script loads instead of one-shot guarding them.
- Route reviewed bridge events through tested `reviewPage` methods and a page-global reviewed-action queue that survives Livewire remounts.
- Rebuild reviewed state from persisted `ReviewedFile` rows after toggles so stale Livewire snapshots cannot drop existing marks.
- Split the duplicate `reviewed-summary` island into `reviewed-toggle` and `reviewed-counter`, then refresh all reviewed and visibility islands explicitly.
- Island the status-strip copy trigger so it hides when all files are reviewed and hidden.
- Move reviewed checkbox dispatch inline at the Blade boundary so it does not depend on stale cached JS methods.
- Harden `./rfa` inbox directory creation by moving aside stale non-directory ancestors before creating the path.
- Refresh the reviewed-state docs and JS loading conventions.

## Testing
```bash
composer test:lint
composer test:types
npm test
php artisan test --compact tests/Unit/Actions/ToggleReviewedActionTest.php tests/Unit/Livewire/ReviewPageReviewedUndoTest.php tests/Unit/LocalAssetTest.php tests/Arch/BladeConventionsTest.php tests/Unit/Scripts/RfaTerminalHelperTest.php --filter='ToggleReviewedAction|reviewed|local asset|version first-party|terminal helper|hide-reviewed|status-strip copy'
composer test:browser -- --filter='hide reviewed removes|status strip copy menu hides|a second mark in normal mode advances|checking reviewed updates sidebar indicator|checked reviewed checkbox keeps'
for run in {1..20}; do composer test:browser -- --filter='a second mark in normal mode advances' || exit 1; done
php artisan test --compact tests/Arch/SessionRecoveryTest.php
composer test
composer test:browser
```

## Deployment
- Migrations: none
- Cache clear: none
- Monitor: reviewed checkbox glyph, Hide reviewed, status-strip reviewed count, and copy trigger visibility in the packaged app.
