### PR TITLE
Centralize keyboard shortcuts in single config source

### DIFF
--- a/app/Providers/NativeAppServiceProvider.php
+++ b/app/Providers/NativeAppServiceProvider.php
@@ -15,6 +15,7 @@ use App\Listeners\HandleMenuItemClicked;
 use App\Listeners\HandleZoomShortcutPressed;
 use App\Listeners\RegisterNativeGlobalShortcuts;
 use App\Listeners\UnregisterNativeGlobalShortcuts;
+use App\Support\Shortcuts;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Context;
@@ -201,7 +202,7 @@ class NativeAppServiceProvider implements ProvidesPhpIni
             Menu::make(
                 Menu::label('Add Single Repository...')
                     ->id('open-repo')
-                    ->hotkey('CmdOrCtrl+O')
+                    ->hotkey(Shortcuts::accelerator('app.add-repo'))
                     ->icon(resource_path('icons/add-repoTemplate.png')),
                 Menu::label('Scan Folder for Repos...')
                     ->id('scan-directory')
@@ -221,7 +222,7 @@ class NativeAppServiceProvider implements ProvidesPhpIni
             Menu::make(
                 Menu::label('Show Context Files...')
                     ->id('show-context')
-                    ->hotkey('CmdOrCtrl+Shift+K'),
+                    ->hotkey(Shortcuts::accelerator('app.context-files')),
                 Menu::separator(),
                 Menu::label('Actual Size')->id('reset-zoom'),
                 Menu::label('Zoom In')->id('zoom-in'),

--- a/app/Support/Shortcuts.php
+++ b/app/Support/Shortcuts.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Read accessor for the keyboard-shortcut catalog (config/shortcuts.php).
+ *
+ * Shortcut ids contain dots (e.g. `project-picker.toggle`), so `config()`
+ * dot-notation can't reach a single entry — it would read the dot as nesting.
+ * This helper looks entries up by their literal id instead, giving Blade, the
+ * native menu, and the JS bridge one consistent way to read combos and labels.
+ */
+final class Shortcuts
+{
+    /** @return array<string, array<string, mixed>> */
+    public static function all(): array
+    {
+        /** @var array<string, array<string, mixed>> */
+        return config('shortcuts.shortcuts', []);
+    }
+
+    /** @return list<string> */
+    public static function groups(): array
+    {
+        /** @var list<string> */
+        return config('shortcuts.groups', []);
+    }
+
+    /** The match/combo string used by the keymap store (e.g. `⌘K`, `j`). */
+    public static function combo(string $id): string
+    {
+        return (string) self::field($id, 'combo');
+    }
+
+    /** The human-facing combo for the cheat sheet (`display` override, else combo). */
+    public static function display(string $id): string
+    {
+        $entry = self::all()[$id] ?? [];
+
+        return (string) ($entry['display'] ?? $entry['combo'] ?? '');
+    }
+
+    /** The Electron accelerator for natively-owned shortcuts (menu / globalShortcut). */
+    public static function accelerator(string $id): ?string
+    {
+        $value = self::field($id, 'accelerator');
+
+        return $value === null ? null : (string) $value;
+    }
+
+    private static function field(string $id, string $key): mixed
+    {
+        // Ids contain dots, so index by the literal id, then the field — never a
+        // single dotted path, which Arr::get / config would read as nesting.
+        return (self::all()[$id] ?? [])[$key] ?? null;
+    }
+}

--- a/app/Support/Shortcuts.php
+++ b/app/Support/Shortcuts.php
@@ -28,16 +28,10 @@ final class Shortcuts
         return config('shortcuts.groups', []);
     }
 
-    /** The match/combo string used by the keymap store (e.g. `⌘K`, `j`). */
-    public static function combo(string $id): string
-    {
-        return (string) self::field($id, 'combo');
-    }
-
     /** The human-facing combo for the cheat sheet (`display` override, else combo). */
     public static function display(string $id): string
     {
-        $entry = self::all()[$id] ?? [];
+        $entry = self::entry($id);
 
         return (string) ($entry['display'] ?? $entry['combo'] ?? '');
     }
@@ -45,14 +39,14 @@ final class Shortcuts
     /** The Electron accelerator for natively-owned shortcuts (menu / globalShortcut). */
     public static function accelerator(string $id): ?string
     {
-        $value = self::field($id, 'accelerator');
+        $accelerator = self::entry($id)['accelerator'] ?? null;
 
-        return $value === null ? null : (string) $value;
+        return $accelerator === null ? null : (string) $accelerator;
     }
 
-    private static function field(string $id, string $key): mixed
+    /** @return array<string, mixed> */
+    private static function entry(string $id): array
     {
-        // Index by literal [id, key] segments so data_get never splits the dotted id.
-        return data_get(self::all(), [$id, $key]);
+        return self::all()[$id] ?? [];
     }
 }

--- a/app/Support/Shortcuts.php
+++ b/app/Support/Shortcuts.php
@@ -8,9 +8,9 @@ namespace App\Support;
  * Read accessor for the keyboard-shortcut catalog (config/shortcuts.php).
  *
  * Shortcut ids contain dots (e.g. `project-picker.toggle`), so `config()`
- * dot-notation can't reach a single entry — it would read the dot as nesting.
- * This helper looks entries up by their literal id instead, giving Blade, the
- * native menu, and the JS bridge one consistent way to read combos and labels.
+ * dot-notation reads the dot as nesting and can't reach a single entry.
+ * This helper indexes entries by their literal id instead, giving Blade,
+ * the native menu, and the JS bridge one way to read combos and labels.
  */
 final class Shortcuts
 {
@@ -52,8 +52,7 @@ final class Shortcuts
 
     private static function field(string $id, string $key): mixed
     {
-        // Ids contain dots, so index by the literal id, then the field — never a
-        // single dotted path, which Arr::get / config would read as nesting.
-        return (self::all()[$id] ?? [])[$key] ?? null;
+        // Index by literal [id, key] segments so data_get never splits the dotted id.
+        return data_get(self::all(), [$id, $key]);
     }
 }

--- a/config/shortcuts.php
+++ b/config/shortcuts.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Events\HardReloadShortcutPressed;
+use App\Events\RefreshShortcutPressed;
+use App\Events\ZoomShortcutPressed;
+
+/*
+|--------------------------------------------------------------------------
+| Keyboard shortcuts — single source of truth
+|--------------------------------------------------------------------------
+|
+| Every documented shortcut lives here. Three consumers read this catalog so
+| the combo and label are defined exactly once:
+|
+|   1. The Alpine `$store.shortcuts` (public/js/shortcuts-store.js) — call
+|      sites register handlers by `id`, never by a literal combo, e.g.
+|      `$store.shortcuts.register('project-picker.toggle', () => toggle())`.
+|      The combo string and `allowInEditable` flag come from here.
+|   2. The cheat-sheet modal (`<x-shortcuts-help>`), opened with `?`, renders
+|      this catalog grouped by `group`.
+|   3. The native menu (NativeAppServiceProvider) reads `accelerator` for the
+|      menu items it owns. App-level global shortcuts (refresh, zoom) keep
+|      their Electron accelerators on the Event classes; we reference those
+|      constants here so the catalog never drifts from the registry.
+|
+| Combo notation (mac-only):
+|   - `⌘`/`⇧` glyphs = Cmd / Shift modifiers (keymap-store also treats ⌘ as
+|     Ctrl so the browser dev build keeps working off-mac).
+|   - `↵` = Enter/Return.
+|   - A bare character ('j', '/', '[') matches that exact `event.key`. Its
+|     shifted form is written as the produced character: '⇧C' for Shift+C,
+|     '?' for Shift+/. `display` overrides the label shown in the cheat sheet.
+|
+| `wired` documents how the shortcut reaches its handler. `keymap` shortcuts
+| flow through `$store.shortcuts.register`; `native` ones are owned by Electron
+| (menu / globalShortcut) and are documentation-only on the JS side; `custom`
+| ones have a bespoke renderer handler (find-in-page).
+|
+*/
+
+return [
+
+    // Display order of the groups in the cheat sheet.
+    'groups' => ['Navigation', 'Review', 'Editing', 'View', 'Help'],
+
+    'shortcuts' => [
+
+        // -- Navigation --
+        'project-picker.toggle' => [
+            'combo' => '⌘K',
+            'label' => 'Switch repository',
+            'group' => 'Navigation',
+            'allowInEditable' => true,
+            'wired' => 'keymap',
+        ],
+        'comments-drawer.toggle' => [
+            'combo' => '⌘J',
+            'label' => 'Toggle comments',
+            'group' => 'Navigation',
+            'wired' => 'keymap',
+        ],
+        'branch-explorer.toggle' => [
+            'combo' => '⌘B',
+            'label' => 'Switch branch',
+            'group' => 'Navigation',
+            'wired' => 'keymap',
+        ],
+
+        // -- Review --
+        'review.filter' => [
+            'combo' => '/',
+            'label' => 'Focus file filter',
+            'group' => 'Review',
+            'wired' => 'keymap',
+        ],
+        'review.next-file' => [
+            'combo' => 'j',
+            'label' => 'Next file',
+            'group' => 'Review',
+            'wired' => 'keymap',
+        ],
+        'review.prev-file' => [
+            'combo' => 'k',
+            'label' => 'Previous file',
+            'group' => 'Review',
+            'wired' => 'keymap',
+        ],
+        'review.collapse-all' => [
+            'combo' => 'C',
+            'display' => '⇧C',
+            'label' => 'Collapse all files',
+            'group' => 'Review',
+            'wired' => 'keymap',
+        ],
+        'review.expand-all' => [
+            'combo' => 'E',
+            'display' => '⇧E',
+            'label' => 'Expand all files',
+            'group' => 'Review',
+            'wired' => 'keymap',
+        ],
+        'review.prev-commit' => [
+            'combo' => '[',
+            'label' => 'Previous commit',
+            'group' => 'Review',
+            'wired' => 'keymap',
+        ],
+        'review.next-commit' => [
+            'combo' => ']',
+            'label' => 'Next commit',
+            'group' => 'Review',
+            'wired' => 'keymap',
+        ],
+
+        // -- Editing --
+        'comment.save' => [
+            'combo' => '⌘↵',
+            'label' => 'Save comment',
+            'group' => 'Editing',
+            'allowInEditable' => true,
+            'wired' => 'keymap',
+        ],
+        'review.undo' => [
+            'combo' => '⌘Z',
+            'label' => 'Undo last action',
+            'group' => 'Editing',
+            'wired' => 'keymap',
+        ],
+
+        // -- View / App --
+        'app.refresh' => [
+            'combo' => '⌘R',
+            'label' => 'Refresh',
+            'group' => 'View',
+            'allowInEditable' => true,
+            'accelerator' => RefreshShortcutPressed::KEY,
+            'wired' => 'keymap',
+        ],
+        'app.hard-reload' => [
+            'combo' => '⌘⇧R',
+            'label' => 'Hard reload',
+            'group' => 'View',
+            'allowInEditable' => true,
+            'accelerator' => HardReloadShortcutPressed::KEY,
+            'wired' => 'keymap',
+        ],
+        'app.find' => [
+            'combo' => '⌘F',
+            'label' => 'Find in page',
+            'group' => 'View',
+            'wired' => 'custom',
+        ],
+        'app.zoom-in' => [
+            'combo' => '⌘+',
+            'label' => 'Zoom in',
+            'group' => 'View',
+            'accelerator' => ZoomShortcutPressed::ZOOM_IN,
+            'wired' => 'native',
+        ],
+        'app.zoom-out' => [
+            'combo' => '⌘-',
+            'label' => 'Zoom out',
+            'group' => 'View',
+            'accelerator' => ZoomShortcutPressed::ZOOM_OUT,
+            'wired' => 'native',
+        ],
+        'app.zoom-reset' => [
+            'combo' => '⌘0',
+            'label' => 'Reset zoom',
+            'group' => 'View',
+            'accelerator' => ZoomShortcutPressed::RESET,
+            'wired' => 'native',
+        ],
+        'app.add-repo' => [
+            'combo' => '⌘O',
+            'label' => 'Add repository',
+            'group' => 'View',
+            'accelerator' => 'CmdOrCtrl+O',
+            'wired' => 'native',
+        ],
+        'app.context-files' => [
+            'combo' => '⌘⇧K',
+            'label' => 'Show context files',
+            'group' => 'View',
+            'accelerator' => 'CmdOrCtrl+Shift+K',
+            'wired' => 'native',
+        ],
+
+        // -- Help --
+        'help.shortcuts' => [
+            'combo' => '?',
+            'label' => 'Show keyboard shortcuts',
+            'group' => 'Help',
+            'wired' => 'keymap',
+        ],
+    ],
+];

