### PR TITLE
Add View-menu triggers for code review and agents instructions

### DIFF
--- a/app/Events/ShowShortcutsRequested.php
+++ b/app/Events/ShowShortcutsRequested.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Broadcast to the renderer over NativePHP's `nativephp` channel when the
+ * "Keyboard Shortcuts" View-menu item is clicked. The menu lives in the main
+ * process while the cheat-sheet is a renderer-side Flux modal, so the click
+ * crosses the bridge as a `native:` event the layout listens for and opens the
+ * same modal the `?` shortcut shows.
+ */
+final class ShowShortcutsRequested implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets;
+
+    /** @return array<int, Channel> */
+    public function broadcastOn(): array
+    {
+        return [new Channel('nativephp')];
+    }
+}

--- a/app/Listeners/HandleMenuItemClicked.php
+++ b/app/Listeners/HandleMenuItemClicked.php
@@ -8,6 +8,7 @@ use App\Actions\OpenRepositoryDialogAction;
 use App\Actions\RecordRuntimeDiagnosticAction;
 use App\Actions\ResolveProjectByIdAction;
 use App\Actions\ScanDirectoryDialogAction;
+use App\Events\ShowShortcutsRequested;
 use Illuminate\Support\Facades\Cache;
 use Native\Desktop\Events\Menu\MenuItemClicked;
 use Native\Desktop\Facades\AutoUpdater;
@@ -34,8 +35,9 @@ final readonly class HandleMenuItemClicked
             'open-repo' => $this->handleOpenRepo(),
             'scan-directory' => app(ScanDirectoryDialogAction::class)->handle(),
             'check-updates' => $this->handleCheckUpdates(),
-            'show-context' => $this->handleShowContext(),
-            'review-code' => $this->handleReviewCode(),
+            'show-context' => $this->navigateToActiveProject('context-page', 'menu.show_context.completed'),
+            'review-code' => $this->navigateToActiveProject('review-page', 'menu.review_code.completed'),
+            'show-shortcuts' => ShowShortcutsRequested::dispatch(),
             default => null,
         };
     }
@@ -63,16 +65,6 @@ final readonly class HandleMenuItemClicked
 
             Window::get('main')->url(route('review-page', ['slug' => $project->slug]));
         }
-    }
-
-    private function handleShowContext(): void
-    {
-        $this->navigateToActiveProject('context-page', 'menu.show_context.completed');
-    }
-
-    private function handleReviewCode(): void
-    {
-        $this->navigateToActiveProject('review-page', 'menu.review_code.completed');
     }
 
     /**

--- a/app/Listeners/HandleMenuItemClicked.php
+++ b/app/Listeners/HandleMenuItemClicked.php
@@ -35,6 +35,7 @@ final readonly class HandleMenuItemClicked
             'scan-directory' => app(ScanDirectoryDialogAction::class)->handle(),
             'check-updates' => $this->handleCheckUpdates(),
             'show-context' => $this->handleShowContext(),
+            'review-code' => $this->handleReviewCode(),
             default => null,
         };
     }
@@ -64,12 +65,23 @@ final readonly class HandleMenuItemClicked
         }
     }
 
-    /**
-     * Resolve the active project from the renderer's mount-time cache write.
-     * Falls back to the file picker when the cache is empty or stale (project
-     * deleted, or user is on select-repo-page which forgets the key).
-     */
     private function handleShowContext(): void
