### PR TITLE
Reset submit bar when deleting the submitted review

### DIFF
--- a/app/Concerns/ReviewPage/ExportsReview.php
+++ b/app/Concerns/ReviewPage/ExportsReview.php
@@ -6,6 +6,7 @@ namespace App\Concerns\ReviewPage;
 
 use App\Actions\ExportReviewAction;
 use App\Actions\ExportReviewSnapshotAction;
+use App\DTOs\ReviewFilePair;
 use Flux\Flux;
 
 /**
@@ -18,7 +19,8 @@ use Flux\Flux;
  * editor returns.
  *
  * Component state read/written: $comments, $globalComment, $files,
- * $reviewedFiles, $repoPath, $projectName, $exportResult, $submitted. Calls
+ * $reviewedFiles, $repoPath, $projectName, $exportResult, $submitted,
+ * $submittedReviewBasename. Calls
  * into the coordinator (saveSession, buildDiffTarget, scanReviewFiles,
  * dispatchFileComments, the reviewState computed) and the render pipeline
  * (skipRender, dispatch). submitReview renders (it swaps the submit bar);
@@ -36,6 +38,7 @@ trait ExportsReview
         $result = app(ExportReviewAction::class)->handle($this->repoPath, $finalizedComments, $this->globalComment, $this->files, $target);
 
         $this->exportResult = $result['clipboard'];
+        $this->submittedReviewBasename = ReviewFilePair::extractBasename($result['md']);
         $this->submitted = true;
 
         $this->scanReviewFiles();
@@ -129,7 +132,17 @@ trait ExportsReview
 
     public function startNewReview(): void
     {
+        $this->resetSubmittedState();
+    }
+
+    /**
+     * Return the submit bar to its editing state and forget the review file it
+     * referenced. Shared by startNewReview and by deleting the submitted review.
+     */
+    private function resetSubmittedState(): void
+    {
         $this->submitted = false;
         $this->exportResult = null;
+        $this->submittedReviewBasename = null;
     }
 }

--- a/resources/CLAUDE.md
+++ b/resources/CLAUDE.md
@@ -10,7 +10,7 @@
 - Use `rfa-logo` class for the "rfa" wordmark (bold, tight tracking)
 - Use `section-label` class for uppercase section headers (e.g. "Files", "Reviews", "Local", "Remote"). Defaults to display font; add `font-mono` when the label content is technical data like a path or hash (see the picker's group header over `$commonDir`)
 - Use `tracking-brutal` (-0.04em) on headings and `tracking-brutal-tight` (-0.06em) for display sizes
-- Diff code areas stay dense: `font-mono text-xs leading-5`
+- Diff code areas stay dense and `font-mono`. The `.diff-grid` wrapper carries `text-xs leading-5` as the baseline for inline comment/expand rows (`.diff-fullspan`); the code cells themselves (`.diff-cell`) are bumped to `font-size: 1rem` (text-base) with a proportional `line-height: 1.667` in `layouts/app.blade.php`, so the diff text renders ~two zoom steps larger than the surrounding chrome.
 
 ## Paths & identifiers
 

--- a/resources/views/components/arm-commit-button.blade.php
+++ b/resources/views/components/arm-commit-button.blade.php
@@ -45,7 +45,7 @@
         @click.stop.prevent="handle()"
         x-bind:class="armed && '!text-gh-red hover:!bg-gh-red/10'"
     >
-        <flux:icon :icon="$icon" variant="outline" />
+        <flux:icon :icon="$icon" variant="outline" class="!size-4" />
     </flux:button>
     <div
         aria-hidden="true"

--- a/resources/views/components/commit-context-bar.blade.php
+++ b/resources/views/components/commit-context-bar.blade.php
@@ -8,7 +8,7 @@
      navigation — the actions only navigate within the commit context the
      bar describes. --}}
 <div data-testid="commit-context-bar" class="sticky top-[var(--header-h)] z-40 bg-gh-surface border-b border-gh-border px-5 py-2.5 flex items-center gap-3 text-xs" style="--commit-bar-h: 40px;">
