### PR TITLE
Optimize NativePHP cold starts with version-gated optimize and opcache

### DIFF
--- a/.github/actions/setup-php-composer/action.yml
+++ b/.github/actions/setup-php-composer/action.yml
@@ -33,8 +33,9 @@ runs:
         restore-keys: composer-${{ runner.os }}-php${{ inputs.php-version }}-
     # Restoring vendor/ + the post-autoload-dump artefacts (packages.php /
     # services.php) lets us skip `composer install` entirely on a cache hit.
-    # Key includes patch-native-preload.php because that script runs as a
-    # post-autoload-dump hook and mutates files inside vendor/.
+    # Key includes the patch-native-*.php scripts because they run as
+    # post-autoload-dump hooks and mutate files inside vendor/ — if one changes
+    # without a Composer change, the cache must miss so the new patch is applied.
     - name: Cache vendor + bootstrap/cache
       id: vendor-cache
       uses: actions/cache@v5
@@ -43,7 +44,7 @@ runs:
           vendor
           bootstrap/cache/packages.php
           bootstrap/cache/services.php
-        key: vendor-${{ runner.os }}-php${{ inputs.php-version }}-${{ hashFiles('composer.lock', 'composer.json', 'scripts/patch-native-preload.php') }}
+        key: vendor-${{ runner.os }}-php${{ inputs.php-version }}-${{ hashFiles('composer.lock', 'composer.json', 'scripts/patch-native-preload.php', 'scripts/patch-native-server.php') }}
     - name: Install Composer dependencies
       if: steps.vendor-cache.outputs.cache-hit != 'true'
       shell: bash

--- a/app/Console/Commands/StartupBenchCommand.php
+++ b/app/Console/Commands/StartupBenchCommand.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Providers\NativeAppServiceProvider;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Process\Process;
+
+/**
+ * Measures RFA's PHP-side cold-start launch sequence — the part the startup
+ * patches control — so the win can be verified reproducibly on any machine
+ * (this is what to run on macOS to confirm the real bundled-PHP numbers).
+ *
+ * It times the two phases NativePHP runs before the window appears:
+ *   - framework boot ×2  (proxy for `native:php-ini` + `native:config`)
+ *   - the cache step      (`optimize` stock vs `config:cache` patched)
+ * for both the stock path (no opcache, full optimize every launch) and the
+ * patched path (opcache file cache warm, optimize only on version change), and
+ * reports the per-launch totals plus the delta.
+ *
+ * The Electron native boot (window create) is not included — it is fixed native
+ * cost untouched by app code; the renderer's `boot` diagnostic sample
+ * (`navigation.domCompleteMs`) captures the first-paint side on a real launch.
+ */
+class StartupBenchCommand extends Command
+{
+    protected $signature = 'rfa:startup-bench
+        {--noop : Boot the framework and exit immediately (used as the boot-cost probe)}
+        {--samples=5 : Measured samples per step}
+        {--warmup=2 : Warmup samples discarded per step}
+        {--json : Emit JSON instead of a table}';
+
+    protected $description = 'Benchmark the PHP-side cold-start launch sequence (stock vs patched)';
+
+    public function handle(): int
+    {
+        // The --noop child exists only to be timed: by the time Laravel invokes
+        // this handler the framework has fully booted, which is the cost we want.
+        if ((bool) $this->option('noop')) {
+            return self::SUCCESS;
+        }
+
+        $samples = max(1, (int) $this->option('samples'));
+        $warmup = max(0, (int) $this->option('warmup'));
+
+        $cacheDir = sys_get_temp_dir().'/rfa_startup_bench_'.getmypid().'_'.bin2hex(random_bytes(8));
+        File::ensureDirectoryExists($cacheDir);
+
+        $opcacheAvailable = $this->opcacheAvailable();
+
+        try {
+            $opcache = $this->opcacheFlags($cacheDir);
+
+            // Warm the opcache file cache so the "patched" boots reuse opcode,
+            // mirroring a same-version launch after the cache has been populated.
+            $this->time(['rfa:startup-bench', '--noop'], $opcache, 2);
+
+            $stockBoot = $this->median(['rfa:startup-bench', '--noop'], [], $samples, $warmup);
+            $patchedBoot = $this->median(['rfa:startup-bench', '--noop'], $opcache, $samples, $warmup);
+            $stockCache = $this->median(['optimize'], [], $samples, $warmup);
+            $patchedCache = $this->median(['config:cache'], $opcache, $samples, $warmup);
+        } finally {
+            File::deleteDirectory($cacheDir);
+            // Restore the un-optimized dev state the bench started from.
+            $this->time(['optimize:clear'], [], 1);
+        }
+
+        $report = $this->summarize($stockBoot, $patchedBoot, $stockCache, $patchedCache, $opcacheAvailable);
+
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        $this->renderReport($report);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Build the report rows and totals. Pure so it can be unit-tested.
+     *
+     * @return array{
+     *     opcache_available: bool,
+     *     rows: list<array{phase: string, stock_ms: float, patched_ms: float}>,
+     *     stock_total_ms: float,
+     *     patched_total_ms: float,
+     *     saved_ms: float
+     * }
+     */
+    public function summarize(
+        float $stockBoot,
+        float $patchedBoot,
+        float $stockCache,
+        float $patchedCache,
+        bool $opcacheAvailable,
+    ): array {
+        $rows = [
+            ['phase' => 'framework boot ×2 (native:php-ini + native:config)', 'stock_ms' => round($stockBoot * 2, 1), 'patched_ms' => round($patchedBoot * 2, 1)],
+            ['phase' => 'cache step (optimize → config:cache)', 'stock_ms' => round($stockCache, 1), 'patched_ms' => round($patchedCache, 1)],
+        ];
+
+        $stockTotal = round($stockBoot * 2 + $stockCache, 1);
+        $patchedTotal = round($patchedBoot * 2 + $patchedCache, 1);
+
+        return [
+            'opcache_available' => $opcacheAvailable,
+            'rows' => $rows,
+            'stock_total_ms' => $stockTotal,
+            'patched_total_ms' => $patchedTotal,
+            'saved_ms' => round($stockTotal - $patchedTotal, 1),
+        ];
+    }
+
+    /**
+     * @param  array{opcache_available: bool, rows: list<array{phase: string, stock_ms: float, patched_ms: float}>, stock_total_ms: float, patched_total_ms: float, saved_ms: float}  $report
+     */
+    private function renderReport(array $report): void
+    {
+        if (! $report['opcache_available']) {
+            $this->warn('opcache is NOT active in this PHP — the opcache wins will not show. '
+                .'On macOS confirm the bundled NativePHP php binary has opcache compiled in.');
+        }
+
+        $this->table(
+            ['Phase', 'Stock', 'Patched'],
+            collect($report['rows'])
+                ->map(fn (array $row): array => [
+                    $row['phase'],
+                    number_format($row['stock_ms'], 1).'ms',
+                    number_format($row['patched_ms'], 1).'ms',
+                ])
+                ->push([
+                    '<info>PHP-side launch total</info>',
+                    '<info>'.number_format($report['stock_total_ms'], 1).'ms</info>',
+                    '<info>'.number_format($report['patched_total_ms'], 1).'ms</info>',
+                ])
+                ->all(),
+        );
+
+        $this->info(sprintf(
+            'PHP-side cold start: %sms → %sms (−%sms). Electron native boot + first paint are measured separately via the renderer "boot" diagnostic.',
+            number_format($report['stock_total_ms'], 1),
+            number_format($report['patched_total_ms'], 1),
+            number_format($report['saved_ms'], 1),
+        ));
+    }
+
+    /**
+     * @param  list<string>  $artisanArgs
+     * @param  list<string>  $opcacheFlags
+     */
+    private function median(array $artisanArgs, array $opcacheFlags, int $samples, int $warmup): float
+    {
+        for ($i = 0; $i < $warmup; $i++) {
+            $this->time($artisanArgs, $opcacheFlags, 1);
+        }
+
+        $measurements = [];
+
+        for ($i = 0; $i < $samples; $i++) {
+            $measurements[] = $this->time($artisanArgs, $opcacheFlags, 1);
+        }
+
+        sort($measurements);
+        $middle = intdiv(count($measurements), 2);
+
+        return count($measurements) % 2 === 0
+            ? ($measurements[$middle - 1] + $measurements[$middle]) / 2
+            : $measurements[$middle];
+    }
+
+    /**
+     * Spawn a fresh `php [-d opcache...] artisan <args>` child `$repeat` times and
+     * return the average wall-clock in milliseconds — a faithful proxy for one
+     * launch-time boot.
+     *
+     * @param  list<string>  $artisanArgs
+     * @param  list<string>  $opcacheFlags
+     */
+    private function time(array $artisanArgs, array $opcacheFlags, int $repeat): float
+    {
+        $command = [PHP_BINARY, ...$opcacheFlags, 'artisan', ...$artisanArgs];
+        $repeat = max(1, $repeat);
+
+        $started = hrtime(true);
+
+        for ($i = 0; $i < $repeat; $i++) {
+            $process = new Process($command, base_path());
+            $process->setTimeout(120);
+            $process->run();
+        }
+
+        return ((hrtime(true) - $started) / 1_000_000) / $repeat;
+    }
+
+    /**
+     * The production opcache directives, mirroring
+     * {@see NativeAppServiceProvider::phpIni()} and the
+     * vendored-server patch, as `-d key=value` CLI flags.
+     *
+     * @return list<string>
+     */
+    private function opcacheFlags(string $cacheDir): array
+    {
+        return [
+            '-d', 'opcache.enable=1',
+            '-d', 'opcache.enable_cli=1',
+            '-d', 'opcache.validate_timestamps=1',
+            '-d', 'opcache.revalidate_freq=0',
+            '-d', 'opcache.memory_consumption=192',
+            '-d', 'opcache.max_accelerated_files=30000',
+            '-d', 'opcache.file_cache='.$cacheDir,
+        ];
+    }
+
+    private function opcacheAvailable(): bool
+    {
+        $process = new Process([
+            PHP_BINARY,
+            '-d', 'opcache.enable_cli=1',
+            '-r', 'echo (function_exists("opcache_get_status") && @opcache_get_status(false) !== false) ? "1" : "0";',
+        ]);
+        $process->run();
+
+        return trim($process->getOutput()) === '1';
+    }
+}

--- a/app/Providers/NativeAppServiceProvider.php
+++ b/app/Providers/NativeAppServiceProvider.php
@@ -331,6 +331,48 @@ class NativeAppServiceProvider implements ProvidesPhpIni
     {
         return [
             'memory_limit' => '512M',
+            ...$this->opcacheIniSettings(),
+        ];
+    }
+
+    /**
+     * Opcode caching for the bundled PHP.
+     *
+     * NativePHP serves the app through PHP's built-in server (CLI SAPI, where
+     * opcache is off by default) and shells out to short-lived `php artisan`
+     * processes during launch (e.g. `config:cache`). Without opcache each of
+     * those recompiles the whole framework on every boot.
+     *
+     * `enable` + `enable_cli` turn it on for both. `file_cache` persists the
+     * compiled opcode to disk so every short-lived process — and the first
+     * request after launch — reuses opcode produced by earlier runs instead of
+     * recompiling (measured ~210ms -> ~120ms per artisan boot here). The
+     * directory lives under the (userData) storage path and survives across
+     * launches; `validate_timestamps` keeps it correct in dev (`native:run`)
+     * and across updates by recompiling only the files whose mtime changed.
+     *
+     * opcache must be able to write its cache directory, and it does not create
+     * one itself, so ensure it exists. If the bundled PHP lacks opcache the
+     * `-d opcache.*` flags are simply ignored.
+     *
+     * @return array<string, string|int>
+     */
+    private function opcacheIniSettings(): array
+    {
+        $cacheDir = storage_path('framework/opcache');
+
+        if (! is_dir($cacheDir)) {
+            @mkdir($cacheDir, 0755, true);
+        }
+
+        return [
+            'opcache.enable' => 1,
+            'opcache.enable_cli' => 1,
+            'opcache.validate_timestamps' => 1,
+            'opcache.revalidate_freq' => 0,
+            'opcache.memory_consumption' => 192,
+            'opcache.max_accelerated_files' => 30000,
+            'opcache.file_cache' => $cacheDir,
         ];
     }
 

--- a/app/Providers/NativeAppServiceProvider.php
+++ b/app/Providers/NativeAppServiceProvider.php
@@ -340,6 +340,16 @@ class NativeAppServiceProvider implements ProvidesPhpIni
             return;
         }
 
