### PR TITLE
Seed comments with the selected diff text as a citation

### DIFF
--- a/config/shortcuts.php
+++ b/config/shortcuts.php
@@ -87,6 +87,12 @@ return [
             'group' => 'Review',
             'wired' => 'keymap',
         ],
+        'review.comment-selection' => [
+            'combo' => 'c',
+            'label' => 'Comment on selection',
+            'group' => 'Review',
+            'wired' => 'keymap',
+        ],
         'review.collapse-all' => [
             'combo' => 'C',
             'display' => '⇧C',

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -78,6 +78,57 @@
         return false;
     }
 
+    // Formats selected diff text as a GitHub-style blockquote citation that
+    // seeds a fresh comment. Every line is prefixed with `> ` and a blank line
+    // follows so the cursor lands below the quote. Leading/trailing blank lines
+    // are trimmed; interior blank lines are preserved (and still quoted).
+    // Returns '' for empty/whitespace-only input so callers can skip pre-filling.
+    function formatCitation(text) {
+        if (typeof text !== 'string') return '';
+        const trimmed = text.replace(/^\s+|\s+$/g, '');
+        if (trimmed === '') return '';
+
+        return trimmed.split('\n').map((line) => `> ${line}`).join('\n') + '\n\n';
+    }
+
+    // Walks up from a Selection/Range node to the `.diff-line` row it sits in.
+    // Text nodes resolve through their parent element. Returns null when the
+    // node isn't inside a diff row (e.g. a selection in a comment box).
+    function closestDiffLine(node) {
+        const el = node && node.nodeType === 3 ? node.parentElement : node;
+        return el && typeof el.closest === 'function' ? el.closest('.diff-line') : null;
+    }
+
+    function rowLineForSide(row, side) {
+        if (!row) return null;
+        const raw = side === 'left' ? row.dataset.lineOld : row.dataset.lineNew;
+        if (raw === undefined || raw === '') return null;
+        const value = parseInt(raw, 10);
+
+        return Number.isFinite(value) ? value : null;
+    }
+
+    // Maps a text-selection Range onto the diff line(s) it covers, scoped to
+    // `root` (a single diff-file element). The side is anchored off the start
+    // row — new (right) when it carries a `data-line-new`, else old (left) — and
+    // both endpoints are read on that side. Returns null when the selection
+    // doesn't start on a diff row inside `root`, so non-matching files ignore it.
+    function selectionLineRange(range, root) {
+        if (!range) return null;
+        const startRow = closestDiffLine(range.startContainer);
+        if (!startRow || (root && !root.contains(startRow))) return null;
+
+        const side = startRow.dataset.lineNew ? 'right' : 'left';
+        const startLine = rowLineForSide(startRow, side);
+        if (startLine === null) return null;
+
+        let endRow = closestDiffLine(range.endContainer);
+        if (!endRow || (root && !root.contains(endRow))) endRow = startRow;
+        const endLine = rowLineForSide(endRow, side) ?? startLine;
+
+        return { side, startLine, endLine };
+    }
+
     // In-progress comment form state, keyed by file id. Filtering or hiding
     // reviewed files unmounts diff-file components that leave the server-visible
     // list; snapshotting the open form on destroy lets a later remount restore
@@ -103,6 +154,9 @@
             formStartPoint: null,
             formEndPoint: null,
             formBody: '',
+            // Citation captured at line-number mousedown, applied when the form
+            // opens (drag end / shift-click). Holds a formatted `> …` block or ''.
+            _pendingCitation: '',
             lastClickedPoint: null,
             showForm: false,
             editingCommentId: null,
@@ -208,7 +262,15 @@
 
             focusCommentInput() {
                 this.$dispatch('comment-form-opened', { fileId: this.fileId });
-                this.$nextTick(() => { this.$refs.commentInput?.focus(); });
+                this.$nextTick(() => {
+                    const input = this.$refs.commentInput;
+                    if (!input) return;
+                    input.focus();
+                    // Drop the caret after any pre-filled text (citation / edited
+                    // body) so the user types below the quote instead of inside it.
+                    const end = input.value?.length ?? 0;
+                    input.setSelectionRange?.(end, end);
+                });
             },
 
             closeEmptyFormFromAnotherFile(openedFileId) {
@@ -226,8 +288,16 @@
                 const clickedPoint = createLinePoint(lineNum, side);
                 if (clickedPoint == null) return;
 
+                // Snapshot any active text selection as a citation now: the
+                // gutter's `mousedown.prevent` stops the click from collapsing it,
+                // but it must be read before the form (drag end / shift-click) opens.
+                const citation = formatCitation(this._selectionTextWithinFile());
+
                 if (event.shiftKey && this.lastClickedPoint?.side === clickedPoint.side) {
                     this.setLineSelection(this.lastClickedPoint, clickedPoint);
+                    if (citation && this.formBody.trim() === '') {
+                        this.formBody = citation;
+                    }
                     this.showForm = true;
                     this.focusCommentInput();
                     return;
@@ -253,6 +323,7 @@
                 this.isDragging = true;
                 this.dragStartPoint = clickedPoint;
                 this.dragSide = side;
+                this._pendingCitation = citation;
                 this.setLineSelection(clickedPoint, clickedPoint);
                 this.showForm = false;
 
@@ -293,6 +364,10 @@
                 this.stopDragTracking();
                 this._cachedFileHeader = null;
                 this.showForm = true;
+                if (this._pendingCitation && this.formBody.trim() === '') {
+                    this.formBody = this._pendingCitation;
+                }
+                this._pendingCitation = '';
                 this.lastClickedPoint = this.formEndPoint ? { ...this.formEndPoint } : null;
                 this.focusCommentInput();
             },
@@ -301,6 +376,7 @@
                 this.stopDragTracking();
                 this.showForm = false;
                 this.formBody = '';
+                this._pendingCitation = '';
                 this.clearLineSelection();
                 this.escHint = false;
                 if (this.escTimer) { clearTimeout(this.escTimer); this.escTimer = null; }
@@ -428,6 +504,55 @@
                         this.$refs.fileCommentForm?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
                     });
                 });
