### PR TITLE
feat: "Since the beginning" entire-repo review mode + predictable picker

### DIFF
--- a/.claude/plans/the-one-we-need-elegant-riddle.md
+++ b/.claude/plans/the-one-we-need-elegant-riddle.md
@@ -1,0 +1,274 @@
+# Plan: "Since the beginning" — review the entire repo as one diff
+
+## Context
+
+RFA lets you review git diffs and comment on them. Today the broadest scoped
+view is **"Since {base}"** — every commit on the branch plus uncommitted changes,
+collapsed into a single diff (`git diff <merge-base>` against the working tree).
+
+We want a sibling that goes all the way back: **the entire repository as one
+cumulative diff** — every line currently in the repo (committed + uncommitted),
+rendered as pure additions, so you can comment anywhere in the codebase.
+
+- **Name:** "Since the beginning" (chosen for symmetry with "Since {base}").
+- **Semantics (locked):** cumulative — one combined diff, *not* commit-by-commit.
+- **Mechanism:** `git diff <empty-tree>` against the working tree. The empty-tree
+  hash (`4b825dc642cb6eb9a060e54bf8d69288fbee4904`) is the universal "before
+  nothing" ref. Diffing from it = the whole codebase. This is exactly
+  "Since {base}" with `from` pushed back from the merge-base to the empty tree.
+
+The empty-tree approach is preferred over `<root-commit>^` because a repo can
+have **multiple root commits** (orphan branches, merged histories); the empty
+tree captures everything regardless. `DiffTarget::EMPTY_TREE_HASH` already exists.
+
+> This plan was reviewed by Codex (focus: edge cases, maintainability,
+> over-engineering). Its findings are folded in — notably two High-severity
+> safety issues (§ "Safety") and a simpler architecture (reuse `RangeToWorking`
+> instead of a new enum kind). See "Decisions" for the resolved trade-offs.
+
+## What already works (verified, no change needed)
+
+The existing range-to-working pipeline carries the empty-tree hash end to end:
+
+- **Route** `/p/{slug}/rw/{rangeFromWorking}` regex `[0-9a-fA-F]{4,40}\^?` already
+  matches the 40-char empty-tree hash.
+- **`ResolveRangeToWorkingAction`** calls `resolveRefExpression(from)`. For the
+  empty-tree hash, `resolveRef` returns `null` (it forces `^{commit}` and the
+  empty tree is a *tree*, not a commit), so `resolveRefExpression` **gracefully
+  falls back to the raw string** → `DiffTarget::rangeToWorking('4b825dc…')` →
+  `git diff 4b825dc…`. Verified: produces the full repo (623 files here).
+- **`GitDiffService`**: `to === null` ⇒ working-directory mode ⇒ untracked files
+  included too. Correct for "entire repo".
+- **Caching**: `to === null` ⇒ `isImmutable() === false` ⇒ treated as a
+  working-tree diff (re-computed, not pinned). Correct.
+- **`persistCurrentView`** already maps the `rangeFromWorking` arrival to
+  `LastViewKind::RangeToWorking` (when not since-base). We reuse that kind — no
+  persist-logic change, no `PersistProjectViewAction` change.
+
+## The restore trap (and its localized fix)
+
+`GitMetadataService::resolveRef()` appends `^{commit}`, returning `null` for the
+empty-tree hash. Harmless in `mount` (graceful fallback above), but on **restore**
+`ResolveProjectEntryUrlAction::buildRangeToWorkingUrl()` gates on `refExists()`
+(= `resolveRef !== null`). Persisted as `RangeToWorking` with `from = empty-tree`,
+re-entry would fail that check and **silently drop back to the working tree**.
+
+→ Fix is one early return, not a new enum: in `buildRangeToWorkingUrl()`,
+special-case `DiffTarget::EMPTY_TREE_HASH` (it always exists) and build the URL
+without the `refExists` gate. "Since the beginning" is a literal *immutable*
+diff-from, so — unlike `SinceBase`, which must re-resolve the merge-base over
+time — it needs no dedicated `LastViewKind`. (Do **not** teach `resolveRef()` to
+return tree objects; every other caller expects a commit.)
+
+## Safety (Codex High-severity findings — both verified)
+
+### A. Suppress the discard button in this mode (data-loss risk)
+`file-header.blade.php:73` shows "Discard changes" whenever `diffTo === null`. In
+"Since the beginning" every tracked file is `status === 'added'` & not untracked,
+so `DiscardFileChangesAction::executeDiscard()` line 85 runs `git rm -f -- <path>`
+— a clean **committed** file gets removed from the worktree/index. Discard is
+coherent in working-tree / since-base / `/rw/<commit>` views (the diff reflects
+real user changes); it is meaningless and destructive when `from` is the empty
+tree.
+- **Fix:** thread an `allowDiscard` (false when `diffFrom === EMPTY_TREE_HASH`)
+  from `⚡review-page` → `⚡diff-file` → `<x-diff.file-header>`, and gate the
+  `@if` at `file-header.blade.php:73` on it. Targeted to empty-tree; leaves all
+  other modes untouched. (Broader "explicit can-discard concept" is noted as
+  future hardening, out of scope.)
+
+### B. Don't let the explorer's Apply mangle the mode
+When active on `/rw/<empty-tree>`, reopening the branch-explorer rehydrates
+selection (`branch-explorer.js:482`) by filling `selectedHashes` with all
+*loaded* commits (`_hashesInRange` already special-cases `EMPTY_TREE_HASH` at
+line 524). With pagination or multiple roots, pressing **Apply** rewrites the
+view to `/rw/<oldest-loaded>^` — silently losing "entire repo".
+- **Fix:** add an explicit `sinceBeginningActive` getter. It must be
+  `activeCommitHash === null && activeDiffFrom === EMPTY_TREE_HASH` — **not** just
+  the empty-tree check: a root-commit view (`/c/{root}`) also has
+  `diffFrom === EMPTY_TREE_HASH` because `DiffTarget::commit()` uses the empty
+  tree as a parentless root's parent (`DiffTarget.php:26`), and the page passes
+  `diffTo` as `activeCommitHash` (review-page:1288). The `activeCommitHash ===
+  null` clause disambiguates (since-beginning has `diffTo === null`; a root-commit
+  view has `diffTo === <hash>`). In the rehydrate path, when active, leave
+  `selectedHashes = []` / `workingTreeSelected = false` so Apply is a no-op until
+  the user makes a deliberate new selection. Highlight the new row (§ Affordance)
+  as active in that state.
+  - The PHP-side `isSinceBeginningView` is already safe: it requires
+    `$this->diffTo === null`, which a root-commit view never satisfies.
+
+## Changes
+
+### 1. Page — `resources/views/pages/⚡review-page.blade.php`
+- New `public bool $isSinceBeginningView = false;`.
+- Compute it **once after `diffFrom`/`diffTo` are resolved in `mount()`** (right
+  after the mode branches, near line 245), inline — no Action, no git:
+  `$this->isSinceBeginningView = $this->diffTo === null && $this->diffFrom ===
+  DiffTarget::EMPTY_TREE_HASH;`. (Per Codex: `rehydrateForTarget()` is the wrong
+  hook — it only reloads lists/session.)
+- **Header label** (match at line 1268): add an arm *before* the generic
+  `$diffTo === null` arm:
+  `$isSinceBeginningView => ['Since the beginning', 'Entire repository (every commit + uncommitted)']`.
+- Pass `allowDiscard` (= `! $isSinceBeginningView`) down to the `<livewire:diff-file>`
+  children, and add `is_since_beginning_view` to the `page.review.mounted`
+  diagnostics payload (line 257) and `Context::add` (line 531), beside the
+  since-base flag.
+- Persist logic at line 278 is **unchanged** — empty-tree persists as
+  `RangeToWorking` (since-base detection returns false for the empty tree because
+  `resolveRef` can't commit-resolve it).
+
+### 2. Restore — `app/Actions/ResolveProjectEntryUrlAction.php`
+In `buildRangeToWorkingUrl()`, before the `refExists` gate: if `$fromBase ===
+DiffTarget::EMPTY_TREE_HASH`, return the `review-page.range-to-working` route with
+`rangeFromWorking => DiffTarget::EMPTY_TREE_HASH`. (Import `DiffTarget`.)
+
+### 3. Discard gate — `⚡diff-file` + `<x-diff.file-header>`
+Add an `allowDiscard` prop (default `true`) on `⚡diff-file.blade.php`, forward it
+to `<x-diff.file-header>`, and change the discard `@if` at `file-header.blade.php:73`
+to also require `$allowDiscard`. Default `true` keeps every existing call site
+behaving identically.
+
+### 4. Affordance — branch-explorer (the actual entry point)
+Per `pages/CLAUDE.md`, a mode exists only once something navigates to it. This
+feature adds the "Since the beginning" row **and** makes the picker more
+predictable by giving "Since {base}" a stable, always-present position.
+
+**Predictability principle (this picker):** scope-selection affordances keep a
+fixed position and are *disabled with a one-line reason* when unavailable —
+never removed. Removing a row shifts the layout and makes the option feel like it
+doesn't exist; a disabled row with a reason teaches what it is and why it's off.
+
+#### 4a. "Since the beginning" row (new)
+- **`public/js/branch-explorer.js`**: add `viewSinceBeginning()` →
+  `Livewire.navigate(\`/p/${this.projectSlug}/rw/${EMPTY_TREE_HASH}\`)` reusing the
+  **existing** `EMPTY_TREE_HASH` constant (no new literal). Direct navigation like
+  `viewWorkingTree()` — not the selection/Apply path. Add the `sinceBeginningActive`
+  getter and the rehydrate guard from § Safety B.
+- **`⚡branch-explorer.blade.php`**: a row just after the "Since {base}" block
+  (~line 444), `data-testid="since-beginning-row"`, label "Since the beginning",
+  subtext "entire repository". **Always available and enabled** — empty-tree →
+  working tree is well-defined on any branch and needs no base config. Active
+  highlight bound to `sinceBeginningActive`.
+
+#### 4b. "Since {base}" — always shown, disable-with-reason (predictability)
+Today `sinceBaseRowVisible` (branch-explorer.js:141) hides the row in **two**
+cases: when the picker browses a non-current branch, and when `state ===
+on_base_branch`. The other states (`up_to_date`, `missing_ref`, `not_configured`)
+already render with text. Make the row **always render** in a fixed position with
+a unified actionable-vs-disabled presentation across all six states:
+
+| Condition | Presentation | Reason line |
+|---|---|---|
+| `ready` (on current branch) | **enabled / clickable** | "{N} commits + uncommitted changes" |
+| `up_to_date` | disabled | "no commits ahead" |
+| `missing_ref` | disabled | "base ref not found locally — run `git fetch`" |
+| `not_configured` | disabled | "set a base branch in project settings" |
+| `on_base_branch` (NEW — was hidden) | disabled | "you're on the base branch" |
+| browsing a different branch (NEW — was hidden) | disabled | "compares against your current branch ({currentBranch})" |
+
+- **`branch-explorer.js`**: replace `sinceBaseRowVisible` (now effectively always
+  true) with `sinceBaseActionable` (`state === ready && selectedBranch ===
+  currentBranch`) and a `sinceBaseReason` getter returning the per-state reason
+  string from the table. `selectSinceBase()` early-returns unless
+  `sinceBaseActionable` (already guards on `Ready`; add the branch check).
+  - **Null-safety:** the component initializes `branchBase` to `null`
+    (`⚡branch-explorer.blade.php:53`); today the outer `x-if="sinceBaseRowVisible"`
+    shields the inner `$wire.branchBase.state` reads until data loads. Removing
+    that guard means `sinceBaseActionable` / `sinceBaseReason` and every
+    label/subtext binding must handle `!this.$wire.branchBase` without touching
+    `.state` / `.baseBranch` — treat a null `branchBase` as disabled (loading /
+    `not_configured`-style), never throw.
+- **`⚡branch-explorer.blade.php`**: collapse the four existing per-state `x-if`
+  templates (lines ~361–443) into one always-rendered row — clickable when
+  `sinceBaseActionable`, otherwise the shared disabled treatment (dimmed, no
+  checkbox, `aria-disabled`, reason via `sinceBaseReason`). This *reduces* template
+  branching while covering two more states. Mirror the disabled styling already
+  used by the working-tree checkbox's `!workingTreeSelectable` state for
+  consistency.
+
+#### 4c. Follow-up issue (app-wide audit)
+Scope here is the picker only. File a GitHub issue (repo `fgilio/rfa`, `gh issue
+create`) capturing the broader principle for a later pass — created during
+implementation, not in plan mode. Draft body:
+
+> **Title:** Predictable UI: disable-with-reason instead of hiding affordances
+> **Body:** The branch-explorer now keeps scope options ("Since {base}", "Since
+> the beginning", working tree) in a fixed position and disables them with a
+> reason when unavailable, rather than hiding them (PR: this feature). Audit the
+> rest of the app for affordances that appear/disappear based on state — header
+> buttons, native menu items (`HandleMenuItemClicked`), settings entries, remote
+> actions — and convert conditional *hiding* to *disable-with-reason* where the
+> option is real but currently unusable. Goal: a stable, learnable layout where
+> nothing silently vanishes. Out of scope: options that are genuinely
+> inapplicable (not merely unavailable).
+
+## Tests (mirror existing siblings)
+
+- `tests/Unit/Actions/ResolveProjectEntryUrlActionTest.php` — a session persisted
+  as `RangeToWorking` with `from = EMPTY_TREE_HASH` restores to `/rw/{empty-tree}`
+  (regression guard for the `refExists` trap). Template: existing since-base test.
+- `tests/Unit/Livewire/ReviewPageRangeAndSelectionTest.php` — mounting
+  `rangeFromWorking = <empty-tree>` sets `isSinceBeginningView = true`, renders
+  "Since the beginning", and the diff-file children receive `allowDiscard = false`.
+- **Discard guard test** — assert no discard affordance / the discard `@if` is
+  false when `diffFrom === EMPTY_TREE_HASH`, true otherwise (the data-loss guard).
+- `tests/Feature/ReviewPageRoutesTest.php` — the `rw` route resolves the empty-tree
+  hash and the page mounts with the full file set; **plus an unborn-HEAD repo**
+  (no commits) mounts `/rw/<empty-tree>` without error.
+- `tests/Js/branch-explorer.test.js` — `viewSinceBeginning()` navigates to the
+  empty-tree `rw` URL; the row is always visible; reopening while
+  `sinceBeginningActive` leaves `selectedHashes` empty so Apply is a no-op.
+- **Predictable "Since {base}" tests** (`branch-explorer.test.js` +
+  `tests/Browser/`): the row renders for **all six** states; `sinceBaseActionable`
+  is true only for `ready` on the current branch; `sinceBaseReason` returns the
+  right line per state; the disabled row ignores clicks (no navigation) for
+  `on_base_branch` and the different-branch case (the two newly-shown states).
+- `tests/Unit/DTOs/DiffTargetTest.php` — `rangeToWorking(EMPTY_TREE_HASH)` →
+  `['diff', '4b825dc…']` and `isWorkingDirectory() === true`.
+- **JS/PHP constant parity** — a small test asserting the JS `EMPTY_TREE_HASH`
+  equals `DiffTarget::EMPTY_TREE_HASH` (cheap guard against drift since the JS
+  layer can't import the PHP constant).
+
+## Verification (end to end)
+
+1. `composer test:lint && composer test:types`
+2. `php artisan test --compact` (or `--filter` the files above).
+3. Manual via `composer native:dev`:
+   - Open a repo → branch-explorer → "Since the beginning" → whole codebase
+     renders as additions; header reads "Since the beginning"; **no discard
+     buttons** on file headers.
+   - Comment, navigate away, re-enter the project → restores to "Since the
+     beginning" (not working tree) — the `refExists` regression.
+   - Reopen the explorer while in this mode → the row shows active, no commits
+     pre-selected, Apply does nothing → mode preserved (Safety B).
+   - Repo with an orphan/second root branch → every root's files appear.
+   - Unborn repo (no commits) → the row mounts without error.
+   - "Since {base}" predictability: on the base branch, with no base configured,
+     with a missing ref, and while browsing a different branch → the row is
+     **present but disabled** with the right reason each time (never missing).
+4. After approval: `gh issue create` for the app-wide predictability audit
+   (§ 4c), then paste the issue URL into the PR description.
+
+## Decisions (resolved with Codex)
+
+1. **No dedicated `LastViewKind`.** Reuse `RangeToWorking`; fix restore with the
+   one-line `EMPTY_TREE_HASH` special-case in `buildRangeToWorkingUrl()`. Less
+   state, no persist/`PersistProjectViewAction` change. The empty tree is an
+   immutable diff-from, so the re-resolution rationale that earns `SinceBase` its
+   own kind doesn't apply here.
+2. **No `IsSinceBeginningViewAction`.** It's a constant compare — inline it.
+   (`IsSinceBaseViewAction` earns its class by shelling out to merge-base.)
+3. **Reuse the existing JS `EMPTY_TREE_HASH` constant**; add the parity test so it
+   can't drift from the PHP constant. (Passing it from Blade was considered but
+   the constant is already used in `_hashesInRange`; one source within JS + a
+   drift guard is the lighter call.)
+4. **Big-repo guardrail.** Diff bodies already lazy-load per file on intersect, so
+   the cost is bounded at view time. The open risk is the file-header *count*
+   (one Livewire `diff-file` per repo file — cf. the `TooManyComponentsException`
+   note in `resources/CLAUDE.md`). **Recommend** a soft preflight: if the
+   resolved file count exceeds a threshold, show a one-line "Entire repo — N
+   files" notice. Treat a hard cap as out of scope unless testing on a large repo
+   shows a real failure.
+5. **Unborn HEAD.** `/rw/<empty-tree>` avoids `git diff HEAD` (that runs only in
+   default working-tree mode), and divergence/commit-log paths already rescue to
+   sentinels/empties. Covered by the explicit unborn-HEAD tests above rather than
+   new guards.

--- a/app/Actions/ResolveProjectEntryUrlAction.php
+++ b/app/Actions/ResolveProjectEntryUrlAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\DTOs\DiffTarget;
 use App\Enums\LastViewKind;
 use App\Enums\LastViewMode;
 use App\Models\Project;
@@ -155,6 +156,17 @@ final readonly class ResolveProjectEntryUrlAction
         }
 
         $fromBase = str_ends_with($from, '^') ? substr($from, 0, -1) : $from;
+
+        // "Since the beginning" diffs from git's empty tree, which always exists
+        // but is a tree, not a commit, so resolveRef (which forces ^{commit})
+        // can't verify it. Rebuild the URL directly rather than failing the gate.
+        if ($fromBase === DiffTarget::EMPTY_TREE_HASH) {
+            return route('review-page.range-to-working', [
+                'slug' => $slug,
+                'rangeFromWorking' => DiffTarget::EMPTY_TREE_HASH,
+            ]);
+        }
+
         if ($fromBase !== '' && ! $this->refExists($project->path, $fromBase)) {
             return null;
         }

--- a/app/Concerns/ReviewPage/ManagesReviewTrash.php
+++ b/app/Concerns/ReviewPage/ManagesReviewTrash.php
@@ -36,6 +36,13 @@ trait ManagesReviewTrash
             return;
         }
 