+    {
+        $this->navigateToActiveProject('context-page', 'menu.show_context.completed');
+    }
+
+    private function handleReviewCode(): void
+    {
+        $this->navigateToActiveProject('review-page', 'menu.review_code.completed');
+    }
+
+    /**
+     * Resolve the active project from the renderer's mount-time cache write and
+     * point the main window at the given route for it. Falls back to the file
+     * picker when the cache is empty or stale (project deleted, or user is on
+     * select-repo-page which forgets the key).
+     */
+    private function navigateToActiveProject(string $routeName, string $diagnostic): void
     {
         $cachedId = Cache::get(self::ACTIVE_PROJECT_CACHE_KEY);
         $project = is_int($cachedId) ? app(ResolveProjectByIdAction::class)->handle($cachedId) : null;
@@ -79,13 +91,13 @@ final readonly class HandleMenuItemClicked
         }
 
         if ($project) {
-            app(RecordRuntimeDiagnosticAction::class)->handle('menu.show_context.completed', [
+            app(RecordRuntimeDiagnosticAction::class)->handle($diagnostic, [
                 'project_id' => $project->id,
                 'project_slug' => $project->slug,
                 'used_cached_project' => is_int($cachedId),
             ]);
 
-            Window::get('main')->url(route('context-page', ['slug' => $project->slug]));
+            Window::get('main')->url(route($routeName, ['slug' => $project->slug]));
         }
     }
 }

--- a/app/Providers/NativeAppServiceProvider.php
+++ b/app/Providers/NativeAppServiceProvider.php
@@ -220,7 +220,10 @@ class NativeAppServiceProvider implements ProvidesPhpIni
             //     fire it. Only mouse clicks do (electron/electron#19559,
             //     #15496). Explicit menu accelerators do not help.
             Menu::make(
-                Menu::label('Show Context Files...')
+                Menu::label('Review Code')
+                    ->id('review-code')
+                    ->hotkey(Shortcuts::accelerator('app.review-code')),
+                Menu::label('Review Agents instructions')
                     ->id('show-context')
                     ->hotkey(Shortcuts::accelerator('app.context-files')),
                 Menu::separator(),

--- a/app/Providers/NativeAppServiceProvider.php
+++ b/app/Providers/NativeAppServiceProvider.php
@@ -226,6 +226,8 @@ class NativeAppServiceProvider implements ProvidesPhpIni
                 Menu::label('Review Agents instructions')
                     ->id('show-context')
                     ->hotkey(Shortcuts::accelerator('app.context-files')),
+                Menu::label('Keyboard Shortcuts')
+                    ->id('show-shortcuts'),
                 Menu::separator(),
                 Menu::label('Actual Size')->id('reset-zoom'),
                 Menu::label('Zoom In')->id('zoom-in'),

--- a/config/shortcuts.php
+++ b/config/shortcuts.php
@@ -180,9 +180,16 @@ return [
             'accelerator' => 'CmdOrCtrl+O',
             'wired' => 'native',
         ],
+        'app.review-code' => [
+            'combo' => '⌘⇧C',
+            'label' => 'Review code',
+            'group' => 'View',
+            'accelerator' => 'CmdOrCtrl+Shift+C',
+            'wired' => 'native',
+        ],
         'app.context-files' => [
             'combo' => '⌘⇧K',
-            'label' => 'Show context files',
+            'label' => 'Review agents instructions',
             'group' => 'View',
             'accelerator' => 'CmdOrCtrl+Shift+K',
             'wired' => 'native',

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -342,6 +342,12 @@
             window.Livewire.on('native:App\\Events\\HardReloadShortcutPressed', () => {
                 window.location.reload();
             });
+
+            {{-- The native "Keyboard Shortcuts" menu item opens the same cheat-sheet
+                 modal as the `?` shortcut, crossing the main→renderer bridge. --}}
+            window.Livewire.on('native:App\\Events\\ShowShortcutsRequested', () => {
+                window.Flux?.modal('keyboard-shortcuts').show();
+            });
         });
     </script>
     @fluxScripts

