### PR TITLE
fix(release): prevent electron-builder duplicate-draft race

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -11,6 +11,7 @@ git push --tags
 - Build runs on `macos-15` (arm64), publishes to GitHub Releases as **draft**
 - Publish the draft via `gh release edit vX.Y.Z --draft=false`
 - Tag must be `vX.Y.Z` (semver with `v` prefix). Version injected from tag automatically.
+- The workflow **pre-creates the draft** before the build so electron-builder attaches to it instead of racing to create one. Without this, multiple publishers (zip/dmg/blockmaps/`latest-mac.yml`) each create a draft and the assets split across two incomplete drafts — a published release then 404s the macOS updater. A post-build **Verify release artifacts** step fails the job if there isn't exactly one release with all five expected assets.
 
 ## Updater
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,30 @@ jobs:
       - name: "Patch NativePHP: npm ci -> npm install (dev-l13-compatibility workaround)"
         run: sed -i '' "s/->run('npm ci'/->run('npm install'/" vendor/nativephp/desktop/src/Drivers/Electron/Commands/BuildCommand.php
 
+      # electron-builder's GitHub publisher creates a draft release per artifact when none
+      # exists yet: getOrCreateRelease() lists releases, and only when no draft matches the
+      # tag does it call createRelease(). With several artifacts (zip, dmg, their blockmaps,
+      # latest-mac.yml) finishing near-simultaneously, multiple publishers clear that check
+      # before any draft exists and each creates its own draft. The assets then split across
+      # two drafts, leaving both incomplete — e.g. the .zip the macOS updater needs lands on
+      # a different draft than latest-mac.yml, so a published release 404s every auto-update.
+      # Pre-creating the draft closes the window: every publisher finds this draft (it returns
+      # early on a matching draft) and attaches to it instead of racing to create one.
+      - name: Pre-create draft release (prevents electron-builder duplicate-draft race)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release for $tag already exists; reusing it."
+          else
+            gh release create "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --draft \
+              --title "${{ steps.version.outputs.value }}" \
+              --notes "Release notes are added before publishing."
+          fi
+
       - name: Build and publish to GitHub Releases
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -95,6 +119,47 @@ jobs:
           ELECTRON_CACHE: ~/Library/Caches/electron
           ELECTRON_BUILDER_CACHE: ~/Library/Caches/electron-builder
         run: php artisan native:build mac arm64 --publish --no-interaction
+
+      # Defense in depth: even with the pre-created draft, fail loudly if the publish didn't
+      # land exactly one release carrying every expected artifact. A split or a dropped upload
+      # must never reach a human as a publishable draft — the macOS updater 404s when
+      # latest-mac.yml points at a .zip that isn't attached. Asset names track the mac
+      # artifactName template in electron-builder.mjs (`rfa-${version}-arm64.${ext}`).
+      - name: Verify release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          version="${{ steps.version.outputs.value }}"
+
+          count=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+            --jq "[.[] | select(.tag_name == \"$tag\")] | length")
+          if [ "$count" -ne 1 ]; then
+            echo "::error::Expected exactly 1 release for $tag, found $count (duplicate-draft race?)."
+            gh api "repos/${GITHUB_REPOSITORY}/releases" \
+              --jq ".[] | select(.tag_name == \"$tag\") | {id, draft, assets: [.assets[].name]}"
+            exit 1
+          fi
+
+          assets=$(gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')
+          missing=0
+          for expected in \
+            "latest-mac.yml" \
+            "rfa-${version}-arm64.zip" \
+            "rfa-${version}-arm64.zip.blockmap" \
+            "rfa-${version}-arm64.dmg" \
+            "rfa-${version}-arm64.dmg.blockmap"; do
+            if ! printf '%s\n' "$assets" | grep -qxF "$expected"; then
+              echo "::error::Missing release asset: $expected"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "Assets present:"; printf '%s\n' "$assets"
+            exit 1
+          fi
+          echo "✓ $tag: one draft with all expected artifacts."
 
       - name: Upload build logs on failure
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,15 +93,21 @@ jobs:
       - name: Pre-create draft release (prevents electron-builder duplicate-draft race)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
+          set -euo pipefail
+          # Derive the version in-shell from the ref rather than interpolating a
+          # workflow expression into the script: a tag like v1.2.3$(...) would be
+          # expanded before the shell parses it, executing attacker-controlled code.
           tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
           if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "Release for $tag already exists; reusing it."
           else
             gh release create "$tag" \
               --repo "$GITHUB_REPOSITORY" \
               --draft \
-              --title "${{ steps.version.outputs.value }}" \
+              --title "$version" \
               --notes "Release notes are added before publishing."
           fi
 
@@ -128,38 +134,45 @@ jobs:
       - name: Verify release artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"
-          version="${{ steps.version.outputs.value }}"
+          version="${tag#v}"
 
-          count=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
-            --jq "[.[] | select(.tag_name == \"$tag\")] | length")
+          # --slurp collapses every page into one JSON document before jq runs.
+          # Without it, --paginate applies --jq per page, so once releases span
+          # more than one page `count` becomes multi-line and the -ne test below
+          # errors out and silently bypasses this guard.
+          releases=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate --slurp)
+
+          count=$(jq --arg tag "$tag" '[.[][] | select(.tag_name == $tag)] | length' <<<"$releases")
           if [ "$count" -ne 1 ]; then
             echo "::error::Expected exactly 1 release for $tag, found $count (duplicate-draft race?)."