+        // In the entire-repo view every tracked file diffs as "added" from the
+        // empty tree, so discarding one would run `git rm -f` on an otherwise
+        // clean committed file. Refuse here regardless of which control fired.
+        if ($this->isSinceBeginningView) {
+            return;
+        }
+
         $file = collect($this->files)->firstWhere('id', $fileId);
         if (! $file || $file['status'] === 'commented' || ($file['isExternal'] ?? false)) {
             return;

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -132,17 +132,55 @@
             },
 
             /**
-             * Showing the "Since {base}" row only makes sense for the project's
-             * current branch - the configured base is HEAD-relative, not relative
-             * to whichever branch the picker happens to be displaying. The
-             * `on_base_branch` state is also hidden because comparing a branch
-             * to itself is nonsense.
+             * The "Since {base}" row is always rendered for a predictable layout,
+             * but it's only clickable on the project's current branch with a base
+             * that's configured, resolved, and ahead of HEAD. The configured base
+             * is HEAD-relative, so it's meaningless while browsing another branch.
              */
-            get sinceBaseRowVisible() {
-                if (this.selectedBranch !== currentBranch) return false;
+            get sinceBaseActionable() {
                 const base = this.$wire.branchBase;
                 if (!base) return false;
-                return base.state !== BranchBaseState.OnBaseBranch;
+                if (this.selectedBranch !== this.currentBranch) return false;
+                return base.state === BranchBaseState.Ready;
+            },
+
+            /**
+             * One-line explanation under the "Since {base}" row. For the ready
+             * state it's the scope summary; otherwise it names why the row can't
+             * be used right now. Null-safe: the row renders before branchBase
+             * loads, so a missing snapshot must not throw.
+             */
+            get sinceBaseReason() {
+                const base = this.$wire.branchBase;
+                if (!base) return '';
+                if (this.selectedBranch !== this.currentBranch) {
+                    return `compares against your current branch (${this.currentBranch})`;
+                }
+
+                switch (base.state) {
+                    case BranchBaseState.Ready:
+                        return `${base.commitCount} commit${base.commitCount === 1 ? '' : 's'} + uncommitted changes`;
+                    case BranchBaseState.UpToDate:
+                        return 'no commits ahead';
+                    case BranchBaseState.MissingRef:
+                        return 'base ref not found locally (run git fetch)';
+                    case BranchBaseState.OnBaseBranch:
+                        return "you're on the base branch";
+                    case BranchBaseState.NotConfigured:
+                        return 'set a base branch in project settings';
+                    default:
+                        return '';
+                }
+            },
+
+            /**
+             * True when the active view is the whole repo ("Since the beginning").
+             * The empty-tree check alone is ambiguous: a root commit's diff also
+             * starts from the empty tree, so require `activeCommitHash === null`
+             * (working-tree target) to tell the two apart.
+             */
+            get sinceBeginningActive() {
+                return this.activeCommitHash === null && this.activeDiffFrom === EMPTY_TREE_HASH;
             },
 
             get sinceBaseSelected() {
@@ -362,6 +400,10 @@
                 Livewire.navigate(`/p/${this.projectSlug}`);
             },
 
+            viewSinceBeginning() {
+                Livewire.navigate(`/p/${this.projectSlug}/rw/${EMPTY_TREE_HASH}`);
+            },
+
             isSelected(hash) {
                 return this.selectedHashes.includes(hash);
             },
@@ -471,6 +513,18 @@
                 const from = this.activeDiffFrom;
                 const tip = this.activeCommitHash;
 
+                // "Since the beginning" is a fixed whole-repo view, not a commit
+                // range. Leave the multi-select empty so Apply stays a no-op until
+                // the user makes a deliberate selection - otherwise rehydrating it
+                // as "all loaded commits + WT" would let Apply rewrite the mode.
+                if (this.sinceBeginningActive) {
+                    this.workingTreeSelected = false;
+                    this.selectedHashes = [];
+                    this.lastSelectionAnchorIsWT = false;
+                    this.lastSelectionIndex = -1;
+                    return;
+                }
+
                 if (tip === null && from === 'HEAD') {
                     this.workingTreeSelected = true;
                     this.selectedHashes = [];
@@ -565,8 +619,8 @@
              * selected.
              */
             selectSinceBase() {
+                if (!this.sinceBaseActionable) return;
                 const base = this.$wire.branchBase;
-                if (!base || base.state !== BranchBaseState.Ready) return;
                 this._clearSelectionError();
 
                 if (this.sinceBaseSelected) {
@@ -680,5 +734,5 @@
         }
     }
 
-    return { BranchBaseState, isSinceBaseExactly, violatesTipAnchor, stripRemotePrefix, createBranchExplorer, install, autoInstall };
+    return { BranchBaseState, EMPTY_TREE_HASH, isSinceBaseExactly, violatesTipAnchor, stripRemotePrefix, createBranchExplorer, install, autoInstall };
 });