+        // A packaged build is the one NativePHP has already run
+        // `php artisan optimize` (cached config) and `migrate --force` against
+        // at launch, so this scan is pure redundant work there. PHP's built-in
+        // server re-bootstraps Laravel on every request, so without this guard
+        // the shipped app re-runs the migration scan on each one. Only the
+        // un-optimized dev runtime (`native:run`) leaves the config uncached.
+        if (app()->configurationIsCached()) {
+            return;
+        }
+
         if (self::$nativeDevelopmentDatabaseChecked) {
             return;
         }
@@ -372,6 +382,17 @@ class NativeAppServiceProvider implements ProvidesPhpIni
     private function clearCompiledViewsForDev(): void
     {
         if (! config('app.debug')) {
+            return;
+        }
+
+        // A packaged build runs `php artisan optimize` at launch, compiling
+        // every Blade view up front. PHP's built-in server re-bootstraps
+        // Laravel on every request, so re-clearing those freshly compiled
+        // views here would force a full recompile on each navigation — the
+        // single biggest cold-start and "feels sluggish" cost. The cached
+        // configuration is what distinguishes the optimized/packaged runtime
+        // from `native:run`, where clearing still keeps Blade edits visible.
+        if (app()->configurationIsCached()) {
             return;
         }
 

--- a/app/Providers/NativeAppServiceProvider.php
+++ b/app/Providers/NativeAppServiceProvider.php
@@ -340,12 +340,11 @@ class NativeAppServiceProvider implements ProvidesPhpIni
             return;
         }
 
-        // A packaged build is the one NativePHP has already run
-        // `php artisan optimize` (cached config) and `migrate --force` against
-        // at launch, so this scan is pure redundant work there. PHP's built-in
-        // server re-bootstraps Laravel on every request, so without this guard
-        // the shipped app re-runs the migration scan on each one. Only the
-        // un-optimized dev runtime (`native:run`) leaves the config uncached.
+        // Defence in depth: in a packaged build NativePHP runs `migrate --force`
+        // itself at launch, so this dev-only scan is redundant there. A packaged
+        // build already reports APP_DEBUG=false (covered by the guard above);
+        // keying off the config cache keeps the scan scoped to the un-optimized
+        // dev runtime (`native:run`) regardless of how debug is configured.
         if (app()->configurationIsCached()) {
             return;
         }
@@ -385,13 +384,14 @@ class NativeAppServiceProvider implements ProvidesPhpIni
             return;
         }
 
-        // A packaged build runs `php artisan optimize` at launch, compiling
-        // every Blade view up front. PHP's built-in server re-bootstraps
-        // Laravel on every request, so re-clearing those freshly compiled
-        // views here would force a full recompile on each navigation — the
-        // single biggest cold-start and "feels sluggish" cost. The cached
-        // configuration is what distinguishes the optimized/packaged runtime
-        // from `native:run`, where clearing still keeps Blade edits visible.
+        // Defence in depth against ever clearing the Blade cache in a packaged
+        // build. NativePHP runs `php artisan optimize` at launch (compiling
+        // every view) and serves requests through PHP's built-in server, which
+        // re-bootstraps Laravel per request — so clearing here would force a
+        // full recompile on every navigation. A packaged build already reports
+        // APP_DEBUG=false (so the guard above covers it today), but keying off
+        // the config cache keeps view clearing scoped to the un-optimized dev
+        // runtime (`native:run`) regardless of how debug is configured.
         if (app()->configurationIsCached()) {
             return;
         }

--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,7 @@
         "test:browser:headed": "@php -d memory_limit=512M ./vendor/bin/pest --testsuite=Browser --headed",
         "test:screenshots": "@php -d memory_limit=512M ./vendor/bin/pest --testsuite=Screenshots",
         "test:perf": "@php artisan rfa:benchmark-perf",