-    <flux:icon icon="code-bracket" variant="outline" class="text-gh-muted shrink-0" />
+    <flux:icon icon="code-bracket" variant="outline" class="!size-4 text-gh-muted shrink-0" />
     <x-stat-chip class="shrink-0">{{ $commitInfo['shortHash'] }}</x-stat-chip>
     <span class="text-gh-text truncate font-medium" title="{{ $commitInfo['message'] }}">{{ $commitInfo['message'] }}</span>
     <span class="text-gh-muted shrink-0">{{ $commitInfo['author'] }}</span>

--- a/resources/views/components/diff/file-header.blade.php
+++ b/resources/views/components/diff/file-header.blade.php
@@ -28,8 +28,8 @@
         <button :aria-label="collapsed ? 'Expand file' : 'Collapse file'"
                 :aria-expanded="!collapsed"
                 class="text-gh-muted hover:text-gh-text transition-colors">
-            <flux:icon icon="chevron-down" variant="outline" x-show="!collapsed" />
-            <flux:icon icon="chevron-right" variant="outline" x-show="collapsed" x-cloak />
+            <flux:icon icon="chevron-down" variant="outline" class="!size-4" x-show="!collapsed" />
+            <flux:icon icon="chevron-right" variant="outline" class="!size-4" x-show="collapsed" x-cloak />
         </button>
 
         <x-file-path

--- a/resources/views/components/feedback-submit-bar.blade.php
+++ b/resources/views/components/feedback-submit-bar.blade.php
@@ -31,7 +31,7 @@
     @if($submitted)
         <div class="px-5 py-3.5 flex items-center justify-between gap-4">
             <div class="flex items-center gap-3 min-w-0">
-                <flux:icon icon="check-circle" variant="outline" class="text-gh-green shrink-0" />
+                <flux:icon icon="check-circle" variant="outline" class="!size-4 text-gh-green shrink-0" />
                 <span class="font-semibold tracking-brutal shrink-0">{{ $submittedHeading }}</span>
                 <x-stat-chip class="truncate">{{ $exportResult }}</x-stat-chip>
             </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -118,7 +118,14 @@
         .diff-grid[data-view-mode="split"] .diff-line[data-type="context"] { grid-column: 1 / -1; }
 
         .diff-grid .diff-fullspan { grid-column: 1 / -1; }