--- a/resources/views/components/diff/file-header.blade.php
+++ b/resources/views/components/diff/file-header.blade.php
@@ -7,6 +7,7 @@
     'hasRemote' => false,
     'diffTo' => null,
     'repoPath' => '',
+    'allowDiscard' => true,
 ])
 
 @php
@@ -70,7 +71,7 @@
                 </flux:dropdown>
             @endif
 
-            @if($diffTo === null && ($file['status'] ?? '') !== 'commented' && ! ($file['isExternal'] ?? false))
+            @if($allowDiscard && $diffTo === null && ($file['status'] ?? '') !== 'commented' && ! ($file['isExternal'] ?? false))
                 <flux:button
                     tooltip="Discard changes"
                     aria-label="Discard changes"

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -355,94 +355,66 @@ new class extends Component {
 
                     {{-- Commits list --}}
                     <div class="overflow-y-auto flex-1" x-ref="commitList">
-                        {{-- "Since {base}" shortcut: a single click fills the
-                             multi-select with every commit in base..HEAD plus
-                             working tree, so the user can trim before applying. --}}
-                        <template x-if="sinceBaseRowVisible">
-                            <div data-testid="since-base-row">
-                                {{-- Ready: clickable shortcut --}}
-                                <template x-if="$wire.branchBase.state === 'ready'">
-                                    <div
-                                        class="px-4 py-2.5 border-b border-gh-border/50 hover:bg-gh-border/20 transition-colors group cursor-pointer"
-                                        @click="selectSinceBase()"
-                                        :class="{ 'bg-gh-link/5 border-l-2 border-l-gh-link': sinceBaseSelected }"
-                                        :aria-pressed="sinceBaseSelected"
-                                    >
-                                        <div class="flex items-start gap-2">
-                                            <span
-                                                class="mt-0.5 size-4 shrink-0 grid place-items-center rounded border transition-colors"
-                                                :class="sinceBaseSelected
-                                                    ? 'border-gh-link bg-gh-link/20 text-gh-link'
-                                                    : 'border-gh-border opacity-0 group-hover:opacity-100'"
-                                                aria-hidden="true"
-                                            >
-                                                <template x-if="sinceBaseSelected">
-                                                    <flux:icon icon="check" variant="outline" class="!size-3" />
-                                                </template>
-                                            </span>
-                                            <div class="min-w-0 flex-1">
-                                                <div class="text-xs text-gh-text truncate font-medium tracking-tight">
-                                                    Since <span class="font-mono" x-text="$wire.branchBase.baseBranch"></span>
-                                                </div>
-                                                <span
-                                                    class="block mt-0.5 text-[10px] font-mono text-gh-muted"
-                                                    x-text="$wire.branchBase.commitCount + ' commit' + ($wire.branchBase.commitCount === 1 ? '' : 's') + ' + uncommitted changes'"
-                                                ></span>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </template>
+                        {{-- The three scope rows are cumulative ranges ending at the
+                             working tree, ordered widest first so reach-back shrinks
+                             going down: entire repo, then base..HEAD, then just the
+                             working tree as the hinge before the per-commit list. --}}
 
-                                {{-- Up to date with base: dimmed, not actionable --}}
-                                <template x-if="$wire.branchBase.state === 'up_to_date'">
-                                    <div class="px-4 py-2.5 border-b border-gh-border/50">
-                                        <div class="flex items-start gap-2 opacity-60">
-                                            <span class="mt-0.5 size-4 shrink-0" aria-hidden="true"></span>
-                                            <div class="min-w-0 flex-1">
-                                                <div class="text-xs text-gh-text truncate tracking-tight">
-                                                    Up to date with <span class="font-mono" x-text="$wire.branchBase.baseBranch"></span>
-                                                </div>
-                                                <span class="block mt-0.5 text-[10px] font-mono text-gh-muted">no commits ahead</span>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </template>
-
-                                {{-- Missing ref: actionable hint --}}
-                                <template x-if="$wire.branchBase.state === 'missing_ref'">
-                                    <div class="px-4 py-2.5 border-b border-gh-border/50">
-                                        <div class="flex items-start gap-2">
-                                            <span class="mt-0.5 size-4 shrink-0 text-gh-muted" aria-hidden="true">
-                                                <flux:icon icon="exclamation-triangle" variant="outline" class="!size-3.5" />
-                                            </span>
-                                            <div class="min-w-0 flex-1">
-                                                <div class="text-xs text-gh-text truncate tracking-tight">
-                                                    Run <span class="font-mono">git fetch</span> to compare with <span class="font-mono" x-text="$wire.branchBase.baseBranch"></span>
-                                                </div>
-                                                <span class="block mt-0.5 text-[10px] font-mono text-gh-muted">base ref not found locally</span>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </template>
-
-                                {{-- Not configured: nudge to settings --}}
-                                <template x-if="$wire.branchBase.state === 'not_configured'">
-                                    <div class="px-4 py-2.5 border-b border-gh-border/50">
-                                        <div class="flex items-start gap-2 opacity-80">
-                                            <span class="mt-0.5 size-4 shrink-0 text-gh-muted" aria-hidden="true">
-                                                <flux:icon icon="cog-6-tooth" variant="outline" class="!size-3.5" />
-                                            </span>
-                                            <div class="min-w-0 flex-1">
-                                                <div class="text-xs text-gh-text truncate tracking-tight">Pick a base branch to compare against</div>
-                                                <span class="block mt-0.5 text-[10px] font-mono text-gh-muted">set it from the project settings menu</span>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </template>
-
-                                {{-- on_base_branch: hidden entirely (comparing X..X is nonsense) --}}
+                        {{-- "Since the beginning": the whole repo (git's empty tree
+                             through the working tree) as one diff. Always available.
+                             Needs no base branch and works on any branch. --}}
+                        <div
+                            data-testid="since-beginning-row"
+                            class="px-4 py-2.5 border-b border-gh-border/50 hover:bg-gh-border/20 transition-colors group cursor-pointer"
+                            @click="viewSinceBeginning()"
+                            :class="{ 'bg-gh-text/5 border-l-2 border-l-gh-text': sinceBeginningActive }"
+                            :aria-current="sinceBeginningActive ? 'true' : null"
+                        >
+                            <div class="flex items-start gap-2">
+                                <span class="mt-0.5 size-4 shrink-0" aria-hidden="true"></span>
+                                <div class="min-w-0 flex-1">
+                                    <div class="text-xs text-gh-text truncate font-medium tracking-tight">Since the beginning</div>
+                                    <span class="block mt-0.5 text-[10px] font-mono text-gh-muted">entire repository</span>
+                                </div>
                             </div>
-                        </template>
+                        </div>
+
+                        {{-- "Since {base}" row: always present so its position never
+                             shifts. Clickable when the base is configured, resolved,
+                             and HEAD is ahead; otherwise disabled with a reason that
+                             names why it can't be used right now. --}}
+                        <div
+                            data-testid="since-base-row"
+                            class="px-4 py-2.5 border-b border-gh-border/50 group"
+                            :class="sinceBaseActionable
+                                ? ('cursor-pointer hover:bg-gh-border/20 transition-colors' + (sinceBaseSelected ? ' bg-gh-link/5 border-l-2 border-l-gh-link' : ''))
+                                : 'opacity-60 cursor-not-allowed'"
+                            :aria-disabled="sinceBaseActionable ? null : 'true'"
+                            :aria-pressed="sinceBaseActionable ? (sinceBaseSelected ? 'true' : 'false') : null"
+                            @click="sinceBaseActionable && selectSinceBase()"
+                        >
+                            <div class="flex items-start gap-2">
+                                <span
+                                    class="mt-0.5 size-4 shrink-0 grid place-items-center rounded border transition-colors"
+                                    :class="!sinceBaseActionable
+                                        ? 'border-gh-border opacity-30'
+                                        : (sinceBaseSelected
+                                            ? 'border-gh-link bg-gh-link/20 text-gh-link'
+                                            : 'border-gh-border opacity-0 group-hover:opacity-100')"
+                                    aria-hidden="true"
+                                >
+                                    <template x-if="sinceBaseActionable && sinceBaseSelected">
+                                        <flux:icon icon="check" variant="outline" class="!size-3" />
+                                    </template>
+                                </span>
+                                <div class="min-w-0 flex-1">
+                                    <div class="text-xs text-gh-text truncate font-medium tracking-tight">
+                                        Since <span class="font-mono" x-text="($wire.branchBase && $wire.branchBase.baseBranch) || 'base branch'"></span>
+                                    </div>
+                                    <span class="block mt-0.5 text-[10px] font-mono text-gh-muted" x-text="sinceBaseReason"></span>
+                                </div>
+                            </div>
+                        </div>
 
                         <div
                             data-testid="working-tree-row"

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -36,6 +36,10 @@ new class extends Component {
     #[Locked]
     public ?string $diffTo = null;
 
+    /** False suppresses the discard affordance where it would be destructive, e.g. the empty-tree "Since the beginning" view. */
+    #[Locked]
+    public bool $allowDiscard = true;
+
     public bool $isReviewed = false;
 
     public bool $singleFile = false;
@@ -421,6 +425,7 @@ HTML;
         :has-remote="$hasRemote"
         :diff-to="$diffTo"
         :repo-path="$repoPath"
+        :allow-discard="$allowDiscard"
     />
 
     {{-- File body --}}

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -132,6 +132,10 @@ new #[Layout('layouts.app')] class extends Component
     #[Locked]
     public bool $isSinceBaseView = false;
 
+    /** True when the active diff is the whole repo: git's empty tree through the working tree. */
+    #[Locked]
+    public bool $isSinceBeginningView = false;
+
     /** @var array{shortHash: string, message: string, author: string, prevHash: ?string, nextHash: ?string}|null */
     #[Locked]
     public ?array $commitInfo = null;
@@ -243,6 +247,7 @@ new #[Layout('layouts.app')] class extends Component
         }
 
         $this->isSinceBaseView = $this->detectSinceBaseView();
+        $this->isSinceBeginningView = $this->diffTo === null && $this->diffFrom === DiffTarget::EMPTY_TREE_HASH;
 
         $this->rehydrateForTarget();
         $this->checkHeadDivergence();
@@ -255,6 +260,7 @@ new #[Layout('layouts.app')] class extends Component
             'repo_hash' => hash('xxh128', $this->repoPath),
             'target' => $this->buildDiffTarget()->contextKey(),
             'is_since_base_view' => $this->isSinceBaseView,
+            'is_since_beginning_view' => $this->isSinceBeginningView,
             'file_count' => count($this->files),
             'source_file_count' => count($this->sourceFiles),
             'comment_count' => count($this->comments),
@@ -529,6 +535,7 @@ new #[Layout('layouts.app')] class extends Component
             Context::add('rfa.project_slug', $this->projectSlug);
             Context::add('rfa.target', $this->buildDiffTarget()->contextKey());
             Context::add('rfa.is_since_base_view', $this->isSinceBaseView);
+            Context::add('rfa.is_since_beginning_view', $this->isSinceBeginningView);
             Context::add('rfa.file_count_before', count($before));
             Context::add('rfa.diff_refresh_token', $this->diffRefreshToken);
             Context::add('rfa.duration_ms', (int) round((microtime(true) - $startedAt) * 1000));
@@ -1270,6 +1277,8 @@ new #[Layout('layouts.app')] class extends Component
                             => ['Working tree', 'Working tree changes'],
                         $isSinceBaseView
                             => ['Since '.$defaultBaseBranch, 'All changes since '.$defaultBaseBranch.' (commits + uncommitted)'],
+                        $isSinceBeginningView
+                            => ['Since the beginning', 'Entire repository (every commit + uncommitted)'],
                         $diffTo === null
                             => ['WT · '.$shortFrom, 'Working tree + commits through '.$diffFrom],
                         $diffFrom === $diffTo.'^'
@@ -1744,6 +1753,7 @@ new #[Layout('layouts.app')] class extends Component
                                     :has-remote="$hasRemote"
                                     :diff-from="$diffFrom"
                                     :diff-to="$diffTo"
+                                    :allow-discard="! $isSinceBeginningView"
                                 />
                             </div>
                         </div>
@@ -1777,6 +1787,7 @@ new #[Layout('layouts.app')] class extends Component
                                 :has-remote="$hasRemote"
                                 :diff-from="$diffFrom"
                                 :diff-to="$diffTo"
+                                :allow-discard="! $isSinceBeginningView"
                             />
                         </div>
                     @empty

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1648,7 +1648,7 @@ new #[Layout('layouts.app')] class extends Component
                             <flux:tooltip.content>{{ $isReviewed ? 'Un-mark as reviewed' : 'Mark as reviewed' }}</flux:tooltip.content>
                         </flux:tooltip>
                         <span class="shrink-0 size-3.5 flex items-center justify-center">
-                            @if(! $this->isCommitMode() && $file['status'] !== 'commented' && ! ($file['isExternal'] ?? false))
+                            @if(! $this->isCommitMode() && ! $isSinceBeginningView && $file['status'] !== 'commented' && ! ($file['isExternal'] ?? false))
                                 <flux:tooltip content="Discard changes">
                                     <button
                                         class="opacity-0 group-hover:opacity-100 transition-opacity text-gh-muted hover:text-gh-text data-loading:pointer-events-none data-loading:opacity-50"

--- a/tests/Js/branch-explorer.test.js
+++ b/tests/Js/branch-explorer.test.js
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import branchExplorer from '../../public/js/branch-explorer.js';
 
-const { BranchBaseState, isSinceBaseExactly, stripRemotePrefix, createBranchExplorer, install } = branchExplorer;
+const { BranchBaseState, EMPTY_TREE_HASH, isSinceBaseExactly, stripRemotePrefix, createBranchExplorer, install } = branchExplorer;
 
 /** Minimal factory wrapper for tests that exercise the Alpine state machine
  *  directly. Provides a stub `$wire` that the production code reads from. */
@@ -588,6 +588,87 @@ describe('_rehydrateSelectionFromActiveView', () => {
         a._rehydrateSelectionFromActiveView();
 
         expect(a.selectedHashes).toEqual(['unknown-tip']);
+    });
+});
+
+describe('since the beginning (entire repo)', () => {
+    afterEach(() => {
+        delete global.Livewire;
+        delete window.Livewire;
+    });
+
+    it('viewSinceBeginning navigates to the empty-tree range-to-working URL', () => {
+        const navigate = vi.fn();
+        global.Livewire = window.Livewire = { navigate };
+
+        makeForView().viewSinceBeginning();
+
+        expect(navigate).toHaveBeenCalledWith(`/p/p/rw/${EMPTY_TREE_HASH}`);
+    });
+
+    it('sinceBeginningActive is true only for the whole-repo working-tree view', () => {
+        expect(makeForView({ activeCommitHash: null, activeDiffFrom: EMPTY_TREE_HASH }).sinceBeginningActive).toBe(true);
+    });
+
+    it('sinceBeginningActive is false for a root commit view (empty-tree from, pinned commit)', () => {
+        expect(makeForView({ activeCommitHash: 'aaa1', activeDiffFrom: EMPTY_TREE_HASH }).sinceBeginningActive).toBe(false);
+    });
+
+    it('sinceBeginningActive is false for an ordinary working-tree view', () => {
+        expect(makeForView({ activeCommitHash: null, activeDiffFrom: 'HEAD' }).sinceBeginningActive).toBe(false);
+    });
+
+    it('rehydrate leaves the selection empty so Apply stays a no-op', () => {
+        const a = makeForView({ activeCommitHash: null, activeDiffFrom: EMPTY_TREE_HASH, commits: longCommits });
+        a._rehydrateSelectionFromActiveView();
+
+        expect(a.workingTreeSelected).toBe(false);
+        expect(a.selectedHashes).toEqual([]);
+        expect(a.lastSelectionAnchorIsWT).toBe(false);
+        expect(a.lastSelectionIndex).toBe(-1);
+    });
+});
+
+describe('since-base row predictability', () => {
+    function withBase(state, { branch = 'main', baseBranch = 'main', commitCount = 3 } = {}) {
+        return makeForView({
+            branch,
+            branchBase: state === null
+                ? null
+                : { state, baseBranch, commitCount, baseSha: 'base', hashesInRange: [] },
+        });
+    }
+
+    it('is actionable only in the ready state on the current branch', () => {
+        expect(withBase(BranchBaseState.Ready).sinceBaseActionable).toBe(true);
+        expect(withBase(BranchBaseState.UpToDate).sinceBaseActionable).toBe(false);
+        expect(withBase(BranchBaseState.MissingRef).sinceBaseActionable).toBe(false);
+        expect(withBase(BranchBaseState.NotConfigured).sinceBaseActionable).toBe(false);
+        expect(withBase(BranchBaseState.OnBaseBranch).sinceBaseActionable).toBe(false);
+    });
+
+    it('is not actionable while browsing a different branch even when ready', () => {
+        expect(withBase(BranchBaseState.Ready, { branch: 'feature/x' }).sinceBaseActionable).toBe(false);
+    });
+
+    it('gives a reason for every state', () => {
+        expect(withBase(BranchBaseState.Ready, { commitCount: 1 }).sinceBaseReason).toBe('1 commit + uncommitted changes');
+        expect(withBase(BranchBaseState.Ready, { commitCount: 3 }).sinceBaseReason).toBe('3 commits + uncommitted changes');
+        expect(withBase(BranchBaseState.UpToDate).sinceBaseReason).toBe('no commits ahead');
+        expect(withBase(BranchBaseState.MissingRef).sinceBaseReason).toBe('base ref not found locally (run git fetch)');
+        expect(withBase(BranchBaseState.OnBaseBranch).sinceBaseReason).toBe("you're on the base branch");
+        expect(withBase(BranchBaseState.NotConfigured).sinceBaseReason).toBe('set a base branch in project settings');
+    });
+
+    it('explains the off-branch case with the current branch name', () => {
+        expect(withBase(BranchBaseState.Ready, { branch: 'feature/x' }).sinceBaseReason)
+            .toBe('compares against your current branch (main)');
+    });
+
+    it('is null-safe before the branch-base snapshot loads', () => {
+        const a = withBase(null);
+        expect(a.sinceBaseActionable).toBe(false);
+        expect(a.sinceBaseReason).toBe('');
     });
 });
 

--- a/tests/Unit/Actions/ResolveProjectEntryUrlActionTest.php
+++ b/tests/Unit/Actions/ResolveProjectEntryUrlActionTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Actions\ResolveProjectEntryUrlAction;
+use App\DTOs\DiffTarget;
 use App\Enums\LastViewKind;
 use App\Enums\LastViewMode;
 use App\Models\Project;
@@ -174,6 +175,25 @@ test('falls back to working tree when range-to-working from no longer resolves',
 
     expect($this->action->handle($this->project->slug))
         ->toBe(route('review-page', ['slug' => 'entry-test']));
+});
+
+test('rebuilds the entire-repo URL from the empty tree without a ref check', function () {
+    // The empty tree always exists but is a tree, not a commit, so resolveRef
+    // (which forces ^{commit}) returns null for it. Restore must special-case it
+    // rather than fall through to the working tree.
+    ReviewSession::create([
+        'project_id' => $this->project->id,
+        'repo_path' => $this->repoPath,
+        'last_view_mode' => LastViewMode::Review,
+        'last_view_kind' => LastViewKind::RangeToWorking,
+        'last_view_from' => DiffTarget::EMPTY_TREE_HASH,
+    ]);
+
+    expect($this->action->handle($this->project->slug))
+        ->toBe(route('review-page.range-to-working', [
+            'slug' => 'entry-test',
+            'rangeFromWorking' => DiffTarget::EMPTY_TREE_HASH,
+        ]));
 });
 
 // -- since_base re-resolution --