--- a/config/shortcuts.php
+++ b/config/shortcuts.php
@@ -8,13 +8,13 @@ use App\Events\ZoomShortcutPressed;
 
 /*
 |--------------------------------------------------------------------------
-| Keyboard shortcuts — single source of truth
+| Keyboard shortcuts: single source of truth
 |--------------------------------------------------------------------------
 |
 | Every documented shortcut lives here. Three consumers read this catalog so
 | the combo and label are defined exactly once:
 |
-|   1. The Alpine `$store.shortcuts` (public/js/shortcuts-store.js) — call
+|   1. The Alpine `$store.shortcuts` (public/js/shortcuts-store.js). Call
 |      sites register handlers by `id`, never by a literal combo, e.g.
 |      `$store.shortcuts.register('project-picker.toggle', () => toggle())`.
 |      The combo string and `allowInEditable` flag come from here.
@@ -22,7 +22,7 @@ use App\Events\ZoomShortcutPressed;
 |      this catalog grouped by `group`.
 |   3. The native menu (NativeAppServiceProvider) reads `accelerator` for the
 |      menu items it owns. App-level global shortcuts (refresh, zoom) keep
-|      their Electron accelerators on the Event classes; we reference those
+|      their Electron accelerators on the Event classes. We reference those
 |      constants here so the catalog never drifts from the registry.
 |
 | Combo notation (mac-only):
@@ -34,8 +34,8 @@ use App\Events\ZoomShortcutPressed;
 |     '?' for Shift+/. `display` overrides the label shown in the cheat sheet.
 |
 | `wired` documents how the shortcut reaches its handler. `keymap` shortcuts
-| flow through `$store.shortcuts.register`; `native` ones are owned by Electron
-| (menu / globalShortcut) and are documentation-only on the JS side; `custom`
+| flow through `$store.shortcuts.register`. `native` ones are owned by Electron
+| (menu or globalShortcut) and are documentation-only on the JS side. `custom`
 | ones have a bespoke renderer handler (find-in-page).
 |
 */

