### PR TITLE
Order changed-file list folders-first

### DIFF
--- a/app/Actions/GetFileListAction.php
+++ b/app/Actions/GetFileListAction.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\DTOs\DiffTarget;
+use App\DTOs\FileListEntry;
 use App\DTOs\ReviewChangeset;
 use App\Models\Project;
 use App\Services\ExternalFilesService;
 use App\Services\GitDiffService;
 use App\Support\DiffCacheKey;
+use App\Support\FilePathSorter;
 
 final readonly class GetFileListAction
 {
@@ -59,6 +61,8 @@ final readonly class GetFileListAction
                 ];
             }
         }
+
+        usort($files, fn (FileListEntry $a, FileListEntry $b): int => FilePathSorter::compare($a->path, $b->path));
 
         return new ReviewChangeset(
             repoPath: $repoPath,

--- a/app/Support/FilePathSorter.php
+++ b/app/Support/FilePathSorter.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Orders file paths the way file trees do: within any directory, sub-folders
+ * come before loose files ("folders-first"), then alphabetically by segment.
+ *
+ * Git's own `diff --name-status` output (which the file list inherits) is a
+ * flat byte-wise sort of the full path, so a loose file sorts against sibling
+ * directory names by its next character - e.g. `Content/CLAUDE.md` lands ahead
+ * of `Content/Jobs/...` because `C` < `J`. That reads as out of place to anyone
+ * used to VS Code or GitHub's PR file tree, both of which list folders first.
+ * This comparator restores that expectation while keeping a single flat list.
+ */
+final class FilePathSorter
+{
+    /**
+     * Compare two paths folders-first. At the first differing segment, a path
+     * that still has directories below it wins over one whose segment is a
+     * leaf; otherwise the segments are compared byte-wise, matching git.
+     */
+    public static function compare(string $a, string $b): int
+    {
+        $segmentsA = explode('/', $a);
+        $segmentsB = explode('/', $b);
+        $countA = count($segmentsA);
+        $countB = count($segmentsB);
+        $shared = min($countA, $countB);
+
+        for ($i = 0; $i < $shared; $i++) {
+            if ($segmentsA[$i] === $segmentsB[$i]) {
+                continue;
+            }
+
+            $aIsDirectory = $i < $countA - 1;
+            $bIsDirectory = $i < $countB - 1;
+
+            if ($aIsDirectory !== $bIsDirectory) {
+                return $aIsDirectory ? -1 : 1;
+            }
+
+            return strcmp($segmentsA[$i], $segmentsB[$i]);
+        }
+
+        // One path is a prefix of the other (e.g. `a/b` vs `a/b/c`); the
+        // shallower one sorts first. Distinct files never nest this way, but
+        // handle it deterministically regardless.
+        return $countA <=> $countB;
+    }
+}

--- a/app/Support/FilePathSorter.php
+++ b/app/Support/FilePathSorter.php
@@ -18,9 +18,9 @@ namespace App\Support;
 final class FilePathSorter
 {
     /**
-     * Compare two paths folders-first. At the first differing segment, a path
-     * that still has directories below it wins over one whose segment is a
-     * leaf; otherwise the segments are compared byte-wise, matching git.
+     * Compare two paths folders-first. At each segment a path that still has
+     * directories below it sorts before one whose segment is a leaf; otherwise
+     * the segments are compared byte-wise, matching git.
      */
     public static function compare(string $a, string $b): int
     {
@@ -31,23 +31,27 @@ final class FilePathSorter
         $shared = min($countA, $countB);
 
         for ($i = 0; $i < $shared; $i++) {
-            if ($segmentsA[$i] === $segmentsB[$i]) {
-                continue;
-            }
-
             $aIsDirectory = $i < $countA - 1;
             $bIsDirectory = $i < $countB - 1;
 
+            // Folder beats file the moment the paths part ways - including when
+            // the segment names match but one path descends further (a file `a`
+            // replaced by a directory `a/...`). Settling this at the divergence
+            // point rather than via a post-loop length fallback keeps the order
+            // a true total order: a length tiebreaker disagrees with this rule
+            // (`b/a` < `a`, yet `a` < `a/a`), which makes `usort` non-transitive
+            // and the file list order depend on git's incoming order.
             if ($aIsDirectory !== $bIsDirectory) {
                 return $aIsDirectory ? -1 : 1;
             }
 
-            return strcmp($segmentsA[$i], $segmentsB[$i]);
+            if ($segmentsA[$i] !== $segmentsB[$i]) {
+                return strcmp($segmentsA[$i], $segmentsB[$i]);
+            }
         }
 
-        // One path is a prefix of the other (e.g. `a/b` vs `a/b/c`); the
-        // shallower one sorts first. Distinct files never nest this way, but
-        // handle it deterministically regardless.
+        // Reached only when every segment matched in both name and depth, i.e.
+        // the paths are identical.
         return $countA <=> $countB;
     }
 }

--- a/tests/Unit/Actions/GetFileListActionTest.php
+++ b/tests/Unit/Actions/GetFileListActionTest.php
@@ -50,6 +50,25 @@ test('loads typed changeset using existing file entries', function () {
         ->and($changeset->filesToArray()[0])->toHaveKeys(['id', 'path', 'status', 'additions', 'deletions', 'isBinary', 'isUntracked']);
 });
 
+test('returns the changeset files folders-first', function () {
+    // `z/` sorts after the root file `a.txt` in git's flat path order, so a
+    // folders-first result (directory contents first, nested folders before
+    // loose files) proves changeset() applies FilePathSorter, not git's order.
+    File::makeDirectory($this->tmpDir.'/z/c', recursive: true);
+    File::put($this->tmpDir.'/a.txt', "a\n");
+    File::put($this->tmpDir.'/z/b.txt', "b\n");
+    File::put($this->tmpDir.'/z/c/d.txt', "d\n");
+
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class));
+    $paths = collect($action->changeset($this->tmpDir)->files)->map(fn ($file) => $file->path)->all();
+
+    expect($paths)->toBe([
+        'z/c/d.txt',
+        'z/b.txt',
+        'a.txt',
+    ]);
+});
+
 test('clears cache by default', function () {
     File::put($this->tmpDir.'/file.txt', "changed\n");
 

--- a/tests/Unit/Support/FilePathSorterTest.php
+++ b/tests/Unit/Support/FilePathSorterTest.php
@@ -48,6 +48,28 @@ test('sorts directories alphabetically then files alphabetically', function () {
     ]);
 });
 