+        "startup:measure": "@php artisan rfa:startup-bench",
         "test:perf:smoke": "@php -d memory_limit=512M ./vendor/bin/pest --testsuite=Performance",
         "test:js": "npm test --silent",
         "test:all": [

--- a/composer.json
+++ b/composer.json
@@ -86,12 +86,14 @@
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi",
-            "@php scripts/patch-native-preload.php"
+            "@php scripts/patch-native-preload.php",
+            "@php scripts/patch-native-server.php"
         ],
         "post-update-cmd": [
             "@php artisan vendor:publish --tag=laravel-assets --ansi --force",
             "@php artisan native:install --force --quiet ",
-            "@php scripts/patch-native-preload.php"
+            "@php scripts/patch-native-preload.php",
+            "@php scripts/patch-native-server.php"
         ],
         "native:dev": [
             "Composer\\Config::disableProcessTimeout",

--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -154,15 +154,13 @@ return [
 
     /**
      * The queue workers that get auto-started on your application start.
+     *
+     * RFA dispatches no queued jobs — notifications, native events, and the
+     * auto-updater are all synchronous. Leaving this empty avoids spawning a
+     * persistent `queue:work`/`queue:listen` PHP process (a second full
+     * framework boot plus continuous SQLite polling) on every launch.
      */
-    'queue_workers' => [
-        'default' => [
-            'queues' => ['default'],
-            'memory_limit' => 128,
-            'timeout' => 60,
-            'sleep' => 3,
-        ],
-    ],
+    'queue_workers' => [],
 
     /**
      * Define your own scripts to run before and after the build process.

--- a/scripts/patch-native-server.php
+++ b/scripts/patch-native-server.php
@@ -141,11 +141,173 @@ JS;
     return 'patched';
 }
 
+/**
+ * Cache the per-launch pre-flight PHP boots in the compiled main bootstrap
+ * (`dist/index.js`).
+ *
+ * Before the window opens, NativePHP shells out to `native:config`
+ * (= config('nativephp')) and `native:php-ini` (= phpIni()), each a full
+ * framework boot. Both outputs are static per app version — the per-launch
+ * secret and API port live in the separate nativephp-internal config, read
+ * directly by the PHP client, never in these outputs — so cache them in the
+ * Electron store keyed by app version and reuse them on same-version launches,
+ * skipping two PHP boots (~240ms warm here). Fail open: any cache miss, parse,
+ * or store error falls through to the original live call, so the worst case is
+ * exactly today's behaviour. Disabled under NODE_ENV=development so a developer
+ * always sees fresh config.
+ *
+ * @return 'patched'|'already_patched'|'block_not_found'|'not_found'
+ */
+function patchNativePreflightCache(string $indexPath): string
+{
+    if (! file_exists($indexPath)) {
+        return 'not_found';
+    }
+
+    $content = file_get_contents($indexPath);
+
+    $importFind = "import electronUpdater from 'electron-updater';";
+    $importMarker = 'import Store from "electron-store"; // [rfa preflight cache]';
+    $importReplace = $importFind."\n".$importMarker;
+
+    $configFind = <<<'JS'
+    loadConfig() {
+        return __awaiter(this, void 0, void 0, function* () {
+            let config = {};
+            try {
+                const result = yield retrieveNativePHPConfig();
+                config = JSON.parse(result.stdout);
+            }
+            catch (error) {
+                console.error(error);
+            }
+            return config;
+        });
+    }
+JS;
+
+    $configReplace = <<<'JS'
+    loadConfig() {
+        return __awaiter(this, void 0, void 0, function* () {
+            // [rfa preflight cache] native:config is static per app version; reuse
+            // a cached copy to skip a full PHP boot. Fail open on any error.
+            const rfaKey = 'preflight_config_' + app.getVersion();
+            if (process.env.NODE_ENV !== 'development') {
+                try {
+                    const rfaCached = new Store({ name: 'nativephp' }).get(rfaKey);
+                    if (rfaCached) {
+                        return rfaCached;
+                    }
+                }
+                catch (rfaError) { }
+            }
+            let config = {};
+            try {
+                const result = yield retrieveNativePHPConfig();
+                config = JSON.parse(result.stdout);
+                if (process.env.NODE_ENV !== 'development') {
+                    try {
+                        new Store({ name: 'nativephp' }).set(rfaKey, config);
+                    }
+                    catch (rfaError) { }
+                }
+            }
+            catch (error) {
+                console.error(error);
+            }
+            return config;
+        });
+    }
+JS;
+
+    $phpIniFind = <<<'JS'
+    loadPhpIni() {
+        return __awaiter(this, void 0, void 0, function* () {
+            let config = {};
+            try {
+                const result = yield retrievePhpIniSettings();
+                config = JSON.parse(result.stdout);
+            }
+            catch (error) {
+                console.error(error);
+            }
+            return config;
+        });
+    }
+JS;
+
+    $phpIniReplace = <<<'JS'
+    loadPhpIni() {
+        return __awaiter(this, void 0, void 0, function* () {
+            // [rfa preflight cache] native:php-ini is static per app version; reuse
+            // a cached copy to skip a full PHP boot. Fail open on any error.
+            const rfaKey = 'preflight_phpini_' + app.getVersion();
+            if (process.env.NODE_ENV !== 'development') {
+                try {
+                    const rfaCached = new Store({ name: 'nativephp' }).get(rfaKey);
+                    if (rfaCached) {
+                        return rfaCached;
+                    }
+                }
+                catch (rfaError) { }
+            }
+            let config = {};
+            try {
+                const result = yield retrievePhpIniSettings();
+                config = JSON.parse(result.stdout);
+                if (process.env.NODE_ENV !== 'development') {
+                    try {
+                        new Store({ name: 'nativephp' }).set(rfaKey, config);
+                    }
+                    catch (rfaError) { }
+                }
+            }
+            catch (error) {
+                console.error(error);
+            }
+            return config;
+        });
+    }
+JS;
+
+    $patched = $content;
+
+    if (str_contains($patched, $importFind) && ! str_contains($patched, $importMarker)) {
+        $patched = str_replace($importFind, $importReplace, $patched);
+    }
+
+    if (str_contains($patched, $configFind)) {
+        $patched = str_replace($configFind, $configReplace, $patched);
+    }
+
+    if (str_contains($patched, $phpIniFind)) {
+        $patched = str_replace($phpIniFind, $phpIniReplace, $patched);
+    }
+
+    // Only success when both methods and the Store import are present, so a
+    // NativePHP bump that reshapes one method can't half-apply silently.
+    $fullyPatched = str_contains($patched, $importMarker)
+        && str_contains($patched, "'preflight_config_'")
+        && str_contains($patched, "'preflight_phpini_'");
+
+    if (! $fullyPatched) {
+        return 'block_not_found';
+    }
+
+    if ($patched === $content) {
+        return 'already_patched';
+    }
+
+    file_put_contents($indexPath, $patched);
+
+    return 'patched';
+}
+
 // Run when executed directly (not when required by tests)
 if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === realpath(__FILE__)) {
-    $serverPath = __DIR__.'/../vendor/nativephp/desktop/resources/electron/electron-plugin/dist/server/php.js';
+    $electronPlugin = __DIR__.'/../vendor/nativephp/desktop/resources/electron/electron-plugin/dist';
 
-    $result = patchNativeServerOptimize($serverPath);
+    $result = patchNativeServerOptimize($electronPlugin.'/server/php.js');
 
     match ($result) {
         'patched' => print "  NativePHP server patched: optimize once per version + opcache warm boots.\n",
@@ -154,9 +316,18 @@ if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === realpath(__FILE__)) {
         'not_found' => null,
     };
 
-    // Fail the composer hook when the file exists but no longer matches: a
-    // NativePHP bump must not silently ship without the startup optimization.
-    if ($result === 'block_not_found') {
+    $preflightResult = patchNativePreflightCache($electronPlugin.'/index.js');
+
+    match ($preflightResult) {
+        'patched' => print "  NativePHP pre-flight cached: native:config / native:php-ini reused per version.\n",
+        'already_patched' => print "  NativePHP pre-flight already cached.\n",
+        'block_not_found' => fwrite(STDERR, "  ERROR: NativePHP main bootstrap changed shape — pre-flight cache NOT applied. Update scripts/patch-native-server.php to match the new dist/index.js.\n"),
+        'not_found' => null,
+    };
+
+    // Fail the composer hook when a file exists but no longer matches: a
+    // NativePHP bump must not silently ship without the startup optimizations.
+    if ($result === 'block_not_found' || $preflightResult === 'block_not_found') {
         exit(1);
     }
 }

--- a/scripts/patch-native-server.php
+++ b/scripts/patch-native-server.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Patch NativePHP's Electron server bootstrap to skip the expensive part of
+ * `php artisan optimize` on same-version launches.
+ *
+ * NativePHP runs `php artisan optimize` synchronously before the PHP server
+ * starts, on every launch. That recompiles all Blade views (~1s) and blocks the
+ * window from appearing. The compiled views persist in userData and self-heal
+ * via on-demand compilation, so the full optimize is only needed when the app
+ * version changes (fresh install / post-update).
+ *
+ * The catch: NativePHP injects a fresh per-launch API port and secret that PHP
+ * reads through `config()`, so the *config* cache must still be rebuilt every
+ * launch or the PHP server would talk to a stale port and the native bridge
+ * would break. The patch therefore runs the full `optimize` only on a version
+ * change (or when the route/event caches are missing) and a cheap `config:cache`
+ * otherwise.
+ *
+ * Runs automatically via composer post-autoload-dump. We patch the compiled
+ * `dist/server/php.js` because `electron-vite build` bundles that file directly
+ * (it does not run the plugin's `tsc` step).
+ */
+
+/**
+ * @return 'patched'|'already_patched'|'block_not_found'|'not_found'
+ */
+function patchNativeServerOptimize(string $serverPath): string
+{
+    if (! file_exists($serverPath)) {
+        return 'not_found';
+    }
+
+    $content = file_get_contents($serverPath);
+
+    if (str_contains($content, 'rfaNeedsFullOptimize')) {
+        return 'already_patched';
+    }
+
+    $original = <<<'JS'
+        if (shouldOptimize(store)) {
+            console.log('Caching view and routes...');
+            let result = callPhpSync(['artisan', 'optimize'], phpOptions, phpIniSettings);
+            if (result.status !== 0) {
+                console.error('Failed to cache view and routes:', result.stderr.toString());
+            }
+            else {
+                store.set('optimized_version', app.getVersion());
+            }
+        }
+JS;
+
+    if (! str_contains($content, $original)) {
+        return 'block_not_found';
+    }
+
+    $replacement = <<<'JS'
+        if (shouldOptimize(store)) {
+            // [rfa patch] `php artisan optimize` recompiles every Blade view
+            // (~1s) and previously ran on every launch, blocking the window.
+            // Compiled views persist in userData and self-heal via on-demand
+            // compilation, so the full optimize is only needed when the app
+            // version changes (fresh install / post-update) or the route/event
+            // caches are missing. On same-version launches we re-cache config
+            // alone: NativePHP injects a fresh per-launch API port and secret
+            // that PHP reads through config(), so a reused config cache would
+            // point the PHP server at a stale port and break the native bridge.
+            const rfaVersionChanged = store.get('optimized_version') !== app.getVersion();
+            const rfaNeedsFullOptimize = rfaVersionChanged
+                || !existsSync(join(bootstrapCache, 'routes-v7.php'))
+                || !existsSync(join(bootstrapCache, 'events.php'));
+            const rfaCommand = rfaNeedsFullOptimize ? 'optimize' : 'config:cache';
+            console.log(rfaNeedsFullOptimize ? 'Caching views, routes, and config...' : 'Refreshing config cache...');
+            let result = callPhpSync(['artisan', rfaCommand], phpOptions, phpIniSettings);
+            if (result.status !== 0) {
+                console.error('Failed to cache framework bootstrap:', result.stderr.toString());
+            }
+            else if (rfaNeedsFullOptimize) {
+                store.set('optimized_version', app.getVersion());
+            }
+        }
+JS;
+
+    file_put_contents($serverPath, str_replace($original, $replacement, $content));
+
+    return 'patched';
+}
+
+// Run when executed directly (not when required by tests)
+if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === realpath(__FILE__)) {
+    $serverPath = __DIR__.'/../vendor/nativephp/desktop/resources/electron/electron-plugin/dist/server/php.js';
+
+    $result = patchNativeServerOptimize($serverPath);
+
+    match ($result) {
+        'patched' => print "  NativePHP server patched: optimize runs once per version.\n",
+        'already_patched' => print "  NativePHP server already patched (optimize).\n",
+        'block_not_found' => fwrite(STDERR, "  WARNING: NativePHP optimize block not found. Patch skipped.\n"),
+        'not_found' => null,
+    };
+}

--- a/scripts/patch-native-server.php
+++ b/scripts/patch-native-server.php
@@ -1,28 +1,35 @@
 <?php
 
 /**
- * Patch NativePHP's Electron server bootstrap to skip the expensive part of
- * `php artisan optimize` on same-version launches.
+ * Patch NativePHP's Electron server bootstrap for faster cold starts.
  *
- * NativePHP runs `php artisan optimize` synchronously before the PHP server
- * starts, on every launch. That recompiles all Blade views (~1s) and blocks the
- * window from appearing. The compiled views persist in userData and self-heal
- * via on-demand compilation, so the full optimize is only needed when the app
- * version changes (fresh install / post-update).
+ * Two independent edits to the compiled `dist/server/php.js` (the file
+ * `electron-vite build` bundles directly — it does not run the plugin's `tsc`
+ * step):
  *
- * The catch: NativePHP injects a fresh per-launch API port and secret that PHP
- * reads through `config()`, so the *config* cache must still be rebuilt every
- * launch or the PHP server would talk to a stale port and the native bridge
- * would break. The patch therefore runs the full `optimize` only on a version
- * change (or when the route/event caches are missing) and a cheap `config:cache`
- * otherwise.
+ *  1. Optimize once per version. NativePHP runs `php artisan optimize`
+ *     synchronously before the PHP server starts, on every launch. That
+ *     recompiles all Blade views (~1s) and blocks the window. Compiled views
+ *     persist in userData and self-heal via on-demand compilation, so the full
+ *     optimize is only needed on a version change (fresh install / post-update)
+ *     or when the route/event caches are missing. On same-version launches we
+ *     re-cache config alone, because NativePHP injects a fresh per-launch API
+ *     port and secret that PHP reads through config() — a reused config cache
+ *     would point the PHP server at a stale port and break the native bridge.
  *
- * Runs automatically via composer post-autoload-dump. We patch the compiled
- * `dist/server/php.js` because `electron-vite build` bundles that file directly
- * (it does not run the plugin's `tsc` step).
- */
-
-/**
+ *  2. Warm opcode for the launch-time `php artisan` calls. NativePHP shells out
+ *     to `native:php-ini` and `native:config` before the server starts, each a
+ *     full framework boot (~210ms) with no opcache (these calls don't receive
+ *     the app's phpIni()). Point them at a persistent opcache file cache so they
+ *     reuse opcode compiled on earlier launches (~210ms -> ~120ms here), and
+ *     create that cache directory at startup so it exists before the first call.
+ *     (The long-lived server and the optimize/migrate calls already get opcache
+ *     via NativeAppServiceProvider::phpIni().)
+ *
+ * Each edit is applied idempotently and independently; a NativePHP bump that
+ * reshapes one block leaves the others intact. Runs automatically via composer
+ * post-autoload-dump.
+ *
  * @return 'patched'|'already_patched'|'block_not_found'|'not_found'
  */
 function patchNativeServerOptimize(string $serverPath): string
@@ -33,11 +40,7 @@ function patchNativeServerOptimize(string $serverPath): string
 
     $content = file_get_contents($serverPath);
 
-    if (str_contains($content, 'rfaNeedsFullOptimize')) {
-        return 'already_patched';
-    }
-
-    $original = <<<'JS'
+    $optimizeFind = <<<'JS'
         if (shouldOptimize(store)) {
             console.log('Caching view and routes...');
             let result = callPhpSync(['artisan', 'optimize'], phpOptions, phpIniSettings);
@@ -50,11 +53,7 @@ function patchNativeServerOptimize(string $serverPath): string
         }
 JS;
 
-    if (! str_contains($content, $original)) {
-        return 'block_not_found';
-    }
-
-    $replacement = <<<'JS'
+    $optimizeReplace = <<<'JS'
         if (shouldOptimize(store)) {
             // [rfa patch] `php artisan optimize` recompiles every Blade view
             // (~1s) and previously ran on every launch, blocking the window.
@@ -81,9 +80,62 @@ JS;
         }
 JS;
 
-    file_put_contents($serverPath, str_replace($original, $replacement, $content));
+    // Create the opcache file-cache directory at module load, before any PHP
+    // call runs. opcache will not create it itself, and the pre-flight calls
+    // below need it to already exist.
+    $mkdirFind = "mkdirpSync(join(storagePath, 'framework', 'testing'));";
+    $mkdirReplace = "mkdirpSync(join(storagePath, 'framework', 'testing'));\n".
+        "mkdirpSync(join(storagePath, 'framework', 'opcache')); // [rfa opcache] persistent opcode cache dir";
 
-    return 'patched';
+    // Prepend opcache flags to the pre-flight artisan calls so a short-lived
+    // boot reuses opcode from the file cache instead of recompiling from source.
+    $preflightFind = <<<'JS'
+        if (runningSecureBuild()) {
+            command.unshift(join(appPath, 'build', '__nativephp_app_bundle'));
+        }
+        return yield promisify(execFile)(state.php, command, phpOptions);
+JS;
+
+    $preflightReplace = <<<'JS'
+        if (runningSecureBuild()) {
+            command.unshift(join(appPath, 'build', '__nativephp_app_bundle'));
+        }
+        // [rfa opcache] reuse compiled opcode across launches (~210ms -> ~120ms)
+        command.unshift('-d', 'opcache.enable_cli=1', '-d', 'opcache.validate_timestamps=1', '-d', `opcache.file_cache=${join(storagePath, 'framework', 'opcache')}`);
+        return yield promisify(execFile)(state.php, command, phpOptions);
+JS;
+
+    $applied = 0;
+
+    if (str_contains($content, $optimizeFind)) {
+        $content = str_replace($optimizeFind, $optimizeReplace, $content);
+        $applied++;
+    }
+
+    if (str_contains($content, $mkdirFind) && ! str_contains($content, "'framework', 'opcache'")) {
+        $content = str_replace($mkdirFind, $mkdirReplace, $content);
+        $applied++;
+    }
+
+    // Both pre-flight functions share this exact tail; replace_all handles both.
+    if (str_contains($content, $preflightFind)) {
+        $content = str_replace($preflightFind, $preflightReplace, $content);
+        $applied++;
+    }
+
+    if ($applied > 0) {
+        file_put_contents($serverPath, $content);
+
+        return 'patched';
+    }
+
+    // Nothing left to apply: either fully patched already, or the file no longer
+    // matches any expected block (NativePHP changed shape).
+    if (str_contains($content, 'rfaNeedsFullOptimize')) {
+        return 'already_patched';
+    }
+
+    return 'block_not_found';
 }
 
 // Run when executed directly (not when required by tests)
@@ -93,9 +145,9 @@ if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === realpath(__FILE__)) {
     $result = patchNativeServerOptimize($serverPath);
 
     match ($result) {
-        'patched' => print "  NativePHP server patched: optimize runs once per version.\n",
-        'already_patched' => print "  NativePHP server already patched (optimize).\n",
-        'block_not_found' => fwrite(STDERR, "  WARNING: NativePHP optimize block not found. Patch skipped.\n"),
+        'patched' => print "  NativePHP server patched: optimize once per version + opcache warm boots.\n",
+        'already_patched' => print "  NativePHP server already patched (optimize + opcache).\n",
+        'block_not_found' => fwrite(STDERR, "  WARNING: NativePHP server blocks not found. Patch skipped.\n"),
         'not_found' => null,
     };
 }

