### PR TITLE
Auto-follow checked-out branch on fresh open when review target is gone

### DIFF
--- a/app/Actions/ResolveDivergenceStateAction.php
+++ b/app/Actions/ResolveDivergenceStateAction.php
@@ -62,15 +62,23 @@ final readonly class ResolveDivergenceStateAction
             return DivergenceDecision::detached($target, $head->sha);
         }
 
-        if ($target !== '' && $head->targetExists === false) {
+        // `targetExists` is tri-state: true exists, false is a confirmed
+        // absence, null means the existence probe couldn't complete (transient
+        // git failure). Treat anything that isn't a confirmed presence as a
+        // missing target for banner purposes, but only *persist* a retarget when
+        // the absence is confirmed (see below).
+        if ($target !== '' && $head->targetExists !== true) {
             if ($dismissedAtBranch === $head->branch) {
                 return DivergenceDecision::aligned();
             }
 
-            // Fresh open: the stored target is just stale state from a prior
-            // session, and the gone branch can't be reviewed anyway. Land the
-            // user on the branch they have checked out rather than nagging.
-            if ($isInitialResolve) {
+            // Fresh open with the target confirmed gone: it's stale state from a
+            // prior session and can't be reviewed anyway, so land the user on the
+            // branch they have checked out rather than nagging. An unconfirmed
+            // (null) probe stays on the recoverable banner — silently overwriting
+            // the saved target on a transient failure could strand the user off a
+            // branch that still exists.
+            if ($isInitialResolve && $head->targetExists === false) {
                 return DivergenceDecision::autoFollow((string) $head->branch);
             }
 

--- a/app/Actions/ResolveDivergenceStateAction.php
+++ b/app/Actions/ResolveDivergenceStateAction.php
@@ -23,6 +23,15 @@ final readonly class ResolveDivergenceStateAction
     /**
      * @param  Closure(): bool  $hasPersistedComments
      * @param  Closure(): int  $persistedCommentCount
+     * @param  bool  $isInitialResolve  True on the first resolve after mount (a
+     *                                  fresh open, e.g. the `rfa` CLI deep-link).
+     *                                  There is no in-progress review to protect
+     *                                  yet, so a stored target that no longer
+     *                                  exists auto-follows HEAD's checked-out
+     *                                  branch instead of surfacing the blocking
+     *                                  missing-target banner. Poll ticks pass
+     *                                  false so a branch vanishing mid-review
+     *                                  still surfaces the banner.
      */
     public function handle(
         CurrentHeadResult $head,
@@ -31,6 +40,7 @@ final readonly class ResolveDivergenceStateAction
         ?string $dismissedAtBranch,
         Closure $hasPersistedComments,
         Closure $persistedCommentCount,
+        bool $isInitialResolve = false,
     ): DivergenceDecision {
         // Sentinel: GetCurrentHeadAction returns sha='' when git fails transiently
         // (e.g. mid-rebase). Leave state untouched and retry next tick.
@@ -55,6 +65,13 @@ final readonly class ResolveDivergenceStateAction
         if ($target !== '' && $head->targetExists === false) {
             if ($dismissedAtBranch === $head->branch) {
                 return DivergenceDecision::aligned();
+            }
+
+            // Fresh open: the stored target is just stale state from a prior
+            // session, and the gone branch can't be reviewed anyway. Land the
+            // user on the branch they have checked out rather than nagging.
+            if ($isInitialResolve) {
+                return DivergenceDecision::autoFollow((string) $head->branch);
             }
 
             return DivergenceDecision::missingTarget($target, (string) $head->branch, $head->sha);

--- a/app/Concerns/ReviewPage/ReviewsBranchDivergence.php
+++ b/app/Concerns/ReviewPage/ReviewsBranchDivergence.php
@@ -66,8 +66,12 @@ trait ReviewsBranchDivergence
      * Kept separate from `checkHeadDivergence()` so callers like `softRefresh`
      * can update divergence without latching `skipRender()` onto a response
      * that still needs to morph because files did change.
+     *
+     * `$isInitialResolve` is set only by the mount path: on a fresh open a
+     * stored target that has since disappeared auto-follows HEAD instead of
+     * surfacing the missing-target banner.
      */
-    private function refreshDivergenceState(): bool
+    private function refreshDivergenceState(bool $isInitialResolve = false): bool
     {
         if ($this->isCommitMode()) {
             $changed = ! $this->divergenceChecked;
@@ -79,7 +83,7 @@ trait ReviewsBranchDivergence
         $before = [$this->divergenceState, $this->divergenceContext, $this->dismissedAtHead, $this->dismissedAtBranch, $this->projectBranch];
 
         $head = app(GetCurrentHeadAction::class)->handle($this->repoPath, $this->projectBranch ?: null);
-        $this->resolveDivergenceState($head);
+        $this->resolveDivergenceState($head, $isInitialResolve);
 
         $after = [$this->divergenceState, $this->divergenceContext, $this->dismissedAtHead, $this->dismissedAtBranch, $this->projectBranch];
 
@@ -89,7 +93,7 @@ trait ReviewsBranchDivergence
         return $changed;
     }
 
-    private function resolveDivergenceState(CurrentHeadResult $head): void
+    private function resolveDivergenceState(CurrentHeadResult $head, bool $isInitialResolve = false): void
     {
         $decision = app(ResolveDivergenceStateAction::class)->handle(
             $head,
@@ -98,6 +102,7 @@ trait ReviewsBranchDivergence
             $this->dismissedAtBranch,
             fn (): bool => $this->hasPersistedComments(),
             fn (): int => $this->persistedCommentCount(),
+            $isInitialResolve,
         );
 
         match ($decision->kind) {

--- a/app/Services/GitMetadataService.php
+++ b/app/Services/GitMetadataService.php
@@ -111,17 +111,35 @@ class GitMetadataService
         return trim($this->git->run($directory, ['rev-parse', 'HEAD']));
     }
 
-    public function branchExists(string $directory, string $branch): bool
+    /**
+     * Whether `$branch` exists as a local ref.
+     *
+     * Tri-state so callers can tell a confirmed absence apart from a probe that
+     * could not complete: `true` exists, `false` is a confirmed absence (git
+     * reported the ref as unknown), `null` is indeterminate (timeout, lock, or
+     * any other git failure). Collapsing every error to `false` would let a
+     * transient git hiccup read as a deletion — and downstream that can silently
+     * retarget a review away from a branch that is still there.
+     */
+    public function branchExists(string $directory, string $branch): ?bool
     {
         if ($branch === '' || str_starts_with($branch, '-')) {
             return false;
         }
 
-        return rescue(function () use ($directory, $branch): bool {
+        try {
             $this->git->run($directory, ['rev-parse', '--verify', '--quiet', 'refs/heads/'.$branch]);
 
             return true;
-        }, rescue: false, report: false);
+        } catch (GitCommandException $e) {
+            // `rev-parse --verify --quiet` exits 1 with no output for an unknown
+            // ref; any other exit code (e.g. 128 for "not a git repository") is a
+            // failure we can't read as a definitive absence.
+            return $e->exitCode === 1 ? false : null;
+        } catch (\Throwable) {
+            // Timeout / process error: we genuinely don't know.
+            return null;
+        }
     }
 
     public function getFileContent(string $repoPath, string $path, string $ref = GitRef::Working->value): ?string

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -256,7 +256,10 @@ new #[Layout('layouts.app')] class extends Component
         $this->isSinceBeginningView = $this->diffTo === null && $this->diffFrom === DiffTarget::EMPTY_TREE_HASH;
 
         $this->rehydrateForTarget();
-        $this->checkHeadDivergence();
+        // Initial resolve: a stored target that has since vanished auto-follows
+        // the checked-out branch instead of greeting a fresh open (e.g. the
+        // `rfa` CLI deep-link) with the missing-target banner.
+        $this->refreshDivergenceState(isInitialResolve: true);
 
         $this->persistCurrentView($hash, $from, $to, $ref, $baseRef, $rangeFromWorking);
 

--- a/tests/Unit/Actions/ResolveDivergenceStateActionTest.php
+++ b/tests/Unit/Actions/ResolveDivergenceStateActionTest.php
@@ -112,6 +112,31 @@ test('auto-follows HEAD on the initial resolve when the reviewed branch is gone'
         ->and($this->countCalls)->toBe(0);
 });
 
+test('keeps the recoverable banner on the initial resolve when branch existence is unverifiable', function () {
+    // targetExists === null means the existence probe couldn't complete (a
+    // transient git failure), not a confirmed deletion. The initial-resolve
+    // auto-follow must NOT fire here: silently persisting a retarget could
+    // strand the user off a branch that still exists.
+    $decision = ($this->resolve)(
+        new CurrentHeadResult(branch: 'feature', sha: 'abc1234', detached: false, targetExists: null),
+        'main',
+        isInitialResolve: true,
+    );
+
+    expect($decision->kind)->toBe(DivergenceDecisionKind::Show)
+        ->and($decision->state)->toBe(DivergenceState::MissingTarget);
+});
+
+test('surfaces the missing-target banner on a poll tick when existence is unverifiable', function () {
+    $decision = ($this->resolve)(
+        new CurrentHeadResult(branch: 'feature', sha: 'abc1234', detached: false, targetExists: null),
+        'main',
+    );
+
+    expect($decision->kind)->toBe(DivergenceDecisionKind::Show)
+        ->and($decision->state)->toBe(DivergenceState::MissingTarget);
+});
+
 test('a missing target dismissed by branch identity wins over the initial-resolve auto-follow', function () {
     $decision = ($this->resolve)(
         new CurrentHeadResult(branch: 'feature', sha: 'abc1234', detached: false, targetExists: false),

--- a/tests/Unit/Actions/ResolveDivergenceStateActionTest.php
+++ b/tests/Unit/Actions/ResolveDivergenceStateActionTest.php
@@ -23,13 +23,14 @@ beforeEach(function () {
         return 3;
     };
 
-    $this->resolve = fn (CurrentHeadResult $head, string $branch = 'main', ?string $dismissedAtHead = null, ?string $dismissedAtBranch = null) => $this->action->handle(
+    $this->resolve = fn (CurrentHeadResult $head, string $branch = 'main', ?string $dismissedAtHead = null, ?string $dismissedAtBranch = null, bool $isInitialResolve = false) => $this->action->handle(
         $head,
         $branch,
         $dismissedAtHead,
         $dismissedAtBranch,
         $this->hasComments,
         $this->commentCount,
+        $isInitialResolve,
     );
 });
 
@@ -94,6 +95,32 @@ test('surfaces a missing-target banner when the reviewed branch no longer exists
             'currentSha' => 'abc1234',
             'shortSha' => 'abc1234',
         ]);
+});
+
+test('auto-follows HEAD on the initial resolve when the reviewed branch is gone', function () {
+    $decision = ($this->resolve)(
+        new CurrentHeadResult(branch: 'feature', sha: 'abc1234', detached: false, targetExists: false),
+        'main',
+        isInitialResolve: true,
+    );
+
+    // A fresh open lands on the checked-out branch rather than the blocking
+    // banner — the stored target is gone and can't be reviewed anyway.
+    expect($decision->kind)->toBe(DivergenceDecisionKind::AutoFollow)
+        ->and($decision->autoFollowBranch)->toBe('feature')
+        ->and($this->hasCommentsCalls)->toBe(0)
+        ->and($this->countCalls)->toBe(0);
+});
+
+test('a missing target dismissed by branch identity wins over the initial-resolve auto-follow', function () {
+    $decision = ($this->resolve)(
+        new CurrentHeadResult(branch: 'feature', sha: 'abc1234', detached: false, targetExists: false),
+        'main',
+        dismissedAtBranch: 'feature',
+        isInitialResolve: true,
+    );
+
+    expect($decision->kind)->toBe(DivergenceDecisionKind::Aligned);
 });
 
 test('aligns a missing target the user dismissed by branch identity', function () {

--- a/tests/Unit/Livewire/ReviewPageBranchDivergenceTest.php
+++ b/tests/Unit/Livewire/ReviewPageBranchDivergenceTest.php
@@ -185,6 +185,20 @@ test('initial open auto-follows the checked-out branch when the stored target is
     $component->assertDontSeeHtml('data-testid="divergence-banner-missing"');
 });
 
+test('initial open keeps the banner and does not retarget when branch existence is unverifiable', function () {
+    // The existence probe couldn't complete (transient git failure) — targetExists
+    // is null, not a confirmed false. A fresh open must not silently overwrite the
+    // saved target; it shows the recoverable banner instead.
+    bindFakeCurrentHeadAction(new CurrentHeadResult(branch: 'feature-x', sha: 'e'.str_repeat('0', 39), detached: false, targetExists: null));
+
+    $component = Livewire::test('pages::review-page', ['slug' => 'divergence-test']);
+
+    expect($component->get('divergenceState'))->toBe(DivergenceState::MissingTarget);
+    expect($component->get('projectBranch'))->toBe('main');
+    expect($this->project->fresh()->branch)->toBe('main');
+    $component->assertSeeHtml('data-testid="divergence-banner-missing"');
+});
+
 test('keepReviewing suppresses the banner for that branch, even across new commits', function () {
     Comment::create([
         'id' => 'c1',

--- a/tests/Unit/Livewire/ReviewPageBranchDivergenceTest.php
+++ b/tests/Unit/Livewire/ReviewPageBranchDivergenceTest.php
@@ -156,15 +156,33 @@ test('detached banner shown when HEAD is detached', function () {
     $component->assertSeeHtml('data-testid="divergence-banner-detached"');
 });
 
-test('missing_target banner shown when target branch no longer exists', function () {
-    bindFakeCurrentHeadAction(new CurrentHeadResult(branch: 'feature-x', sha: 'e'.str_repeat('0', 39), detached: false, targetExists: false));
+test('missing_target banner shown when the target vanishes mid-review', function () {
+    // Mount aligned, then the target branch disappears under an active session.
+    $fake = bindFakeCurrentHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
 
     $component = Livewire::test('pages::review-page', ['slug' => 'divergence-test']);
+    expect($component->get('divergenceState'))->toBe(DivergenceState::Aligned);
+
+    $fake->result = new CurrentHeadResult(branch: 'feature-x', sha: 'e'.str_repeat('0', 39), detached: false, targetExists: false);
+    $component->call('checkHeadDivergence');
 
     expect($component->get('divergenceState'))->toBe(DivergenceState::MissingTarget);
     expect($component->get('divergenceContext.target'))->toBe('main');
     expect($component->get('divergenceContext.currentBranch'))->toBe('feature-x');
     $component->assertSeeHtml('data-testid="divergence-banner-missing"');
+});
+
+test('initial open auto-follows the checked-out branch when the stored target is gone', function () {
+    // A fresh open (e.g. the `rfa` CLI deep-link) where the persisted target
+    // branch no longer exists: land on HEAD's branch, no banner.
+    bindFakeCurrentHeadAction(new CurrentHeadResult(branch: 'feature-x', sha: 'e'.str_repeat('0', 39), detached: false, targetExists: false));
+
+    $component = Livewire::test('pages::review-page', ['slug' => 'divergence-test']);
+
+    expect($component->get('divergenceState'))->toBe(DivergenceState::Aligned);
+    expect($component->get('projectBranch'))->toBe('feature-x');
+    expect($this->project->fresh()->branch)->toBe('feature-x');
+    $component->assertDontSeeHtml('data-testid="divergence-banner-missing"');
 });
 
 test('keepReviewing suppresses the banner for that branch, even across new commits', function () {
@@ -359,9 +377,15 @@ test('switchReviewToHead is undoable and undo restores the original target', fun
 });
 
 test('dismissMissingTarget suppresses the missing-target banner for that branch', function () {
-    $fake = bindFakeCurrentHeadAction(new CurrentHeadResult(branch: 'feature-x', sha: 'e'.str_repeat('0', 39), detached: false, targetExists: false));
+    // Mount aligned so the initial resolve doesn't auto-follow the gone target;
+    // the banner is a mid-review (poll-tick) state.
+    $fake = bindFakeCurrentHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
 
     $component = Livewire::test('pages::review-page', ['slug' => 'divergence-test']);
+    expect($component->get('divergenceState'))->toBe(DivergenceState::Aligned);
+
+    $fake->result = new CurrentHeadResult(branch: 'feature-x', sha: 'e'.str_repeat('0', 39), detached: false, targetExists: false);
+    $component->call('checkHeadDivergence');
     expect($component->get('divergenceState'))->toBe(DivergenceState::MissingTarget);
 
     $component->call('dismissMissingTarget');

--- a/tests/Unit/Services/GitMetadataServiceBranchExistsTest.php
+++ b/tests/Unit/Services/GitMetadataServiceBranchExistsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Exceptions\GitCommandException;
+use App\Services\GitMetadataService;
+use App\Services\GitProcessService;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    $this->tmpDir = $this->createTempDirectory('rfa_branch_exists_test_');
+    $this->initTestRepo($this->tmpDir);
+
+    File::put($this->tmpDir.'/file.txt', "ok\n");
+    $this->commitTestRepo($this->tmpDir, 'init');
+
+    $this->service = new GitMetadataService(new GitProcessService);
+});
+
+test('returns true for a branch that exists', function () {
+    expect($this->service->branchExists($this->tmpDir, 'main'))->toBeTrue();
+});
+
+test('returns false for a confirmed absent branch', function () {
+    expect($this->service->branchExists($this->tmpDir, 'does-not-exist'))->toBeFalse();
+});
+
+test('returns false for syntactically invalid branch names without running git', function () {
+    expect($this->service->branchExists($this->tmpDir, ''))->toBeFalse()
+        ->and($this->service->branchExists($this->tmpDir, '-dashed'))->toBeFalse();
+});
+
+test('returns null when the existence probe fails for a reason other than a missing ref', function () {
+    // exitCode 128 (e.g. "not a git repository") is a failure we can't read as a
+    // definitive absence — the branch may well still exist.
+    $service = new GitMetadataService(new class extends GitProcessService
+    {
+        public function run(string $repoPath, array $args): string
+        {
+            throw new GitCommandException(command: 'git '.implode(' ', $args), stderr: 'fatal: not a git repository', exitCode: 128);
+        }
+    });
+
+    expect($service->branchExists('/tmp/whatever', 'main'))->toBeNull();
+});
+
+test('returns null when the existence probe throws a non-git failure', function () {
+    $service = new GitMetadataService(new class extends GitProcessService
+    {
+        public function run(string $repoPath, array $args): string
+        {
+            throw new RuntimeException('process timed out');
+        }
+    });
+
+    expect($service->branchExists('/tmp/whatever', 'main'))->toBeNull();
+});


### PR DESCRIPTION
When RFA opens a project (e.g. via the `rfa` CLI deep-link) whose stored
review target branch no longer exists, land on the currently checked-out
branch instead of greeting the user with the blocking "Review target no
longer exists" banner. On a fresh mount there is no in-progress review to
protect and the gone branch can't be reviewed anyway, so silently
auto-follow HEAD — the same outcome as clicking "Switch review here".

The banner is preserved for the mid-review case: a branch vanishing under
an active session (detected on a poll tick) still surfaces it. The new
behavior is gated on a first-resolve flag threaded from mount through
ReviewsBranchDivergence into ResolveDivergenceStateAction.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UHZAWuaLVUWzkQHUsENvV1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review-page behavior when the previously selected branch is no longer available.
  * On first open, the page now follows the currently checked-out branch instead of showing a missing-branch warning.
  * During an active review, missing-branch warnings still appear when the branch disappears mid-review, with existing dismissal behavior preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->