--- a/tests/Unit/Actions/ResolveRangeToWorkingActionTest.php
+++ b/tests/Unit/Actions/ResolveRangeToWorkingActionTest.php
@@ -59,3 +59,22 @@ test('resolves a plain short from ref to a full hash', function () {
     expect($target->from())->toBe($this->rootSha)
         ->and($target->to())->toBeNull();
 });
+
+test('passes the empty-tree hash through unchanged for the entire-repo view', function () {
+    $target = $this->action->handle($this->tmpDir, DiffTarget::EMPTY_TREE_HASH);
+
+    expect($target->from())->toBe(DiffTarget::EMPTY_TREE_HASH)
+        ->and($target->to())->toBeNull()
+        ->and($target->isWorkingDirectory())->toBeTrue();
+});
+
+test('resolves the empty tree on an unborn repo without error', function () {
+    $unborn = $this->createTempDirectory('rfa_unborn_repo_test_');
+    $this->initTestRepo($unborn);
+    File::put($unborn.'/staged.txt', "wip\n");
+
+    $target = $this->action->handle($unborn, DiffTarget::EMPTY_TREE_HASH);
+
+    expect($target->from())->toBe(DiffTarget::EMPTY_TREE_HASH)
+        ->and($target->to())->toBeNull();
+});