-            gh api "repos/${GITHUB_REPOSITORY}/releases" \
-              --jq ".[] | select(.tag_name == \"$tag\") | {id, draft, assets: [.assets[].name]}"
+            jq --arg tag "$tag" '.[][] | select(.tag_name == $tag) | {id, draft, assets: [.assets[].name]}' <<<"$releases"
             exit 1
           fi
 
-          assets=$(gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')
-          missing=0
-          for expected in \
+          # The release must carry exactly the expected set — no missing artifacts
+          # (a split/dropped upload) and no stale extras from a prior attempt.
+          actual=$(jq -r --arg tag "$tag" '.[][] | select(.tag_name == $tag) | .assets[].name' <<<"$releases" | sort)
+          expected=$(printf '%s\n' \
             "latest-mac.yml" \
             "rfa-${version}-arm64.zip" \
             "rfa-${version}-arm64.zip.blockmap" \
             "rfa-${version}-arm64.dmg" \
-            "rfa-${version}-arm64.dmg.blockmap"; do
-            if ! printf '%s\n' "$assets" | grep -qxF "$expected"; then
-              echo "::error::Missing release asset: $expected"
-              missing=1
-            fi
-          done
-          if [ "$missing" -ne 0 ]; then
-            echo "Assets present:"; printf '%s\n' "$assets"
+            "rfa-${version}-arm64.dmg.blockmap" | sort)
+
+          missing=$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$actual"))
+          unexpected=$(comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$actual"))
+          if [ -n "$missing" ] || [ -n "$unexpected" ]; then
+            [ -z "$missing" ] || echo "::error::Missing release assets: $(printf '%s' "$missing" | paste -sd, -)"
+            [ -z "$unexpected" ] || echo "::error::Unexpected release assets: $(printf '%s' "$unexpected" | paste -sd, -)"
+            echo "Expected:"; printf '%s\n' "$expected"
+            echo "Actual:";   printf '%s\n' "$actual"
             exit 1
           fi
-          echo "✓ $tag: one draft with all expected artifacts."
+          echo "✓ $tag: one release with exactly the expected artifacts."
 
       - name: Upload build logs on failure
         if: failure()

--- a/tests/Arch/ReleaseWorkflowTest.php
+++ b/tests/Arch/ReleaseWorkflowTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Duplicate-draft race guard. electron-builder's GitHub publisher creates a
+ * draft release per artifact when none exists yet, so concurrent artifact
+ * uploads (zip, dmg, blockmaps, latest-mac.yml) can each create a draft and
+ * split the assets across two incomplete releases. A published release built
+ * from a split draft 404s the macOS updater (latest-mac.yml points at a .zip
+ * that lives on the other draft).
+ *
+ * Two workflow steps prevent that: pre-creating the draft so every publisher
+ * attaches to it, and verifying after the build that exactly one release holds
+ * all expected artifacts. If either regresses, the split can return silently.
+ */
+test('release workflow pre-creates the draft before building', function () {
+    $workflow = file_get_contents(dirname(__DIR__, 2).'/.github/workflows/release.yml');
+
+    expect($workflow)
+        ->toContain('Pre-create draft release')
+        ->toContain('gh release create')
+        ->toContain('--draft');
+
+    // The pre-create step must run before electron-builder publishes, otherwise
+    // there is no existing draft for the publishers to attach to.
+    $preCreatePosition = strpos($workflow, 'Pre-create draft release');
+    $buildPosition = strpos($workflow, 'native:build mac arm64 --publish');
+
+    expect($preCreatePosition)->toBeLessThan($buildPosition);
+});
+
+test('release workflow verifies one release with every expected artifact', function () {
+    $workflow = file_get_contents(dirname(__DIR__, 2).'/.github/workflows/release.yml');
+
+    expect($workflow)
+        ->toContain('Verify release artifacts')
+        ->toContain('Expected exactly 1 release')
+        ->toContain('latest-mac.yml')
+        ->toContain('rfa-${version}-arm64.zip')
+        ->toContain('rfa-${version}-arm64.zip.blockmap')
+        ->toContain('rfa-${version}-arm64.dmg')
+        ->toContain('rfa-${version}-arm64.dmg.blockmap');
+
+    // Verification must run after the build so it inspects the published assets.
+    $buildPosition = strpos($workflow, 'native:build mac arm64 --publish');
+    $verifyPosition = strpos($workflow, 'Verify release artifacts');
+
+    expect($verifyPosition)->toBeGreaterThan($buildPosition);
+});

--- a/tests/Arch/ReleaseWorkflowTest.php
+++ b/tests/Arch/ReleaseWorkflowTest.php
@@ -28,7 +28,7 @@ test('release workflow pre-creates the draft before building', function () {
     expect($preCreatePosition)->toBeLessThan($buildPosition);
 });
 
-test('release workflow verifies one release with every expected artifact', function () {
+test('release workflow verifies one release with exactly the expected artifacts', function () {
     $workflow = file_get_contents(dirname(__DIR__, 2).'/.github/workflows/release.yml');
 
     expect($workflow)
@@ -38,11 +38,25 @@ test('release workflow verifies one release with every expected artifact', funct
         ->toContain('rfa-${version}-arm64.zip')
         ->toContain('rfa-${version}-arm64.zip.blockmap')
         ->toContain('rfa-${version}-arm64.dmg')
-        ->toContain('rfa-${version}-arm64.dmg.blockmap');
+        ->toContain('rfa-${version}-arm64.dmg.blockmap')
+        // Exact-set check: a stale extra asset must fail the job, not just a missing one.
+        ->toContain('Unexpected release assets')
+        // --slurp collapses paginated results so the count test can't be bypassed.
+        ->toContain('--paginate --slurp');
 
     // Verification must run after the build so it inspects the published assets.
     $buildPosition = strpos($workflow, 'native:build mac arm64 --publish');
     $verifyPosition = strpos($workflow, 'Verify release artifacts');
 
     expect($verifyPosition)->toBeGreaterThan($buildPosition);
+});
+
+test('release workflow derives the version in-shell to avoid template injection', function () {
+    $workflow = file_get_contents(dirname(__DIR__, 2).'/.github/workflows/release.yml');
+
+    // Tag-derived values are expanded in-shell; interpolating ${{ }} into a run
+    // block would let a tag like v1.2.3$(...) execute before the shell parses it.
+    expect($workflow)
+        ->toContain('version="${tag#v}"')
+        ->not->toContain('--title "${{ steps.version.outputs.value }}"');
 });


### PR DESCRIPTION
## Why

The v0.17.4 release build succeeded but produced a **broken release**: electron-builder created **two draft releases** for the tag and split the assets across them. One draft held `rfa-0.17.4-arm64.zip`; the other held `latest-mac.yml`, the `.dmg`, and the blockmaps. Publishing either alone would have **404'd every existing user's macOS auto-updater**, because `latest-mac.yml` points at a `.zip` that lived on the other draft.

Root cause confirmed against the installed source (`electron-publish/out/gitHubPublisher.js`, `getOrCreateRelease` at lines 55–103): the publisher lists releases and only calls `createRelease()` when no draft matches the tag. When multiple artifacts finish near-simultaneously, several publishers clear that check before any draft exists and each creates its own draft — a classic check-then-create (TOCTOU) race.

## What

- **Pre-create the draft** before the build. With the draft already present, every publisher matches it and returns early (`if (release.draft) return release`) instead of racing to create one. Idempotent — skips creation if a release for the tag already exists, so re-runs are safe.
- **Verify release artifacts** after the build. Fails the job unless **exactly one** release for the tag carries all five expected assets (`latest-mac.yml`, `…-arm64.zip`, `…-arm64.zip.blockmap`, `…-arm64.dmg`, `…-arm64.dmg.blockmap`). A split or dropped upload can no longer reach a human as a publishable draft.
- **Arch test** (`tests/Arch/ReleaseWorkflowTest.php`) guards both steps — presence and ordering (pre-create before build, verify after) — against silent removal.
- **Docs** updated in `.github/CLAUDE.md`.

## Testing

- `composer test:lint` — pass
- `composer test:types` — 0 errors
- Core suite — 1513 passed (incl. 2 new arch tests)
- `actionlint` + YAML parse — clean

Note: this workflow change can only be exercised on the next real tag push (PR CI runs lint/types/tests, not the macOS release build). The v0.17.4 release itself was already manually repaired and published correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation to prevent duplicate release drafts and ensure all macOS build artifacts are included before publishing.

* **Tests**
  * Added workflow validation tests to verify release process integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->