--- a/public/js/keymap-store.js
+++ b/public/js/keymap-store.js
@@ -19,20 +19,39 @@
         api.autoInstall(root);
     }
 })(typeof window !== 'undefined' ? window : null, function () {
+    // Glyphs in a combo that don't equal their KeyboardEvent.key spelling.
+    const GLYPH_KEYS = { '↵': 'enter' };
+
     /**
-     * @param {string} combo       e.g. '⌘K' (also matches Ctrl on non-mac)
+     * @param {string} stripped  combo with modifier glyphs removed
+     * @returns {string}
+     */
+    function comboKey(stripped) {
+        return GLYPH_KEYS[stripped] ?? stripped;
+    }
+
+    /**
+     * @param {string} combo       e.g. '⌘K', '⌘↵', or a bare key like 'j' / '⇧C' / '?'
      * @param {KeyboardEvent|{key: string, metaKey?: boolean, ctrlKey?: boolean, shiftKey?: boolean, altKey?: boolean}} e
      * @returns {boolean}
      */
     function matches(combo, e) {
-        const wantCmd = combo.includes('⌘');
-        const wantShift = combo.includes('⇧');
-        const hasCmd = e.metaKey || e.ctrlKey;
-        if (wantCmd !== hasCmd) return false;
-        if (wantShift !== e.shiftKey) return false;
         if (e.altKey) return false;
-        const key = combo.replace(/[⌘⇧]/g, '').toLowerCase();
-        return e.key.toLowerCase() === key;
+        const hasCmd = e.metaKey || e.ctrlKey;
+
+        if (combo.includes('⌘')) {
+            // Cmd combo: explicit ⌘/⇧ requirements, base key matched case-insensitively.
+            if (!hasCmd) return false;
+            if (combo.includes('⇧') !== e.shiftKey) return false;
+            const key = comboKey(combo.replace(/[⌘⇧]/g, '')).toLowerCase();
+            return e.key.toLowerCase() === key;
+        }
+
+        // Bare-character combo: no command modifier. The character itself —
+        // including its shifted form ('C' from Shift+C, '?' from Shift+/) — is
+        // matched case-sensitively, so the shift state is encoded by the glyph.
+        if (hasCmd) return false;
+        return e.key === comboKey(combo);
     }
 
     /**

--- a/public/js/keymap-store.js
+++ b/public/js/keymap-store.js
@@ -47,9 +47,9 @@
             return e.key.toLowerCase() === key;
         }
 
-        // Bare-character combo: no command modifier. The character itself —
-        // including its shifted form ('C' from Shift+C, '?' from Shift+/) — is
-        // matched case-sensitively, so the shift state is encoded by the glyph.
+        // Bare-character combo: no command modifier. The character itself
+        // (including its shifted form, 'C' from Shift+C or '?' from Shift+/)
+        // is matched case-sensitively, so the glyph encodes the shift state.
         if (hasCmd) return false;
         return e.key === comboKey(combo);
     }

--- a/public/js/review-page.js
+++ b/public/js/review-page.js
@@ -108,15 +108,15 @@
                 this.pendingSavesGuard?.attach();
                 this.registerShortcuts();
             },
-            // Page-scoped review shortcuts. Registered by catalog id (combos live
-            // in config/shortcuts.php); cleared on navigate by the keymap store and
-            // re-registered when the next review page mounts.
+            // Page-scoped review shortcuts, registered by catalog id (combos live
+            // in config/shortcuts.php). The keymap store clears them on navigate
+            // and they re-register when the next review page mounts.
             registerShortcuts() {
                 const reg = (id, handler) => {
                     this.$store.shortcuts.register(id, handler);
                     this.registeredShortcutIds.push(id);
                 };
-                const commitUrl = (hash) => '/p/' + this.config.projectSlug + '/c/' + hash;
+                const commitUrl = (hash) => `/p/${this.config.projectSlug}/c/${hash}`;
 
                 reg('review.filter', () => this.$refs.fileFilterInput?.focus());
                 reg('review.next-file', () => this.focusAdjacentFile(1));

--- a/public/js/review-page.js
+++ b/public/js/review-page.js
@@ -105,6 +105,33 @@
                 });
 
                 this.pendingSavesGuard?.attach();
+                this.registerShortcuts();
+            },
+            // Page-scoped review shortcuts. Registered by catalog id (combos live
+            // in config/shortcuts.php); cleared on navigate by the keymap store and
+            // re-registered when the next review page mounts.
+            registerShortcuts() {
+                const s = this.$store.shortcuts;
+                s.register('review.filter', () => this.$refs.fileFilterInput?.focus());
+                s.register('review.next-file', () => this.focusAdjacentFile(1));
+                s.register('review.prev-file', () => this.focusAdjacentFile(-1));
+                s.register('review.collapse-all', () => {
+                    this.$store.settings.collapseAll = true;
+                    this.$dispatch('collapse-all-files');
+                });
+                s.register('review.expand-all', () => {
+                    this.$store.settings.collapseAll = false;
+                    this.$dispatch('expand-all-files');
+                });
+                if (this.config.prevCommitHash) {
+                    s.register('review.prev-commit', () => Livewire.navigate(this.commitUrl(this.config.prevCommitHash)));
+                }
+                if (this.config.nextCommitHash) {
+                    s.register('review.next-commit', () => Livewire.navigate(this.commitUrl(this.config.nextCommitHash)));
+                }
+            },
+            commitUrl(hash) {
+                return '/p/' + this.config.projectSlug + '/c/' + hash;
             },
             jsonData(name, fallback) {
                 try {
@@ -235,6 +262,9 @@
                 this.pendingSavesGuard?.detach();
                 this.pendingSavesGuard = null;
                 clearTimeout(this.commentScrollPollId);
+                ['review.filter', 'review.next-file', 'review.prev-file', 'review.collapse-all',
+                    'review.expand-all', 'review.prev-commit', 'review.next-commit']
+                    .forEach((id) => this.$store.shortcuts.unregister(id));
             },
         };
     }
@@ -271,7 +301,9 @@
             softRefresh() { this.$wire.softRefresh(); },
             hardReload() { window.location.reload(); },
             get tooltip() {
-                if (!this.hasChanges) return 'Refresh · ⌘R · ⌘⇧R to hard reload';
+                if (!this.hasChanges) {
+                    return `Refresh · ${config.refreshCombo} · ${config.hardReloadCombo} to hard reload`;
+                }
                 const n = this.currentCount;
                 const noun = n === 1 ? 'file' : 'files';
                 return `${n} ${noun} changed externally - click to refresh`;
@@ -286,8 +318,8 @@
                 });
                 // Browser build only: the native build routes ⌘R through its menu.
                 if (config.keymapEnabled) {
-                    this.$store.keymap.register('⌘R', () => this.softRefresh(), { allowInEditable: true });
-                    this.$store.keymap.register('⌘⇧R', () => this.hardReload(), { allowInEditable: true });
+                    this.$store.shortcuts.register('app.refresh', () => this.softRefresh());
+                    this.$store.shortcuts.register('app.hard-reload', () => this.hardReload());
                 }
             },
             destroy() {
@@ -297,8 +329,8 @@
                 // dead component. The keymap store is keyed by combo, so this
                 // also keeps a remount from re-binding a stale handler.
                 if (config.keymapEnabled) {
-                    this.$store.keymap.unregister('⌘R');
-                    this.$store.keymap.unregister('⌘⇧R');
+                    this.$store.shortcuts.unregister('app.refresh');
+                    this.$store.shortcuts.unregister('app.hard-reload');
                 }
             },
         };

--- a/public/js/review-page.js
+++ b/public/js/review-page.js
@@ -96,6 +96,7 @@
             repoPath: config.repoPath ?? '',
             remoteMenu: { open: false, x: 0, y: 0, projectSlug: '', type: '', params: {}, label: '', disabled: false, disabledReason: '' },
             commentScrollPollId: null,
+            registeredShortcutIds: [],
             init() {
                 this.pendingSavesGuard = window.rfaPendingSaves?.createPendingSavesGuard({
                     root: window,
@@ -111,27 +112,29 @@
             // in config/shortcuts.php); cleared on navigate by the keymap store and
             // re-registered when the next review page mounts.
             registerShortcuts() {
-                const s = this.$store.shortcuts;
-                s.register('review.filter', () => this.$refs.fileFilterInput?.focus());
-                s.register('review.next-file', () => this.focusAdjacentFile(1));
-                s.register('review.prev-file', () => this.focusAdjacentFile(-1));
-                s.register('review.collapse-all', () => {
+                const reg = (id, handler) => {
+                    this.$store.shortcuts.register(id, handler);
+                    this.registeredShortcutIds.push(id);
+                };
+                const commitUrl = (hash) => '/p/' + this.config.projectSlug + '/c/' + hash;
+
+                reg('review.filter', () => this.$refs.fileFilterInput?.focus());
+                reg('review.next-file', () => this.focusAdjacentFile(1));
+                reg('review.prev-file', () => this.focusAdjacentFile(-1));
+                reg('review.collapse-all', () => {
                     this.$store.settings.collapseAll = true;
                     this.$dispatch('collapse-all-files');
                 });
-                s.register('review.expand-all', () => {
+                reg('review.expand-all', () => {
                     this.$store.settings.collapseAll = false;
                     this.$dispatch('expand-all-files');
                 });
                 if (this.config.prevCommitHash) {
-                    s.register('review.prev-commit', () => Livewire.navigate(this.commitUrl(this.config.prevCommitHash)));
+                    reg('review.prev-commit', () => Livewire.navigate(commitUrl(this.config.prevCommitHash)));
                 }
                 if (this.config.nextCommitHash) {
-                    s.register('review.next-commit', () => Livewire.navigate(this.commitUrl(this.config.nextCommitHash)));
+                    reg('review.next-commit', () => Livewire.navigate(commitUrl(this.config.nextCommitHash)));
                 }
-            },
-            commitUrl(hash) {
-                return '/p/' + this.config.projectSlug + '/c/' + hash;
             },
             jsonData(name, fallback) {
                 try {
@@ -262,9 +265,7 @@
                 this.pendingSavesGuard?.detach();
                 this.pendingSavesGuard = null;
                 clearTimeout(this.commentScrollPollId);
-                ['review.filter', 'review.next-file', 'review.prev-file', 'review.collapse-all',
-                    'review.expand-all', 'review.prev-commit', 'review.next-commit']
-                    .forEach((id) => this.$store.shortcuts.unregister(id));
+                this.registeredShortcutIds.forEach((id) => this.$store.shortcuts.unregister(id));
             },
         };
     }

--- a/public/js/shortcuts-store.js
+++ b/public/js/shortcuts-store.js
@@ -1,0 +1,81 @@
+// Keyboard-shortcut catalog bridge. The combo strings and labels are defined
+// once in PHP (config/shortcuts.php) and injected onto `window.RFA_SHORTCUTS`
+// by the layout. This store exposes them to Alpine so call sites register
+// handlers by stable `id` — never by a hard-coded combo:
+//
+//   $store.shortcuts.register('project-picker.toggle', () => toggle())
+//
+// `register`/`unregister` delegate to `$store.keymap`, pulling the combo and
+// the `allowInEditable` flag from the catalog. That keeps the keyboard wiring
+// and the discoverable cheat sheet reading from a single source, so a combo
+// can't drift between where it fires and where it's documented.
+(function (root, factory) {
+    const api = factory();
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    } else if (root) {
+        root.shortcutsStore = api;
+        api.autoInstall(root);
+    }
+})(typeof window !== 'undefined' ? window : null, function () {
+    /**
+     * @param {object} map  catalog keyed by id (shape of config('shortcuts.shortcuts'))
+     * @param {object} keymap  the `$store.keymap` instance to delegate to
+     */
+    function createStore(map, keymap) {
+        return {
+            map,
+            /**
+             * @param {string} id       catalog id, e.g. 'review.next-file'
+             * @param {Function} handler  receives the KeyboardEvent
+             */
+            register(id, handler) {
+                const entry = this.map[id];
+                if (!entry) {
+                    console.warn(`[shortcuts] unknown id "${id}" — not registered`);
+                    return;
+                }
+                keymap().register(entry.combo, handler, { allowInEditable: !!entry.allowInEditable });
+            },
+            unregister(id) {
+                const entry = this.map[id];
+                if (entry) {
+                    keymap().unregister(entry.combo);
+                }
+            },
+            /** The match/combo string for keymap-store (e.g. '⌘K', 'j'). */
+            combo(id) {
+                return this.map[id]?.combo ?? '';
+            },
+            /** The human-facing combo (e.g. '⇧C'), falling back to the combo. */
+            display(id) {
+                return this.map[id]?.display ?? this.map[id]?.combo ?? '';
+            },
+        };
+    }
+
+    function install(root) {
+        if (typeof root.Alpine === 'undefined' || root.__shortcutsAttached) {
+            return false;
+        }
+        root.__shortcutsAttached = true;
+
+        const map = root.RFA_SHORTCUTS || {};
+        root.Alpine.store(
+            'shortcuts',
+            createStore(map, () => root.Alpine.store('keymap')),
+        );
+
+        return true;
+    }
+
+    function autoInstall(root) {
+        if (root.Alpine) {
+            install(root);
+        } else {
+            root.document.addEventListener('alpine:init', () => install(root));
+        }
+    }
+
+    return { createStore, install, autoInstall };
+});

--- a/public/js/shortcuts-store.js
+++ b/public/js/shortcuts-store.js
@@ -43,14 +43,6 @@
                     keymap().unregister(entry.combo);
                 }
             },
-            /** The match/combo string for keymap-store (e.g. '⌘K', 'j'). */
-            combo(id) {
-                return this.map[id]?.combo ?? '';
-            },
-            /** The human-facing combo (e.g. '⇧C'), falling back to the combo. */
-            display(id) {
-                return this.map[id]?.display ?? this.map[id]?.combo ?? '';
-            },
         };
     }
 

--- a/public/js/shortcuts-store.js
+++ b/public/js/shortcuts-store.js
@@ -1,7 +1,7 @@
 // Keyboard-shortcut catalog bridge. The combo strings and labels are defined
 // once in PHP (config/shortcuts.php) and injected onto `window.RFA_SHORTCUTS`
 // by the layout. This store exposes them to Alpine so call sites register
-// handlers by stable `id` — never by a hard-coded combo:
+// handlers by a stable `id`, never a hard-coded combo:
 //
 //   $store.shortcuts.register('project-picker.toggle', () => toggle())
 //