--- a/tests/Unit/Components/FileHeaderDiscardGuardTest.php
+++ b/tests/Unit/Components/FileHeaderDiscardGuardTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Support\Facades\Blade;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+/**
+ * Render <x-diff.file-header> with a working-tree (diffTo === null) added file,
+ * the exact shape the "Since the beginning" view produces for every tracked
+ * file. The discard control must appear only when discard is allowed.
+ */
+function renderFileHeader(bool $allowDiscard): string
+{
+    return Blade::render(
+        '<x-diff.file-header :file="$file" :repo-path="$repoPath" :diff-to="$diffTo" :allow-discard="$allowDiscard" />',
+        [
+            'file' => [
+                'id' => 'file-1',
+                'path' => 'app/Foo.php',
+                'oldPath' => null,
+                'status' => 'added',
+                'isBinary' => false,
+                'isSymlink' => false,
+                'isUntracked' => false,
+                'isExternal' => false,
+                'additions' => 3,
+                'deletions' => 0,
+            ],
+            'repoPath' => '/tmp/repo',
+            'diffTo' => null,
+            'allowDiscard' => $allowDiscard,
+        ],
+    );
+}
+
+test('shows the discard affordance for a working-tree added file', function () {
+    expect(renderFileHeader(allowDiscard: true))->toContain('Discard changes');
+});
+
+test('hides the discard affordance when discard is disallowed (entire-repo view)', function () {
+    expect(renderFileHeader(allowDiscard: false))->not->toContain('Discard changes');
+});

