### PR TITLE
[codex] Propose reviewed-state pattern reuse points

### DIFF
--- a/app/Concerns/ReviewPage/ReviewsBranchDivergence.php
+++ b/app/Concerns/ReviewPage/ReviewsBranchDivergence.php
@@ -66,6 +66,11 @@ trait ReviewsBranchDivergence
      * Kept separate from `checkHeadDivergence()` so callers like `softRefresh`
      * can update divergence without latching `skipRender()` onto a response
      * that still needs to morph because files did change.
+     *
+     * Proposal: if divergence chrome gains more independent surfaces, split them
+     * into explicit islands and refresh them from this trait after recomputing
+     * state. Today a changed state renders the page. More surfaces would risk
+     * stale banners when callers skip the parent render.
      */
     private function refreshDivergenceState(): bool
     {

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -229,6 +229,10 @@
             async refreshSnapshot(branchName, { clear = false, force = false, minimumCommitCount = 0 } = {}) {
                 if (!force && branchName === this.selectedBranch && this.$wire.commits.length > 0) return true;
 
+                // Proposal: if more branch-picker actions become renderless,
+                // extract the reviewed-action pattern into a named request
+                // coordinator here. Queue mutations that must preserve order,
+                // and keep `_loadId` for latest-response snapshot refreshes.
                 const id = ++this._loadId;
                 await this.$wire.loadSnapshot(branchName, minimumCommitCount);
                 if (this._loadId !== id) return false;

--- a/resources/views/components/copy-paths-button.blade.php
+++ b/resources/views/components/copy-paths-button.blade.php
@@ -27,6 +27,11 @@
      intercepts the click via `@click.capture.stop` before Flux sees it, and
      wraps only the trigger — menu items are siblings, so their clicks aren't
      captured and reach Flux normally.
+
+     Proposal: if more bulk actions depend on "currently visible files", keep
+     their triggers island-owned by the page and let the server compute the
+     file list. Client-side filters can drift from ReviewState during
+     hide-reviewed and search changes.
 --}}
 <div data-testid="{{ $testidPrefix }}"
     @if ($mode === 'bulk' && ($visibleCount ?? 0) <= 0) hidden @endif

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -99,7 +99,14 @@ new class extends Component {
         }
     }
 
-    /** @param  list<string>  $selectedHashes */
+    /**
+     * Proposal: keep applySelection as the server authority when the picker
+     * grows. If selection starts from an island or global shortcut, bridge it
+     * through the branch-explorer root and queue it with snapshot reloads so
+     * stale hashes cannot navigate after a newer selection.
+     *
+     * @param  list<string>  $selectedHashes
+     */
     #[Renderless]
     public function applySelection(string $branch, array $selectedHashes, bool $workingTreeSelected, string $snapshotKey): void
     {

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -152,6 +152,13 @@ HTML;
         };
     }
 
+    /**
+     * Proposal: if expand-context and expand-gap controls gain batching or
+     * keyboard repeat, give each file a request queue keyed by file id and
+     * settle from the loaded diff cache. The expander chrome already depends on
+     * completion events, so ordered server results would prevent older diff loads
+     * from replacing newer expanded hunks.
+     */
     public function expandContext(): void
     {
         $cacheKey = $this->diffCacheKey();

--- a/resources/views/pages/⚡context-page.blade.php
+++ b/resources/views/pages/⚡context-page.blade.php
@@ -451,6 +451,10 @@ new #[Layout('layouts.app')] class extends Component
      * Push the per-file count/draft summary into the sidebar without re-rendering
      * the page. Pairs with skipRender() on every comment mutation — keeps the
      * sidebar's commentSummary in sync without rehydrating N diff-file children.
+     *
+     * Proposal: if context comment controls move into islands, add a root bridge
+     * plus a comment-mutation queue before calling this dispatcher. The sidebar
+     * summary and file children need to observe one server-owned comment snapshot.
      */
     private function dispatchSidebarSummary(): void
     {

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -460,6 +460,11 @@ new #[Layout('layouts.app')] class extends Component
      * only affects which files are listed (external paths, global .gitignore).
      * Lighter than rehydrateForTarget: it leaves the review-pair scan and trash
      * untouched because neither is sensitive to file-list filtering.
+     *
+     * Proposal: if this path is later optimized to skip the parent render, treat
+     * it like reviewed visibility changes. Recompute session state server-side
+     * and render every island that reads the visible file set, because external
+     * paths can add or remove rows from both the sidebar and status chrome.
      */
     private function reloadSessionAfterFileListChange(): void
     {
@@ -667,6 +672,12 @@ new #[Layout('layouts.app')] class extends Component
      * diff-file child (the TooManyComponentsException hazard) and keeps the 1+N
      * contract. Divergence transitions surface through the head-divergence
      * poller, not by piggybacking on comment writes.
+     *
+     * Proposal: if comment writes move behind toolbar or sidebar controls that
+     * can fire in bursts, route them through a root `rfa-comment-*` bridge,
+     * serialize those `$wire` calls on `window`, and reload comments from storage
+     * before settling child or sidebar fragments. That gives overlapping comment
+     * requests the same server-owned convergence as reviewed-state.
      */
     private function applyCommentMutation(?ReviewCommentMutation $mutation): void
     {


### PR DESCRIPTION
## Summary
- Adds targeted proposal comments where the reviewed-state pattern could be reused later.
- Covers queued root bridges, server-owned snapshots, and explicit islands for stale-prone UI surfaces.
- Leaves behavior unchanged.

## Validation
- `vendor/bin/pint --dirty --format agent`
- `composer test:lint`
- `npm test -- tests/Js/branch-explorer.test.js`