### PR TITLE
Fix diff line number contrast by using full muted color

### DIFF
--- a/config/theme.php
+++ b/config/theme.php
@@ -42,9 +42,11 @@ return [
     // Full color values - no opacity modifier needed
     'raw' => [
         'light' => [
-            // Row fills stay light so syntax highlighting reads through; the
-            // change-marker stripe (add-line/del-line) carries the signal at a
-            // confident alpha so adds/dels segment pre-attentively.
+            // Row fills (add-bg/del-bg) stay light so syntax highlighting reads
+            // through. The change-marker (add-line/del-line) is the 2px bar on the
+            // line-number gutter's inner edge (.diff-num-marker) — a confident
+            // saturated color that segments adds/dels pre-attentively without
+            // washing out the digits the way a full-cell fill did.
             'add-bg' => 'rgba(22,163,74,0.10)',
             'add-line' => 'rgba(22,163,74,0.60)',
             'del-bg' => 'rgba(220,38,38,0.10)',

--- a/resources/views/components/diff/line.blade.php
+++ b/resources/views/components/diff/line.blade.php
@@ -14,9 +14,9 @@
     $oldNum = $line['oldLineNum'] ?? null;
     $newNum = $line['newLineNum'] ?? null;
     $lineNum = $newNum ?? $oldNum;
-    [$bgClass, $oldNumBgClass, $newNumBgClass, $prefix, $prefixColor] = match($type) {
-        LineType::Add => ['bg-gh-add-bg', '', 'bg-gh-add-line', '+', 'text-gh-green'],
-        LineType::Remove => ['bg-gh-del-bg', 'bg-gh-del-line', '', '-', 'text-gh-red'],
+    [$bgClass, $oldNumMarker, $newNumMarker, $prefix, $prefixColor] = match($type) {
+        LineType::Add => ['bg-gh-add-bg', '', 'diff-num-marker diff-num-marker-add', '+', 'text-gh-green'],
+        LineType::Remove => ['bg-gh-del-bg', 'diff-num-marker diff-num-marker-del', '', '-', 'text-gh-red'],
         default => ['', '', '', ' ', 'text-gh-muted/30'],
     };
     $lineSide = match($type) {
@@ -48,11 +48,11 @@
     @if($oldNum) data-line-old="{{ $oldNum }}" @endif
     @if($ancestorJs) x-show="!isLineFolded({{ $ancestorJs }})" @endif
 >
-    <div @if($oldNum && ! $newNum) data-testid="diff-line-number" @endif class="diff-cell diff-cell-num diff-cell-num-old {{ $bgClass }} {{ $oldNumBgClass }}"
+    <div @if($oldNum && ! $newNum) data-testid="diff-line-number" @endif class="diff-cell diff-cell-num diff-cell-num-old {{ $bgClass }} {{ $oldNumMarker }}"
         @if($oldNum) @mousedown.prevent="handleLineMousedown({{ $oldNum }}, 'left', $event)" @endif
     >{{ $oldNum ?? '' }}</div>
 
-    <div @if($newNum) data-testid="diff-line-number" @endif class="diff-cell diff-cell-num diff-cell-num-new {{ $bgClass }} {{ $newNumBgClass }}"
+    <div @if($newNum) data-testid="diff-line-number" @endif class="diff-cell diff-cell-num diff-cell-num-new {{ $bgClass }} {{ $newNumMarker }}"
         @if($newNum) @mousedown.prevent="handleLineMousedown({{ $newNum }}, 'right', $event)" @endif
     >{{ $newNum ?? '' }}</div>
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -113,10 +113,29 @@
         .diff-cell-num {
             padding: 0 0.5rem;
             text-align: right;
-            color: rgb(var(--gh-muted) / 0.5);
+            /* Full muted — never an opacity-on-muted, which on the add/del gutter
+               tint compounds to illegibility (see resources/CLAUDE.md). The add/del
+               signal is carried by the .diff-num-marker bar, not a fill behind the
+               digits, so numbers always sit on the faint tint and stay readable. */
+            color: rgb(var(--gh-muted));
             cursor: pointer;
             user-select: none;
         }
+        /* Change-marker: a confident saturated bar on the inner (content-facing)
+           edge of the gutter, replacing the old full-cell stripe that buried the
+           line number under a 0.6-alpha green/red fill. */
+        .diff-num-marker { position: relative; }
+        .diff-num-marker::after {
+            content: "";
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            right: 0;
+            width: 2px;
+            pointer-events: none;
+        }
+        .diff-num-marker-add::after { background: var(--gh-add-line); }
+        .diff-num-marker-del::after { background: var(--gh-del-line); }
         /* Empty num cells (added rows have no old number, deleted rows have no
            new number) have no @mousedown handler — show the default cursor so
            the affordance matches the actual click behavior. */

--- a/tests/Unit/DiffLineNumberContrastTest.php
+++ b/tests/Unit/DiffLineNumberContrastTest.php
@@ -5,6 +5,12 @@ use Tests\TestCase;
 
 uses(TestCase::class);
 
+/** WCAG AA contrast for large/bold text — the floor for numbers on the plain row bg. */
+const CONTRAST_AA_LARGE = 4.5;
+
+/** WCAG floor for UI components / non-text — the floor for numbers on the add/del gutter tint. */
+const CONTRAST_UI_FLOOR = 3.0;
+
 /**
  * Guards diff line-number legibility (see resources/CLAUDE.md "Use real muted
  * color, not opacity"). The original bug rendered line numbers at
@@ -125,18 +131,18 @@ test('line numbers clear the legibility floor on every background', function (st
     $muted = rgbTriple($colors['muted']);
     $bg = rgbTriple($colors['bg']);
 
-    // Context line numbers sit on the plain row background — require AA (4.5:1).
+    // Context line numbers sit on the plain row background — require AA.
     expect(contrastRatio($muted, $bg))
-        ->toBeGreaterThanOrEqual(4.5, "muted on bg ($theme)");
+        ->toBeGreaterThanOrEqual(CONTRAST_AA_LARGE, "muted on bg ($theme)");
 
     // Add/del line numbers sit on the faint add-bg/del-bg tint (the saturated
     // stripe is now a marker bar, not a fill). Colored gutter affordance —
-    // require at least the WCAG UI/large-text floor (3:1), comfortably above
-    // the ~2.4:1 the buried-under-stripe bug produced.
+    // require the WCAG UI floor, comfortably above the ~2.4:1 the
+    // buried-under-stripe bug produced.
     foreach (['add-bg', 'del-bg'] as $token) {
         $tinted = composite(rgbaParts($raw[$token]), $bg);
 
         expect(contrastRatio($muted, $tinted))
-            ->toBeGreaterThanOrEqual(3.0, "muted on $token ($theme)");
+            ->toBeGreaterThanOrEqual(CONTRAST_UI_FLOOR, "muted on $token ($theme)");
     }
 })->with('themes');

--- a/tests/Unit/DiffLineNumberContrastTest.php
+++ b/tests/Unit/DiffLineNumberContrastTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+/**
+ * Guards diff line-number legibility (see resources/CLAUDE.md "Use real muted
+ * color, not opacity"). The original bug rendered line numbers at
+ * `rgb(var(--gh-muted) / 0.5)` and flooded add/del number cells with the
+ * saturated 0.6-alpha gutter stripe, dropping contrast to ~2:1 in both themes.
+ *
+ * These tests pin the fix two ways:
+ *   1. The CSS uses full muted (no opacity divider) for line numbers, and the
+ *      add/del cells no longer carry the full-cell stripe fill.
+ *   2. The computed WCAG contrast of the line-number color against every
+ *      background it actually renders over clears a legibility floor.
+ */
+
+/**
+ * Parse an "R G B" triple (theme.colors) into [r, g, b].
+ *
+ * @return array{0: float, 1: float, 2: float}
+ */
+function rgbTriple(string $value): array
+{
+    [$r, $g, $b] = array_map('floatval', preg_split('/\s+/', trim($value)));
+
+    return [$r, $g, $b];
+}
+
+/**
+ * Parse an "rgba(r,g,b,a)" string (theme.raw) into [r, g, b, a].
+ *
+ * @return array{0: float, 1: float, 2: float, 3: float}
+ */
+function rgbaParts(string $value): array
+{
+    preg_match('/rgba?\(([^)]+)\)/', $value, $m);
+    $parts = array_map('floatval', explode(',', $m[1]));
+
+    return [$parts[0], $parts[1], $parts[2], $parts[3] ?? 1.0];
+}
+
+/**
+ * Composite a translucent foreground over an opaque background (alpha blend).
+ *
+ * @param  array{0: float, 1: float, 2: float, 3: float}  $fg
+ * @param  array{0: float, 1: float, 2: float}  $bg
+ * @return array{0: float, 1: float, 2: float}
+ */
+function composite(array $fg, array $bg): array
+{
+    $a = $fg[3];
+
+    return [
+        $fg[0] * $a + $bg[0] * (1 - $a),
+        $fg[1] * $a + $bg[1] * (1 - $a),
+        $fg[2] * $a + $bg[2] * (1 - $a),
+    ];
+}
+
+/**
+ * WCAG 2.x relative luminance for an [r, g, b] colour (0–255 channels).
+ *
+ * @param  array{0: float, 1: float, 2: float}  $rgb
+ */
+function relativeLuminance(array $rgb): float
+{
+    $channel = function (float $c): float {
+        $c /= 255;
+
+        return $c <= 0.03928 ? $c / 12.92 : (($c + 0.055) / 1.055) ** 2.4;
+    };
+
+    return 0.2126 * $channel($rgb[0]) + 0.7152 * $channel($rgb[1]) + 0.0722 * $channel($rgb[2]);
+}
+
+/**
+ * WCAG contrast ratio between two opaque colours.
+ *
+ * @param  array{0: float, 1: float, 2: float}  $a
+ * @param  array{0: float, 1: float, 2: float}  $b
+ */
+function contrastRatio(array $a, array $b): float
+{
+    $la = relativeLuminance($a);
+    $lb = relativeLuminance($b);
+    [$light, $dark] = [max($la, $lb), min($la, $lb)];
+
+    return ($light + 0.05) / ($dark + 0.05);
+}
+
+test('line numbers use full muted, never opacity-on-muted', function () {
+    $css = file_get_contents(resource_path('views/layouts/app.blade.php'));
+
+    expect($css)->toMatch('/\.diff-cell-num\s*\{[^}]*\}/');
+    preg_match('/\.diff-cell-num\s*\{([^}]*)\}/', $css, $rule);
+    $body = $rule[1];
+
+    // Colour is full muted...
+    expect($body)->toContain('color: rgb(var(--gh-muted))');
+    // ...with no alpha divider that would re-introduce the washed-out bug.
+    expect($body)->not->toMatch('/--gh-muted\)\s*\/\s*[\d.]+/');
+});
+
+test('add/del number cells do not bury the digits under the full-cell stripe', function () {
+    $line = file_get_contents(resource_path('views/components/diff/line.blade.php'));
+
+    // The saturated gutter fill must be a thin marker bar, not a cell background.
+    expect($line)
+        ->not->toContain('bg-gh-add-line')
+        ->not->toContain('bg-gh-del-line')
+        ->toContain('diff-num-marker-add')
+        ->toContain('diff-num-marker-del');
+});
+
+dataset('themes', ['light', 'dark']);
+
+test('line numbers clear the legibility floor on every background', function (string $theme) {
+    $colors = config("theme.colors.$theme");
+    $raw = config("theme.raw.$theme");
+
+    $muted = rgbTriple($colors['muted']);
+    $bg = rgbTriple($colors['bg']);
+
+    // Context line numbers sit on the plain row background — require AA (4.5:1).
+    expect(contrastRatio($muted, $bg))
+        ->toBeGreaterThanOrEqual(4.5, "muted on bg ($theme)");
+
+    // Add/del line numbers sit on the faint add-bg/del-bg tint (the saturated
+    // stripe is now a marker bar, not a fill). Colored gutter affordance —
+    // require at least the WCAG UI/large-text floor (3:1), comfortably above
+    // the ~2.4:1 the buried-under-stripe bug produced.
+    foreach (['add-bg', 'del-bg'] as $token) {
+        $tinted = composite(rgbaParts($raw[$token]), $bg);
+
+        expect(contrastRatio($muted, $tinted))
+            ->toBeGreaterThanOrEqual(3.0, "muted on $token ($theme)");
+    }
+})->with('themes');


### PR DESCRIPTION
## Summary
Fixes a critical accessibility issue where diff line numbers had insufficient contrast against their backgrounds. The original implementation used `rgb(var(--gh-muted) / 0.5)` which, when composited over the saturated add/del gutter stripe, dropped contrast to ~2:1 in both light and dark themes—below WCAG AA standards.

## Changes

- **CSS (`app.blade.php`)**: Changed `.diff-cell-num` color from `rgb(var(--gh-muted) / 0.5)` to `rgb(var(--gh-muted))` (full opacity). Added new `.diff-num-marker` pseudo-element styles that render a thin 2px saturated bar on the inner edge of the gutter instead of a full-cell background fill.

- **Template (`diff/line.blade.php`)**: Replaced `$oldNumBgClass` and `$newNumBgClass` variables with `$oldNumMarker` and `$newNumMarker`. Changed from applying `bg-gh-add-line` / `bg-gh-del-line` background classes to applying `diff-num-marker diff-num-marker-add` / `diff-num-marker diff-num-marker-del` marker classes.

- **Tests (`DiffLineNumberContrastTest.php`)**: Added comprehensive test suite that:
  - Verifies CSS uses full muted color without opacity dividers
  - Confirms add/del cells use marker bars instead of background fills
  - Validates WCAG contrast ratios (4.5:1 on plain backgrounds, 3:1 on tinted backgrounds) across both light and dark themes using actual color compositing

## Implementation Details

The fix separates the visual signal (add/del affordance) from the text legibility concern. The saturated color now appears as a confident marker bar on the content-facing edge of the gutter, while line numbers always render over the faint tint background at full muted opacity. This achieves both accessibility (contrast ≥ 3:1) and visual clarity without compromising the add/del gutter affordance.

https://claude.ai/code/session_01MXmgMYmebVrbj777Bhfzxk