+            },
+
+            // Keyboard entry point (catalog id `review.comment-selection`, 'c'):
+            // open the line-comment composer on the row(s) under the current text
+            // selection, seeded with that text as a citation. Every diff-file
+            // receives the window event; only the one containing the selection
+            // acts (selectionLineRange returns null for the rest).
+            commentOnSelection() {
+                const win = this.$el?.ownerDocument?.defaultView || (typeof window !== 'undefined' ? window : null);
+                const selection = win?.getSelection?.();
+                if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+                    return;
+                }
+
+                const range = selection.getRangeAt(0);
+                const lineRange = selectionLineRange(range, this.$el);
+                if (!lineRange) return;
+
+                const citation = formatCitation(selection.toString());
+
+                this.autoExpandedForComment = false;
+                this.editingCommentId = null;
+                this.setLineSelection(
+                    createLinePoint(lineRange.startLine, lineRange.side),
+                    createLinePoint(lineRange.endLine, lineRange.side),
+                );
+                this.lastClickedPoint = this.formEndPoint ? { ...this.formEndPoint } : null;
+                if (citation && this.formBody.trim() === '') {
+                    this.formBody = citation;
+                }
+                this.showForm = true;
+                this.focusCommentInput();
+            },
+
+            // Current text selection as a string, but only when it begins inside
+            // this file's diff rows — so a stray selection elsewhere (a comment,
+            // another file) never leaks into this file's citation. '' otherwise.
+            _selectionTextWithinFile() {
+                const win = this.$el?.ownerDocument?.defaultView || (typeof window !== 'undefined' ? window : null);
+                const selection = win?.getSelection?.();
+                if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+                    return '';
+                }
+                const row = closestDiffLine(selection.anchorNode);
+                if (!row || !this.$el?.contains(row)) {
+                    return '';
+                }
+
+                return selection.toString();
             },
 
             submitComment(isDraft = false) {
@@ -591,6 +716,9 @@
         createLinePoint,
         areLinePointsEqual,
         rowContainsLinePoint,
+        formatCitation,
+        closestDiffLine,
+        selectionLineRange,
         createDiffFile,
         install,
         autoInstall,

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -288,16 +288,11 @@
                 const clickedPoint = createLinePoint(lineNum, side);
                 if (clickedPoint == null) return;
 
-                // Snapshot any active text selection as a citation now: the
-                // gutter's `mousedown.prevent` stops the click from collapsing it,
-                // but it must be read before the form (drag end / shift-click) opens.
-                const citation = formatCitation(this._selectionTextWithinFile());
-
                 if (event.shiftKey && this.lastClickedPoint?.side === clickedPoint.side) {
                     this.setLineSelection(this.lastClickedPoint, clickedPoint);
-                    if (citation && this.formBody.trim() === '') {
-                        this.formBody = citation;
-                    }
+                    // The gutter's `mousedown.prevent` keeps the text selection
+                    // alive, so it's still readable here to seed the citation.
+                    this._prefillCitation(formatCitation(this._selectionTextWithinFile()));
                     this.showForm = true;
                     this.focusCommentInput();
                     return;
@@ -323,7 +318,9 @@
                 this.isDragging = true;
                 this.dragStartPoint = clickedPoint;
                 this.dragSide = side;
-                this._pendingCitation = citation;
+                // Snapshot the selection now (mousedown.prevent keeps it alive);
+                // it's applied when the drag ends and the form opens.
+                this._pendingCitation = formatCitation(this._selectionTextWithinFile());
                 this.setLineSelection(clickedPoint, clickedPoint);
                 this.showForm = false;
 
@@ -364,9 +361,7 @@
                 this.stopDragTracking();
                 this._cachedFileHeader = null;
                 this.showForm = true;
-                if (this._pendingCitation && this.formBody.trim() === '') {
-                    this.formBody = this._pendingCitation;
-                }
+                this._prefillCitation(this._pendingCitation);
                 this._pendingCitation = '';
                 this.lastClickedPoint = this.formEndPoint ? { ...this.formEndPoint } : null;
                 this.focusCommentInput();
@@ -506,23 +501,39 @@
                 });
             },
 
-            // Keyboard entry point (catalog id `review.comment-selection`, 'c'):
-            // open the line-comment composer on the row(s) under the current text
-            // selection, seeded with that text as a citation. Every diff-file
-            // receives the window event; only the one containing the selection
-            // acts (selectionLineRange returns null for the rest).
-            commentOnSelection() {
+            // The window's current text selection, or null when there is none,
+            // it's collapsed, or it carries no range. Centralizes the
+            // window-resolution + empty-guard for the citation readers below.
+            _activeSelection() {
                 const win = this.$el?.ownerDocument?.defaultView || (typeof window !== 'undefined' ? window : null);
                 const selection = win?.getSelection?.();
                 if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
-                    return;
+                    return null;
                 }
 
-                const range = selection.getRangeAt(0);
-                const lineRange = selectionLineRange(range, this.$el);
-                if (!lineRange) return;
+                return selection;
+            },
 