+test('puts a directory before a same-named file it replaces', function () {
+    // A file `a` deleted and re-added as the directory `a/` can both appear in
+    // one diff; the directory must win so the order stays a total order.
+    expect(sortPaths([
+        'a',
+        'a/a',
+    ]))->toBe([
+        'a/a',
+        'a',
+    ]);
+});
+
+test('stays transitive across a path, its nested child, and a sibling directory', function () {
+    // The cycle a naive length fallback produced: a < a/a, a/a < b/a, b/a < a.
+    // A total order must sort these identically regardless of input order.
+    $expected = ['a/a', 'b/a', 'a'];
+
+    expect(sortPaths(['a', 'a/a', 'b/a']))->toBe($expected)
+        ->and(sortPaths(['b/a', 'a', 'a/a']))->toBe($expected)
+        ->and(sortPaths(['a/a', 'b/a', 'a']))->toBe($expected);
+});
+
 test('keeps deep nesting grouped under its directory', function () {
     expect(sortPaths([
         'a/readme.md',

--- a/tests/Unit/Support/FilePathSorterTest.php
+++ b/tests/Unit/Support/FilePathSorterTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\FilePathSorter;
+
+/**
+ * Sort plain paths with the comparator, mirroring how GetFileListAction
+ * applies it to the file list.
+ *
+ * @param  list<string>  $paths
+ * @return list<string>
+ */
+function sortPaths(array $paths): array
+{
+    usort($paths, FilePathSorter::compare(...));
+
+    return $paths;
+}
+
+// -- folders-first ordering --
+
+test('lists sub-directories before loose files in the same folder', function () {
+    // The artifact this fixes: a flat byte-wise sort puts CLAUDE.md (C) ahead
+    // of the Jobs/ directory (J); folders-first reverses that.
+    expect(sortPaths([
+        'app/Domains/Content/CLAUDE.md',
+        'app/Domains/Content/Jobs/BulkShareIssues.php',
+        'app/Domains/Content/Models/Issue.php',
+    ]))->toBe([
+        'app/Domains/Content/Jobs/BulkShareIssues.php',
+        'app/Domains/Content/Models/Issue.php',
+        'app/Domains/Content/CLAUDE.md',
+    ]);
+});
+
+test('sorts directories alphabetically then files alphabetically', function () {
+    expect(sortPaths([
+        'src/zebra.php',
+        'src/alpha.php',
+        'src/beta/one.php',
+        'src/aardvark/two.php',
+    ]))->toBe([
+        'src/aardvark/two.php',
+        'src/beta/one.php',
+        'src/alpha.php',
+        'src/zebra.php',
+    ]);
+});
+
+test('keeps deep nesting grouped under its directory', function () {
+    expect(sortPaths([
+        'a/readme.md',
+        'a/b/c/deep.php',
+        'a/b/shallow.php',
+    ]))->toBe([
+        'a/b/c/deep.php',
+        'a/b/shallow.php',
+        'a/readme.md',
+    ]);
+});
+
+test('orders root-level files alphabetically', function () {
+    expect(sortPaths([
+        'README.md',
+        'composer.json',
+        '.gitignore',
+    ]))->toBe([
+        '.gitignore',
+        'README.md',
+        'composer.json',
+    ]);
+});
+
+test('is idempotent', function () {
+    $paths = [
+        'app/Services/Git.php',
+        'app/CLAUDE.md',
+        'app/Actions/Run.php',
+        'tests/Unit/Thing.php',
+    ];
+
+    expect(sortPaths(sortPaths($paths)))->toBe(sortPaths($paths));
+});
+
+// -- compare() primitive --
+
+test('compare puts a folder before a sibling file', function () {
+    expect(FilePathSorter::compare('x/dir/file.php', 'x/file.php'))->toBeLessThan(0);
+    expect(FilePathSorter::compare('x/file.php', 'x/dir/file.php'))->toBeGreaterThan(0);
+});
+
+test('compare returns zero for identical paths', function () {
+    expect(FilePathSorter::compare('a/b/c.php', 'a/b/c.php'))->toBe(0);
+});


### PR DESCRIPTION
The review file list inherited git's `diff --name-status` order, a flat
byte-wise sort of the full path. That sorts a loose file against sibling
directory names by its next character, so e.g. `Content/CLAUDE.md` lands
ahead of `Content/Jobs/...` (`C` < `J`) - which reads as out of place to
anyone used to VS Code or GitHub's PR file tree, both of which list
folders before files within a directory.

Add a folders-first path comparator and apply it in GetFileListAction so
the canonical changeset (review page, exports, snapshots) groups
directory contents together while staying a single flat list.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011HHhz883wa92vjyGH3nnjB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File lists are now shown in a consistent, deterministic order.
  * Folder-like paths are grouped before matching files, with nested paths kept together.

* **Tests**
  * Added coverage for path sorting behavior, including folder-vs-file ordering, nested paths, and repeated sorting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->