--- a/tests/Unit/DTOs/DiffTargetTest.php
+++ b/tests/Unit/DTOs/DiffTargetTest.php
@@ -36,6 +36,14 @@ test('rangeToWorking preserves the from commit with a null to', function () {
         ->and($target->isImmutable())->toBeFalse();
 });
 
+test('rangeToWorking from the empty tree diffs the whole repo as a working-tree target', function () {
+    $target = DiffTarget::rangeToWorking(DiffTarget::EMPTY_TREE_HASH);
+
+    expect($target->toDiffArgs())->toBe(['diff', DiffTarget::EMPTY_TREE_HASH])
+        ->and($target->isWorkingDirectory())->toBeTrue()
+        ->and($target->isImmutable())->toBeFalse();
+});
+
 test('fromRefs preserves the from commit when to is null', function () {
     // Regression: fromRefs($from, null) used to collapse to workingDirectory(),
     // forcing per-file diffs in range-to-working views to run against HEAD

--- a/tests/Unit/GitDiffServiceTest.php
+++ b/tests/Unit/GitDiffServiceTest.php
@@ -298,6 +298,36 @@ test('getFileList populates mtime/byteSize in rangeToWorking (1commit+WC / Since
     expect($entries[0]->byteSize)->toBe(File::size($this->tmpDir.'/file.txt'));
 });
 
+test('getFileList returns the whole repo as added files from the empty tree', function () {
+    $this->initTestRepo($this->tmpDir);
+    File::put($this->tmpDir.'/a.txt', "a\n");
+    File::put($this->tmpDir.'/b.txt', "b\n");
+    $this->commitTestRepo($this->tmpDir, 'c1');
+
+    $entries = $this->service->getFileList(
+        $this->tmpDir,
+        target: DiffTarget::rangeToWorking(DiffTarget::EMPTY_TREE_HASH),
+    );
+
+    expect($entries)->toHaveCount(2)
+        ->and(collect($entries)->pluck('status')->unique()->all())->toBe(['added'])
+        ->and(collect($entries)->pluck('path')->sort()->values()->all())->toBe(['a.txt', 'b.txt']);
+});
+
+test('getFileList returns working files from the empty tree on an unborn repo', function () {
+    // No commit: HEAD is unborn, so `git diff HEAD` would fail. Diffing from the
+    // empty tree still surfaces the working files for the entire-repo view.
+    $this->initTestRepo($this->tmpDir);
+    File::put($this->tmpDir.'/wip.txt', "wip\n");
+
+    $entries = $this->service->getFileList(
+        $this->tmpDir,
+        target: DiffTarget::rangeToWorking(DiffTarget::EMPTY_TREE_HASH),
+    );
+
+    expect(collect($entries)->pluck('path')->all())->toContain('wip.txt');
+});
+
 test('getFileList leaves mtime/byteSize null for immutable (commit-to-commit) targets', function () {
     $this->initTestRepo($this->tmpDir);
     File::put($this->tmpDir.'/file.txt', "v1\n");

--- a/tests/Unit/JsConstantParityTest.php
+++ b/tests/Unit/JsConstantParityTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use App\DTOs\DiffTarget;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+/**
+ * branch-explorer.js can't import PHP constants, so it carries its own copy of
+ * the empty-tree hash. Guard the two against drift: the "Since the beginning"
+ * row navigates with the JS value, but restore and diffing use the PHP one.
+ */
+test('branch-explorer.js EMPTY_TREE_HASH matches the PHP constant', function () {
+    $js = File::get(base_path('public/js/branch-explorer.js'));
+
+    expect($js)->toMatch("/EMPTY_TREE_HASH\s*=\s*'".preg_quote(DiffTarget::EMPTY_TREE_HASH, '/')."'/");
+});

--- a/tests/Unit/Livewire/ReviewPageRangeAndSelectionTest.php
+++ b/tests/Unit/Livewire/ReviewPageRangeAndSelectionTest.php
@@ -194,6 +194,30 @@ test('mounting with /rw/{from} sets diffFrom to the commit and diffTo to null', 
     expect($component->get('diffTo'))->toBeNull();
 });
 
+// -- Since the beginning (entire repo) --
+
+test('mounting /rw/{empty-tree} flags the entire-repo view and labels it', function () {
+    $component = Livewire::test('pages::review-page', [
+        'slug' => 'test-project',
+        'rangeFromWorking' => DiffTarget::EMPTY_TREE_HASH,
+    ]);
+
+    expect($component->get('diffFrom'))->toBe(DiffTarget::EMPTY_TREE_HASH)
+        ->and($component->get('diffTo'))->toBeNull()
+        ->and($component->get('isSinceBeginningView'))->toBeTrue();
+
+    $component->assertSee('Since the beginning');
+});
+
+test('a plain range-to-working mount is not the entire-repo view', function () {
+    $component = Livewire::test('pages::review-page', [
+        'slug' => 'test-project',
+        'rangeFromWorking' => 'abc1234',
+    ]);
+
+    expect($component->get('isSinceBeginningView'))->toBeFalse();
+});
+
 test('buildDiffTarget preserves the base commit for range-to-working mounts', function () {
     // Regression: fromRefs($from, null) silently collapses to workingDirectory(),
     // which would reset diffFrom to HEAD and make every downstream consumer

--- a/tests/Unit/Livewire/ReviewPageTest.php
+++ b/tests/Unit/Livewire/ReviewPageTest.php
@@ -6,6 +6,7 @@ use App\Actions\DiscardFileChangesAction;
 use App\Actions\ExportReviewAction;
 use App\Actions\GetFileListAction;
 use App\Actions\ResolveProjectAction;
+use App\Actions\ResolveRangeToWorkingAction;
 use App\Actions\ScanReviewFilesAction;
 use App\Actions\SessionStateAction;
 use App\DTOs\DiffTarget;
@@ -582,6 +583,34 @@ test('discardFileChanges is a no-op for external files', function () {
 
     Livewire::test('pages::review-page', ['slug' => 'test-project'])
         ->dispatch('discard-file', fileId: 'ext789')
+        ->assertNotDispatched('undo-available');
+});
+
+test('discardFileChanges is a no-op in the entire-repo (since the beginning) view', function () {
+    app()->bind(ResolveRangeToWorkingAction::class, fn () => new class
+    {
+        public function handle(string $repoPath, string $from): DiffTarget
+        {
+            return DiffTarget::rangeToWorking($from);
+        }
+    });
+
+    app()->bind(DiscardFileChangesAction::class, fn () => new class
+    {
+        public function handle(string $repoPath, string $path, string $status, int $projectId, ?string $oldPath = null, bool $isUntracked = false, bool $isSymlink = false, array $comments = []): TrashedFile
+        {
+            throw new RuntimeException('DiscardFileChangesAction must not run in the entire-repo view');
+        }
+    });
+
+    $component = Livewire::test('pages::review-page', [
+        'slug' => 'test-project',
+        'rangeFromWorking' => DiffTarget::EMPTY_TREE_HASH,
+    ]);
+
+    expect($component->get('isSinceBeginningView'))->toBeTrue();
+
+    $component->dispatch('discard-file', fileId: 'abc123')
         ->assertNotDispatched('undo-available');
 });
 


### PR DESCRIPTION
Related:
- https://github.com/fgilio/rfa/issues/111

## Summary
Add a "Since the beginning" review mode that diffs the entire repository as one cumulative view, and make the branch-explorer picker predictable by always showing "Since {base}" (disabled with a reason) instead of hiding it.

## Why
- **A whole-codebase scope was missing.** "Since {base}" was the broadest option (branch commits + uncommitted). There was no way to review/comment on the entire repo as it stands. "Since the beginning" pushes the start point all the way back to git's empty tree, so the diff is the whole codebase.
- **The picker hid options instead of disabling them.** "Since {base}" silently disappeared when it couldn't be used (on the base branch, browsing another branch), so the layout shifted and the option felt nonexistent. A stable, disable-with-reason layout is more learnable.

## Solution
- **Reuse the range-to-working pipeline.** The empty-tree hash flows through the existing `/rw/{from}` path as the from-ref, so the diff, caching, and untracked-file handling come for free. No new `LastViewKind`.
- **Restore is the one trap.** `resolveRef` forces `^{commit}` and returns null for the empty tree (a tree, not a commit), so re-entry would drop to the working tree. `ResolveProjectEntryUrlAction` special-cases the empty tree.

## Changes
- **Entire-repo mode**
  - `ResolveProjectEntryUrlAction`: empty-tree special-case in `buildRangeToWorkingUrl` so re-entry restores the view
  - `⚡review-page`: `isSinceBeginningView` flag (computed in mount), "Since the beginning" header label, diagnostics + Context fields
- **Discard safety (data-loss guard)**
  - `allowDiscard` prop threaded `⚡review-page` → `⚡diff-file` → `<x-diff.file-header>`
  - Hides the discard button in this mode, where every tracked file reads as "added" and discard would `git rm -f` a clean committed file
- **Branch-explorer picker**
  - New "Since the beginning" row (direct navigation to the empty-tree view)
  - `sinceBeginningActive` requires `activeCommitHash === null` so a root commit's diff (also empty-tree based) doesn't collide; rehydrate leaves the selection empty so Apply can't rewrite the mode
  - "Since {base}" always rendered, disabled-with-reason across all six `BranchBaseState` cases (incl. the two previously hidden); `sinceBaseActionable` / `sinceBaseReason` replace `sinceBaseRowVisible`, null-safe before the snapshot loads
  - Scope rows ordered widest → narrowest (entire repo, base..HEAD, working tree) down to the working-tree hinge above the commit list
- **Tests**
  - Restore regression, mount/label, discard guard (Blade render), DTO, whole-repo + unborn-HEAD diff, all six picker states + off-branch + null-safety, `viewSinceBeginning` nav
  - JS↔PHP empty-tree constant parity guard

## Testing
```bash
composer test:lint && composer test:types
composer test          # 1551 passed
composer test:js       # 289 passed
./vendor/bin/pest tests/Browser/SelectionFreshnessTest.php tests/Browser/SelectionMultiSelectTest.php
```
Manual: open the picker → "Since the beginning" renders the whole codebase as additions with no discard buttons; navigate away and back restores the view; the "Since {base}" row stays present-but-disabled on the base branch / with no base / on another branch.

## Deployment
- [ ] Migrations: none
- [ ] Cache clear: none
- [ ] Monitor: none (local desktop app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6FvUjZvzjnGPf8DGqdLem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Since the beginning" view option in the branch explorer for inspecting the entire repository as a single cumulative diff, displaying all historical commits and uncommitted changes from project inception.
  * Disabled "Discard changes" functionality in this view to prevent accidental deletion of committed files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->