-                const citation = formatCitation(selection.toString());
+            // Seeds an empty composer with a citation; a non-empty body (an
+            // in-progress draft) is left untouched. Shared by every form-open
+            // path that can carry a selection (shift-click, drag end, keyboard).
+            _prefillCitation(citation) {
+                if (citation && this.formBody.trim() === '') {
+                    this.formBody = citation;
+                }
+            },
+
+            // Keyboard entry point (catalog id `review.comment-selection`, 'c'):
+            // open the line-comment composer on the row(s) under the current text
+            // selection, seeded with that text as a citation. The page resolves
+            // which file owns the selection and targets this handler by id; the
+            // selectionLineRange guard keeps it correct if called directly.
+            commentOnSelection() {
+                const selection = this._activeSelection();
+                if (!selection) return;
+
+                const lineRange = selectionLineRange(selection.getRangeAt(0), this.$el);
+                if (!lineRange) return;
 
                 this.autoExpandedForComment = false;
                 this.editingCommentId = null;
@@ -531,9 +542,7 @@
                     createLinePoint(lineRange.endLine, lineRange.side),
                 );
                 this.lastClickedPoint = this.formEndPoint ? { ...this.formEndPoint } : null;
-                if (citation && this.formBody.trim() === '') {
-                    this.formBody = citation;
-                }
+                this._prefillCitation(formatCitation(selection.toString()));
                 this.showForm = true;
                 this.focusCommentInput();
             },
@@ -542,11 +551,8 @@
             // this file's diff rows — so a stray selection elsewhere (a comment,
             // another file) never leaks into this file's citation. '' otherwise.
             _selectionTextWithinFile() {
-                const win = this.$el?.ownerDocument?.defaultView || (typeof window !== 'undefined' ? window : null);
-                const selection = win?.getSelection?.();
-                if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
-                    return '';
-                }
+                const selection = this._activeSelection();
+                if (!selection) return '';
                 const row = closestDiffLine(selection.anchorNode);
                 if (!row || !this.$el?.contains(row)) {
                     return '';
@@ -649,15 +655,10 @@
             },
 
             _updateSelectionFromPoint() {
-                const el = document.elementFromPoint(this._dragMouseX, this._dragMouseY);
-                if (!el) return;
-                const row = el.closest('.diff-line');
+                const row = closestDiffLine(document.elementFromPoint(this._dragMouseX, this._dragMouseY));
                 if (!row || !this.$el.contains(row)) return;
 
-                const lineNum = this.dragSide === 'left'
-                    ? (row.dataset.lineOld ? parseInt(row.dataset.lineOld) : null)
-                    : (row.dataset.lineNew ? parseInt(row.dataset.lineNew) : null);
-                const point = createLinePoint(lineNum, this.dragSide);
+                const point = createLinePoint(rowLineForSide(row, this.dragSide), this.dragSide);
                 if (point === null || this.dragStartPoint === null) return;
 
                 this.setLineSelection(this.dragStartPoint, point);

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -80,15 +80,19 @@
 
     // Formats selected diff text as a GitHub-style blockquote citation that
     // seeds a fresh comment. Every line is prefixed with `> ` and a blank line
-    // follows so the cursor lands below the quote. Leading/trailing blank lines
-    // are trimmed; interior blank lines are preserved (and still quoted).
-    // Returns '' for empty/whitespace-only input so callers can skip pre-filling.
+    // follows so the cursor lands below the quote. Blank (whitespace-only) lines
+    // at the top and bottom of the selection are dropped (e.g. a trailing
+    // newline), but each remaining line keeps its own indentation so quoted code
+    // isn't dedented; interior blank lines are preserved (and still quoted).
+    // Returns '' when the selection is empty/whitespace-only.
     function formatCitation(text) {
         if (typeof text !== 'string') return '';
-        const trimmed = text.replace(/^\s+|\s+$/g, '');
-        if (trimmed === '') return '';
+        const lines = text.split('\n');
+        while (lines.length && lines[0].trim() === '') { lines.shift(); }
+        while (lines.length && lines[lines.length - 1].trim() === '') { lines.pop(); }
+        if (lines.length === 0) return '';
 
-        return trimmed.split('\n').map((line) => `> ${line}`).join('\n') + '\n\n';
+        return lines.map((line) => `> ${line}`).join('\n') + '\n\n';
     }
 
     // Walks up from a Selection/Range node to the `.diff-line` row it sits in.
@@ -108,17 +112,35 @@
         return Number.isFinite(value) ? value : null;
     }
 