--- a/tests/Arch/ShortcutsTest.php
+++ b/tests/Arch/ShortcutsTest.php
@@ -109,7 +109,7 @@ test('the ids the app wires against are present in the catalog', function () {
         'review.filter', 'review.next-file', 'review.prev-file',
         'review.collapse-all', 'review.expand-all', 'review.prev-commit', 'review.next-commit',
         'comment.save', 'review.undo',
-        'app.refresh', 'app.hard-reload', 'app.add-repo', 'app.context-files',
+        'app.refresh', 'app.hard-reload', 'app.add-repo', 'app.context-files', 'app.review-code',
         'help.shortcuts',
     ];
 
@@ -152,5 +152,6 @@ test('native menu hotkeys are sourced from the catalog', function () {
 
     expect($provider)
         ->toContain("Shortcuts::accelerator('app.add-repo')")
-        ->toContain("Shortcuts::accelerator('app.context-files')");
+        ->toContain("Shortcuts::accelerator('app.context-files')")
+        ->toContain("Shortcuts::accelerator('app.review-code')");
 });

--- a/tests/Feature/Listeners/HandleMenuItemClickedTest.php
+++ b/tests/Feature/Listeners/HandleMenuItemClickedTest.php
@@ -98,6 +98,41 @@ test('show-context with no cached id and no project picked navigates nowhere', f
     expect($this->capturedUrl)->toBeNull();
 });
 
+test('review-code with cached active-project navigates to review-page for that project', function () {
+    $project = Project::factory()->create(['slug' => 'rfa']);
+    Cache::put('rfa.active-project-id', $project->id);
+
+    bindResolveProjectByIdAction($project);
+    bindOpenRepositoryDialogAction(null);
+
+    app(HandleMenuItemClicked::class)->handle(new MenuItemClicked(['id' => 'review-code']));
+
+    expect($this->capturedUrl)->toBe(route('review-page', ['slug' => 'rfa']));
+});
+
+test('review-code with cache miss falls back to the file-picker flow', function () {
+    Cache::forget('rfa.active-project-id');
+    $picked = Project::factory()->create(['slug' => 'picked']);
+
+    bindResolveProjectByIdAction(null);
+    bindOpenRepositoryDialogAction($picked);
+
+    app(HandleMenuItemClicked::class)->handle(new MenuItemClicked(['id' => 'review-code']));
+
+    expect($this->capturedUrl)->toBe(route('review-page', ['slug' => 'picked']));
+});
+
+test('review-code with no cached id and no project picked navigates nowhere', function () {
+    Cache::forget('rfa.active-project-id');
+
+    bindResolveProjectByIdAction(null);
+    bindOpenRepositoryDialogAction(null);
+
+    app(HandleMenuItemClicked::class)->handle(new MenuItemClicked(['id' => 'review-code']));
+
+    expect($this->capturedUrl)->toBeNull();
+});
+
 test('open-repo still routes to review-page', function () {
     $project = Project::factory()->create(['slug' => 'opened']);
 

--- a/tests/Feature/Listeners/HandleMenuItemClickedTest.php
+++ b/tests/Feature/Listeners/HandleMenuItemClickedTest.php
@@ -3,10 +3,12 @@
 use App\Actions\OpenRepositoryDialogAction;
 use App\Actions\ResolveProjectByIdAction;
 use App\Actions\ScanDirectoryDialogAction;
+use App\Events\ShowShortcutsRequested;
 use App\Listeners\HandleMenuItemClicked;
 use App\Models\Project;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
 use Native\Desktop\Events\Menu\MenuItemClicked;
 use Native\Desktop\Facades\Window;
 use Tests\TestCase;
@@ -130,6 +132,18 @@ test('review-code with no cached id and no project picked navigates nowhere', fu
 
     app(HandleMenuItemClicked::class)->handle(new MenuItemClicked(['id' => 'review-code']));
 
+    expect($this->capturedUrl)->toBeNull();
+});
+
+test('show-shortcuts broadcasts the cheat-sheet open request without navigating', function () {
+    Event::fake([ShowShortcutsRequested::class]);
+
+    bindResolveProjectByIdAction(null);
+    bindOpenRepositoryDialogAction(null);
+
+    app(HandleMenuItemClicked::class)->handle(new MenuItemClicked(['id' => 'show-shortcuts']));
+
+    Event::assertDispatched(ShowShortcutsRequested::class);
     expect($this->capturedUrl)->toBeNull();
 });
 

--- a/tests/Unit/Providers/NativeAppServiceProviderTest.php
+++ b/tests/Unit/Providers/NativeAppServiceProviderTest.php
@@ -93,6 +93,16 @@ test('the View submenu declares the review menu items with their accelerators', 
     expect(Shortcuts::accelerator('app.context-files'))->toBe('CmdOrCtrl+Shift+K');
 });
 