@@ -32,7 +32,7 @@
             register(id, handler) {
                 const entry = this.map[id];
                 if (!entry) {
-                    console.warn(`[shortcuts] unknown id "${id}" — not registered`);
+                    console.warn(`[shortcuts] unknown id "${id}", not registered`);
                     return;
                 }
                 keymap().register(entry.combo, handler, { allowInEditable: !!entry.allowInEditable });

--- a/resources/views/components/comment-form.blade.php
+++ b/resources/views/components/comment-form.blade.php
@@ -1,18 +1,7 @@
 {{-- Parent Alpine scope contract: formBody, escHint, handleEscape(), cancelForm(), commentInput (x-ref) --}}
 @props(['save', 'placeholder' => 'Write a comment...', 'borderClass' => 'border-y'])
 
-{{-- ⌘↵ saves the comment form holding focus. Registered here (not globally) so
-     the shortcut's owner is the thing it acts on; the generic focus-routing
-     handler tolerates multiple open forms (Map-keyed by combo). --}}
-<flux:card
-    size="sm"
-    class="!rounded-none {{ $borderClass }} border-gh-border"
-    data-comment-form
-    x-init="$store.shortcuts.register('comment.save', (e) => {
-        const form = e.target.closest('[data-comment-form]');
-        if (form) form.querySelector('[data-comment-save]')?.click();
-    })"
->
+<flux:card size="sm" class="!rounded-none {{ $borderClass }} border-gh-border" data-comment-form>
     {{-- ⌘↵ to save is registered globally (config: comment.save) and routed to
          the focused form's save button; Esc-to-draft stays element-local. --}}
     <flux:textarea

--- a/resources/views/components/comment-form.blade.php
+++ b/resources/views/components/comment-form.blade.php
@@ -3,7 +3,7 @@
 
 <flux:card size="sm" class="!rounded-none {{ $borderClass }} border-gh-border" data-comment-form>
     {{-- ⌘↵ to save is registered globally (config: comment.save) and routed to
-         the focused form's save button; Esc-to-draft stays element-local. --}}
+         the focused form's save button. Esc-to-draft stays element-local. --}}
     <flux:textarea
         x-ref="commentInput"
         x-model="formBody"

--- a/resources/views/components/comment-form.blade.php
+++ b/resources/views/components/comment-form.blade.php
@@ -1,7 +1,18 @@
 {{-- Parent Alpine scope contract: formBody, escHint, handleEscape(), cancelForm(), commentInput (x-ref) --}}
 @props(['save', 'placeholder' => 'Write a comment...', 'borderClass' => 'border-y'])
 
-<flux:card size="sm" class="!rounded-none {{ $borderClass }} border-gh-border" data-comment-form>
+{{-- ⌘↵ saves the comment form holding focus. Registered here (not globally) so
+     the shortcut's owner is the thing it acts on; the generic focus-routing
+     handler tolerates multiple open forms (Map-keyed by combo). --}}
+<flux:card
+    size="sm"
+    class="!rounded-none {{ $borderClass }} border-gh-border"
+    data-comment-form
+    x-init="$store.shortcuts.register('comment.save', (e) => {
+        const form = e.target.closest('[data-comment-form]');
+        if (form) form.querySelector('[data-comment-save]')?.click();
+    })"
+>
     {{-- ⌘↵ to save is registered globally (config: comment.save) and routed to
          the focused form's save button; Esc-to-draft stays element-local. --}}
     <flux:textarea

--- a/resources/views/components/comment-form.blade.php
+++ b/resources/views/components/comment-form.blade.php
@@ -2,13 +2,13 @@
 @props(['save', 'placeholder' => 'Write a comment...', 'borderClass' => 'border-y'])
 
 <flux:card size="sm" class="!rounded-none {{ $borderClass }} border-gh-border" data-comment-form>
+    {{-- ⌘↵ to save is registered globally (config: comment.save) and routed to
+         the focused form's save button; Esc-to-draft stays element-local. --}}
     <flux:textarea
         x-ref="commentInput"
         x-model="formBody"
-        x-on:keydown.meta.enter="{{ $save }}()"
-        x-on:keydown.ctrl.enter="{{ $save }}()"
         x-on:keydown.escape.stop="handleEscape()"
-        placeholder="{{ $placeholder }} (Cmd/Ctrl+Enter to save, Esc to cancel)"
+        placeholder="{{ $placeholder }} ({{ \App\Support\Shortcuts::display('comment.save') }} to save, Esc to cancel)"
         rows="auto"
         resize="none"
         class="font-mono text-xs"
@@ -16,6 +16,6 @@
     <div x-show="escHint" x-cloak class="text-xs text-gh-muted mt-1" data-testid="esc-hint">Press Esc again to save as draft</div>
     <div class="flex justify-end gap-2 mt-2">
         <flux:button variant="ghost" size="sm" x-on:click="cancelForm()">Cancel</flux:button>
-        <flux:button variant="primary" size="sm" x-on:click="{{ $save }}()" x-bind:disabled="!formBody.trim()">Save</flux:button>
+        <flux:button variant="primary" size="sm" data-comment-save x-on:click="{{ $save }}()" x-bind:disabled="!formBody.trim()">Save</flux:button>
     </div>
 </flux:card>

--- a/resources/views/components/shortcuts-help.blade.php
+++ b/resources/views/components/shortcuts-help.blade.php
@@ -12,19 +12,29 @@
         ->sortBy(fn ($_, $group) => $groupIndex[$group] ?? PHP_INT_MAX);
 @endphp
 
+{{-- This component lives in the persistent layout chrome, so its x-init runs
+     once and is NOT re-run when Livewire morphs the body on navigation. The
+     keymap store clears every binding on `livewire:navigating`, so these global
+     shortcuts must be re-registered on `livewire:navigated` or they go dead
+     after the first SPA navigation. Page/Livewire-scoped registrants re-init
+     naturally; these layout-level ones don't. --}}
 <div
-    x-data
-    x-init="
-        $store.shortcuts.register('help.shortcuts', () => $flux.modal('keyboard-shortcuts').show());
-        {{-- ⌘↵ save is registered globally here, not on <x-comment-form>: that
-             component renders once per diff line, so registering there is
-             O(lines) of render + binding churn (measurably regresses diff-large).
-             One global handler routes to whichever comment form holds focus. --}}
-        $store.shortcuts.register('comment.save', (e) => {
-            const form = e.target.closest('[data-comment-form]');
-            if (form) form.querySelector('[data-comment-save]')?.click();
-        });
-    "
+    x-data="{
+        registerGlobalShortcuts() {
+            $store.shortcuts.register('help.shortcuts', () => $flux.modal('keyboard-shortcuts').show());
+            {{-- ⌘↵ save is registered globally here, not on <x-comment-form>: that
+                 component renders once per diff line, so registering there is
+                 O(lines) of render + binding churn (measurably regresses diff-large).
+                 One global handler routes to whichever comment form holds focus. --}}
+            $store.shortcuts.register('comment.save', (e) => {
+                const form = e.target.closest('[data-comment-form]');
+                if (form) form.querySelector('[data-comment-save]')?.click();
+            });
+        },
+    }"
+    x-init="registerGlobalShortcuts()"
+    {{-- x-on: form, not @livewire — the @ collides with Blade's @livewire directive. --}}
+    x-on:livewire:navigated.window="registerGlobalShortcuts()"
 >
     <flux:modal name="keyboard-shortcuts" class="md:w-[32rem]">
         <div class="space-y-6">

--- a/resources/views/components/shortcuts-help.blade.php
+++ b/resources/views/components/shortcuts-help.blade.php
@@ -1,9 +1,9 @@
 @php
     /**
-     * Cheat sheet for every documented keyboard shortcut. Rendered once from the
-     * layout. Content is driven entirely by config/shortcuts.php — the same
-     * catalog the handlers register against — so it can never list a combo that
-     * doesn't fire, or miss one that does.
+     * Cheat sheet for every documented keyboard shortcut, rendered once from
+     * the layout. The content comes entirely from config/shortcuts.php (the
+     * same catalog the handlers register against), so it can never list a
+     * combo that doesn't fire or miss one that does.
      */
     $catalog = collect(\App\Support\Shortcuts::all());
     $groupIndex = array_flip(\App\Support\Shortcuts::groups());
@@ -13,19 +13,17 @@
 @endphp
 
 {{-- This component lives in the persistent layout chrome, so its x-init runs
-     once and is NOT re-run when Livewire morphs the body on navigation. The
-     keymap store clears every binding on `livewire:navigating`, so these global
-     shortcuts must be re-registered on `livewire:navigated` or they go dead
-     after the first SPA navigation. Page/Livewire-scoped registrants re-init
-     naturally; these layout-level ones don't. --}}
+     once and does not re-run when Livewire morphs the body on navigation.
+     The keymap store clears every binding on `livewire:navigating`, so the
+     global shortcuts re-register on `livewire:navigated`. Page and Livewire
+     scoped registrants re-init on navigation on their own. --}}
 <div
     x-data="{
         registerGlobalShortcuts() {
             $store.shortcuts.register('help.shortcuts', () => $flux.modal('keyboard-shortcuts').show());
-            {{-- ⌘↵ save is registered globally here, not on <x-comment-form>: that
-                 component renders once per diff line, so registering there is
-                 O(lines) of render + binding churn (measurably regresses diff-large).
-                 One global handler routes to whichever comment form holds focus. --}}
+            {{-- One global ⌘↵ handler routes to the comment form that holds focus.
+                 The form renders once per diff line, so binding the handler on
+                 each form would cost O(lines) of registration churn on large diffs. --}}
             $store.shortcuts.register('comment.save', (e) => {
                 const form = e.target.closest('[data-comment-form]');
                 if (form) form.querySelector('[data-comment-save]')?.click();
@@ -33,7 +31,8 @@
         },
     }"
     x-init="registerGlobalShortcuts()"
-    {{-- x-on: form, not @livewire — the @ collides with Blade's @livewire directive. --}}
+    {{-- The @ in `@livewire:navigated.window` collides with Blade's @livewire
+         directive, so this uses the x-on: form. --}}
     x-on:livewire:navigated.window="registerGlobalShortcuts()"
 >
     <flux:modal name="keyboard-shortcuts" class="md:w-[32rem]">

--- a/resources/views/components/shortcuts-help.blade.php
+++ b/resources/views/components/shortcuts-help.blade.php
@@ -6,24 +6,15 @@
      * doesn't fire, or miss one that does.
      */
     $catalog = collect(\App\Support\Shortcuts::all());
-    $groupOrder = \App\Support\Shortcuts::groups();
+    $groupIndex = array_flip(\App\Support\Shortcuts::groups());
     $grouped = $catalog
         ->groupBy('group')
-        ->sortBy(fn ($_, $group) => array_search($group, $groupOrder, true) === false
-            ? PHP_INT_MAX
-            : array_search($group, $groupOrder, true));
+        ->sortBy(fn ($_, $group) => $groupIndex[$group] ?? PHP_INT_MAX);
 @endphp
 
 <div
     x-data
-    x-init="
-        $store.shortcuts.register('help.shortcuts', () => $flux.modal('keyboard-shortcuts').show());
-        {{-- Global save: route ⌘↵ to the comment form holding focus. --}}
-        $store.shortcuts.register('comment.save', (e) => {
-            const form = e.target.closest('[data-comment-form]');
-            if (form) form.querySelector('[data-comment-save]')?.click();
-        });
-    "
+    x-init="$store.shortcuts.register('help.shortcuts', () => $flux.modal('keyboard-shortcuts').show())"
 >
     <flux:modal name="keyboard-shortcuts" class="md:w-[32rem]">
         <div class="space-y-6">

--- a/resources/views/components/shortcuts-help.blade.php
+++ b/resources/views/components/shortcuts-help.blade.php
@@ -1,0 +1,50 @@
+@php
+    /**
+     * Cheat sheet for every documented keyboard shortcut. Rendered once from the
+     * layout. Content is driven entirely by config/shortcuts.php — the same
+     * catalog the handlers register against — so it can never list a combo that
+     * doesn't fire, or miss one that does.
+     */
+    $catalog = collect(\App\Support\Shortcuts::all());
+    $groupOrder = \App\Support\Shortcuts::groups();
+    $grouped = $catalog
+        ->groupBy('group')
+        ->sortBy(fn ($_, $group) => array_search($group, $groupOrder, true) === false
+            ? PHP_INT_MAX
+            : array_search($group, $groupOrder, true));
+@endphp
+
+<div
+    x-data
+    x-init="
+        $store.shortcuts.register('help.shortcuts', () => $flux.modal('keyboard-shortcuts').show());
+        {{-- Global save: route ⌘↵ to the comment form holding focus. --}}
+        $store.shortcuts.register('comment.save', (e) => {
+            const form = e.target.closest('[data-comment-form]');
+            if (form) form.querySelector('[data-comment-save]')?.click();
+        });
+    "
+>
+    <flux:modal name="keyboard-shortcuts" class="md:w-[32rem]">
+        <div class="space-y-6">
+            <div>
+                <flux:heading size="lg">Keyboard shortcuts</flux:heading>
+                <flux:subheading>Press <kbd class="font-mono">?</kbd> any time to open this list.</flux:subheading>
+            </div>
+
+            @foreach($grouped as $group => $shortcuts)
+                <div class="space-y-1.5">
+                    <p class="section-label text-gh-muted">{{ $group }}</p>
+                    <div class="divide-y divide-gh-border/60">
+                        @foreach($shortcuts as $shortcut)
+                            <div class="flex items-center justify-between gap-4 py-1.5">
+                                <span class="text-sm text-gh-text">{{ $shortcut['label'] }}</span>
+                                <kbd class="shrink-0 font-mono text-xs px-2 py-0.5 rounded border border-gh-border bg-gh-surface text-gh-muted">{{ $shortcut['display'] ?? $shortcut['combo'] }}</kbd>
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    </flux:modal>
+</div>

--- a/resources/views/components/shortcuts-help.blade.php
+++ b/resources/views/components/shortcuts-help.blade.php
@@ -14,7 +14,17 @@
 
 <div
     x-data
-    x-init="$store.shortcuts.register('help.shortcuts', () => $flux.modal('keyboard-shortcuts').show())"
+    x-init="
+        $store.shortcuts.register('help.shortcuts', () => $flux.modal('keyboard-shortcuts').show());
+        {{-- ⌘↵ save is registered globally here, not on <x-comment-form>: that
+             component renders once per diff line, so registering there is
+             O(lines) of render + binding churn (measurably regresses diff-large).
+             One global handler routes to whichever comment form holds focus. --}}
+        $store.shortcuts.register('comment.save', (e) => {
+            const form = e.target.closest('[data-comment-form]');
+            if (form) form.querySelector('[data-comment-save]')?.click();
+        });
+    "
 >
     <flux:modal name="keyboard-shortcuts" class="md:w-[32rem]">
         <div class="space-y-6">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -16,10 +16,16 @@
             processSampleIntervalMs: @js((int) config('rfa.diagnostics.process_sample_interval_ms')),
         };
     </script>
+    <script>
+        // Single source of truth for keyboard shortcuts (config/shortcuts.php).
+        // shortcuts-store.js reads this to wire handlers and the cheat sheet.
+        window.RFA_SHORTCUTS = @js(\App\Support\Shortcuts::all());
+    </script>
     @localScript('js/runtime-diagnostics.js')
     @localScript('js/settings-store.js')
     @localScript('js/overlays-store.js')
     @localScript('js/keymap-store.js')
+    @localScript('js/shortcuts-store.js')
     @localScript('js/page-search.js')
     @localScript('js/session-recovery.js')
     @localScript('js/smart-poll.js')
@@ -323,6 +329,8 @@
             </svg>
         </button>
     </div>
+
+    <x-shortcuts-help />
 
     <livewire:keepalive />
     {{-- Single defined home for Flux toasts (bottom-right), clear of the undo-toast

--- a/resources/views/livewire/undo-toast.blade.php
+++ b/resources/views/livewire/undo-toast.blade.php
@@ -61,14 +61,19 @@
         stopTicker() {
             if (this.intervalId) { clearInterval(this.intervalId); this.intervalId = null; }
         },
-        destroy() { this.stopTicker(); }
+        init() {
+            // allowInEditable is false in the catalog, so the keymap store already
+            // suppresses ⌘Z while focus is in a textarea/input.
+            this.$store.shortcuts.register('review.undo', () => {
+                if (this.visible && this.current) this.undo();
+            });
+        },
+        destroy() {
+            this.stopTicker();
+            this.$store.shortcuts.unregister('review.undo');
+        }
     }"
     @undo-available.window="push($event.detail)"
-    @keydown.window="
-        if (!visible || !current) return;
-        if ($event.target.tagName === 'TEXTAREA' || $event.target.tagName === 'INPUT') return;
-        if (($event.metaKey || $event.ctrlKey) && $event.key === 'z') { undo(); $event.preventDefault(); }
-    "
     x-show="visible"
     x-cloak
     x-transition:enter="transition ease-out duration-200"

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -161,7 +161,7 @@ new class extends Component {
         projectSlug: @js($projectSlug),
         branches: @js($branches),
     })"
-    x-init="$store.keymap.register('⌘B', () => open ? closePanel() : openPanel())"
+    x-init="$store.shortcuts.register('branch-explorer.toggle', () => open ? closePanel() : openPanel())"
     @keydown.window="handleKeydown($event)"
     @open-selection-drawer.window="openPanel()"
     @branch-explorer-selection-error.window="showSelectionError($event.detail.message)"
@@ -171,11 +171,11 @@ new class extends Component {
 >
     <div class="inline-flex items-stretch rounded-md border border-gh-border/70 bg-gh-surface/30 hover:border-gh-text/30 transition-colors">
         <div @if($hasRemote) @contextmenu.prevent="openRemoteContext($event, 'branch', { name: currentBranch }, 'branch ' + currentBranch)" @endif class="inline-flex">
-            <flux:tooltip content="Switch branch · ⌘B">
+            <flux:tooltip content="Switch branch · {{ \App\Support\Shortcuts::display('branch-explorer.toggle') }}">
                 <button
                     type="button"
                     class="group inline-flex items-center gap-1.5 px-2 py-1 text-xs font-mono text-gh-muted hover:text-gh-text hover:bg-gh-border/25 rounded-l-md transition-colors cursor-pointer"
-                    aria-label="Switch branch (⌘B)"
+                    aria-label="Switch branch ({{ \App\Support\Shortcuts::display('branch-explorer.toggle') }})"
                     aria-haspopup="dialog"
                     x-on:click="openPanel()"
                     x-bind:aria-expanded="open"
@@ -189,11 +189,11 @@ new class extends Component {
         <span class="w-px self-stretch bg-gh-border/70" aria-hidden="true"></span>
 
         <div @if($hasRemote) @contextmenu.prevent="openSelectionRemoteContext($event)" @endif class="inline-flex">
-            <flux:tooltip content="{{ $selectionTitle }} · ⌘B">
+            <flux:tooltip content="{{ $selectionTitle }} · {{ \App\Support\Shortcuts::display('branch-explorer.toggle') }}">
                 <button
                     type="button"
                     class="group inline-flex items-center gap-1.5 px-2 py-1 text-xs font-mono text-gh-text hover:bg-gh-border/25 rounded-r-md transition-colors cursor-pointer"
-                    aria-label="Open selection drawer (⌘B)"
+                    aria-label="Open selection drawer ({{ \App\Support\Shortcuts::display('branch-explorer.toggle') }})"
                     aria-haspopup="dialog"
                     x-on:click="openPanel()"
                     x-bind:aria-expanded="open"

--- a/resources/views/livewire/⚡comments-drawer.blade.php
+++ b/resources/views/livewire/⚡comments-drawer.blade.php
@@ -84,7 +84,7 @@ class extends Component
 {{-- Keep the trigger button visible at first paint so the header layout doesn't
      shift; the real component hydrates and supplies the count + drawer body. --}}
 <div class="relative">
-    <flux:tooltip content="All comments · ⌘J">
+    <flux:tooltip content="All comments · {{ \App\Support\Shortcuts::display('comments-drawer.toggle') }}">
         <flux:button variant="ghost" size="sm" icon="chat-bubble-left-right" icon:variant="outline" aria-label="All comments in this repo" />
     </flux:tooltip>
 </div>
@@ -108,7 +108,7 @@ class extends Component
             this.close();
         },
     }"
-    x-init="$store.keymap.register('⌘J', () => toggle())"
+    x-init="$store.shortcuts.register('comments-drawer.toggle', () => toggle())"
     @keydown.window="if (open && $event.key === 'Escape') { $event.preventDefault(); close(); return; }"
     x-effect="if (open && !$store.overlays.is('comments-drawer')) close()"
     class="relative"
@@ -118,7 +118,7 @@ class extends Component
          server-side. The trigger doesn't strictly need a reactive
          aria-expanded — a static aria-haspopup is sufficient for screen
          readers to announce that this button opens a dialog. --}}
-    <flux:tooltip content="All comments · ⌘J">
+    <flux:tooltip content="All comments · {{ \App\Support\Shortcuts::display('comments-drawer.toggle') }}">
         <flux:button
             variant="ghost"
             size="sm"

--- a/resources/views/livewire/⚡project-picker.blade.php
+++ b/resources/views/livewire/⚡project-picker.blade.php
@@ -144,7 +144,7 @@ class extends Component
             if (slug) this.selectSlug(slug);
         },
     }"
-    x-init="$store.keymap.register('⌘K', () => toggle(), { allowInEditable: true })"
+    x-init="$store.shortcuts.register('project-picker.toggle', () => toggle())"
     @project-picker:toggle.window="toggle()"
     @project-picker:close.window="close()"
     x-effect="if (open && !$store.overlays.is('project-picker')) close()"
@@ -158,8 +158,8 @@ class extends Component
     "
 >
     <x-header-picker-trigger
-        tooltip="Switch repo · ⌘K"
-        aria-label="Switch repo (⌘K)"
+        tooltip="Switch repo · {{ \App\Support\Shortcuts::display('project-picker.toggle') }}"
+        aria-label="Switch repo ({{ \App\Support\Shortcuts::display('project-picker.toggle') }})"
         variant="display"
         x-on:click="toggle()"
         x-bind:aria-expanded="open"

--- a/resources/views/pages/⚡context-page.blade.php
+++ b/resources/views/pages/⚡context-page.blade.php
@@ -472,8 +472,8 @@ new #[Layout('layouts.app')] class extends Component
         },
         init() {
             @browser
-            $store.keymap.register('⌘R', () => $wire.refresh(), { allowInEditable: true });
-            $store.keymap.register('⌘⇧R', () => window.location.reload(), { allowInEditable: true });
+            $store.shortcuts.register('app.refresh', () => $wire.refresh());
+            $store.shortcuts.register('app.hard-reload', () => window.location.reload());
             @endbrowser
         },
     }"

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1166,6 +1166,8 @@ new #[Layout('layouts.app')] class extends Component
         diffFrom: @js($diffFrom),
         diffTo: @js($diffTo),
         repoPath: @js($repoPath),
+        prevCommitHash: @js($commitInfo['prevHash'] ?? null),
+        nextCommitHash: @js($commitInfo['nextHash'] ?? null),
     })"
     @scroll-to-comment.window="scrollToComment($event.detail.commentId, $event.detail.filePath)"
     @open-remote-menu.window="showRemoteMenu($event)"
@@ -1173,19 +1175,15 @@ new #[Layout('layouts.app')] class extends Component
     x-on:rfa-hide-reviewed.window="hideReviewedFiles()"
     x-on:rfa-show-all-files.window="showAllFiles()"
     x-on:rfa-clear-recently-reviewed.window="clearRecentlyReviewed()"
-    @keydown.window="
-        if ($event.target.tagName === 'TEXTAREA' || $event.target.tagName === 'INPUT') {
-            if ($event.key === 'Escape' && !$event.target.closest('[data-comment-form]')) { $wire.clearFileFilter(); $event.target.blur(); $event.preventDefault(); }
-            return;
+    {{-- Filter/file/commit shortcuts are registered through the keymap store
+         (see registerShortcuts() in review-page.js). Only the in-input Escape
+         that clears the file filter stays here, since the store suppresses
+         shortcuts while focus is in an input. --}}
+    @keydown.escape.window="
+        if (($event.target.tagName === 'TEXTAREA' || $event.target.tagName === 'INPUT')
+            && !$event.target.closest('[data-comment-form]')) {
+            $wire.clearFileFilter(); $event.target.blur(); $event.preventDefault();
         }
-        if ($event.key === '/') { $refs.fileFilterInput?.focus(); $event.preventDefault(); }
-        if (($event.key === 'j' || $event.key === 'k') && !$event.metaKey && !$event.ctrlKey && !$event.altKey) { focusAdjacentFile($event.key === 'j' ? 1 : -1); $event.preventDefault(); }
-        if ($event.shiftKey && $event.key === 'C') { $store.settings.collapseAll = true; $dispatch('collapse-all-files'); $event.preventDefault(); }
-        if ($event.shiftKey && $event.key === 'E') { $store.settings.collapseAll = false; $dispatch('expand-all-files'); $event.preventDefault(); }
-        @if($commitInfo)
-            if ($event.key === '[' && @js($commitInfo['prevHash'])) { Livewire.navigate('/p/{{ $projectSlug }}/c/' + @js($commitInfo['prevHash'])); $event.preventDefault(); }
-            if ($event.key === ']' && @js($commitInfo['nextHash'])) { Livewire.navigate('/p/{{ $projectSlug }}/c/' + @js($commitInfo['nextHash'])); $event.preventDefault(); }
-        @endif
     "
 >
     @if($hasRemote)
@@ -1362,6 +1360,8 @@ new #[Layout('layouts.app')] class extends Component
                         x-data="reviewChangePoller({
                             projectId: {{ $projectId }},
                             keymapEnabled: @js(! config('nativephp-internal.running')),
+                            refreshCombo: @js(\App\Support\Shortcuts::display('app.refresh')),
+                            hardReloadCombo: @js(\App\Support\Shortcuts::display('app.hard-reload')),
                         })"
                     @fingerprint-reset.window="reset()"
                     class="relative flex items-center">

--- a/tests/Arch/ShortcutsTest.php
+++ b/tests/Arch/ShortcutsTest.php
@@ -129,9 +129,11 @@ test('keyboard registration goes through the shortcuts store, never keymap direc
 
         $contents = file_get_contents($file);
 
+        // Match both `keymap.register(` and the `keymap().register(` accessor form
+        // so neither can bypass the guard from a non-store file.
         expect($contents)
-            ->not->toContain('keymap.register(', "$file should register via \$store.shortcuts, not keymap directly")
-            ->not->toContain('keymap.unregister(', "$file should unregister via \$store.shortcuts, not keymap directly");
+            ->not->toMatch('/\bkeymap(?:\(\))?\s*\.\s*register\s*\(/')
+            ->not->toMatch('/\bkeymap(?:\(\))?\s*\.\s*unregister\s*\(/');
     }
 });
 