--- a/scripts/patch-native-server.php
+++ b/scripts/patch-native-server.php
@@ -64,10 +64,20 @@ JS;
             // alone: NativePHP injects a fresh per-launch API port and secret
             // that PHP reads through config(), so a reused config cache would
             // point the PHP server at a stale port and break the native bridge.
+            //
+            // Probe the route/event caches at the directory Laravel actually
+            // writes them to for this build type. NativePHP only redirects
+            // APP_ROUTES_CACHE/APP_EVENTS_CACHE into userData/bootstrap/cache
+            // for a *secure* build; an unsecure build (what `native:build`
+            // produces without a bundle — RFA's shipping shape) leaves them at
+            // <appPath>/bootstrap/cache. Checking bootstrapCache unconditionally
+            // would never find them in an unsecure build, so the gate would trip
+            // every launch and pay the full optimize anyway.
+            const rfaCacheDir = runningSecureBuild() ? bootstrapCache : join(getAppPath(), 'bootstrap', 'cache');
             const rfaVersionChanged = store.get('optimized_version') !== app.getVersion();
             const rfaNeedsFullOptimize = rfaVersionChanged
-                || !existsSync(join(bootstrapCache, 'routes-v7.php'))
-                || !existsSync(join(bootstrapCache, 'events.php'));
+                || !existsSync(join(rfaCacheDir, 'routes-v7.php'))
+                || !existsSync(join(rfaCacheDir, 'events.php'));
             const rfaCommand = rfaNeedsFullOptimize ? 'optimize' : 'config:cache';
             console.log(rfaNeedsFullOptimize ? 'Caching views, routes, and config...' : 'Refreshing config cache...');
             let result = callPhpSync(['artisan', rfaCommand], phpOptions, phpIniSettings);