+test('the View submenu declares the keyboard-shortcuts menu item', function () {
+    // No hotkey: the `?` keymap shortcut already opens the cheat sheet, so the
+    // menu item is a click-only affordance that broadcasts ShowShortcutsRequested.
+    $source = file_get_contents((new ReflectionClass(NativeAppServiceProvider::class))->getFileName());
+
+    expect($source)
+        ->toContain("Menu::label('Keyboard Shortcuts')")
+        ->toContain("->id('show-shortcuts')");
+});
+
 // -- Inbox parser --
 
 test('two-line inbox with context mode routes to context-page', function () {

--- a/tests/Unit/Providers/NativeAppServiceProviderTest.php
+++ b/tests/Unit/Providers/NativeAppServiceProviderTest.php
@@ -74,18 +74,22 @@ test('dev compiled view cleanup skips deletion in testing environment', function
 
 // -- Menu structure --
 
-test('the View submenu declares the show-context menu item with the cmd-shift-k accelerator', function () {
-    // The hotkey lives in the menu builder DSL, which is wired through the
+test('the View submenu declares the review menu items with their accelerators', function () {
+    // The hotkeys live in the menu builder DSL, which is wired through the
     // native bridge. Read the source directly so the assertion stays fast
-    // and decoupled from the bridge. The accelerator itself is sourced from the
+    // and decoupled from the bridge. The accelerators are sourced from the
     // shortcuts catalog so the menu and the cheat sheet can't drift.
     $source = file_get_contents((new ReflectionClass(NativeAppServiceProvider::class))->getFileName());
 
     expect($source)
-        ->toContain("Menu::label('Show Context Files...')")
+        ->toContain("Menu::label('Review Code')")
+        ->toContain("->id('review-code')")
+        ->toContain("->hotkey(Shortcuts::accelerator('app.review-code'))")
+        ->toContain("Menu::label('Review Agents instructions')")
         ->toContain("->id('show-context')")
         ->toContain("->hotkey(Shortcuts::accelerator('app.context-files'))");
 
+    expect(Shortcuts::accelerator('app.review-code'))->toBe('CmdOrCtrl+Shift+C');
     expect(Shortcuts::accelerator('app.context-files'))->toBe('CmdOrCtrl+Shift+K');
 });
 


### PR DESCRIPTION
## What

Splits the single **"Show Context Files…"** View-menu item into two explicit triggers:

| Menu item | Hotkey | Navigates to |
|---|---|---|
| **Review Code** | ⌘⇧C | review-page (diff/code view) |
| **Review Agents instructions** | ⌘⇧K | context-page (renamed from "Show Context Files…") |

## Why

The View menu only offered a one-way jump to the context (agents-instructions) page. This adds the opposite direction — jumping back to the code review — and renames both entries to say plainly what they do.

## How

- **`config/shortcuts.php`** — adds `app.review-code` (⌘⇧C / `CmdOrCtrl+Shift+C`) and renames the `app.context-files` label to "Review agents instructions". The catalog is the single source of truth, so the native menu **and** the `?` cheat sheet both pick this up — they can't drift.
- **`NativeAppServiceProvider`** — two menu items at the top of the View submenu, each sourcing its accelerator from the catalog.
- **`HandleMenuItemClicked`** — new `review-code` arm. Both items resolve the active project the same way (renderer's mount-time cache write, falling back to the file picker on a cache miss/stale id), so the handler now shares one `navigateToActiveProject()` path.

## Tests

- Menu-structure unit test updated to assert both items and accelerators.
- 3 new menu-click cases for `review-code` (cached project, cache-miss fallback, no-project no-op).
- Arch catalog assertions extended for the new native shortcut.

Pint ✓ · PHPStan ✓ · 28 affected tests ✓

## Note

⌘⇧C is new menu wiring, so it only takes effect in a rebuilt app (`composer native:dev` or a packaged release) — the menu is constructed at boot, not hot-reloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRWtKbEfRB1xZJx1jsgGPU)_