--- a/tests/Arch/ShortcutsTest.php
+++ b/tests/Arch/ShortcutsTest.php
@@ -78,14 +78,12 @@ test('every shortcuts-store id used in views and scripts exists in the catalog',
 test('every Shortcuts accessor id referenced in PHP exists in the catalog', function () {
     $ids = array_keys(shortcutsConfig()['shortcuts']);
 
-    $root = dirname(__DIR__, 2);
-    $phpFiles = [
-        ...glob($root.'/resources/views/**/*.blade.php') ?: [],
-        ...glob($root.'/resources/views/**/**/*.blade.php') ?: [],
-        $root.'/app/Providers/NativeAppServiceProvider.php',
+    $files = [
+        ...shortcutFiles(),
+        dirname(__DIR__, 2).'/app/Providers/NativeAppServiceProvider.php',
     ];
 
-    foreach ($phpFiles as $file) {
+    foreach ($files as $file) {
         $contents = file_get_contents($file);
 
         preg_match_all(

--- a/tests/Arch/ShortcutsTest.php
+++ b/tests/Arch/ShortcutsTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Keyboard-shortcut catalog contract. config/shortcuts.php is the single source
+ * of truth for every documented shortcut; these rules keep the three consumers
+ * (the Alpine shortcuts store, the cheat sheet, the native menu) honest and stop
+ * combos from drifting back into hard-coded call sites.
+ */
+
+/** @return array{groups: list<string>, shortcuts: array<string, array<string, mixed>>} */
+function shortcutsConfig(): array
+{
+    return require dirname(__DIR__, 2).'/config/shortcuts.php';
+}
+
+/** @return list<string> */
+function shortcutFiles(): array
+{
+    $root = dirname(__DIR__, 2);
+    $files = [];
+
+    foreach (['resources/views', 'public/js'] as $dir) {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root.'/'.$dir, FilesystemIterator::SKIP_DOTS),
+        );
+
+        foreach ($iterator as $file) {
+            if (in_array($file->getExtension(), ['php', 'js'], true)) {
+                $files[] = $file->getPathname();
+            }
+        }
+    }
+
+    return $files;
+}
+
+test('every shortcut entry has a combo, label, and known group', function () {
+    $config = shortcutsConfig();
+    $groups = $config['groups'];
+
+    expect($groups)->toBeArray()->not->toBeEmpty();
+
+    foreach ($config['shortcuts'] as $id => $entry) {
+        expect($entry['combo'] ?? '')->toBeString()->not->toBe('', "[$id] needs a combo");
+        expect($entry['label'] ?? '')->toBeString()->not->toBe('', "[$id] needs a label");
+        expect($entry['group'] ?? null)->toBeIn($groups, "[$id] group must be one of the declared groups");
+    }
+});
+
+test('native and menu shortcuts declare an Electron accelerator', function () {
+    foreach (shortcutsConfig()['shortcuts'] as $id => $entry) {
+        if (($entry['wired'] ?? null) === 'native') {
+            expect($entry['accelerator'] ?? '')->toBeString()->not->toBe('', "[$id] is native and needs an accelerator");
+        }
+    }
+});
+
+test('every shortcuts-store id used in views and scripts exists in the catalog', function () {
+    $ids = array_keys(shortcutsConfig()['shortcuts']);
+
+    foreach (shortcutFiles() as $file) {
+        $contents = file_get_contents($file);
+
+        preg_match_all(
+            "/shortcuts\.(?:register|unregister|combo|display)\(\s*['\"]([^'\"]+)['\"]/",
+            $contents,
+            $matches,
+        );
+
+        foreach ($matches[1] as $id) {
+            expect(in_array($id, $ids, true))->toBeTrue("$file references unknown shortcut id \"$id\"");
+        }
+    }
+});
+
+test('every Shortcuts accessor id referenced in PHP exists in the catalog', function () {
+    $ids = array_keys(shortcutsConfig()['shortcuts']);
+
+    $root = dirname(__DIR__, 2);
+    $phpFiles = [
+        ...glob($root.'/resources/views/**/*.blade.php') ?: [],
+        ...glob($root.'/resources/views/**/**/*.blade.php') ?: [],
+        $root.'/app/Providers/NativeAppServiceProvider.php',
+    ];
+
+    foreach ($phpFiles as $file) {
+        $contents = file_get_contents($file);
+
+        preg_match_all(
+            "/Shortcuts::(?:combo|display|accelerator)\(\s*'([^']+)'/",
+            $contents,
+            $matches,
+        );
+
+        foreach ($matches[1] as $id) {
+            expect(in_array($id, $ids, true))->toBeTrue("$file references unknown shortcut id \"$id\"");
+        }
+    }
+});
+
+test('the ids the app wires against are present in the catalog', function () {
+    // Spelled out because some call sites alias the store (`const s = $store.shortcuts`)
+    // and so escape the textual scans above. Renaming an id in the catalog without
+    // updating these breaks a real shortcut.
+    $ids = array_keys(shortcutsConfig()['shortcuts']);
+
+    $required = [
+        'project-picker.toggle', 'comments-drawer.toggle', 'branch-explorer.toggle',
+        'review.filter', 'review.next-file', 'review.prev-file',
+        'review.collapse-all', 'review.expand-all', 'review.prev-commit', 'review.next-commit',
+        'comment.save', 'review.undo',
+        'app.refresh', 'app.hard-reload', 'app.add-repo', 'app.context-files',
+        'help.shortcuts',
+    ];
+
+    foreach ($required as $id) {
+        expect(in_array($id, $ids, true))->toBeTrue("catalog is missing required shortcut id \"$id\"");
+    }
+});
+
+test('keyboard registration goes through the shortcuts store, never keymap directly', function () {
+    foreach (shortcutFiles() as $file) {
+        // keymap-store.js *defines* register/unregister; shortcuts-store.js is the
+        // one allowed caller (via `keymap().register`). Everything else must route
+        // through `$store.shortcuts` so the combo comes from the catalog.
+        if (str_ends_with($file, 'keymap-store.js') || str_ends_with($file, 'shortcuts-store.js')) {
+            continue;
+        }
+
+        $contents = file_get_contents($file);
+
+        expect($contents)
+            ->not->toContain('keymap.register(', "$file should register via \$store.shortcuts, not keymap directly")
+            ->not->toContain('keymap.unregister(', "$file should unregister via \$store.shortcuts, not keymap directly");
+    }
+});
+
+test('layout injects the catalog and loads the shortcuts store', function () {
+    $layout = file_get_contents(dirname(__DIR__, 2).'/resources/views/layouts/app.blade.php');
+
+    expect($layout)
+        ->toContain('window.RFA_SHORTCUTS')
+        ->toContain('Shortcuts::all()')
+        ->toContain("@localScript('js/shortcuts-store.js')")
+        ->toContain('<x-shortcuts-help />');
+});
+
+test('native menu hotkeys are sourced from the catalog', function () {
+    $provider = file_get_contents(dirname(__DIR__, 2).'/app/Providers/NativeAppServiceProvider.php');
+
+    expect($provider)
+        ->toContain("Shortcuts::accelerator('app.add-repo')")
+        ->toContain("Shortcuts::accelerator('app.context-files')");
+});

--- a/tests/Browser/ShortcutPersistenceTest.php
+++ b/tests/Browser/ShortcutPersistenceTest.php
@@ -1,0 +1,30 @@
+<?php
+
+beforeEach(function () {
+    $this->setUpCommitHistoryRepo();
+});
+
+// The shortcuts-help component lives in the persistent layout chrome, so its
+// x-init runs once and is not re-run when Livewire morphs the body. The keymap
+// store clears every binding on `livewire:navigating`, so without an explicit
+// re-registration on `livewire:navigated` the global `?` (and ⌘↵ save) would go
+// dead after the first SPA navigation.
+test('the global help shortcut survives a Livewire navigation', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $page->page()->getByTestId('review-component')->first()->waitFor();
+
+    $hasHelpBinding = "Alpine.store('keymap').bindings.has('?')";
+
+    // Registered on the initial page load.
+    $page->page()->waitForFunction($hasHelpBinding);
+    expect($page->page()->evaluate($hasHelpBinding))->toBeTrue();
+
+    // SPA-navigate to a commit page; the binding is cleared on navigating and
+    // must be re-registered on navigated.
+    $page->page()->evaluate("Livewire.navigate('".$this->projectUrl().'/c/'.$this->commitHashes[1]."')");
+    $page->page()->getByTestId('commit-context-bar')->waitFor();
+
+    $page->page()->waitForFunction($hasHelpBinding);
+    expect($page->page()->evaluate($hasHelpBinding))->toBeTrue();
+});

--- a/tests/Js/keymap-store.test.js
+++ b/tests/Js/keymap-store.test.js
@@ -26,6 +26,19 @@ describe('matches', () => {
         ['⌘K rejects wrong key', '⌘K', { key: 'j', metaKey: true }, false],
         ['⌘K rejects when no modifier is held', '⌘K', { key: 'k' }, false],
         ['⇧⌘K rejects without cmd', '⇧⌘K', { key: 'k', shiftKey: true }, false],
+        // ⌘↵ maps the Enter glyph to the KeyboardEvent.key spelling.
+        ['⌘↵ matches meta+Enter', '⌘↵', { key: 'Enter', metaKey: true }, true],
+        ['⌘↵ matches ctrl+Enter', '⌘↵', { key: 'Enter', ctrlKey: true }, true],
+        ['⌘↵ rejects bare Enter', '⌘↵', { key: 'Enter' }, false],
+        // Bare-character combos: exact key, no command modifier.
+        ['j matches a bare j', 'j', { key: 'j' }, true],
+        ['j rejects ⌘+j', 'j', { key: 'j', metaKey: true }, false],
+        ['j rejects shift+J (case-sensitive)', 'j', { key: 'J', shiftKey: true }, false],
+        ['⇧-letter combo C matches the shifted character', 'C', { key: 'C', shiftKey: true }, true],
+        ['C rejects a lowercase c', 'C', { key: 'c' }, false],
+        ['? matches its shifted character', '?', { key: '?', shiftKey: true }, true],
+        ['/ matches a bare slash', '/', { key: '/' }, true],
+        ['[ rejects when alt is held', '[', { key: '[', altKey: true }, false],
     ])('%s', (_label, combo, props, expected) => {
         expect(matches(combo, event(props))).toBe(expected);
     });

--- a/tests/Js/review-page.test.js
+++ b/tests/Js/review-page.test.js
@@ -189,7 +189,7 @@ describe('createChangePoller', () => {
     });
 
     it('renders the changed-file count in the tooltip', () => {
-        const poller = createChangePoller({ projectId: 5 });
+        const poller = createChangePoller({ projectId: 5, refreshCombo: '⌘R', hardReloadCombo: '⌘⇧R' });
         expect(poller.tooltip).toBe('Refresh · ⌘R · ⌘⇧R to hard reload');
 
         poller.hasChanges = true;
@@ -202,36 +202,36 @@ describe('createChangePoller', () => {
 
     it('registers refresh shortcuts on init and unregisters them on destroy (browser build)', () => {
         const stopPoll = vi.fn();
-        const keymap = { register: vi.fn(), unregister: vi.fn() };
+        const shortcuts = { register: vi.fn(), unregister: vi.fn() };
         window.smartPoll = { startSmartPoll: () => stopPoll, isFocused: () => true };
         respondWith({ fingerprint: 'fp-1', count: 0 });
 
         const poller = createChangePoller({ projectId: 5, keymapEnabled: true });
-        poller.$store = { keymap };
+        poller.$store = { shortcuts };
 
         poller.init();
-        expect(keymap.register).toHaveBeenCalledWith('⌘R', expect.any(Function), { allowInEditable: true });
-        expect(keymap.register).toHaveBeenCalledWith('⌘⇧R', expect.any(Function), { allowInEditable: true });
+        expect(shortcuts.register).toHaveBeenCalledWith('app.refresh', expect.any(Function));
+        expect(shortcuts.register).toHaveBeenCalledWith('app.hard-reload', expect.any(Function));
 
         poller.destroy();
-        expect(keymap.unregister).toHaveBeenCalledWith('⌘R');
-        expect(keymap.unregister).toHaveBeenCalledWith('⌘⇧R');
+        expect(shortcuts.unregister).toHaveBeenCalledWith('app.refresh');
+        expect(shortcuts.unregister).toHaveBeenCalledWith('app.hard-reload');
         expect(stopPoll).toHaveBeenCalled();
     });
 
     it('leaves shortcuts alone in the native build where keymap is disabled', () => {
-        const keymap = { register: vi.fn(), unregister: vi.fn() };
+        const shortcuts = { register: vi.fn(), unregister: vi.fn() };
         window.smartPoll = { startSmartPoll: () => vi.fn(), isFocused: () => true };
         respondWith({ fingerprint: 'fp-1', count: 0 });
 
         const poller = createChangePoller({ projectId: 5, keymapEnabled: false });
-        poller.$store = { keymap };
+        poller.$store = { shortcuts };
 
         poller.init();
         poller.destroy();
 
-        expect(keymap.register).not.toHaveBeenCalled();
-        expect(keymap.unregister).not.toHaveBeenCalled();
+        expect(shortcuts.register).not.toHaveBeenCalled();
+        expect(shortcuts.unregister).not.toHaveBeenCalled();
     });
 });
 

--- a/tests/Js/shortcuts-store.test.js
+++ b/tests/Js/shortcuts-store.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import shortcutsStore from '../../public/js/shortcuts-store.js';
+
+const { createStore } = shortcutsStore;
+
+const catalog = {
+    'project-picker.toggle': { combo: '⌘K', label: 'Switch repository', allowInEditable: true },
+    'review.collapse-all': { combo: 'C', display: '⇧C', label: 'Collapse all files' },
+    'review.next-file': { combo: 'j', label: 'Next file' },
+};
+
+function setup() {
+    const keymap = { register: vi.fn(), unregister: vi.fn() };
+    const store = createStore(catalog, () => keymap);
+    return { keymap, store };
+}
+
+describe('register', () => {
+    it('delegates to keymap with the catalog combo and allowInEditable flag', () => {
+        const { keymap, store } = setup();
+        const handler = vi.fn();
+
+        store.register('project-picker.toggle', handler);
+
+        expect(keymap.register).toHaveBeenCalledWith('⌘K', handler, { allowInEditable: true });
+    });
+
+    it('defaults allowInEditable to false when the catalog omits it', () => {
+        const { keymap, store } = setup();
+        const handler = vi.fn();
+
+        store.register('review.next-file', handler);
+
+        expect(keymap.register).toHaveBeenCalledWith('j', handler, { allowInEditable: false });
+    });
+
+    it('warns and skips an unknown id instead of registering a dead combo', () => {
+        const { keymap, store } = setup();
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        store.register('does.not.exist', vi.fn());
+
+        expect(keymap.register).not.toHaveBeenCalled();
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+    });
+});
+
+describe('unregister', () => {
+    it('removes the catalog combo from keymap', () => {
+        const { keymap, store } = setup();
+
+        store.unregister('project-picker.toggle');
+
+        expect(keymap.unregister).toHaveBeenCalledWith('⌘K');
+    });
+
+    it('is a no-op for an unknown id', () => {
+        const { keymap, store } = setup();
+
+        store.unregister('does.not.exist');
+
+        expect(keymap.unregister).not.toHaveBeenCalled();
+    });
+});
+
+describe('combo / display', () => {
+    it('returns the combo used for matching', () => {
+        const { store } = setup();
+        expect(store.combo('review.collapse-all')).toBe('C');
+        expect(store.combo('review.next-file')).toBe('j');
+    });
+
+    it('prefers the display override, falling back to the combo', () => {
+        const { store } = setup();
+        expect(store.display('review.collapse-all')).toBe('⇧C');
+        expect(store.display('project-picker.toggle')).toBe('⌘K');
+    });
+
+    it('returns empty strings for an unknown id', () => {
+        const { store } = setup();
+        expect(store.combo('nope')).toBe('');
+        expect(store.display('nope')).toBe('');
+    });
+});

--- a/tests/Js/shortcuts-store.test.js
+++ b/tests/Js/shortcuts-store.test.js
@@ -63,23 +63,3 @@ describe('unregister', () => {
         expect(keymap.unregister).not.toHaveBeenCalled();
     });
 });
-
-describe('combo / display', () => {
-    it('returns the combo used for matching', () => {
-        const { store } = setup();
-        expect(store.combo('review.collapse-all')).toBe('C');
-        expect(store.combo('review.next-file')).toBe('j');
-    });
-
-    it('prefers the display override, falling back to the combo', () => {
-        const { store } = setup();
-        expect(store.display('review.collapse-all')).toBe('⇧C');
-        expect(store.display('project-picker.toggle')).toBe('⌘K');
-    });
-
-    it('returns empty strings for an unknown id', () => {
-        const { store } = setup();
-        expect(store.combo('nope')).toBe('');
-        expect(store.display('nope')).toBe('');
-    });
-});

--- a/tests/Unit/Providers/NativeAppServiceProviderTest.php
+++ b/tests/Unit/Providers/NativeAppServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 use App\Console\Benchmark\BenchmarkIsolation;
 use App\Providers\NativeAppServiceProvider;
+use App\Support\Shortcuts;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
@@ -76,13 +77,16 @@ test('dev compiled view cleanup skips deletion in testing environment', function
 test('the View submenu declares the show-context menu item with the cmd-shift-k accelerator', function () {
     // The hotkey lives in the menu builder DSL, which is wired through the
     // native bridge. Read the source directly so the assertion stays fast
-    // and decoupled from the bridge.
+    // and decoupled from the bridge. The accelerator itself is sourced from the
+    // shortcuts catalog so the menu and the cheat sheet can't drift.
     $source = file_get_contents((new ReflectionClass(NativeAppServiceProvider::class))->getFileName());
 
     expect($source)
         ->toContain("Menu::label('Show Context Files...')")
         ->toContain("->id('show-context')")
-        ->toContain("->hotkey('CmdOrCtrl+Shift+K')");
+        ->toContain("->hotkey(Shortcuts::accelerator('app.context-files'))");
+
+    expect(Shortcuts::accelerator('app.context-files'))->toBe('CmdOrCtrl+Shift+K');
 });
 
 // -- Inbox parser --


### PR DESCRIPTION
## Summary

Introduces a single source of truth for keyboard shortcuts (`config/shortcuts.php`) that three consumers read from: the Alpine shortcuts store (JS), the cheat-sheet modal, and the native Electron menu. This eliminates combo drift between where shortcuts fire and where they're documented, and makes it trivial to discover all available shortcuts.

## Key Changes

- **New `config/shortcuts.php`** — Catalog of all documented shortcuts with combo, label, group, and wiring metadata. Includes 20+ shortcuts across Navigation, Review, Editing, View, and Help groups.

- **New `app/Support/Shortcuts` helper** — Read accessor for the catalog. Provides `combo()`, `display()`, `accelerator()`, and `all()` methods so Blade, the native menu, and JS bridge access entries by stable id (e.g., `'project-picker.toggle'`) instead of hard-coded combos.

- **New `public/js/shortcuts-store.js`** — Alpine store that bridges the PHP catalog to the keymap store. Call sites register handlers by id (`$store.shortcuts.register('review.next-file', handler)`) and the store pulls the combo and `allowInEditable` flag from the catalog. Unregistration is also id-based.

- **New `resources/views/components/shortcuts-help.blade.php`** — Cheat-sheet modal (opened with `?`) that renders the entire catalog grouped by category. Content is 100% driven by the config, so it can never list a combo that doesn't fire or miss one that does.

- **Enhanced `public/js/keymap-store.js`** — Extended `matches()` to handle bare-character combos (e.g., `'j'`, `'⇧C'`, `'?'`) and glyph-to-key mapping (e.g., `'↵'` → `'enter'`). Supports both modifier-based (`'⌘K'`) and character-based (`'j'`) combo notation.

- **Updated review page** (`public/js/review-page.js`, `resources/views/pages/⚡review-page.blade.php`) — Registers review-scoped shortcuts (filter, next/prev file, collapse/expand, prev/next commit) via the shortcuts store on init and unregisters them on destroy. Passes `prevCommitHash` and `nextCommitHash` to the component config.

- **Updated comment form** (`resources/views/components/comment-form.blade.php`) — Registers `'comment.save'` (⌘↵) via the shortcuts store instead of hard-coded `x-on:keydown.meta.enter`.

- **Updated undo toast** (`resources/views/livewire/undo-toast.blade.php`) — Registers `'review.undo'` (⌘Z) via the shortcuts store on init and unregisters on destroy.

- **Updated navigation components** — `project-picker`, `branch-explorer`, `comments-drawer`, and `context-page` now register their shortcuts via `$store.shortcuts.register()` with catalog ids instead of hard-coded combos.

- **Layout injection** (`resources/views/layouts/app.blade.php`) — Injects the entire shortcuts catalog as `window.RFA_SHORTCUTS` so the JS store can access it.

- **Comprehensive tests** — New `tests/Arch/ShortcutsTest.php` validates the catalog contract: every entry has required fields, native shortcuts declare accelerators, all referenced ids exist, and the layout properly injects and loads the store. New `tests/Js/shortcuts-store.test.js` tests registration, unregistration, and error handling.

## Implementation Details

- **Combo notation** — Supports both modifier-based (`'⌘K'`, `'⌘⇧R'`, `'⌘↵'`) and bare-character (`'j'`, `'C'`, `'?'`) combos. The `display` field can override the label shown in the cheat sheet (e.g., `'C'` displays as `'⇧C'`).

- **Wiring modes** — `'keymap'` shortcuts flow through the Alpine store;

https://claude.ai/code/session_01XRWtKbEfRB1xZJx1jsgGPU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/strengthened a keyboard shortcuts help modal (press `?` to view available shortcuts).
  * Centralized shortcut definitions and registration, with shortcut IDs powering UI labels and actions across the app.

* **Bug Fixes**
  * Improved keyboard shortcut matching (glyph normalization, refined modifier behavior, and clearer command-vs-character handling).
  * Updated common shortcuts (comment save, undo toast, review/navigation, refresh/hard-reload) to use the unified shortcut system and show configured values.

* **Tests**
  * Added/updated coverage to enforce shortcut catalog consistency and prevent shortcut wiring regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->