### PR TITLE
Annotate markdown tables with grid metadata instead of padding

### DIFF
--- a/app/Actions/LoadFileDiffAction.php
+++ b/app/Actions/LoadFileDiffAction.php
@@ -79,15 +79,15 @@ final readonly class LoadFileDiffAction
             }
 
             $fileDiff = $fileDiff->withHunks(
-                $this->markdownTableAligner->alignTables($fileDiff->hunks, $fileDiff->path)
-            );
-
-            $fileDiff = $fileDiff->withHunks(
                 $this->csvAligner->alignRows($fileDiff->hunks, $fileDiff->path)
             );
 
             $highlightedHunks = $this->syntaxHighlightService->highlightHunks($fileDiff->hunks, $fileDiff->path);
             $annotatedHunks = $this->markdownRegionService->annotate($highlightedHunks, $fileDiff->path);
+
+            // Table grid metadata is attached last so it survives the line
+            // reconstruction that highlighting and heading annotation perform.
+            $annotatedHunks = $this->markdownTableAligner->alignTables($annotatedHunks, $fileDiff->path);
 
             $css = '';
             foreach ($this->syntaxHighlightService->getStyleMap() as $cls => $styles) {

--- a/app/DTOs/DiffLine.php
+++ b/app/DTOs/DiffLine.php
@@ -11,7 +11,7 @@ class DiffLine
     /**
      * @param  int[]  $headingAncestors
      * @param  'old'|'new'|null  $moved
-     * @param  array{separator: true}|array{separator: false, header: bool, cells: string[], template: string, maxWidth: int}|null  $table
+     * @param  array{separator: true}|array{separator: true, cells: string[], template: string, maxWidth: int}|array{separator: false, header: bool, cells: string[], template: string, maxWidth: int}|null  $table
      */
     public function __construct(
         public readonly LineType $type,

--- a/app/DTOs/DiffLine.php
+++ b/app/DTOs/DiffLine.php
@@ -11,6 +11,7 @@ class DiffLine
     /**
      * @param  int[]  $headingAncestors
      * @param  'old'|'new'|null  $moved
+     * @param  array{separator: true}|array{separator: false, header: bool, cells: string[], template: string, maxWidth: int}|null  $table
      */
     public function __construct(
         public readonly LineType $type,
@@ -22,6 +23,7 @@ class DiffLine
         public readonly ?int $headingId = null,
         public readonly array $headingAncestors = [],
         public readonly ?string $moved = null,
+        public readonly ?array $table = null,
     ) {}
 
     /** @return array<string, mixed> */
@@ -49,6 +51,10 @@ class DiffLine
 
         if ($this->moved !== null) {
             $array['moved'] = $this->moved;
+        }
+
+        if ($this->table !== null) {
+            $array['table'] = $this->table;
         }
 
         return $array;

--- a/app/Services/MarkdownTableAlignerService.php
+++ b/app/Services/MarkdownTableAlignerService.php
@@ -6,6 +6,7 @@ namespace App\Services;
 
 use App\DTOs\DiffLine;
 use App\DTOs\Hunk;
+use App\Enums\LineType;
 use App\Support\MarkdownPath;
 
 class MarkdownTableAlignerService
@@ -127,7 +128,7 @@ class MarkdownTableAlignerService
             $row = $parsed[$offset];
 
             $table = $row['isSeparator']
-                ? ['separator' => true]
+                ? $this->separatorTable($line, $row['cells'], $template, $maxWidth)
                 : [
                     'separator' => false,
                     'header' => $offset < $firstSeparator,
@@ -140,6 +141,32 @@ class MarkdownTableAlignerService
         }
 
         return $result;
+    }
+
+    /**
+     * Build the table metadata for a separator row.
+     *
+     * An unchanged separator carries no information for the reader, so it
+     * collapses to a thin header rule. A separator that is itself part of the
+     * diff (added or removed) instead renders its own `:---`/`---:` cells on the
+     * shared column template, so the change in alignment markers is visible
+     * rather than flattened to two indistinguishable rules.
+     *
+     * @param  string[]  $cells
+     * @return array{separator: true}|array{separator: true, cells: string[], template: string, maxWidth: int}
+     */
+    private function separatorTable(DiffLine $line, array $cells, string $template, int $maxWidth): array
+    {
+        if ($line->type === LineType::Context) {
+            return ['separator' => true];
+        }
+
+        return [
+            'separator' => true,
+            'cells' => $cells,
+            'template' => $template,
+            'maxWidth' => $maxWidth,
+        ];
     }
 
     /**
@@ -169,7 +196,7 @@ class MarkdownTableAlignerService
     }
 
     /**
-     * @param  array{separator: true}|array{separator: false, header: bool, cells: string[], template: string, maxWidth: int}  $table
+     * @param  array{separator: true}|array{separator: true, cells: string[], template: string, maxWidth: int}|array{separator: false, header: bool, cells: string[], template: string, maxWidth: int}  $table
      */
     private function withTable(DiffLine $line, array $table): DiffLine
     {

--- a/app/Services/MarkdownTableAlignerService.php
+++ b/app/Services/MarkdownTableAlignerService.php
@@ -11,6 +11,24 @@ use App\Support\MarkdownPath;
 class MarkdownTableAlignerService
 {
     /**
+     * Per-column weight ceiling, in characters. A prose column (paragraph-length
+     * cells) is capped here so it shares the available width with its siblings
+     * instead of dominating; short label columns keep their natural width.
+     */
+    private const COLUMN_WEIGHT_CAP = 60;
+
+    /**
+     * Floor so a separator column still resolves to a usable track.
+     */
+    private const COLUMN_WEIGHT_MIN = 3;
+
+    /**
+     * Annotate contiguous markdown table rows with the structured cell data and
+     * shared column template the diff view needs to lay each row out as a real
+     * CSS grid. The source content is left untouched; only `table` metadata is
+     * attached. Runs last in the diff pipeline so highlighting and heading
+     * annotation are preserved on the rebuilt lines.
+     *
      * @param  Hunk[]  $hunks
      * @return Hunk[]
      */
@@ -20,10 +38,10 @@ class MarkdownTableAlignerService
             return $hunks;
         }
 
-        return array_map(fn (Hunk $hunk) => $this->alignHunk($hunk), $hunks);
+        return array_map(fn (Hunk $hunk) => $this->annotateHunk($hunk), $hunks);
     }
 
-    private function alignHunk(Hunk $hunk): Hunk
+    private function annotateHunk(Hunk $hunk): Hunk
     {
         $lines = $hunk->lines;
         $count = count($lines);
@@ -43,9 +61,9 @@ class MarkdownTableAlignerService
                     $i++;
                 }
 
-                $aligned = $this->alignTableGroup(array_slice($lines, $groupStart, $i - $groupStart));
+                $annotated = $this->annotateTableGroup(array_slice($lines, $groupStart, $i - $groupStart));
 
-                foreach ($aligned as $offset => $line) {
+                foreach ($annotated as $offset => $line) {
                     if ($line !== $lines[$groupStart + $offset]) {
                         $modified = true;
                     }
@@ -79,69 +97,99 @@ class MarkdownTableAlignerService
      * @param  DiffLine[]  $group
      * @return DiffLine[]
      */
-    private function alignTableGroup(array $group): array
+    private function annotateTableGroup(array $group): array
     {
-        $parsed = [];
-        $maxCols = 0;
+        $parsed = array_map(fn (DiffLine $line) => $this->parseCells($line->content), $group);
 
-        foreach ($group as $line) {
-            $row = $this->parseCells($line->content);
-            $parsed[] = $row;
-            $maxCols = max($maxCols, count($row['cells']));
+        $firstSeparator = null;
+        foreach ($parsed as $index => $row) {
+            if ($row['isSeparator']) {
+                $firstSeparator = $index;
+                break;
+            }
         }
+
+        // A pipe-prefixed block without a separator row (`| --- |`) is not a GFM
+        // table — leave it as plain source rather than forcing a grid onto it.
+        if ($firstSeparator === null || count($group) < 2) {
+            return $group;
+        }
+
+        $maxCols = max(array_map(fn (array $row) => count($row['cells']), $parsed));
 
         if ($maxCols === 0) {
             return $group;
         }
 
-        // Compute max width per column (excluding separator rows)
-        $colWidths = array_fill(0, $maxCols, 0);
+        $weights = $this->columnWeights($parsed, $maxCols);
+        $template = collect($weights)
+            ->map(fn (int $weight) => "minmax(0,{$weight}fr)")
+            ->implode(' ');
+        $maxWidth = array_sum($weights);
+
+        $result = [];
+        foreach ($group as $offset => $line) {
+            $row = $parsed[$offset];
+
+            $table = $row['isSeparator']
+                ? ['separator' => true]
+                : [
+                    'separator' => false,
+                    'header' => $offset < $firstSeparator,
+                    'cells' => $row['cells'],
+                    'template' => $template,
+                    'maxWidth' => $maxWidth,
+                ];
+
+            $result[] = $this->withTable($line, $table);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Column weight is the widest cell in that column, capped so a prose column
+     * can't starve its neighbours. Used as the `fr` ratio for the grid track.
+     *
+     * @param  array<int, array{indent: string, cells: string[], isSeparator: bool}>  $parsed
+     * @return int[]
+     */
+    private function columnWeights(array $parsed, int $maxCols): array
+    {
+        $widths = array_fill(0, $maxCols, 0);
+
         foreach ($parsed as $row) {
             if ($row['isSeparator']) {
                 continue;
             }
             foreach ($row['cells'] as $colIndex => $cell) {
-                $colWidths[$colIndex] = max($colWidths[$colIndex], $this->displayWidth($cell));
+                $widths[$colIndex] = max($widths[$colIndex], $this->displayWidth($cell));
             }
         }
 
-        // Ensure separator rows also contribute a minimum width of 3 (for ---)
-        foreach ($colWidths as $colIndex => $width) {
-            $colWidths[$colIndex] = max($width, 3);
-        }
+        return array_map(
+            fn (int $width) => max(self::COLUMN_WEIGHT_MIN, min($width, self::COLUMN_WEIGHT_CAP)),
+            $widths,
+        );
+    }
 
-        // Rebuild each line with padded cells
-        $result = [];
-        foreach ($group as $i => $line) {
-            $row = $parsed[$i];
-            $paddedCells = [];
-
-            for ($col = 0; $col < $maxCols; $col++) {
-                $cell = $row['cells'][$col] ?? '';
-
-                if ($row['isSeparator']) {
-                    $paddedCells[] = $this->padSeparatorCell($cell, $colWidths[$col]);
-                } else {
-                    $paddedCells[] = $this->padContentCell($cell, $colWidths[$col]);
-                }
-            }
-
-            $newContent = $row['indent'].'| '.implode(' | ', $paddedCells).' |';
-
-            if ($newContent === $line->content) {
-                $result[] = $line;
-            } else {
-                $result[] = new DiffLine(
-                    type: $line->type,
-                    content: $newContent,
-                    oldLineNum: $line->oldLineNum,
-                    newLineNum: $line->newLineNum,
-                    moved: $line->moved,
-                );
-            }
-        }
-
-        return $result;
+    /**
+     * @param  array{separator: true}|array{separator: false, header: bool, cells: string[], template: string, maxWidth: int}  $table
+     */
+    private function withTable(DiffLine $line, array $table): DiffLine
+    {
+        return new DiffLine(
+            type: $line->type,
+            content: $line->content,
+            oldLineNum: $line->oldLineNum,
+            newLineNum: $line->newLineNum,
+            highlightedContent: $line->highlightedContent,
+            headingLevel: $line->headingLevel,
+            headingId: $line->headingId,
+            headingAncestors: $line->headingAncestors,
+            moved: $line->moved,
+            table: $table,
+        );
     }
 
     /**
@@ -175,13 +223,6 @@ class MarkdownTableAlignerService
         ];
     }
 
-    private function padContentCell(string $cell, int $width): string
-    {
-        $padding = max(0, $width - $this->displayWidth($cell));
-
-        return $cell.str_repeat(' ', $padding);
-    }
-
     /**
      * Display width of a cell: an escaped pipe (`\|`) is two source characters but
      * renders as one, so it must count as a single column for alignment.
@@ -189,21 +230,5 @@ class MarkdownTableAlignerService
     private function displayWidth(string $cell): int
     {
         return mb_strwidth(str_replace('\\|', '|', $cell));
-    }
-
-    private function padSeparatorCell(string $cell, int $width): string
-    {
-        if ($cell === '') {
-            return str_repeat('-', $width);
-        }
-
-        // Detect alignment markers
-        $leftColon = str_starts_with($cell, ':');
-        $rightColon = str_ends_with($cell, ':');
-
-        $dashCount = $width - ($leftColon ? 1 : 0) - ($rightColon ? 1 : 0);
-        $dashCount = max(1, $dashCount);
-
-        return ($leftColon ? ':' : '').str_repeat('-', $dashCount).($rightColon ? ':' : '');
     }
 }

--- a/app/Services/MarkdownTableAlignerService.php
+++ b/app/Services/MarkdownTableAlignerService.php
@@ -102,22 +102,17 @@ class MarkdownTableAlignerService
         $parsed = array_map(fn (DiffLine $line) => $this->parseCells($line->content), $group);
 
         $firstSeparator = null;
+        $maxCols = 0;
         foreach ($parsed as $index => $row) {
-            if ($row['isSeparator']) {
+            if ($row['isSeparator'] && $firstSeparator === null) {
                 $firstSeparator = $index;
-                break;
             }
+            $maxCols = max($maxCols, count($row['cells']));
         }
 
         // A pipe-prefixed block without a separator row (`| --- |`) is not a GFM
         // table — leave it as plain source rather than forcing a grid onto it.
-        if ($firstSeparator === null || count($group) < 2) {
-            return $group;
-        }
-
-        $maxCols = max(array_map(fn (array $row) => count($row['cells']), $parsed));
-
-        if ($maxCols === 0) {
+        if ($firstSeparator === null || count($group) < 2 || $maxCols === 0) {
             return $group;
         }
 

--- a/resources/views/components/diff/line.blade.php
+++ b/resources/views/components/diff/line.blade.php
@@ -25,6 +25,7 @@
         default => 'context',
     };
     $headingId = $line['headingId'] ?? null;
+    $table = $line['table'] ?? null;
     $headingAncestors = $line['headingAncestors'] ?? [];
     $ancestorJs = $headingAncestors === [] ? null : json_encode($headingAncestors);
 
@@ -58,7 +59,7 @@
 
     <div class="diff-cell diff-cell-prefix {{ $bgClass }} {{ $prefixColor }}">{{ $prefix }}</div>
 
-    <div class="diff-cell diff-cell-content {{ $bgClass }}">@if($headingId !== null)<button
+    <div @class(['diff-cell', 'diff-cell-content', 'diff-cell-table' => $table !== null, $bgClass])>@if($table !== null)<x-diff.md-table :table="$table" />@elseif($headingId !== null)<button
             type="button"
             data-testid="heading-fold-toggle"
             data-heading-id="{{ $headingId }}"
@@ -66,11 +67,11 @@
             :aria-label="foldedHeadings[{{ $headingId }}] ? 'Expand section' : 'Collapse section'"
             :aria-expanded="!foldedHeadings[{{ $headingId }}]"
             class="inline-flex align-middle -my-0.5 mr-1 size-4 items-center justify-center text-gh-muted/60 hover:text-gh-text"
-        ><flux:icon icon="chevron-down" variant="outline" class="!size-3" x-show="!foldedHeadings[{{ $headingId }}]" /><flux:icon icon="chevron-right" variant="outline" class="!size-3" x-show="foldedHeadings[{{ $headingId }}]" x-cloak /></button>@endif{!! $line['highlightedContent'] ?? e($line['content']) !!}</div>
+        ><flux:icon icon="chevron-down" variant="outline" class="!size-3" x-show="!foldedHeadings[{{ $headingId }}]" /><flux:icon icon="chevron-right" variant="outline" class="!size-3" x-show="foldedHeadings[{{ $headingId }}]" x-cloak /></button>{!! $line['highlightedContent'] ?? e($line['content']) !!}@else{!! $line['highlightedContent'] ?? e($line['content']) !!}@endif</div>
 
     @if($type === LineType::Context)
         {{-- Mirror cell: shown only in split mode (CSS hides in unified). --}}
-        <div class="diff-cell diff-cell-content diff-cell-content-mirror {{ $bgClass }}" aria-hidden="true">{!! $line['highlightedContent'] ?? e($line['content']) !!}</div>
+        <div @class(['diff-cell', 'diff-cell-content', 'diff-cell-content-mirror', 'diff-cell-table' => $table !== null, $bgClass]) aria-hidden="true">@if($table !== null)<x-diff.md-table :table="$table" />@else{!! $line['highlightedContent'] ?? e($line['content']) !!}@endif</div>
     @endif
 </div>
 

--- a/resources/views/components/diff/line.blade.php
+++ b/resources/views/components/diff/line.blade.php
@@ -26,6 +26,7 @@
     };
     $headingId = $line['headingId'] ?? null;
     $table = $line['table'] ?? null;
+    $cellContent = $line['highlightedContent'] ?? e($line['content']);
     $headingAncestors = $line['headingAncestors'] ?? [];
     $ancestorJs = $headingAncestors === [] ? null : json_encode($headingAncestors);
 
@@ -67,11 +68,11 @@
             :aria-label="foldedHeadings[{{ $headingId }}] ? 'Expand section' : 'Collapse section'"
             :aria-expanded="!foldedHeadings[{{ $headingId }}]"
             class="inline-flex align-middle -my-0.5 mr-1 size-4 items-center justify-center text-gh-muted/60 hover:text-gh-text"
-        ><flux:icon icon="chevron-down" variant="outline" class="!size-3" x-show="!foldedHeadings[{{ $headingId }}]" /><flux:icon icon="chevron-right" variant="outline" class="!size-3" x-show="foldedHeadings[{{ $headingId }}]" x-cloak /></button>{!! $line['highlightedContent'] ?? e($line['content']) !!}@else{!! $line['highlightedContent'] ?? e($line['content']) !!}@endif</div>
+        ><flux:icon icon="chevron-down" variant="outline" class="!size-3" x-show="!foldedHeadings[{{ $headingId }}]" /><flux:icon icon="chevron-right" variant="outline" class="!size-3" x-show="foldedHeadings[{{ $headingId }}]" x-cloak /></button>{!! $cellContent !!}@else{!! $cellContent !!}@endif</div>
 
     @if($type === LineType::Context)
         {{-- Mirror cell: shown only in split mode (CSS hides in unified). --}}
-        <div @class(['diff-cell', 'diff-cell-content', 'diff-cell-content-mirror', 'diff-cell-table' => $table !== null, $bgClass]) aria-hidden="true">@if($table !== null)<x-diff.md-table :table="$table" />@else{!! $line['highlightedContent'] ?? e($line['content']) !!}@endif</div>
+        <div @class(['diff-cell', 'diff-cell-content', 'diff-cell-content-mirror', 'diff-cell-table' => $table !== null, $bgClass]) aria-hidden="true">@if($table !== null)<x-diff.md-table :table="$table" />@else{!! $cellContent !!}@endif</div>
     @endif
 </div>
 

--- a/resources/views/components/diff/md-table.blade.php
+++ b/resources/views/components/diff/md-table.blade.php
@@ -1,0 +1,13 @@
+{{-- Renders one markdown table row as a CSS grid so each cell wraps within its
+     own column. Every row in a group shares the same `template`, so columns line
+     up across rows regardless of cell length. The separator row (`| --- |`)
+     becomes a thin header rule. --}}
+@props(['table'])
+
+@if($table['separator'])
+    <div class="diff-md-sep" aria-hidden="true"></div>
+@else
+    <div class="diff-md-table" style="grid-template-columns:{{ $table['template'] }};max-width:{{ $table['maxWidth'] }}ch">
+        @foreach($table['cells'] as $cell)<div @class(['diff-md-td', 'diff-md-th' => $table['header']])>{{ $cell }}</div>@endforeach
+    </div>
+@endif

--- a/resources/views/components/diff/md-table.blade.php
+++ b/resources/views/components/diff/md-table.blade.php
@@ -1,13 +1,17 @@
 {{-- Renders one markdown table row as a CSS grid so each cell wraps within its
      own column. Every row in a group shares the same `template`, so columns line
-     up across rows regardless of cell length. The separator row (`| --- |`)
-     becomes a thin header rule. --}}
+     up across rows regardless of cell length.
+
+     An unchanged separator (`| --- |`) collapses to a thin header rule. A
+     separator that is part of the diff carries its own cells, so the changed
+     alignment markers stay visible (muted) on the same column grid instead of
+     flattening to two indistinguishable rules. --}}
 @props(['table'])
 
-@if($table['separator'])
+@if($table['separator'] && ! isset($table['cells']))
     <div class="diff-md-sep" aria-hidden="true"></div>
 @else
     <div class="diff-md-table" style="grid-template-columns:{{ $table['template'] }};max-width:{{ $table['maxWidth'] }}ch">
-        @foreach($table['cells'] as $cell)<div @class(['diff-md-td', 'diff-md-th' => $table['header']])>{{ $cell }}</div>@endforeach
+        @foreach($table['cells'] as $cell)<div @class(['diff-md-td', 'diff-md-th' => $table['header'] ?? false, 'diff-md-sep-cell' => $table['separator']])>{{ $cell }}</div>@endforeach
     </div>
 @endif

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -125,6 +125,25 @@
         .diff-cell-prefix { padding: 0 0.25rem; text-align: center; user-select: none; }
         .diff-cell-content { padding: 0 0.5rem; white-space: pre-wrap; word-break: break-all; }
 
+        /* Markdown table rows render their cells as a real grid so each cell wraps
+           within its own column instead of the whole row wrapping mid-character.
+           Every row in a group shares the same grid-template-columns, so columns
+           line up across rows. The cell drops pre-wrap/break-all (set for raw
+           source) so blade whitespace collapses and prose wraps on word bounds. */
+        .diff-cell-table { white-space: normal; }
+        .diff-md-table { display: grid; align-items: start; width: 100%; }
+        .diff-md-td {
+            min-width: 0;
+            padding: 0 0.6rem;
+            white-space: normal;
+            overflow-wrap: anywhere;
+            word-break: normal;
+            border-left: 1px solid rgb(var(--gh-border) / 0.6);
+        }
+        .diff-md-td:first-child { padding-left: 0; border-left: 0; }
+        .diff-md-th { font-weight: 600; color: rgb(var(--gh-text)); }
+        .diff-md-sep { height: 0; border-bottom: 1px solid rgb(var(--gh-border)); margin: 0.15rem 0; }
+
         /* Unified: cells fill cols 1-4 in source order. */
         .diff-grid[data-view-mode="unified"] .diff-cell-num-old { grid-column: 1; }
         .diff-grid[data-view-mode="unified"] .diff-cell-num-new { grid-column: 2; }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -143,6 +143,9 @@
         .diff-md-td:first-child { padding-left: 0; border-left: 0; }
         .diff-md-th { font-weight: 600; color: rgb(var(--gh-text)); }
         .diff-md-sep { height: 0; border-bottom: 1px solid rgb(var(--gh-border)); margin: 0.15rem 0; }
+        /* A changed separator shows its raw `:---`/`---:` markers, muted so they
+           read as structure rather than content. */
+        .diff-md-sep-cell { color: rgb(var(--gh-muted)); }
 
         /* Unified: cells fill cols 1-4 in source order. */
         .diff-grid[data-view-mode="unified"] .diff-cell-num-old { grid-column: 1; }

--- a/tests/Unit/MarkdownTableAlignerServiceTest.php
+++ b/tests/Unit/MarkdownTableAlignerServiceTest.php
@@ -65,6 +65,67 @@ test('attaches grid cell metadata to each table row', function () {
     ]);
 });
 
+test('renders a changed separator as aligned cells instead of a rule', function () {
+    $hunks = [
+        new Hunk('', 1, 4, 1, 4, [
+            new DiffLine(LineType::Context, '| Name | Default |', 1, 1),
+            new DiffLine(LineType::Remove, '| --- | --- |', 2, null),
+            new DiffLine(LineType::Add, '| :--- | ---: |', null, 2),
+            new DiffLine(LineType::Context, '| a | b |', 3, 3),
+        ]),
+    ];
+
+    $lines = $this->aligner->alignTables($hunks, 'readme.md')[0]->lines;
+
+    // The removed separator keeps its `---` markers on the shared column grid.
+    expect($lines[1]->table)->toMatchArray([
+        'separator' => true,
+        'cells' => ['---', '---'],
+    ])
+        ->and($lines[1]->table['template'])->toBe($lines[0]->table['template'])
+        ->and($lines[1]->table['maxWidth'])->toBe($lines[0]->table['maxWidth']);
+
+    // The added separator shows the new alignment markers, aligned the same way.
+    expect($lines[2]->table)->toMatchArray([
+        'separator' => true,
+        'cells' => [':---', '---:'],
+    ])
+        ->and($lines[2]->table['template'])->toBe($lines[0]->table['template']);
+});
+
+test('keeps an unchanged separator as a thin rule', function () {
+    $hunks = [
+        new Hunk('', 1, 4, 1, 4, [
+            new DiffLine(LineType::Context, '| Name | Default |', 1, 1),
+            new DiffLine(LineType::Context, '| --- | --- |', 2, 2),
+            new DiffLine(LineType::Remove, '| a | old |', 3, null),
+            new DiffLine(LineType::Add, '| a | new |', null, 3),
+        ]),
+    ];
+
+    $lines = $this->aligner->alignTables($hunks, 'readme.md')[0]->lines;
+
+    // An unchanged (context) separator carries no diff signal, so it collapses
+    // to a rule with no cells regardless of body-cell changes around it.
+    expect($lines[1]->table)->toBe(['separator' => true]);
+});
+
+test('a changed separator does not inflate its column widths', function () {
+    $hunks = [
+        new Hunk('', 1, 3, 1, 3, [
+            new DiffLine(LineType::Context, '| A | B |', 1, 1),
+            new DiffLine(LineType::Add, '| :--------------- | ---------------: |', null, 2),
+            new DiffLine(LineType::Context, '| x | y |', 3, 3),
+        ]),
+    ];
+
+    $lines = $this->aligner->alignTables($hunks, 'readme.md')[0]->lines;
+
+    // The long dash runs in the separator must not set the column weights —
+    // those still come from the (short) body/header cells.
+    expect($lines[0]->table['template'])->toBe('minmax(0,3fr) minmax(0,3fr)');
+});
+
 test('leaves source content untouched', function () {
     $hunks = [
         new Hunk('', 1, 3, 1, 3, [

--- a/tests/Unit/MarkdownTableAlignerServiceTest.php
+++ b/tests/Unit/MarkdownTableAlignerServiceTest.php
@@ -33,7 +33,55 @@ test('returns hunks unchanged when no tables present', function () {
     expect($result)->toBe($hunks);
 });
 
-test('keeps an escaped pipe inside a cell instead of splitting the column', function () {
+test('attaches grid cell metadata to each table row', function () {
+    $hunks = [
+        new Hunk('', 1, 3, 1, 3, [
+            new DiffLine(LineType::Context, '| Name | Description |', 1, 1),
+            new DiffLine(LineType::Context, '| --- | --- |', 2, 2),
+            new DiffLine(LineType::Context, '| a | a longer description |', 3, 3),
+        ]),
+    ];
+
+    $lines = $this->aligner->alignTables($hunks, 'readme.md')[0]->lines;
+
+    expect($lines[0]->table)->toMatchArray([
+        'separator' => false,
+        'header' => true,
+        'cells' => ['Name', 'Description'],
+    ]);
+    // Every row in the group shares the same column template, so they align.
+    expect($lines[0]->table['template'])->toBe($lines[2]->table['template'])
+        ->and($lines[0]->table['template'])->toContain('minmax(0,')
+        ->and($lines[0]->table['maxWidth'])->toBeInt();
+
+    // The separator row collapses to a header rule, not cells.
+    expect($lines[1]->table)->toBe(['separator' => true]);
+
+    // The body row is not a header and carries its own cells.
+    expect($lines[2]->table)->toMatchArray([
+        'separator' => false,
+        'header' => false,
+        'cells' => ['a', 'a longer description'],
+    ]);
+});
+
+test('leaves source content untouched', function () {
+    $hunks = [
+        new Hunk('', 1, 3, 1, 3, [
+            new DiffLine(LineType::Context, '| Name | Description |', 1, 1),
+            new DiffLine(LineType::Context, '| --- | --- |', 2, 2),
+            new DiffLine(LineType::Context, '| a | longer |', 3, 3),
+        ]),
+    ];
+
+    $lines = $this->aligner->alignTables($hunks, 'readme.md')[0]->lines;
+
+    // No padding is written into the content — the grid handles alignment.
+    expect($lines[0]->content)->toBe('| Name | Description |')
+        ->and($lines[2]->content)->toBe('| a | longer |');
+});
+
+test('keeps an escaped pipe inside a single cell', function () {
     $hunks = [
         new Hunk('', 1, 3, 1, 3, [
             new DiffLine(LineType::Context, '| a \| b | second column |', 1, 1),
@@ -42,158 +90,96 @@ test('keeps an escaped pipe inside a cell instead of splitting the column', func
         ]),
     ];
 
-    $result = $this->aligner->alignTables($hunks, 'doc.md');
-    $lines = $result[0]->lines;
+    $lines = $this->aligner->alignTables($hunks, 'doc.md')[0]->lines;
 
-    // The literal pipe (\|) stays inside cell 1 rather than shattering it.
-    expect($lines[0]->content)->toContain('a \| b');
-    // The separator keeps exactly two columns (3 delimiter pipes), not three.
-    expect(substr_count($lines[1]->content, '|'))->toBe(3);
+    // The literal pipe (\|) stays inside cell 1 rather than shattering it into two.
+    expect($lines[0]->table['cells'])->toBe(['a \| b', 'second column']);
 });
 
-test('aligns simple table columns', function () {
+test('does not annotate a pipe block without a separator row', function () {
     $hunks = [
-        new Hunk('', 1, 4, 1, 4, [
-            new DiffLine(LineType::Context, '| Name | Description | Notes |', 1, 1),
-            new DiffLine(LineType::Context, '|---|---|---|', 2, 2),
-            new DiffLine(LineType::Context, '| a | A longer description | n |', 3, 3),
-            new DiffLine(LineType::Context, '| longer name | b | some notes here |', 4, 4),
+        new Hunk('', 1, 2, 1, 2, [
+            new DiffLine(LineType::Context, '| just | some |', 1, 1),
+            new DiffLine(LineType::Context, '| pipe | lines |', 2, 2),
         ]),
     ];
 
     $result = $this->aligner->alignTables($hunks, 'readme.md');
 
-    // All columns padded to widest cell in each column
-    expect($result[0]->lines[0]->content)->toBe('| Name        | Description          | Notes           |');
-    expect($result[0]->lines[1]->content)->toMatch('/^\| -+ \| -+ \| -+ \|$/');
-    expect($result[0]->lines[2]->content)->toBe('| a           | A longer description | n               |');
-    expect($result[0]->lines[3]->content)->toBe('| longer name | b                    | some notes here |');
+    // No GFM separator -> not a table -> left as plain source.
+    expect($result)->toBe($hunks);
 });
 
-test('handles mixed diff types in table group', function () {
+test('annotates mixed diff types in a table group and preserves types', function () {
     $hunks = [
-        new Hunk('', 1, 3, 1, 3, [
+        new Hunk('', 1, 4, 1, 4, [
             new DiffLine(LineType::Context, '| Col | Value |', 1, 1),
-            new DiffLine(LineType::Context, '|---|---|', 2, 2),
+            new DiffLine(LineType::Context, '| --- | --- |', 2, 2),
             new DiffLine(LineType::Remove, '| short | x |', 3, null),
             new DiffLine(LineType::Add, '| a much longer cell | updated |', null, 3),
         ]),
     ];
 
-    $result = $this->aligner->alignTables($hunks, 'docs.md');
+    $lines = $this->aligner->alignTables($hunks, 'docs.md')[0]->lines;
 
-    $lines = $result[0]->lines;
-    // All lines aligned to the widest content across all types
-    expect($lines[0]->content)->toBe('| Col                | Value   |');
-    expect($lines[2]->content)->toBe('| short              | x       |');
-    expect($lines[2]->type)->toBe(LineType::Remove);
-    expect($lines[3]->content)->toBe('| a much longer cell | updated |');
-    expect($lines[3]->type)->toBe(LineType::Add);
+    expect($lines[2]->type)->toBe(LineType::Remove)
+        ->and($lines[2]->table['cells'])->toBe(['short', 'x'])
+        ->and($lines[3]->type)->toBe(LineType::Add)
+        ->and($lines[3]->table['cells'])->toBe(['a much longer cell', 'updated'])
+        // Shared template keeps both sides aligned to the widest column.
+        ->and($lines[2]->table['template'])->toBe($lines[3]->table['template']);
 });
 
-test('extends separator row dashes to match column width', function () {
+test('caps a prose column so it does not starve its neighbours', function () {
+    $prose = str_repeat('word ', 60);
     $hunks = [
         new Hunk('', 1, 3, 1, 3, [
-            new DiffLine(LineType::Context, '| Header One | H2 |', 1, 1),
-            new DiffLine(LineType::Context, '|---|---|', 2, 2),
-            new DiffLine(LineType::Context, '| data | d |', 3, 3),
+            new DiffLine(LineType::Context, '| Item | Why it bites |', 1, 1),
+            new DiffLine(LineType::Context, '| --- | --- |', 2, 2),
+            new DiffLine(LineType::Context, "| composer.lock | {$prose} |", 3, 3),
         ]),
     ];
 
-    $result = $this->aligner->alignTables($hunks, 'readme.md');
+    $lines = $this->aligner->alignTables($hunks, 'readme.md')[0]->lines;
 
-    expect($result[0]->lines[1]->content)->toBe('| ---------- | --- |');
+    // 'composer.lock' (13) keeps its width; the long prose column is capped at 60.
+    expect($lines[0]->table['template'])->toBe('minmax(0,13fr) minmax(0,60fr)');
 });
 
-test('preserves separator alignment markers', function () {
+test('marks every header row before the separator', function () {
     $hunks = [
         new Hunk('', 1, 3, 1, 3, [
-            new DiffLine(LineType::Context, '| Left Longer | Center Longer | Right Longer |', 1, 1),
-            new DiffLine(LineType::Context, '|:---|:---:|---:|', 2, 2),
-            new DiffLine(LineType::Context, '| data | data | data |', 3, 3),
+            new DiffLine(LineType::Context, '| H1 | H2 |', 1, 1),
+            new DiffLine(LineType::Context, '| --- | --- |', 2, 2),
+            new DiffLine(LineType::Context, '| body | row |', 3, 3),
         ]),
     ];
 
-    $result = $this->aligner->alignTables($hunks, 'readme.md');
+    $lines = $this->aligner->alignTables($hunks, 'readme.md')[0]->lines;
 
-    $sep = $result[0]->lines[1]->content;
-    // Left-aligned: starts with :
-    expect($sep)->toContain(':----');
-    // Center-aligned: starts and ends with :
-    expect($sep)->toMatch('/:---+:/');
-    // Right-aligned: ends with :
-    expect($sep)->toMatch('/---+: \|$/');
-});
-
-test('handles tables with different column counts', function () {
-    $hunks = [
-        new Hunk('', 1, 2, 1, 2, [
-            new DiffLine(LineType::Context, '| a | b | c |', 1, 1),
-            new DiffLine(LineType::Add, '| x | y |', null, 2),
-        ]),
-    ];
-
-    $result = $this->aligner->alignTables($hunks, 'readme.md');
-
-    // All columns padded to minimum width of 3 (separator minimum)
-    $lines = $result[0]->lines;
-    expect($lines[0]->content)->toBe('| a   | b   | c   |');
-    expect($lines[1]->content)->toBe('| x   | y   |     |');
-});
-
-test('preserves indented tables', function () {
-    $hunks = [
-        new Hunk('', 1, 3, 1, 3, [
-            new DiffLine(LineType::Context, '    | Col | Value |', 1, 1),
-            new DiffLine(LineType::Context, '    |---|---|', 2, 2),
-            new DiffLine(LineType::Context, '    | longer | x |', 3, 3),
-        ]),
-    ];
-
-    $result = $this->aligner->alignTables($hunks, 'readme.md');
-
-    expect($result[0]->lines[0]->content)->toStartWith('    |');
-    expect($result[0]->lines[2]->content)->toStartWith('    |');
-    // Column alignment should work within the indented table
-    expect($result[0]->lines[0]->content)->toBe('    | Col    | Value |');
-    expect($result[0]->lines[2]->content)->toBe('    | longer | x     |');
-});
-
-test('does not align non-table pipe lines', function () {
-    $hunks = [
-        new Hunk('', 1, 2, 1, 2, [
-            new DiffLine(LineType::Context, 'echo foo | grep bar', 1, 1),
-            new DiffLine(LineType::Context, 'cat file | wc -l', 2, 2),
-        ]),
-    ];
-
-    $result = $this->aligner->alignTables($hunks, 'readme.md');
-
-    expect($result)->toBe($hunks);
+    expect($lines[0]->table['header'])->toBeTrue()
+        ->and($lines[2]->table['header'])->toBeFalse();
 });
 
 test('handles multiple table groups in one hunk', function () {
     $hunks = [
         new Hunk('', 1, 7, 1, 7, [
             new DiffLine(LineType::Context, '| a | b |', 1, 1),
-            new DiffLine(LineType::Context, '|---|---|', 2, 2),
+            new DiffLine(LineType::Context, '| --- | --- |', 2, 2),
             new DiffLine(LineType::Context, '| longer | x |', 3, 3),
             new DiffLine(LineType::Context, '', 4, 4),
             new DiffLine(LineType::Context, '| c | d |', 5, 5),
-            new DiffLine(LineType::Context, '|---|---|', 6, 6),
+            new DiffLine(LineType::Context, '| --- | --- |', 6, 6),
             new DiffLine(LineType::Context, '| y | much longer |', 7, 7),
         ]),
     ];
 
-    $result = $this->aligner->alignTables($hunks, 'readme.md');
+    $lines = $this->aligner->alignTables($hunks, 'readme.md')[0]->lines;
 
-    // First table: "longer" is widest in col 0, min width 3 for col 1
-    expect($result[0]->lines[0]->content)->toBe('| a      | b   |');
-    expect($result[0]->lines[2]->content)->toBe('| longer | x   |');
-
-    // Second table: "y" and "c" in col 0, "much longer" and "d" in col 1
-    expect($result[0]->lines[4]->content)->toBe('| c   | d           |');
-    expect($result[0]->lines[6]->content)->toBe('| y   | much longer |');
+    expect($lines[0]->table['cells'])->toBe(['a', 'b'])
+        ->and($lines[3]->table)->toBeNull()
+        ->and($lines[4]->table['cells'])->toBe(['c', 'd'])
+        ->and($lines[6]->table['cells'])->toBe(['y', 'much longer']);
 });
 
 test('handles empty hunks', function () {
@@ -206,31 +192,52 @@ test('processes mdx files', function () {
     $hunks = [
         new Hunk('', 1, 3, 1, 3, [
             new DiffLine(LineType::Context, '| Short | Value |', 1, 1),
-            new DiffLine(LineType::Context, '|---|---|', 2, 2),
+            new DiffLine(LineType::Context, '| --- | --- |', 2, 2),
             new DiffLine(LineType::Context, '| a longer name | x |', 3, 3),
         ]),
     ];
 
-    $result = $this->aligner->alignTables($hunks, 'docs/page.mdx');
+    $lines = $this->aligner->alignTables($hunks, 'docs/page.mdx')[0]->lines;
 
-    expect($result[0]->lines[0]->content)->toBe('| Short         | Value |');
-    expect($result[0]->lines[2]->content)->toBe('| a longer name | x     |');
+    expect($lines[2]->table['cells'])->toBe(['a longer name', 'x']);
 });
 
 test('preserves line numbers and types', function () {
     $hunks = [
         new Hunk('', 10, 3, 10, 3, [
             new DiffLine(LineType::Context, '| a | b |', 10, 10),
-            new DiffLine(LineType::Context, '|---|---|', 11, 11),
+            new DiffLine(LineType::Context, '| --- | --- |', 11, 11),
             new DiffLine(LineType::Add, '| longer | x |', null, 12),
         ]),
     ];
 
-    $result = $this->aligner->alignTables($hunks, 'readme.md');
+    $lines = $this->aligner->alignTables($hunks, 'readme.md')[0]->lines;
 
-    expect($result[0]->lines[0]->oldLineNum)->toBe(10)
-        ->and($result[0]->lines[0]->newLineNum)->toBe(10)
-        ->and($result[0]->lines[2]->type)->toBe(LineType::Add)
-        ->and($result[0]->lines[2]->oldLineNum)->toBeNull()
-        ->and($result[0]->lines[2]->newLineNum)->toBe(12);
+    expect($lines[0]->oldLineNum)->toBe(10)
+        ->and($lines[0]->newLineNum)->toBe(10)
+        ->and($lines[2]->type)->toBe(LineType::Add)
+        ->and($lines[2]->oldLineNum)->toBeNull()
+        ->and($lines[2]->newLineNum)->toBe(12);
+});
+
+test('preserves highlighting and heading metadata already on the line', function () {
+    $hunks = [
+        new Hunk('', 1, 2, 1, 2, [
+            new DiffLine(
+                type: LineType::Add,
+                content: '| a | b |',
+                oldLineNum: null,
+                newLineNum: 1,
+                highlightedContent: '<span>| a | b |</span>',
+                headingAncestors: [5],
+            ),
+            new DiffLine(LineType::Add, '| --- | --- |', null, 2),
+        ]),
+    ];
+
+    $line = $this->aligner->alignTables($hunks, 'readme.md')[0]->lines[0];
+
+    expect($line->highlightedContent)->toBe('<span>| a | b |</span>')
+        ->and($line->headingAncestors)->toBe([5])
+        ->and($line->table['cells'])->toBe(['a', 'b']);
 });


### PR DESCRIPTION
## Summary

Refactors the markdown table alignment service to attach structured grid metadata to table rows instead of padding cell content. This enables the diff view to render tables as CSS grids where each cell wraps within its own column, rather than padding source content and relying on monospace wrapping.

## Key Changes

- **Service refactor**: `MarkdownTableAlignerService` now annotates each table row with a `table` property containing:
  - Cell content (unpadded)
  - A shared CSS grid `template` (e.g., `minmax(0,13fr) minmax(0,60fr)`) so columns align across rows
  - Metadata flags (`separator`, `header`) to distinguish row types
  - A `maxWidth` cap in characters to prevent prose columns from starving neighbors

- **Column weight calculation**: Replaces fixed padding logic with a weight-based system:
  - Each column's weight is the widest cell in that column
  - Weights are capped at 60 characters (prose columns) and floored at 3 (separator minimum)
  - Weights become `fr` ratios in the grid template

- **Source preservation**: Cell content is left untouched; only metadata is attached. Existing line properties (`highlightedContent`, `headingAncestors`, etc.) are preserved through the `withTable()` helper.

- **View layer**: New `md-table.blade.php` component renders table rows as CSS grids:
  - Separator rows become thin visual rules
  - Header and body rows render cells in a grid with the shared template
  - Cell content wraps on word boundaries within its column width

- **Styling**: Added CSS classes for grid layout, cell styling, and separator rules in `app.blade.php`

- **Pipeline order**: Table annotation now runs last (after syntax highlighting and heading annotation) so metadata survives the full diff pipeline

## Implementation Details

- Escaped pipes (`\|`) are correctly handled: they stay within a single cell and count as one character for width calculation
- Tables without a separator row (`| --- |`) are left as plain source (not forced into a grid)
- Mixed diff types (Add/Remove/Context) in the same table group share the same column template for alignment
- Line numbers, types, and other metadata are preserved on rebuilt lines

https://claude.ai/code/session_01Qm7c9HCtQ9PZFJBQdSCWVd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown tables in diffs now display using CSS Grid-based layout for consistent cell alignment across rows and columns.

* **Tests**
  * Updated to validate new table rendering and alignment approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->