### PR TITLE
fix(startup): keep not_found non-fatal so release builds pass

### DIFF
--- a/scripts/patch-native-server.php
+++ b/scripts/patch-native-server.php
@@ -327,7 +327,11 @@ if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === realpath(__FILE__)) {
         'patched' => print "  NativePHP server patched: optimize once per version + opcache warm boots.\n",
         'already_patched' => print "  NativePHP server already patched (optimize + opcache).\n",
         'block_not_found' => fwrite(STDERR, "  ERROR: NativePHP server bootstrap changed shape — startup patch NOT applied. Update scripts/patch-native-server.php to match the new dist/server/php.js.\n"),
-        'not_found' => fwrite(STDERR, "  ERROR: NativePHP server bootstrap not found at dist/server/php.js — startup patch NOT applied. The vendored path likely moved in a NativePHP bump; update scripts/patch-native-server.php.\n"),
+        // not_found is benign: the release build runs `composer install --no-dev`
+        // on a pruned copy where the electron-plugin dist isn't present at this
+        // path, so the hook fires with nothing to patch. Skip silently — the real
+        // vendor dist (which the build bundles) was patched on the primary install.
+        'not_found' => null,
     };
 
     $preflightResult = patchNativePreflightCache($electronPlugin.'/index.js');
@@ -336,16 +340,16 @@ if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === realpath(__FILE__)) {
         'patched' => print "  NativePHP pre-flight cached: native:config / native:php-ini reused per version.\n",
         'already_patched' => print "  NativePHP pre-flight already cached.\n",
         'block_not_found' => fwrite(STDERR, "  ERROR: NativePHP main bootstrap changed shape — pre-flight cache NOT applied. Update scripts/patch-native-server.php to match the new dist/index.js.\n"),
-        'not_found' => fwrite(STDERR, "  ERROR: NativePHP main bootstrap not found at dist/index.js — pre-flight cache NOT applied. The vendored path likely moved in a NativePHP bump; update scripts/patch-native-server.php.\n"),
+        'not_found' => null,
     };
 
-    // Fail the composer hook when the patch can't be applied — whether the file
-    // is missing (not_found: vendored path moved / package absent) or present but
-    // reshaped (block_not_found). nativephp/desktop is a `require` dependency, so
-    // these files always exist by the time post-autoload-dump runs; a miss means
-    // a NativePHP bump that must not silently ship without the startup optimizations.
-    if (in_array($result, ['block_not_found', 'not_found'], true)
-        || in_array($preflightResult, ['block_not_found', 'not_found'], true)) {
+    // Fail the composer hook only when a vendored file is present but no longer
+    // matches (block_not_found): a NativePHP bump that reshaped the bootstrap must
+    // not silently ship without the startup optimizations. `not_found` is NOT
+    // fatal — the release build re-runs this hook via `composer install --no-dev`
+    // on a pruned copy where the dist legitimately isn't at this path, and that
+    // must not break the build (the bundled dist was already patched on install).
+    if ($result === 'block_not_found' || $preflightResult === 'block_not_found') {
         exit(1);
     }
 }


### PR DESCRIPTION
## Summary

The v0.20.0 release build failed at `post-autoload-dump`:

```
ERROR: NativePHP server bootstrap not found at dist/server/php.js …
Script @php scripts/patch-native-server.php ... returned with error code 1
```

A prior change (addressing a CodeRabbit suggestion) made the patch hook `exit(1)` on `not_found`. But the release pipeline re-runs the hook via `composer install --no-dev` on the **pruned build copy**, where the electron-plugin `dist/` isn't present at the probed path — so it legitimately returns `not_found`. That's how every release before this worked; treating it as fatal broke `native:build`.

## Fix

Revert `not_found` to a non-fatal skip. `block_not_found` (vendor file present but reshaped by a NativePHP bump) **remains fatal** — that's the realistic regression we want to catch loudly. `not_found` is benign because the real vendor dist that the build bundles was already patched on the primary install.

Verified with a local `native:build` that the post-autoload-dump / prune step now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)