### PR TITLE
Fix glob pattern matching for ** to respect segment boundaries

### DIFF
--- a/app/Actions/SessionStateAction.php
+++ b/app/Actions/SessionStateAction.php
@@ -100,10 +100,10 @@ final readonly class SessionStateAction
      */
     private function collectOrphanedPaths(array $resolved, array $currentFiles): array
     {
-        $presentPaths = collect($currentFiles)->pluck('path')->all();
+        $presentPaths = collect($currentFiles)->pluck('path')->flip();
 
         return collect($resolved)
-            ->filter(fn (array $c) => ! in_array($c['file'], $presentPaths, true))
+            ->reject(fn (array $c) => $presentPaths->has($c['file']))
             ->pluck('file')
             ->unique()
             ->values()

--- a/app/Services/IgnoreService.php
+++ b/app/Services/IgnoreService.php
@@ -181,10 +181,17 @@ class IgnoreService
 
             if ($char === '*') {
                 if (($glob[$i + 1] ?? '') === '*') {
-                    $regex .= '.*';
-                    $i++;
+                    $i++; // consume the second '*'
                     if (($glob[$i + 1] ?? '') === '/') {
-                        $i++;
+                        // `**/` matches zero or more whole path segments, so the
+                        // separator stays part of the match: `(?:.*/)?`. Emitting
+                        // a bare `.*` and swallowing the slash drops the segment
+                        // boundary, letting `**/build` match `prebuild` or
+                        // `a/**/b` match `a/xb`.
+                        $i++; // consume the '/'
+                        $regex .= '(?:.*/)?';
+                    } else {
+                        $regex .= '.*';
                     }
                 } else {
                     $regex .= '[^/]*';

--- a/tests/Unit/IgnoreServiceTest.php
+++ b/tests/Unit/IgnoreServiceTest.php
@@ -146,3 +146,33 @@ test('isPathExcluded anchors a leading-slash pattern to the repo root', function
     expect($this->service->isPathExcluded('dist/a.js', $rules))->toBeTrue();
     expect($this->service->isPathExcluded('packages/x/dist/a.js', $rules))->toBeFalse();
 });
+
+test('isPathExcluded matches a mid-path ** across zero or more whole segments', function () {
+    $rules = $this->service->compile(['a/**/b']);
+
+    expect($this->service->isPathExcluded('a/b', $rules))->toBeTrue();
+    expect($this->service->isPathExcluded('a/x/b', $rules))->toBeTrue();
+    expect($this->service->isPathExcluded('a/x/y/b', $rules))->toBeTrue();
+    // `**/` must not bridge into a partial segment name: `a/xb` is not `a/.../b`.
+    expect($this->service->isPathExcluded('a/xb', $rules))->toBeFalse();
+});
+
+test('isPathExcluded leading **/ matches a name at any depth without over-matching a partial segment', function () {
+    $rules = $this->service->compile(['**/build']);
+
+    expect($this->service->isPathExcluded('build', $rules))->toBeTrue();
+    expect($this->service->isPathExcluded('build/out.js', $rules))->toBeTrue();
+    expect($this->service->isPathExcluded('pkg/a/build', $rules))->toBeTrue();
+    expect($this->service->isPathExcluded('pkg/a/build/out.js', $rules))->toBeTrue();
+    // A bare `.*` body would wrongly swallow these — the segment boundary forbids it.
+    expect($this->service->isPathExcluded('prebuild', $rules))->toBeFalse();
+    expect($this->service->isPathExcluded('pkg/prebuild/out.js', $rules))->toBeFalse();
+});
+
+test('isPathExcluded trailing ** matches everything under a directory', function () {
+    $rules = $this->service->compile(['logs/**']);
+
+    expect($this->service->isPathExcluded('logs/a.txt', $rules))->toBeTrue();
+    expect($this->service->isPathExcluded('logs/sub/b.txt', $rules))->toBeTrue();
+    expect($this->service->isPathExcluded('src/a.txt', $rules))->toBeFalse();
+});


### PR DESCRIPTION
## Summary
Fixes the `IgnoreService` glob-to-regex compiler to correctly handle `**` (double-star) patterns by respecting path segment boundaries. Previously, `**/` patterns would match partial segment names (e.g., `**/build` matching `prebuild`), violating gitignore semantics.

## Key Changes

- **IgnoreService.php**: Updated `globToRegex()` to emit `(?:.*/)?` for `**/` patterns instead of bare `.*`, preserving the segment boundary that prevents partial-name matches. Trailing `**` (without `/`) still emits `.*` to match everything under a directory.

- **IgnoreServiceTest.php**: Added three comprehensive test cases:
  - Mid-path `**` matching zero or more whole segments (`a/**/b`)
  - Leading `**/` matching at any depth without over-matching partial segments (`**/build`)
  - Trailing `**` matching everything under a directory (`logs/**`)

- **SessionStateAction.php**: Optimized `collectOrphanedPaths()` to use `flip()` and `has()` for O(1) lookup instead of `in_array()`, improving performance when checking file presence.

## Implementation Details
The fix ensures that `**` only matches complete path segments separated by `/`, not arbitrary character sequences. This aligns with standard gitignore behavior where `**/build` matches `pkg/build` and `pkg/a/build` but not `prebuild` or `pkg/prebuild`.

https://claude.ai/code/session_01J5uogCguQarBtFsUS5DGZ4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved glob pattern matching to correctly handle directory path boundaries and prevent unintended partial-name matches.

* **Tests**
  * Added test coverage for glob pattern behavior with directory wildcards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->