-        .diff-cell { min-width: 0; }
+        /* Diff code text size. Bumped two type-scale steps up from the
+           inherited text-xs (12px) to text-base (16px) so the diff reads
+           larger by default — equivalent to two browser zoom-in presses.
+           line-height keeps the prior 20/12 density ratio (1.667) so rows
+           scale proportionally, exactly like zoom. Scoped to the cells, not
+           the .diff-grid wrapper, so inline comment/expand rows
+           (.diff-fullspan) keep their own smaller sizing. */
+        .diff-cell { min-width: 0; font-size: 1rem; line-height: 1.667; }
         .diff-cell-num {
             padding: 0 0.5rem;
             text-align: right;

--- a/resources/views/livewire/undo-toast.blade.php
+++ b/resources/views/livewire/undo-toast.blade.php
@@ -108,7 +108,10 @@
                         data-testid="undo-ok-button"
                     >OK</button>
                 </template>
-                <span class="font-mono text-xs text-gh-muted tabular-nums" x-text="remaining + 's'"></span>
+                {{-- aria-hidden so the per-second countdown inside this aria-live
+                     region doesn't re-announce the toast every tick; the message and
+                     Undo action stay announced. --}}
+                <span class="font-mono text-xs text-gh-muted tabular-nums" x-text="remaining + 's'" aria-hidden="true"></span>
             </div>
         </div>
         <button

--- a/resources/views/livewire/undo-toast.blade.php
+++ b/resources/views/livewire/undo-toast.blade.php
@@ -85,25 +85,31 @@
     role="status"
     aria-live="polite"
     data-testid="undo-toast"
-    class="fixed bottom-20 left-1/2 -translate-x-1/2 z-50 max-w-sm"
+    class="fixed bottom-20 left-1/2 -translate-x-1/2 z-50 w-96 max-w-[calc(100vw-2rem)]"
 >
-    <div class="p-2 flex rounded-xl shadow-lg bg-gh-surface border border-gh-border"
+    <div class="p-2 flex items-center rounded-xl shadow-lg bg-gh-surface border border-gh-border"
         :class="current?.type === 'discard' && 'border-l-2 border-l-gh-accent'">
-        <div class="flex-1 flex items-center gap-3 py-1.5 px-2.5 text-sm">
-            <span x-text="current?.message" class="font-medium text-gh-text"></span>
-            <button
-                @click="undo()"
-                class="font-medium text-gh-link hover:underline shrink-0"
-                data-testid="undo-button"
-            >Undo</button>
-            <template x-if="current?.type === 'discard'">
+        <div class="flex-1 min-w-0 flex items-center gap-3 py-1.5 px-2.5 text-sm">
+            <span
+                x-text="current?.message"
+                :title="current?.message"
+                class="min-w-0 flex-1 truncate font-medium text-gh-text"
+            ></span>
+            <div class="flex items-center gap-3 shrink-0">
                 <button
-                    @click="dismiss()"
-                    class="font-medium text-gh-muted hover:text-gh-text shrink-0"
-                    data-testid="undo-ok-button"
-                >OK</button>
-            </template>
-            <span class="font-mono text-xs text-gh-muted tabular-nums shrink-0" x-text="remaining + 's'"></span>
+                    @click="undo()"
+                    class="font-medium text-gh-link hover:underline"
+                    data-testid="undo-button"
+                >Undo</button>
+                <template x-if="current?.type === 'discard'">
+                    <button
+                        @click="dismiss()"
+                        class="font-medium text-gh-muted hover:text-gh-text"
+                        data-testid="undo-ok-button"
+                    >OK</button>
+                </template>
+                <span class="font-mono text-xs text-gh-muted tabular-nums" x-text="remaining + 's'"></span>
+            </div>
         </div>
         <button
             @click="dismiss()"

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -211,7 +211,7 @@ new class extends Component {
                 {{-- Left pane: branches --}}
                 <div class="w-[180px] shrink-0 border-r border-gh-border flex flex-col min-h-0">
                     {{-- Search input --}}
-                    <div class="px-2 py-3 border-b border-gh-border">
+                    <div class="px-3 py-3 border-b border-gh-border">
                         <flux:input
                             x-ref="searchInput"
                             x-model.debounce.100ms="search"
@@ -244,7 +244,7 @@ new class extends Component {
                                     >
                                         <button
                                             @click="selectBranchAt(i)"
-                                            class="w-full text-left px-3 py-2 text-xs font-mono flex items-center gap-2 transition-colors cursor-pointer"
+                                            class="w-full text-left px-3 py-2.5 text-xs font-mono flex items-center gap-2 transition-colors cursor-pointer"
                                             :class="selectedIndex === i ? 'bg-gh-text/10 text-gh-text font-medium' : 'text-gh-muted hover:bg-gh-border/30 hover:text-gh-text'"
                                             :data-selected="selectedIndex === i"
                                             :title="branch.name"
@@ -275,7 +275,7 @@ new class extends Component {
                                     >
                                         <button
                                             @click="selectBranchAt(filteredLocal.length + j)"
-                                            class="w-full text-left px-3 py-2 text-xs font-mono flex items-center gap-2 transition-colors cursor-pointer"
+                                            class="w-full text-left px-3 py-2.5 text-xs font-mono flex items-center gap-2 transition-colors cursor-pointer"
                                             :class="selectedIndex === (filteredLocal.length + j) ? 'bg-gh-text/10 text-gh-text font-medium' : 'text-gh-muted hover:bg-gh-border/30 hover:text-gh-text'"
                                             :data-selected="selectedIndex === (filteredLocal.length + j)"
                                             :title="branch.name"

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -249,7 +249,7 @@ new class extends Component {
                                             :data-selected="selectedIndex === i"
                                             :title="branch.name"
                                         >
-                                            <flux:icon icon="check" variant="outline" class="shrink-0" x-show="branch.isCurrent" x-cloak />
+                                            <flux:icon icon="check" variant="outline" class="!size-3 shrink-0" x-show="branch.isCurrent" x-cloak />
                                             <span class="shrink-0 w-3" x-show="!branch.isCurrent"></span>
                                             <span class="truncate" x-text="branch.name"></span>
                                         </button>
@@ -304,7 +304,7 @@ new class extends Component {
                 <div class="flex-1 flex flex-col min-h-0 min-w-0">
                     {{-- Commits header --}}
                     <div class="px-4 py-2.5 border-b border-gh-border flex items-center gap-2 shrink-0">
-                        <flux:icon icon="clock" variant="outline" class="text-gh-muted" />
+                        <flux:icon icon="clock" variant="outline" class="!size-4 text-gh-muted" />
                         <span class="text-xs font-semibold tracking-brutal text-gh-text truncate" x-text="selectedBranch || 'Select a branch'" :title="selectedBranch"></span>
                         <span class="text-xs font-mono text-gh-muted" x-show="$wire.commits.length > 0" x-text="'(' + $wire.commits.length + ($wire.hasMore ? '+' : '') + ')'"></span>
 

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -475,7 +475,7 @@ HTML;
         @if(($file['isSymlink'] ?? false) || ($diffData['isSymlink'] ?? false))
             @php $target = $file['symlinkTarget'] ?? ($diffData['symlinkTarget'] ?? ''); @endphp
             <div class="px-4 py-8 text-center">
-                <flux:icon icon="link" variant="outline" class="inline-block text-gh-muted mr-1" aria-hidden="true" />
+                <flux:icon icon="link" variant="outline" class="!size-4 inline-block text-gh-muted mr-1" aria-hidden="true" />
                 <flux:text variant="subtle" size="sm" inline>
                     Symbolic link &rarr; <span class="font-mono">{{ $target }}</span>
                 </flux:text>
@@ -541,12 +541,12 @@ HTML;
             </div>
         @elseif($diffData['tooLarge'] ?? false)
             <div class="px-4 py-8 text-center">
-                <flux:icon icon="exclamation-triangle" variant="outline" class="inline-block text-gh-muted mr-1" />
+                <flux:icon icon="exclamation-triangle" variant="outline" class="!size-4 inline-block text-gh-muted mr-1" />
                 <flux:text variant="subtle" size="sm" inline>File diff too large to display</flux:text>
             </div>
         @elseif($diffData['error'] ?? false)
             <div class="px-4 py-8 text-center">
-                <flux:icon icon="exclamation-triangle" variant="outline" class="inline-block text-gh-red mr-1" />
+                <flux:icon icon="exclamation-triangle" variant="outline" class="!size-4 inline-block text-gh-red mr-1" />
                 <flux:text variant="subtle" size="sm" inline>Git error: {{ $diffData['error'] }}</flux:text>
             </div>
         @elseif(empty($diffData['hunks']))

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -87,6 +87,12 @@ new #[Layout('layouts.app')] class extends Component
 
     public bool $submitted = false;
 
+    /**
+     * Basename of the review file the "Review submitted" bar currently points
+     * at. Lets a delete of that same review reset the bar (see deleteReviewPair).
+     */
+    public ?string $submittedReviewBasename = null;
+
     public ?string $gitError = null;
 
     /** @var array<string, string> */
@@ -1042,6 +1048,12 @@ new #[Layout('layouts.app')] class extends Component
             array_filter($this->reviewPairs, fn ($p) => $p['basename'] !== $basename)
         );
 
+        // The "Review submitted" bar points at this file — deleting it leaves
+        // the bar referencing a file that no longer exists, so drop back to the editor.
+        if ($basename === $this->submittedReviewBasename) {
+            $this->resetSubmittedState();
+        }
+
         Flux::toast(text: 'Review deleted', variant: 'success');
     }
 
@@ -1056,6 +1068,10 @@ new #[Layout('layouts.app')] class extends Component
         app(DeleteReviewFilesAction::class)->handle($this->repoPath, $basenames);
 
         $this->reviewPairs = [];
+
+        if (in_array($this->submittedReviewBasename, $basenames, true)) {
+            $this->resetSubmittedState();
+        }
 
         Flux::toast(text: 'All reviews deleted', variant: 'success');
     }

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1741,14 +1741,16 @@ new #[Layout('layouts.app')] class extends Component
                                 <button @click="collapsed = !collapsed"
                                     :aria-label="collapsed ? 'Expand review' : 'Collapse review'"
                                     :aria-expanded="!collapsed"
-                                    class="text-gh-muted hover:text-gh-text transition-colors">
+                                    class="shrink-0 text-gh-muted hover:text-gh-text transition-colors">
                                     <flux:icon icon="chevron-down" variant="outline" class="!size-4" x-show="!collapsed" />
                                     <flux:icon icon="chevron-right" variant="outline" class="!size-4" x-show="collapsed" x-cloak />
                                 </button>
-                                <span class="text-[10px] font-mono font-medium text-gh-link shrink-0">R</span>
-                                <span class="font-mono text-sm truncate" title="{{ $pair['displayName'] }}">{{ $pair['displayName'] }}</span>
-                                <span class="text-[10px] font-mono text-gh-muted">.md</span>
-                                <span class="ml-auto">
+                                <div class="flex items-center gap-1.5 min-w-0 flex-1">
+                                    <span class="text-[10px] font-mono font-medium text-gh-link shrink-0">R</span>
+                                    <span class="font-mono text-sm truncate min-w-0" title="{{ $pair['displayName'] }}">{{ $pair['displayName'] }}</span>
+                                    <span class="text-[10px] font-mono text-gh-muted shrink-0">.md</span>
+                                </div>
+                                <span class="shrink-0">
                                     <x-arm-commit-button
                                         icon="trash"
                                         tooltip="Delete review"

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1742,8 +1742,8 @@ new #[Layout('layouts.app')] class extends Component
                                     :aria-label="collapsed ? 'Expand review' : 'Collapse review'"
                                     :aria-expanded="!collapsed"
                                     class="text-gh-muted hover:text-gh-text transition-colors">
-                                    <flux:icon icon="chevron-down" variant="outline" x-show="!collapsed" />
-                                    <flux:icon icon="chevron-right" variant="outline" x-show="collapsed" x-cloak />
+                                    <flux:icon icon="chevron-down" variant="outline" class="!size-4" x-show="!collapsed" />
+                                    <flux:icon icon="chevron-right" variant="outline" class="!size-4" x-show="collapsed" x-cloak />
                                 </button>
                                 <span class="text-[10px] font-mono font-medium text-gh-link shrink-0">R</span>
                                 <span class="font-mono text-sm truncate" title="{{ $pair['displayName'] }}">{{ $pair['displayName'] }}</span>

--- a/tests/Browser/SplitDiffMultiHunkTest.php
+++ b/tests/Browser/SplitDiffMultiHunkTest.php
@@ -34,7 +34,10 @@ test('split view does not pair removes and adds across hunk boundaries', functio
 test('split view context lines render at one line-height', function () {
     // Regression: Phiki emits a trailing "\n" token on every line. With
     // white-space: pre-wrap on the cell, that newline rendered as a visible
-    // second line, doubling each context row to 40px.
+    // second line, doubling each context row. At the diff code size
+    // (.diff-cell: 16px text, 1.667 line-height) one row is ~26.7px, so a
+    // doubled row would be ~53px — the bounds below bracket the single-line
+    // height and stay well under the doubled threshold.
     $page = $this->visitAndLoad($this->projectUrl());
     $page->page()->getByLabel('Switch to split view')->click();
     $page->page()->locator('[data-testid="diff-table"][data-view-mode="split"]')->first()->waitFor();
@@ -50,6 +53,6 @@ test('split view context lines render at one line-height', function () {
     expect($heights)->toHaveCount(5);
 
     foreach ($heights as $h) {
-        expect($h)->toBeGreaterThan(15.0)->toBeLessThan(25.0);
+        expect($h)->toBeGreaterThan(20.0)->toBeLessThan(40.0);
     }
 });

--- a/tests/Unit/Livewire/ReviewPageTest.php
+++ b/tests/Unit/Livewire/ReviewPageTest.php
@@ -2,6 +2,7 @@
 
 use App\Actions\BackfillGlobalGitignoreAction;
 use App\Actions\CleanExpiredTrashAction;
+use App\Actions\DeleteReviewFilesAction;
 use App\Actions\DiscardFileChangesAction;
 use App\Actions\ExportReviewAction;
 use App\Actions\GetFileListAction;
@@ -355,6 +356,71 @@ test('submitReview refreshes file list and populates reviewPairs', function () {
 
     expect($component->get('reviewPairs'))->toHaveCount(1);
     expect($component->get('submitted'))->toBeTrue();
+});
+
+test('deleting the submitted review resets the submit bar', function () {
+    $basename = '20260227_173000_comments_abcd1234';
+
+    app()->bind(ExportReviewAction::class, fn () => new class($basename)
+    {
+        public function __construct(private string $basename) {}
+
+        public function handle(string $repoPath, array $comments, string $globalComment, array $files, ?DiffTarget $target = null): array
+        {
+            return [
+                'md' => ".rfa/{$this->basename}.md",
+                'clipboard' => 'review exported',
+                'submittedIds' => array_column($comments, 'id'),
+            ];
+        }
+    });
+    app()->bind(DeleteReviewFilesAction::class, fn () => new class
+    {
+        public function handle(string $repoPath, array|string $basenames): void {}
+    });
+
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('add-comment', fileId: 'abc123', side: 'right', startLine: 1, endLine: 1, body: 'Test comment')
+        ->call('submitReview');
+
+    expect($component->get('submitted'))->toBeTrue();
+    expect($component->get('submittedReviewBasename'))->toBe($basename);
+
+    $component->call('deleteReviewPair', $basename);
+
+    expect($component->get('submitted'))->toBeFalse();
+    expect($component->get('exportResult'))->toBeNull();
+    expect($component->get('submittedReviewBasename'))->toBeNull();
+});
+
+test('deleting a different review leaves the submit bar untouched', function () {
+    $basename = '20260227_173000_comments_abcd1234';
+
+    app()->bind(ExportReviewAction::class, fn () => new class($basename)
+    {
+        public function __construct(private string $basename) {}
+
+        public function handle(string $repoPath, array $comments, string $globalComment, array $files, ?DiffTarget $target = null): array
+        {
+            return [
+                'md' => ".rfa/{$this->basename}.md",
+                'clipboard' => 'review exported',
+                'submittedIds' => array_column($comments, 'id'),
+            ];
+        }
+    });
+    app()->bind(DeleteReviewFilesAction::class, fn () => new class
+    {
+        public function handle(string $repoPath, array|string $basenames): void {}
+    });
+
+    $component = Livewire::test('pages::review-page', ['slug' => 'test-project'])
+        ->dispatch('add-comment', fileId: 'abc123', side: 'right', startLine: 1, endLine: 1, body: 'Test comment')
+        ->call('submitReview')
+        ->call('deleteReviewPair', '20251010_090000_comments_zzzz9999');
+
+    expect($component->get('submitted'))->toBeTrue();
+    expect($component->get('submittedReviewBasename'))->toBe($basename);
 });
 
 test('startNewReview returns the submit bar to the input state', function () {


### PR DESCRIPTION
## Summary
When a user submits a review and then deletes that same review file, the "Review submitted" bar now correctly resets to the editor state instead of referencing a file that no longer exists.

## Key Changes
- **Track submitted review basename**: Added `$submittedReviewBasename` property to the review page component to track which review file the current submit bar points to
- **Reset on matching delete**: Modified `deleteReviewPair()` to detect when the deleted review matches the submitted one and call `resetSubmittedState()` to clear the bar
- **Reset on bulk delete**: Updated `deleteAllReviewPairs()` to check if the submitted review is among the deleted files and reset accordingly
- **Refactor reset logic**: Extracted `resetSubmittedState()` as a shared private method used by both `startNewReview()` and the delete handlers
- **Extract basename from export result**: Updated `submitReview()` to extract and store the basename from the export result using `ReviewFilePair::extractBasename()`
- **UI polish**: Fixed icon sizing and layout issues in the undo toast, review list items, and various diff/file components to use consistent `!size-4` sizing and improved text truncation with `min-w-0` flex constraints
- **Diff text sizing**: Increased diff code cell font size from `text-xs` (12px) to `text-base` (16px) with proportional line-height to match two browser zoom-in presses
- **Branch explorer spacing**: Adjusted padding and icon sizing in the branch selector for visual consistency

## Testing
Added two new test cases:
- Deleting the submitted review resets the submit bar to editing state
- Deleting a different review leaves the submit bar untouched

https://claude.ai/code/session_01YaG4BaLgU5irXKMx9MJ4LT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review submissions now stay in sync with the selected file, even when review items are deleted.
* **Bug Fixes**
  * Fixed the submitted-review banner so it clears correctly when the referenced file is removed.
  * Improved sizing and spacing across review, branch, diff, toast, and commit UI elements for a more consistent display.
* **Tests**
  * Added coverage for review deletion behavior to verify submitted state resets only when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->