+    // Picks the diff side a selection belongs to. Single-sided rows (add /
+    // remove) are unambiguous. A context row carries both line numbers and, in
+    // split view, renders the original text in the primary content cell (left /
+    // old) and a mirror cell for the new (right) side — so honor whichever cell
+    // the selection started in. Unified view only shows the primary cell, so it
+    // keeps the new-side default.
+    function sideForSelection(node, row) {
+        if (!row.dataset.lineOld) { return 'right'; }
+        if (!row.dataset.lineNew) { return 'left'; }
+
+        const el = node && node.nodeType === 3 ? node.parentElement : node;
+        if (el && typeof el.closest === 'function' && el.closest('.diff-cell-content-mirror')) {
+            return 'right';
+        }
+
+        return row.closest?.('.diff-grid')?.dataset.viewMode === 'split' ? 'left' : 'right';
+    }
+
     // Maps a text-selection Range onto the diff line(s) it covers, scoped to
     // `root` (a single diff-file element). The side is anchored off the start
-    // row — new (right) when it carries a `data-line-new`, else old (left) — and
-    // both endpoints are read on that side. Returns null when the selection
-    // doesn't start on a diff row inside `root`, so non-matching files ignore it.
+    // row (see sideForSelection) and both endpoints are read on that side.
+    // Returns null when the selection doesn't start on a diff row inside `root`,
+    // so non-matching files ignore it.
     function selectionLineRange(range, root) {
         if (!range) return null;
         const startRow = closestDiffLine(range.startContainer);
         if (!startRow || (root && !root.contains(startRow))) return null;
 
-        const side = startRow.dataset.lineNew ? 'right' : 'left';
+        const side = sideForSelection(range.startContainer, startRow);
         const startLine = rowLineForSide(startRow, side);
         if (startLine === null) return null;
 

--- a/public/js/review-page.js
+++ b/public/js/review-page.js
@@ -122,9 +122,21 @@
                 reg('review.next-file', () => this.focusAdjacentFile(1));
                 reg('review.prev-file', () => this.focusAdjacentFile(-1));
                 // Open the comment composer on the line(s) under the current text
-                // selection. Page-level so it's registered once; the matching
-                // diff-file (the one whose $el contains the selection) acts on it.
-                reg('review.comment-selection', () => this.$dispatch('rfa-comment-selection'));
+                // selection. Resolve which file owns the selection once here and
+                // target that diff-file by id (matching the comment-updated /
+                // expand-file convention) rather than waking every component.
+                reg('review.comment-selection', () => {
+                    const selection = window.getSelection?.();
+                    if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+                        return;
+                    }
+                    const node = selection.getRangeAt(0).startContainer;
+                    const el = node?.nodeType === 3 ? node.parentElement : node;
+                    const fileRoot = el?.closest?.('[data-file-id]');
+                    if (fileRoot) {
+                        this.$dispatch('rfa-comment-selection', { fileId: fileRoot.dataset.fileId });
+                    }
+                });
                 reg('review.collapse-all', () => {
                     this.$store.settings.collapseAll = true;
                     this.$dispatch('collapse-all-files');

--- a/public/js/review-page.js
+++ b/public/js/review-page.js
@@ -121,6 +121,10 @@
                 reg('review.filter', () => this.$refs.fileFilterInput?.focus());
                 reg('review.next-file', () => this.focusAdjacentFile(1));
                 reg('review.prev-file', () => this.focusAdjacentFile(-1));
+                // Open the comment composer on the line(s) under the current text
+                // selection. Page-level so it's registered once; the matching
+                // diff-file (the one whose $el contains the selection) acts on it.
+                reg('review.comment-selection', () => this.$dispatch('rfa-comment-selection'));
                 reg('review.collapse-all', () => {
                     this.$store.settings.collapseAll = true;
                     this.$dispatch('collapse-all-files');

--- a/resources/CLAUDE.md
+++ b/resources/CLAUDE.md
@@ -197,6 +197,7 @@ ReviewPage (`resources/views/pages/⚡review-page.blade.php`) renders N DiffFile
 | `rfa-hide-reviewed` | `reviewed-toggle` island button `$dispatch` (window) | ReviewPage root Alpine `@window` -> queued `$wire.hideReviewedFiles` | none |
 | `rfa-show-all-files` | `reviewed-toggle` island button `$dispatch` (window) | ReviewPage root Alpine `@window` -> queued `$wire.showAllFiles` | none |
 | `rfa-clear-recently-reviewed` | Recently-reviewed "Clear" button `$dispatch` (window) | ReviewPage root Alpine `@window` -> queued `$wire.clearRecentlyReviewed` | none |
+| `rfa-comment-selection` | ReviewPage Alpine `$dispatch` (window), fired by the `review.comment-selection` shortcut (`c`) | DiffFile Alpine `@window` -> `commentOnSelection()` (only the file whose `$el` contains the text selection acts) | none |
 | `comment-updated` | ReviewPage PHP dispatch | DiffFile Alpine `@window` | `{fileId, comments}` |
 | `copy-to-clipboard` | DiffFile Alpine/PHP, ReviewPage PHP, comment-display, comments-drawer, branch-explorer | layout `<body>` Alpine `@window` | `{text, toast?}` (if `toast` string is set, a success toast with that text shows on success) |
 | `file-reviewed-changed` | DiffFile Alpine `$dispatch`, sidebar reviewed button | DiffFile Alpine `@window` (targeted by `id`) | `{id, reviewed}` |

--- a/resources/CLAUDE.md
+++ b/resources/CLAUDE.md
@@ -197,7 +197,7 @@ ReviewPage (`resources/views/pages/⚡review-page.blade.php`) renders N DiffFile
 | `rfa-hide-reviewed` | `reviewed-toggle` island button `$dispatch` (window) | ReviewPage root Alpine `@window` -> queued `$wire.hideReviewedFiles` | none |
 | `rfa-show-all-files` | `reviewed-toggle` island button `$dispatch` (window) | ReviewPage root Alpine `@window` -> queued `$wire.showAllFiles` | none |
 | `rfa-clear-recently-reviewed` | Recently-reviewed "Clear" button `$dispatch` (window) | ReviewPage root Alpine `@window` -> queued `$wire.clearRecentlyReviewed` | none |
-| `rfa-comment-selection` | ReviewPage Alpine `$dispatch` (window), fired by the `review.comment-selection` shortcut (`c`) | DiffFile Alpine `@window` -> `commentOnSelection()` (only the file whose `$el` contains the text selection acts) | none |
+| `rfa-comment-selection` | ReviewPage Alpine `$dispatch` (window), fired by the `review.comment-selection` shortcut (`c`); resolves the selection's owning file id from its `[data-file-id]` ancestor | DiffFile Alpine `@window` -> `if ($event.detail.fileId === fileId) commentOnSelection()` | `{fileId}` |
 | `comment-updated` | ReviewPage PHP dispatch | DiffFile Alpine `@window` | `{fileId, comments}` |
 | `copy-to-clipboard` | DiffFile Alpine/PHP, ReviewPage PHP, comment-display, comments-drawer, branch-explorer | layout `<body>` Alpine `@window` | `{text, toast?}` (if `toast` string is set, a success toast with that text shows on success) |
 | `file-reviewed-changed` | DiffFile Alpine `$dispatch`, sidebar reviewed button | DiffFile Alpine `@window` (targeted by `id`) | `{id, reviewed}` |

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -404,7 +404,7 @@ HTML;
     @reset-reviewed-files.window="reviewed = false; collapsed = false"
     @reviewed-files-reverted.window="if ($event.detail.fileIds?.includes(fileId)) { reviewed = false }"
     @comment-form-opened.window="closeEmptyFormFromAnotherFile($event.detail.fileId)"
-    @rfa-comment-selection.window="commentOnSelection()"
+    @rfa-comment-selection.window="if ($event.detail.fileId === fileId) commentOnSelection()"
     {{-- Sync from external mark/un-mark (e.g. sidebar file-list button). Self-dispatched
          events from this component's own checkbox are no-ops since reviewed is already
          in the same state. Only flips collapsed on mark — un-mark leaves it alone so it

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -404,6 +404,7 @@ HTML;
     @reset-reviewed-files.window="reviewed = false; collapsed = false"
     @reviewed-files-reverted.window="if ($event.detail.fileIds?.includes(fileId)) { reviewed = false }"
     @comment-form-opened.window="closeEmptyFormFromAnotherFile($event.detail.fileId)"
+    @rfa-comment-selection.window="commentOnSelection()"
     {{-- Sync from external mark/un-mark (e.g. sidebar file-list button). Self-dispatched
          events from this component's own checkbox are no-ops since reviewed is already
          in the same state. Only flips collapsed on mark — un-mark leaves it alone so it

--- a/tests/Js/diff-file.test.js
+++ b/tests/Js/diff-file.test.js
@@ -608,8 +608,13 @@ describe('formatCitation', () => {
             .toBe('> first line\n> second line\n> third line\n\n');
     });
 
-    it('trims leading and trailing whitespace before quoting', () => {
-        expect(formatCitation('\n  spaced selection  \n')).toBe('> spaced selection\n\n');
+    it('drops blank lines at the edges but keeps each line\'s own indentation', () => {
+        expect(formatCitation('\n  spaced selection  \n')).toBe('>   spaced selection  \n\n');
+    });
+
+    it('preserves the indentation of quoted code (does not dedent the first line)', () => {
+        expect(formatCitation('    if (foo) {\n        bar();\n    }'))
+            .toBe('>     if (foo) {\n>         bar();\n>     }\n\n');
     });
 
     it('still quotes interior blank lines', () => {
@@ -718,6 +723,52 @@ describe('selectionLineRange', () => {
 
     it('returns null for a missing range', () => {
         expect(selectionLineRange(null, root)).toBeNull();
+    });
+});
+
+describe('selectionLineRange in split view', () => {
+    let root;
+
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="file-root" data-file-id="f1">
+                <div class="diff-grid" data-view-mode="split">
+                    <div class="diff-line" data-type="context" data-line-old="10" data-line-new="20">
+                        <div class="diff-cell diff-cell-content">context text</div>
+                        <div class="diff-cell diff-cell-content diff-cell-content-mirror">context text</div>
+                    </div>
+                </div>
+            </div>`;
+        root = document.getElementById('file-root');
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    function rangeIn(selector) {
+        const range = document.createRange();
+        const node = document.querySelector(selector).firstChild;
+        range.setStart(node, 0);
+        range.setEnd(node, node.length);
+        return range;
+    }
+
+    it('anchors a selection in the left content cell to the old side', () => {
+        // The primary `.diff-cell-content` is the original (left) side in split view.
+        expect(selectionLineRange(rangeIn('.diff-cell-content'), root))
+            .toEqual({ side: 'left', startLine: 10, endLine: 10 });
+    });
+
+    it('anchors a selection in the right mirror cell to the new side', () => {
+        expect(selectionLineRange(rangeIn('.diff-cell-content-mirror'), root))
+            .toEqual({ side: 'right', startLine: 20, endLine: 20 });
+    });
+
+    it('keeps the new-side default for a context row in unified view', () => {
+        root.querySelector('.diff-grid').dataset.viewMode = 'unified';
+        expect(selectionLineRange(rangeIn('.diff-cell-content'), root))
+            .toEqual({ side: 'right', startLine: 20, endLine: 20 });
     });
 });
 

--- a/tests/Js/diff-file.test.js
+++ b/tests/Js/diff-file.test.js
@@ -8,6 +8,9 @@ const {
     createLinePoint,
     areLinePointsEqual,
     rowContainsLinePoint,
+    formatCitation,
+    closestDiffLine,
+    selectionLineRange,
     createDiffFile,
     install,
     autoInstall,
@@ -591,5 +594,284 @@ describe('pending comment form cleared on SPA navigation', () => {
 
         expect(second.showForm).toBe(false);
         expect(second.formBody).toBe('');
+    });
+});
+
+describe('formatCitation', () => {
+    it('quotes a single line and appends a blank line for the cursor', () => {
+        expect(formatCitation('Identify the single most undeniable paper cut'))
+            .toBe('> Identify the single most undeniable paper cut\n\n');
+    });
+
+    it('prefixes every line of a multi-line selection', () => {
+        expect(formatCitation('first line\nsecond line\nthird line'))
+            .toBe('> first line\n> second line\n> third line\n\n');
+    });
+
+    it('trims leading and trailing whitespace before quoting', () => {
+        expect(formatCitation('\n  spaced selection  \n')).toBe('> spaced selection\n\n');
+    });
+
+    it('still quotes interior blank lines', () => {
+        expect(formatCitation('para one\n\npara two')).toBe('> para one\n> \n> para two\n\n');
+    });
+
+    it.each([
+        ['', ''],
+        ['   ', ''],
+        ['\n\n', ''],
+    ])('returns empty string for empty/whitespace input (%j)', (input, expected) => {
+        expect(formatCitation(input)).toBe(expected);
+    });
+
+    it.each([[null], [undefined], [42]])('returns empty string for non-string input (%j)', (input) => {
+        expect(formatCitation(input)).toBe('');
+    });
+});
+
+describe('closestDiffLine', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('resolves a text node up to its .diff-line row', () => {
+        document.body.innerHTML = '<div class="diff-line" data-line-new="5"><div class="diff-cell-content">hello</div></div>';
+        const textNode = document.querySelector('.diff-cell-content').firstChild;
+        expect(closestDiffLine(textNode)).toBe(document.querySelector('.diff-line'));
+    });
+
+    it('resolves an element node to its .diff-line row', () => {
+        document.body.innerHTML = '<div class="diff-line" data-line-new="5"><div class="diff-cell-content">hello</div></div>';
+        const cell = document.querySelector('.diff-cell-content');
+        expect(closestDiffLine(cell)).toBe(document.querySelector('.diff-line'));
+    });
+
+    it('returns null when the node is not inside a diff row', () => {
+        document.body.innerHTML = '<div class="comment-box">a comment</div>';
+        expect(closestDiffLine(document.querySelector('.comment-box'))).toBeNull();
+    });
+
+    it('returns null for nullish input', () => {
+        expect(closestDiffLine(null)).toBeNull();
+    });
+});
+
+describe('selectionLineRange', () => {
+    let root;
+
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="file-root">
+                <div class="diff-line" data-line-old="10" data-line-new="10"><div class="diff-cell-content">ctx line</div></div>
+                <div class="diff-line" data-line-new="11"><div class="diff-cell-content">added line</div></div>
+                <div class="diff-line" data-line-old="12"><div class="diff-cell-content">removed line</div></div>
+            </div>
+            <div id="other-root">
+                <div class="diff-line" data-line-new="99"><div class="diff-cell-content">elsewhere</div></div>
+            </div>
+        `;
+        root = document.getElementById('file-root');
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    function rangeOver(startSelector, endSelector = startSelector) {
+        const range = document.createRange();
+        range.setStart(document.querySelector(startSelector).firstChild, 0);
+        const endNode = document.querySelector(endSelector).firstChild;
+        range.setEnd(endNode, endNode.length);
+        return range;
+    }
+
+    it('anchors a single added line to the right side', () => {
+        const range = rangeOver('[data-line-new="11"] .diff-cell-content');
+        expect(selectionLineRange(range, root)).toEqual({ side: 'right', startLine: 11, endLine: 11 });
+    });
+
+    it('prefers the new (right) side on a context row that carries both', () => {
+        const range = rangeOver('[data-line-new="10"] .diff-cell-content');
+        expect(selectionLineRange(range, root)).toEqual({ side: 'right', startLine: 10, endLine: 10 });
+    });
+
+    it('uses the old (left) side for a removed-only row', () => {
+        const range = rangeOver('[data-line-old="12"] .diff-cell-content');
+        expect(selectionLineRange(range, root)).toEqual({ side: 'left', startLine: 12, endLine: 12 });
+    });
+
+    it('spans the start row to the end row on the anchored side', () => {
+        const range = rangeOver('[data-line-new="10"] .diff-cell-content', '[data-line-new="11"] .diff-cell-content');
+        expect(selectionLineRange(range, root)).toEqual({ side: 'right', startLine: 10, endLine: 11 });
+    });
+
+    it('falls back to the start line when the end row lacks the anchored side', () => {
+        // Start on the right side (line 11) but end on a left-only row: endLine stays 11.
+        const range = rangeOver('[data-line-new="11"] .diff-cell-content', '[data-line-old="12"] .diff-cell-content');
+        expect(selectionLineRange(range, root)).toEqual({ side: 'right', startLine: 11, endLine: 11 });
+    });
+
+    it('returns null when the selection starts outside the given root', () => {
+        const range = rangeOver('#other-root [data-line-new="99"] .diff-cell-content');
+        expect(selectionLineRange(range, root)).toBeNull();
+    });
+
+    it('returns null for a missing range', () => {
+        expect(selectionLineRange(null, root)).toBeNull();
+    });
+});
+
+describe('comment on text selection', () => {
+    let root;
+
+    beforeEach(() => {
+        globalThis.Alpine = { store: () => ({ collapseAll: false }) };
+        document.body.innerHTML = `
+            <div id="file-root">
+                <div class="diff-line" data-line-new="13"><div class="diff-cell-content">> Identify the single most undeniable paper cut</div></div>
+                <div class="diff-line" data-line-new="14"><div class="diff-cell-content">more context</div></div>
+            </div>
+        `;
+        root = document.getElementById('file-root');
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        delete globalThis.Alpine;
+        vi.restoreAllMocks();
+    });
+
+    function makeComponent() {
+        const component = createDiffFile({ fileId: 'file-1', filePath: 'README.md', isReviewed: false });
+        component.$el = root;
+        component.$dispatch = vi.fn();
+        component.$nextTick = (fn) => fn();
+        component.$refs = { commentInput: { focus: vi.fn(), value: '', setSelectionRange: vi.fn() } };
+        return component;
+    }
+
+    function stubSelection({ text, startSelector, endSelector = startSelector, collapsed = false }) {
+        const range = document.createRange();
+        const startNode = document.querySelector(startSelector).firstChild;
+        const endNode = document.querySelector(endSelector).firstChild;
+        range.setStart(startNode, 0);
+        range.setEnd(endNode, endNode.length);
+        vi.spyOn(window, 'getSelection').mockReturnValue({
+            rangeCount: 1,
+            isCollapsed: collapsed,
+            anchorNode: startNode,
+            getRangeAt: () => range,
+            toString: () => text,
+        });
+        return range;
+    }
+
+    it('opens the form on the selected line seeded with a citation', () => {
+        const component = makeComponent();
+        stubSelection({
+            text: 'Identify the single most undeniable paper cut',
+            startSelector: '[data-line-new="13"] .diff-cell-content',
+        });
+
+        component.commentOnSelection();
+
+        expect(component.showForm).toBe(true);
+        expect(component.formSide).toBe('right');
+        expect(component.formLine).toBe(13);
+        expect(component.formEndLine).toBe(13);
+        expect(component.formBody).toBe('> Identify the single most undeniable paper cut\n\n');
+        expect(component.$refs.commentInput.focus).toHaveBeenCalled();
+    });
+
+    it('anchors a multi-line selection across the spanned rows', () => {
+        const component = makeComponent();
+        stubSelection({
+            text: 'line thirteen\nline fourteen',
+            startSelector: '[data-line-new="13"] .diff-cell-content',
+            endSelector: '[data-line-new="14"] .diff-cell-content',
+        });
+
+        component.commentOnSelection();
+
+        expect(component.formLine).toBe(13);
+        expect(component.formEndLine).toBe(14);
+        expect(component.formBody).toBe('> line thirteen\n> line fourteen\n\n');
+    });
+
+    it('does nothing when the selection is collapsed', () => {
+        const component = makeComponent();
+        stubSelection({ text: '', startSelector: '[data-line-new="13"] .diff-cell-content', collapsed: true });
+
+        component.commentOnSelection();
+
+        expect(component.showForm).toBe(false);
+        expect(component.formBody).toBe('');
+    });
+
+    it('does not overwrite text already in the composer', () => {
+        const component = makeComponent();
+        component.formBody = 'half-written thought';
+        stubSelection({
+            text: 'Identify the single most undeniable paper cut',
+            startSelector: '[data-line-new="13"] .diff-cell-content',
+        });
+
+        component.commentOnSelection();
+
+        expect(component.formBody).toBe('half-written thought');
+        expect(component.formLine).toBe(13);
+    });
+});
+
+describe('citation pre-fill on the drag path', () => {
+    beforeEach(() => {
+        globalThis.Alpine = { store: () => ({ collapseAll: false }) };
+    });
+
+    afterEach(() => {
+        delete globalThis.Alpine;
+    });
+
+    function makeComponent() {
+        const component = createDiffFile({ fileId: 'file-1', filePath: 'README.md', isReviewed: false });
+        component.$dispatch = vi.fn();
+        component.$nextTick = (fn) => fn();
+        component.$refs = { commentInput: { focus: vi.fn(), value: '', setSelectionRange: vi.fn() } };
+        return component;
+    }
+
+    it('applies the pending citation when the line drag ends', () => {
+        const component = makeComponent();
+        component.isDragging = true;
+        component.setLineSelection({ line: 13, side: 'right' });
+        component._pendingCitation = '> cited line\n\n';
+
+        component.endDrag();
+
+        expect(component.showForm).toBe(true);
+        expect(component.formBody).toBe('> cited line\n\n');
+        expect(component._pendingCitation).toBe('');
+    });
+
+    it('does not overwrite an existing draft when the drag ends', () => {
+        const component = makeComponent();
+        component.isDragging = true;
+        component.formBody = 'existing draft';
+        component._pendingCitation = '> cited line\n\n';
+
+        component.endDrag();
+
+        expect(component.formBody).toBe('existing draft');
+        expect(component._pendingCitation).toBe('');
+    });
+
+    it('clears any pending citation on cancel', () => {
+        const component = makeComponent();
+        component._pendingCitation = '> cited line\n\n';
+
+        component.cancelForm();
+
+        expect(component._pendingCitation).toBe('');
+        expect(component.formBody).toBe('');
     });
 });

--- a/tests/Js/review-page.test.js
+++ b/tests/Js/review-page.test.js
@@ -357,3 +357,63 @@ describe('createReviewPage path helpers', () => {
         expect(page.$wire.toggleReviewed).not.toHaveBeenCalled();
     });
 });
+
+describe('review.comment-selection shortcut', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+        vi.restoreAllMocks();
+    });
+
+    function pageWithShortcut() {
+        const handlers = {};
+        const page = createReviewPage({});
+        page.registeredShortcutIds = [];
+        page.$store = { shortcuts: { register: (id, handler) => { handlers[id] = handler; } }, settings: {} };
+        page.$dispatch = vi.fn();
+        page.$refs = {};
+        page.registerShortcuts();
+        return { page, fire: handlers['review.comment-selection'] };
+    }
+
+    function stubSelection({ startSelector, collapsed = false }) {
+        const node = startSelector ? document.querySelector(startSelector).firstChild : null;
+        vi.spyOn(window, 'getSelection').mockReturnValue({
+            rangeCount: node ? 1 : 0,
+            isCollapsed: collapsed,
+            getRangeAt: () => ({ startContainer: node }),
+        });
+    }
+
+    it('targets the file that owns the selection by id', () => {
+        document.body.innerHTML = `
+            <div data-file-id="file-9">
+                <div class="diff-line" data-line-new="3"><div class="diff-cell-content">hello</div></div>
+            </div>`;
+        const { page, fire } = pageWithShortcut();
+        stubSelection({ startSelector: '[data-file-id="file-9"] .diff-cell-content' });
+
+        fire();
+
+        expect(page.$dispatch).toHaveBeenCalledWith('rfa-comment-selection', { fileId: 'file-9' });
+    });
+
+    it('does nothing when the selection is collapsed', () => {
+        document.body.innerHTML = '<div data-file-id="file-9"><div class="diff-cell-content">hi</div></div>';
+        const { page, fire } = pageWithShortcut();
+        stubSelection({ startSelector: '.diff-cell-content', collapsed: true });
+
+        fire();
+
+        expect(page.$dispatch).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the selection is not inside a file', () => {
+        document.body.innerHTML = '<div class="sidebar">unrelated text</div>';
+        const { page, fire } = pageWithShortcut();
+        stubSelection({ startSelector: '.sidebar' });
+
+        fire();
+
+        expect(page.$dispatch).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## What

When you have text selected in a diff and start a comment, the composer now opens pre-filled with that text as a GitHub-style blockquote, with the cursor below it:

```
> Identify the single most undeniable maintainability paper cut

```

This fires for all three comment-creation paths — the new `c` shortcut, clicking a line number, and dragging the line-number gutter. Multi-line selections quote every line; the gutter/prefix cells are already `user-select: none`, so citations never pick up line numbers or `+`/`-` markers.

## New shortcut: `c`

"Comment on selection" lives in the Review group of the cheat sheet (`?`), next to `j`/`k`. It opens the line-comment composer anchored to the row(s) your selection spans, seeded with the citation. It only fires when text is selected and you're not typing in a field; `⌘C` copy is untouched. With no selection it's a deliberate no-op (there's no notion of a focused line today to anchor to).

## How it's wired

- `config/shortcuts.php` — `review.comment-selection` → combo `c`.
- `review-page.js` — the shortcut resolves the selection's owning file id once (from its `[data-file-id]` ancestor) and dispatches `rfa-comment-selection` targeted by id, matching the existing `comment-updated` / `expand-file` event convention.
- `⚡diff-file.blade.php` — the matching diff-file (`$event.detail.fileId === fileId`) opens the composer via `commentOnSelection()`.
- `diff-file.js` — new pure helpers `formatCitation`, `closestDiffLine`, `selectionLineRange`; selection text is read scoped to the file's own rows so a stray selection elsewhere can't leak in. Shared `_activeSelection()` / `_prefillCitation()` helpers keep the three entry points DRY, and the drag-path row→line resolution now reuses the same helpers.

## Tests

- `tests/Js/diff-file.test.js`: citation formatting (single/multi-line, whitespace, empty), line-range mapping (side anchoring, cross-side fallback, out-of-root rejection), `commentOnSelection`, and drag-path pre-fill (including not clobbering an in-progress draft).
- `tests/Js/review-page.test.js`: page-side file resolution (targets the owning file by id; no-ops on a collapsed selection or one outside any file).
- All green: 310 JS tests, 1540 core tests, shortcuts arch test, Pint, PHPStan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MeA7HbyNfkCQ1oYpcY53wF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeA7HbyNfkCQ1oYpcY53wF)_