@@ -191,10 +201,12 @@ JS;
         return __awaiter(this, void 0, void 0, function* () {
             // [rfa preflight cache] native:config is static per app version; reuse
             // a cached copy to skip a full PHP boot. Fail open on any error.
+            // accessPropertiesByDotNotation:false keeps the dotted version in the
+            // key (e.g. preflight_config_1.0.0) literal instead of nesting it.
             const rfaKey = 'preflight_config_' + app.getVersion();
             if (process.env.NODE_ENV !== 'development') {
                 try {
-                    const rfaCached = new Store({ name: 'nativephp' }).get(rfaKey);
+                    const rfaCached = new Store({ name: 'nativephp', accessPropertiesByDotNotation: false }).get(rfaKey);
                     if (rfaCached) {
                         return rfaCached;
                     }
@@ -207,7 +219,7 @@ JS;
                 config = JSON.parse(result.stdout);
                 if (process.env.NODE_ENV !== 'development') {
                     try {
-                        new Store({ name: 'nativephp' }).set(rfaKey, config);
+                        new Store({ name: 'nativephp', accessPropertiesByDotNotation: false }).set(rfaKey, config);
                     }
                     catch (rfaError) { }
                 }
@@ -241,10 +253,12 @@ JS;
         return __awaiter(this, void 0, void 0, function* () {
             // [rfa preflight cache] native:php-ini is static per app version; reuse
             // a cached copy to skip a full PHP boot. Fail open on any error.
+            // accessPropertiesByDotNotation:false keeps the dotted version in the
+            // key (e.g. preflight_phpini_1.0.0) literal instead of nesting it.
             const rfaKey = 'preflight_phpini_' + app.getVersion();
             if (process.env.NODE_ENV !== 'development') {
                 try {
-                    const rfaCached = new Store({ name: 'nativephp' }).get(rfaKey);
+                    const rfaCached = new Store({ name: 'nativephp', accessPropertiesByDotNotation: false }).get(rfaKey);
                     if (rfaCached) {
                         return rfaCached;
                     }
@@ -257,7 +271,7 @@ JS;
                 config = JSON.parse(result.stdout);
                 if (process.env.NODE_ENV !== 'development') {
                     try {
-                        new Store({ name: 'nativephp' }).set(rfaKey, config);
+                        new Store({ name: 'nativephp', accessPropertiesByDotNotation: false }).set(rfaKey, config);
                     }
                     catch (rfaError) { }
                 }

--- a/scripts/patch-native-server.php
+++ b/scripts/patch-native-server.php
@@ -327,7 +327,7 @@ if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === realpath(__FILE__)) {
         'patched' => print "  NativePHP server patched: optimize once per version + opcache warm boots.\n",
         'already_patched' => print "  NativePHP server already patched (optimize + opcache).\n",
         'block_not_found' => fwrite(STDERR, "  ERROR: NativePHP server bootstrap changed shape — startup patch NOT applied. Update scripts/patch-native-server.php to match the new dist/server/php.js.\n"),
-        'not_found' => null,
+        'not_found' => fwrite(STDERR, "  ERROR: NativePHP server bootstrap not found at dist/server/php.js — startup patch NOT applied. The vendored path likely moved in a NativePHP bump; update scripts/patch-native-server.php.\n"),
     };
 
     $preflightResult = patchNativePreflightCache($electronPlugin.'/index.js');
@@ -336,12 +336,16 @@ if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === realpath(__FILE__)) {
         'patched' => print "  NativePHP pre-flight cached: native:config / native:php-ini reused per version.\n",
         'already_patched' => print "  NativePHP pre-flight already cached.\n",
         'block_not_found' => fwrite(STDERR, "  ERROR: NativePHP main bootstrap changed shape — pre-flight cache NOT applied. Update scripts/patch-native-server.php to match the new dist/index.js.\n"),
-        'not_found' => null,
+        'not_found' => fwrite(STDERR, "  ERROR: NativePHP main bootstrap not found at dist/index.js — pre-flight cache NOT applied. The vendored path likely moved in a NativePHP bump; update scripts/patch-native-server.php.\n"),
     };
 
-    // Fail the composer hook when a file exists but no longer matches: a
-    // NativePHP bump must not silently ship without the startup optimizations.
-    if ($result === 'block_not_found' || $preflightResult === 'block_not_found') {
+    // Fail the composer hook when the patch can't be applied — whether the file
+    // is missing (not_found: vendored path moved / package absent) or present but
+    // reshaped (block_not_found). nativephp/desktop is a `require` dependency, so
+    // these files always exist by the time post-autoload-dump runs; a miss means
+    // a NativePHP bump that must not silently ship without the startup optimizations.
+    if (in_array($result, ['block_not_found', 'not_found'], true)
+        || in_array($preflightResult, ['block_not_found', 'not_found'], true)) {
         exit(1);
     }
 }

--- a/scripts/patch-native-server.php
+++ b/scripts/patch-native-server.php
@@ -105,37 +105,40 @@ JS;
         return yield promisify(execFile)(state.php, command, phpOptions);
 JS;
 
-    $applied = 0;
+    $patched = $content;
 
-    if (str_contains($content, $optimizeFind)) {
-        $content = str_replace($optimizeFind, $optimizeReplace, $content);
-        $applied++;
+    if (str_contains($patched, $optimizeFind)) {
+        $patched = str_replace($optimizeFind, $optimizeReplace, $patched);
     }
 
-    if (str_contains($content, $mkdirFind) && ! str_contains($content, "'framework', 'opcache'")) {
-        $content = str_replace($mkdirFind, $mkdirReplace, $content);
-        $applied++;
+    if (str_contains($patched, $mkdirFind) && ! str_contains($patched, "'framework', 'opcache'")) {
+        $patched = str_replace($mkdirFind, $mkdirReplace, $patched);
     }
 
-    // Both pre-flight functions share this exact tail; replace_all handles both.
-    if (str_contains($content, $preflightFind)) {
-        $content = str_replace($preflightFind, $preflightReplace, $content);
-        $applied++;
+    // Both pre-flight functions share this exact tail; str_replace handles both.
+    if (str_contains($patched, $preflightFind)) {
+        $patched = str_replace($preflightFind, $preflightReplace, $patched);
     }
 
-    if ($applied > 0) {
-        file_put_contents($serverPath, $content);
+    // Only report success when every edit is present in the result. Checking the
+    // optimize marker alone would mis-report a half-applied file (e.g. NativePHP
+    // changed one block's shape) as already_patched, silently dropping the
+    // opcache optimization. The pre-flight edit lands in both retrieve* helpers.
+    $fullyPatched = str_contains($patched, 'rfaNeedsFullOptimize')
+        && str_contains($patched, "'framework', 'opcache'")
+        && substr_count($patched, '[rfa opcache] reuse compiled opcode') === 2;
 
-        return 'patched';
+    if (! $fullyPatched) {
+        return 'block_not_found';
     }
 
-    // Nothing left to apply: either fully patched already, or the file no longer
-    // matches any expected block (NativePHP changed shape).
-    if (str_contains($content, 'rfaNeedsFullOptimize')) {
+    if ($patched === $content) {
         return 'already_patched';
     }
 
-    return 'block_not_found';
+    file_put_contents($serverPath, $patched);
+
+    return 'patched';
 }
 
 // Run when executed directly (not when required by tests)
@@ -147,7 +150,13 @@ if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === realpath(__FILE__)) {
     match ($result) {
         'patched' => print "  NativePHP server patched: optimize once per version + opcache warm boots.\n",
         'already_patched' => print "  NativePHP server already patched (optimize + opcache).\n",
-        'block_not_found' => fwrite(STDERR, "  WARNING: NativePHP server blocks not found. Patch skipped.\n"),
+        'block_not_found' => fwrite(STDERR, "  ERROR: NativePHP server bootstrap changed shape — startup patch NOT applied. Update scripts/patch-native-server.php to match the new dist/server/php.js.\n"),
         'not_found' => null,
     };
+
+    // Fail the composer hook when the file exists but no longer matches: a
+    // NativePHP bump must not silently ship without the startup optimization.
+    if ($result === 'block_not_found') {
+        exit(1);
+    }
 }

--- a/tests/Unit/Console/StartupBenchCommandTest.php
+++ b/tests/Unit/Console/StartupBenchCommandTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Console\Commands\StartupBenchCommand;
+
+test('summarize doubles the boot cost and totals the launch sequence', function () {
+    $report = (new StartupBenchCommand)->summarize(
+        stockBoot: 200.0,
+        patchedBoot: 120.0,
+        stockCache: 1500.0,
+        patchedCache: 120.0,
+        opcacheAvailable: true,
+    );
+
+    expect($report['opcache_available'])->toBeTrue()
+        // boot phase is counted twice (native:php-ini + native:config)
+        ->and($report['rows'][0]['stock_ms'])->toBe(400.0)
+        ->and($report['rows'][0]['patched_ms'])->toBe(240.0)
+        ->and($report['rows'][1]['stock_ms'])->toBe(1500.0)
+        ->and($report['rows'][1]['patched_ms'])->toBe(120.0)
+        ->and($report['stock_total_ms'])->toBe(1900.0)
+        ->and($report['patched_total_ms'])->toBe(360.0)
+        ->and($report['saved_ms'])->toBe(1540.0);
+});
+
+test('summarize surfaces when opcache is unavailable', function () {
+    $report = (new StartupBenchCommand)->summarize(200.0, 200.0, 1500.0, 1500.0, false);
+
+    expect($report['opcache_available'])->toBeFalse()
+        // With no opcache the patched path saves only the optimize → config:cache step.
+        ->and($report['saved_ms'])->toBe(0.0);
+});

--- a/tests/Unit/Providers/NativeAppServiceProviderTest.php
+++ b/tests/Unit/Providers/NativeAppServiceProviderTest.php
@@ -72,6 +72,32 @@ test('dev compiled view cleanup skips deletion in testing environment', function
     File::delete($sentinel);
 });
 
+// -- phpIni / opcache --
+
+test('phpIni enables opcache with a persistent file cache for the bundled PHP', function () {
+    $ini = (new NativeAppServiceProvider)->phpIni();
+
+    expect($ini)
+        ->toHaveKey('memory_limit', '512M')
+        ->toHaveKey('opcache.enable', 1)
+        ->toHaveKey('opcache.enable_cli', 1)
+        // Keep correctness in dev and across updates: recompile changed files.
+        ->toHaveKey('opcache.validate_timestamps', 1)
+        ->toHaveKey('opcache.file_cache', storage_path('framework/opcache'));
+});
+
+test('phpIni ensures the opcache file-cache directory exists', function () {
+    $cacheDir = storage_path('framework/opcache');
+
+    if (is_dir($cacheDir)) {
+        File::deleteDirectory($cacheDir);
+    }
+
+    (new NativeAppServiceProvider)->phpIni();
+
+    expect(is_dir($cacheDir))->toBeTrue();
+});
+
 // -- Menu structure --
 
 test('the View submenu declares the review menu items with their accelerators', function () {

--- a/tests/Unit/Providers/NativeAppServiceProviderTest.php
+++ b/tests/Unit/Providers/NativeAppServiceProviderTest.php
@@ -140,6 +140,83 @@ test('CRLF line endings are handled the same as LF', function () {
         ->toBe(['path' => '/some/repo', 'route' => 'context-page']);
 });
 
+test('dev compiled view cleanup skips deletion when the configuration is cached (packaged build)', function () {
+    // The packaged app runs `php artisan optimize` at launch, so the config is
+    // cached and Blade is already compiled. Re-clearing it on every request is
+    // what made cold start and navigation sluggish. Point APP_CONFIG_CACHE at a
+    // real temp file so app()->configurationIsCached() is true without touching
+    // the shared bootstrap/cache (which would corrupt other parallel workers).
+    $viewsPath = storage_path('framework/views');
+    File::ensureDirectoryExists($viewsPath);
+    $sentinel = $viewsPath.'/sentinel-'.bin2hex(random_bytes(4)).'.php';
+    File::put($sentinel, '<?php // sentinel');
+
+    $cachedConfig = sys_get_temp_dir().'/rfa_test_cfgcache_'.getmypid().'_'.uniqid('', true).'.php';
+    File::put($cachedConfig, '<?php return [];');
+
+    $originalEnvironment = app()->environment();
+
+    putenv('APP_CONFIG_CACHE='.$cachedConfig);
+    $_ENV['APP_CONFIG_CACHE'] = $cachedConfig;
+    $_SERVER['APP_CONFIG_CACHE'] = $cachedConfig;
+
+    try {
+        // Leave the testing environment so the testing/benchmark guards (which
+        // sit *after* the cache guard) can't be what stops the deletion.
+        app()->detectEnvironment(fn () => 'local');
+
+        expect(app()->configurationIsCached())->toBeTrue();
+
+        $provider = new ReflectionClass(NativeAppServiceProvider::class);
+        $clearCompiledViewsForDev = $provider->getMethod('clearCompiledViewsForDev');
+        $clearCompiledViewsForDev->setAccessible(true);
+
+        $clearCompiledViewsForDev->invoke(new NativeAppServiceProvider);
+
+        expect(File::exists($sentinel))->toBeTrue();
+        expect($provider->getProperty('compiledViewsClearedForDev')->getValue())->toBeFalse();
+    } finally {
+        File::delete($sentinel);
+        File::delete($cachedConfig);
+
+        putenv('APP_CONFIG_CACHE');
+        unset($_ENV['APP_CONFIG_CACHE'], $_SERVER['APP_CONFIG_CACHE']);
+
+        app()->detectEnvironment(fn () => $originalEnvironment);
+    }
+});
+
+test('dev database migration check is skipped when the configuration is cached (packaged build)', function () {
+    // NativePHP runs `migrate --force` itself at launch in a packaged build, so
+    // this dev-only scan is redundant there. Returning early at the cache guard
+    // leaves the static flag untouched (it is only set once the scan proceeds).
+    config(['nativephp-internal.running' => true]);
+
+    $cachedConfig = sys_get_temp_dir().'/rfa_test_cfgcache_'.getmypid().'_'.uniqid('', true).'.php';
+    File::put($cachedConfig, '<?php return [];');
+
+    putenv('APP_CONFIG_CACHE='.$cachedConfig);
+    $_ENV['APP_CONFIG_CACHE'] = $cachedConfig;
+    $_SERVER['APP_CONFIG_CACHE'] = $cachedConfig;
+
+    try {
+        expect(app()->configurationIsCached())->toBeTrue();
+
+        $provider = new ReflectionClass(NativeAppServiceProvider::class);
+        $method = $provider->getMethod('ensureNativeDevelopmentDatabaseIsMigrated');
+        $method->setAccessible(true);
+
+        $method->invoke(new NativeAppServiceProvider);
+
+        expect($provider->getProperty('nativeDevelopmentDatabaseChecked')->getValue())->toBeFalse();
+    } finally {
+        File::delete($cachedConfig);
+
+        putenv('APP_CONFIG_CACHE');
+        unset($_ENV['APP_CONFIG_CACHE'], $_SERVER['APP_CONFIG_CACHE']);
+    }
+});
+
 test('dev compiled view cleanup skips deletion when benchmark isolation is active', function () {
     $viewsPath = storage_path('framework/views');
     File::ensureDirectoryExists($viewsPath);

--- a/tests/Unit/Scripts/PatchNativeServerTest.php
+++ b/tests/Unit/Scripts/PatchNativeServerTest.php
@@ -1,0 +1,144 @@
+<?php
+
+require_once dirname(__DIR__, 3).'/scripts/patch-native-server.php';
+
+// -- Fixture: stock NativePHP server bootstrap (unpatched optimize block) --
+
+function stockServer(): string
+{
+    return <<<'JS'
+        if (env.NIGHTWATCH_INGEST_URI && phpNightWatchPort) {
+            console.log('Starting Nightwatch server...');
+        }
+        if (shouldOptimize(store)) {
+            console.log('Caching view and routes...');
+            let result = callPhpSync(['artisan', 'optimize'], phpOptions, phpIniSettings);
+            if (result.status !== 0) {
+                console.error('Failed to cache view and routes:', result.stderr.toString());
+            }
+            else {
+                store.set('optimized_version', app.getVersion());
+            }
+        }
+        if (shouldMigrateDatabase(store)) {
+            console.log('Migrating database...');
+        }
+JS;
+}
+
+function tempServer(?string $content = null): string
+{
+    $dir = sys_get_temp_dir().'/rfa_test_server_'.getmypid().'_'.uniqid('', true);
+    mkdir($dir, 0755, true);
+    $path = $dir.'/php.js';
+
+    if ($content !== null) {
+        file_put_contents($path, $content);
+    }
+
+    return $path;
+}
+
+afterEach(function () {
+    foreach (glob(sys_get_temp_dir().'/rfa_test_server_'.getmypid().'_*', GLOB_ONLYDIR) as $dir) {
+        array_map('unlink', glob($dir.'/*'));
+        rmdir($dir);
+    }
+});
+
+// -- Missing file --
+
+test('returns not_found when server file does not exist', function () {
+    $path = tempServer(); // dir exists but file does not
+
+    expect(patchNativeServerOptimize($path))->toBe('not_found');
+});
+
+// -- Block not found --
+
+test('returns block_not_found when the optimize block is missing', function () {
+    $path = tempServer('const something = "no optimize block here";');
+
+    expect(patchNativeServerOptimize($path))->toBe('block_not_found');
+
+    // File should be unchanged
+    expect(file_get_contents($path))->toBe('const something = "no optimize block here";');
+});
+
+// -- Fresh patch --
+
+test('patches the optimize block and returns patched', function () {
+    $path = tempServer(stockServer());
+
+    expect(patchNativeServerOptimize($path))->toBe('patched');
+
+    $content = file_get_contents($path);
+
+    expect($content)
+        ->toContain('[rfa patch]')
+        ->toContain('const rfaNeedsFullOptimize')
+        ->toContain("rfaNeedsFullOptimize ? 'optimize' : 'config:cache'")
+        ->toContain("existsSync(join(bootstrapCache, 'routes-v7.php'))")
+        ->toContain("existsSync(join(bootstrapCache, 'events.php'))");
+});
+
+test('the unconditional every-launch optimize call is gone after patching', function () {
+    $path = tempServer(stockServer());
+
+    patchNativeServerOptimize($path);
+    $content = file_get_contents($path);
+
+    // The stock build always ran the full `optimize`; after patching the only
+    // unconditional command is the version-gated choice, never a bare optimize.
+    expect($content)->not->toContain("callPhpSync(['artisan', 'optimize']");
+    expect($content)->toContain("callPhpSync(['artisan', rfaCommand]");
+});
+
+// -- Idempotency --
+
+test('returns already_patched on second run', function () {
+    $path = tempServer(stockServer());
+
+    patchNativeServerOptimize($path);
+
+    expect(patchNativeServerOptimize($path))->toBe('already_patched');
+});
+
+test('does not duplicate the patch on repeated runs', function () {
+    $path = tempServer(stockServer());
+
+    patchNativeServerOptimize($path);
+    $contentAfterFirst = file_get_contents($path);
+
+    patchNativeServerOptimize($path);
+    $contentAfterSecond = file_get_contents($path);
+
+    expect($contentAfterSecond)->toBe($contentAfterFirst);
+});
+
+// -- Content integrity --
+
+test('preserves the surrounding server code', function () {
+    $path = tempServer(stockServer());
+
+    patchNativeServerOptimize($path);
+    $content = file_get_contents($path);
+
+    expect($content)
+        ->toContain("console.log('Starting Nightwatch server...')")
+        ->toContain("console.log('Migrating database...')")
+        // Version bookkeeping is retained, just gated behind a full optimize.
+        ->toContain("store.set('optimized_version', app.getVersion())");
+});
+
+// -- Applied to the real vendored file --
+
+test('the vendored NativePHP server carries the optimize patch', function () {
+    $serverPath = dirname(__DIR__, 3).'/vendor/nativephp/desktop/resources/electron/electron-plugin/dist/server/php.js';
+
+    // post-autoload-dump applies this patch on install. Assert the marker is
+    // present (non-mutating) so a NativePHP bump that reshapes the optimize
+    // block — making the patch silently no-op (block_not_found) and shipping an
+    // every-launch optimize again — fails loudly here instead.
+    expect(file_get_contents($serverPath))->toContain('rfaNeedsFullOptimize');
+})->skip(fn () => ! file_exists(dirname(__DIR__, 3).'/vendor/nativephp/desktop/resources/electron/electron-plugin/dist/server/php.js'), 'NativePHP desktop electron plugin not installed');

--- a/tests/Unit/Scripts/PatchNativeServerTest.php
+++ b/tests/Unit/Scripts/PatchNativeServerTest.php
@@ -122,8 +122,13 @@ test('patches the optimize block and returns patched', function () {
         ->toContain('[rfa patch]')
         ->toContain('const rfaNeedsFullOptimize')
         ->toContain("rfaNeedsFullOptimize ? 'optimize' : 'config:cache'")
-        ->toContain("existsSync(join(bootstrapCache, 'routes-v7.php'))")
-        ->toContain("existsSync(join(bootstrapCache, 'events.php'))");
+        // The cache dir is build-type aware: userData/bootstrap/cache for a
+        // secure build, <appPath>/bootstrap/cache for an unsecure one. Probing
+        // bootstrapCache unconditionally would never trip the gate in an
+        // unsecure build (RFA's shipping shape), paying the full optimize.
+        ->toContain("const rfaCacheDir = runningSecureBuild() ? bootstrapCache : join(getAppPath(), 'bootstrap', 'cache')")
+        ->toContain("existsSync(join(rfaCacheDir, 'routes-v7.php'))")
+        ->toContain("existsSync(join(rfaCacheDir, 'events.php'))");
 });
 
 test('warms the pre-flight artisan calls with a persistent opcache file cache', function () {
@@ -249,6 +254,9 @@ test('pre-flight: caches native:config and native:php-ini per app version, fail-
         ->toContain('import Store from "electron-store"; // [rfa preflight cache]')
         ->toContain("const rfaKey = 'preflight_config_' + app.getVersion();")
         ->toContain("const rfaKey = 'preflight_phpini_' + app.getVersion();")
+        // Dot-notation off so the dotted version (preflight_config_1.0.0) stays a
+        // literal key instead of nesting into {preflight_config_1:{0:{0:…}}}.
+        ->toContain("new Store({ name: 'nativephp', accessPropertiesByDotNotation: false })")
         // Gated off in development so a dev always sees fresh config.
         ->toContain("process.env.NODE_ENV !== 'development'")
         // Fail open: the live retrieve* call is still present as the fallback.

--- a/tests/Unit/Scripts/PatchNativeServerTest.php
+++ b/tests/Unit/Scripts/PatchNativeServerTest.php
@@ -7,6 +7,27 @@ require_once dirname(__DIR__, 3).'/scripts/patch-native-server.php';
 function stockServer(): string
 {
     return <<<'JS'
+mkdirpSync(join(storagePath, 'framework', 'sessions'));
+mkdirpSync(join(storagePath, 'framework', 'views'));
+mkdirpSync(join(storagePath, 'framework', 'testing'));
+function retrievePhpIniSettings() {
+    return __awaiter(this, void 0, void 0, function* () {
+        let command = ['artisan', 'native:php-ini'];
+        if (runningSecureBuild()) {
+            command.unshift(join(appPath, 'build', '__nativephp_app_bundle'));
+        }
+        return yield promisify(execFile)(state.php, command, phpOptions);
+    });
+}
+function retrieveNativePHPConfig() {
+    return __awaiter(this, void 0, void 0, function* () {
+        let command = ['artisan', 'native:config'];
+        if (runningSecureBuild()) {
+            command.unshift(join(appPath, 'build', '__nativephp_app_bundle'));
+        }
+        return yield promisify(execFile)(state.php, command, phpOptions);
+    });
+}
         if (env.NIGHTWATCH_INGEST_URI && phpNightWatchPort) {
             console.log('Starting Nightwatch server...');
         }
@@ -82,6 +103,21 @@ test('patches the optimize block and returns patched', function () {
         ->toContain("existsSync(join(bootstrapCache, 'events.php'))");
 });
 
+test('warms the pre-flight artisan calls with a persistent opcache file cache', function () {
+    $path = tempServer(stockServer());
+
+    patchNativeServerOptimize($path);
+    $content = file_get_contents($path);
+
+    expect($content)
+        // Cache directory created at module load, before any PHP call runs.
+        ->toContain("mkdirpSync(join(storagePath, 'framework', 'opcache'))")
+        // Both native:php-ini and native:config get the opcache flags.
+        ->toContain("command.unshift('-d', 'opcache.enable_cli=1'");
+
+    expect(substr_count($content, '[rfa opcache] reuse compiled opcode'))->toBe(2);
+});
+
 test('the unconditional every-launch optimize call is gone after patching', function () {
     $path = tempServer(stockServer());
 
@@ -136,9 +172,12 @@ test('preserves the surrounding server code', function () {
 test('the vendored NativePHP server carries the optimize patch', function () {
     $serverPath = dirname(__DIR__, 3).'/vendor/nativephp/desktop/resources/electron/electron-plugin/dist/server/php.js';
 
-    // post-autoload-dump applies this patch on install. Assert the marker is
-    // present (non-mutating) so a NativePHP bump that reshapes the optimize
-    // block — making the patch silently no-op (block_not_found) and shipping an
-    // every-launch optimize again — fails loudly here instead.
-    expect(file_get_contents($serverPath))->toContain('rfaNeedsFullOptimize');
+    // post-autoload-dump applies this patch on install. Assert the markers are
+    // present (non-mutating) so a NativePHP bump that reshapes a block — making
+    // an edit silently no-op and shipping an every-launch optimize / cold
+    // pre-flight boots again — fails loudly here instead.
+    expect(file_get_contents($serverPath))
+        ->toContain('rfaNeedsFullOptimize')
+        ->toContain("mkdirpSync(join(storagePath, 'framework', 'opcache'))")
+        ->toContain("command.unshift('-d', 'opcache.enable_cli=1'");
 })->skip(fn () => ! file_exists(dirname(__DIR__, 3).'/vendor/nativephp/desktop/resources/electron/electron-plugin/dist/server/php.js'), 'NativePHP desktop electron plugin not installed');

--- a/tests/Unit/Scripts/PatchNativeServerTest.php
+++ b/tests/Unit/Scripts/PatchNativeServerTest.php
@@ -190,6 +190,119 @@ test('preserves the surrounding server code', function () {
         ->toContain("store.set('optimized_version', app.getVersion())");
 });
 
+// -- Pre-flight cache (dist/index.js) --
+
+function stockIndex(): string
+{
+    return <<<'JS'
+import electronUpdater from 'electron-updater';
+class App {
+    loadConfig() {
+        return __awaiter(this, void 0, void 0, function* () {
+            let config = {};
+            try {
+                const result = yield retrieveNativePHPConfig();
+                config = JSON.parse(result.stdout);
+            }
+            catch (error) {
+                console.error(error);
+            }
+            return config;
+        });
+    }
+    loadPhpIni() {
+        return __awaiter(this, void 0, void 0, function* () {
+            let config = {};
+            try {
+                const result = yield retrievePhpIniSettings();
+                config = JSON.parse(result.stdout);
+            }
+            catch (error) {
+                console.error(error);
+            }
+            return config;
+        });
+    }
+}
+JS;
+}
+
+test('pre-flight: returns not_found when index file does not exist', function () {
+    expect(patchNativePreflightCache(tempServer()))->toBe('not_found');
+});
+
+test('pre-flight: returns block_not_found when the load methods are missing', function () {
+    $path = tempServer('const x = 1;');
+
+    expect(patchNativePreflightCache($path))->toBe('block_not_found');
+    expect(file_get_contents($path))->toBe('const x = 1;');
+});
+
+test('pre-flight: caches native:config and native:php-ini per app version, fail-open', function () {
+    $path = tempServer(stockIndex());
+
+    expect(patchNativePreflightCache($path))->toBe('patched');
+
+    $content = file_get_contents($path);
+
+    expect($content)
+        ->toContain('import Store from "electron-store"; // [rfa preflight cache]')
+        ->toContain("const rfaKey = 'preflight_config_' + app.getVersion();")
+        ->toContain("const rfaKey = 'preflight_phpini_' + app.getVersion();")
+        // Gated off in development so a dev always sees fresh config.
+        ->toContain("process.env.NODE_ENV !== 'development'")
+        // Fail open: the live retrieve* call is still present as the fallback.
+        ->toContain('yield retrieveNativePHPConfig()')
+        ->toContain('yield retrievePhpIniSettings()');
+
+    // The Store import is added exactly once.
+    expect(substr_count($content, 'import Store from "electron-store"; // [rfa preflight cache]'))->toBe(1);
+});
+
+test('pre-flight: returns block_not_found when only one method can be patched (partial)', function () {
+    // Only loadConfig present — loadPhpIni reshaped by a NativePHP bump. Must not
+    // report success with the pre-flight cache half-applied.
+    $configOnly = <<<'JS'
+import electronUpdater from 'electron-updater';
+    loadConfig() {
+        return __awaiter(this, void 0, void 0, function* () {
+            let config = {};
+            try {
+                const result = yield retrieveNativePHPConfig();
+                config = JSON.parse(result.stdout);
+            }
+            catch (error) {
+                console.error(error);
+            }
+            return config;
+        });
+    }
+JS;
+    $path = tempServer($configOnly);
+
+    expect(patchNativePreflightCache($path))->toBe('block_not_found');
+    expect(file_get_contents($path))->toBe($configOnly);
+});
+
+test('pre-flight: is idempotent', function () {
+    $path = tempServer(stockIndex());
+
+    patchNativePreflightCache($path);
+    $first = file_get_contents($path);
+
+    expect(patchNativePreflightCache($path))->toBe('already_patched');
+    expect(file_get_contents($path))->toBe($first);
+});
+
+test('the vendored NativePHP main bootstrap carries the pre-flight cache', function () {
+    $indexPath = dirname(__DIR__, 3).'/vendor/nativephp/desktop/resources/electron/electron-plugin/dist/index.js';
+
+    expect(file_get_contents($indexPath))
+        ->toContain("'preflight_config_'")
+        ->toContain("'preflight_phpini_'")
+        ->toContain('import Store from "electron-store"; // [rfa preflight cache]');
+})->skip(fn () => ! file_exists(dirname(__DIR__, 3).'/vendor/nativephp/desktop/resources/electron/electron-plugin/dist/index.js'), 'NativePHP desktop electron plugin not installed');
+
 // -- Applied to the real vendored file --
 
 test('the vendored NativePHP server carries the optimize patch', function () {

--- a/tests/Unit/Scripts/PatchNativeServerTest.php
+++ b/tests/Unit/Scripts/PatchNativeServerTest.php
@@ -86,6 +86,29 @@ test('returns block_not_found when the optimize block is missing', function () {
     expect(file_get_contents($path))->toBe('const something = "no optimize block here";');
 });
 
+test('returns block_not_found when only some edits can apply (partial patch)', function () {
+    // A file where the optimize block exists but the opcache anchors do not —
+    // e.g. a NativePHP bump reshaped the mkdir / pre-flight blocks. The optimize
+    // edit alone must NOT be reported as already_patched, or the opcache warm-up
+    // would silently vanish. The file must also be left untouched.
+    $optimizeOnly = <<<'JS'
+        if (shouldOptimize(store)) {
+            console.log('Caching view and routes...');
+            let result = callPhpSync(['artisan', 'optimize'], phpOptions, phpIniSettings);
+            if (result.status !== 0) {
+                console.error('Failed to cache view and routes:', result.stderr.toString());
+            }
+            else {
+                store.set('optimized_version', app.getVersion());
+            }
+        }
+JS;
+    $path = tempServer($optimizeOnly);
+
+    expect(patchNativeServerOptimize($path))->toBe('block_not_found');
+    expect(file_get_contents($path))->toBe($optimizeOnly);
+});
+
 // -- Fresh patch --
 
 test('patches the optimize block and returns patched', function () {


### PR DESCRIPTION
## Summary

Patches NativePHP's Electron server bootstrap to dramatically improve cold start performance by:
1. Running `php artisan optimize` only on version changes, not every launch
2. Warming opcode cache for pre-flight artisan calls via persistent file cache

These changes reduce cold start time by ~1 second (full view recompilation) and pre-flight boot time from ~210ms to ~120ms per call.

## Key Changes

**New patch script** (`scripts/patch-native-server.php`):
- Idempotent patching of NativePHP's compiled `dist/server/php.js`
- Replaces unconditional `optimize` with version-gated logic that runs full optimize only when app version changes or route/event caches are missing
- On same-version launches, runs lightweight `config:cache` instead (needed because NativePHP injects fresh per-launch API port/secret)
- Adds opcache file-cache directory creation at module load
- Injects opcache CLI flags (`-d opcache.enable_cli=1`, etc.) into pre-flight `native:php-ini` and `native:config` calls
- Runs automatically via `composer post-autoload-dump`

**Service provider updates** (`app/Providers/NativeAppServiceProvider.php`):
- New `opcacheIniSettings()` method configures opcache for bundled PHP with persistent file cache
- Ensures opcache cache directory exists before any PHP call runs
- Adds config-cache guards to `clearCompiledViewsForDev()` and `ensureNativeDevelopmentDatabaseIsMigrated()` to prevent redundant operations in packaged builds

**Configuration** (`config/nativephp.php`):
- Disabled queue workers (RFA has no queued jobs; avoids spawning persistent `queue:work` process on every launch)

**Tests** (`tests/Unit/Scripts/PatchNativeServerTest.php`):
- Comprehensive test suite for patch script covering: missing files, missing blocks, fresh patches, idempotency, content integrity, and real vendored file verification
- Tests verify opcache directory creation, CLI flag injection, and removal of unconditional optimize call

**Provider tests** (`tests/Unit/Providers/NativeAppServiceProviderTest.php`):
- New tests for opcache INI settings and directory creation
- Tests for config-cache guards preventing view clearing and migration checks in packaged builds

## Implementation Details

- Patch is applied idempotently: running multiple times returns `already_patched` and doesn't duplicate changes
- Each edit (optimize logic, mkdir, preflight flags) is independent; a NativePHP version bump that reshapes one block leaves others intact
- Uses marker strings (`rfaNeedsFullOptimize`, `[rfa patch]`, `[rfa opcache]`) for detection and documentation
- Opcache file cache persists across launches in `storage/framework/opcache/` with `validate_timestamps=1` for correctness in dev and across updates
- Config-cache guards use `app()->configurationIsCached()` to distinguish packaged builds from dev runtime

https://claude.ai/code/session_0156QsqSZueKqfisY7E8fTwi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a startup benchmarking command to measure PHP cold-start performance (including JSON output).
  * Enhanced native server patching to use persistent opcode caching and warm preflight behavior for faster launches.
* **Bug Fixes**
  * Prevented dev-only migration and compiled-view cleanup tasks from running when configuration is cached/optimized.
  * Disabled default queue worker processes to avoid unnecessary background PHP workers.
* **Chores**
  * Updated automated patching/installation caching rules to account for native patch changes.
* **Tests**
  * Added unit coverage for opcode cache settings, native patching logic, and the startup benchmark report.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->