### PR TITLE
Skip per-launch config:cache on warm starts, add splash window

### DIFF
--- a/app/Actions/RehydrateNativeRuntimeConfigAction.php
+++ b/app/Actions/RehydrateNativeRuntimeConfigAction.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Providers\AppServiceProvider;
+use Native\Desktop\Client\Client;
+use Native\Desktop\Http\Middleware\PreventRegularBrowserAccess;
+
+/**
+ * Re-reads the per-launch NativePHP runtime values from the live process
+ * environment and overrides them in the (potentially version-cached) config.
+ *
+ * NativePHP injects a fresh API port and IPC secret into the PHP server's
+ * environment on every launch (`NATIVEPHP_API_URL`, `NATIVEPHP_SECRET`). They
+ * are the ONLY `nativephp-internal` values that change between launches of the
+ * same install — every other injected value (storage/database/user paths) is
+ * install-stable. Both are read through `config('nativephp-internal.*')`:
+ *
+ *   - {@see Client} signs every native API call with the
+ *     secret and targets the API URL, and
+ *   - {@see PreventRegularBrowserAccess} compares
+ *     the secret on the `_native/api/booted` / `_native/api/events` requests that
+ *     drive the window and native events.
+ *
+ * A version-cached config froze those two values at cache time, so without this
+ * the launch would have to re-run `config:cache` to re-bake them. Because they
+ * arrive as real process environment variables (not `.env` entries), `env()`
+ * reads them live at runtime even under a cached config — so re-hydrating here
+ * keeps the persisted config valid and lets the startup patch skip the
+ * per-launch `config:cache` boot entirely (see scripts/patch-native-server.php).
+ *
+ * Run from {@see AppServiceProvider::register()} so it lands
+ * before any provider boots and before the request middleware runs.
+ */
+final readonly class RehydrateNativeRuntimeConfigAction
+{
+    /**
+     * config key => environment variable for each per-launch value.
+     *
+     * @var array<string, string>
+     */
+    private const RUNTIME_VALUES = [
+        'nativephp-internal.api_url' => 'NATIVEPHP_API_URL',
+        'nativephp-internal.secret' => 'NATIVEPHP_SECRET',
+    ];
+
+    public function handle(): void
+    {
+        // Only the cached config freezes these. An uncached config (dev
+        // `native:run`, browser, tests) re-evaluates env() in the config file on
+        // every boot, so the values are already live and this is a no-op.
+        if (! app()->configurationIsCached()) {
+            return;
+        }
+
+        $overrides = [];
+
+        foreach (self::RUNTIME_VALUES as $configKey => $envKey) {
+            $value = $this->readEnv($envKey);
+
+            // Keep the cached value when the variable is absent rather than
+            // blanking it — never make the bridge worse than today's behaviour.
+            if ($value !== null) {
+                $overrides[$configKey] = $value;
+            }
+        }
+
+        if ($overrides !== []) {
+            config($overrides);
+        }
+    }
+
+    /**
+     * Read a process environment variable directly. These are set by Electron on
+     * the spawned PHP process (not via `.env`), so $_SERVER / getenv() always see
+     * them — independent of the dotenv repository and of config caching.
+     */
+    private function readEnv(string $key): ?string
+    {
+        // getenv() returns false when unset; $_SERVER/$_ENV env values are always
+        // strings. Anything that is not a non-empty string means "not provided".
+        $value = $_SERVER[$key] ?? $_ENV[$key] ?? getenv($key);
+
+        if (! is_string($value) || $value === '') {
+            return null;
+        }
+
+        return $value;
+    }
+}

--- a/app/Actions/RehydrateNativeRuntimeConfigAction.php
+++ b/app/Actions/RehydrateNativeRuntimeConfigAction.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
-use App\Providers\AppServiceProvider;
 use Native\Desktop\Client\Client;
+use Native\Desktop\Events\EventWatcher;
 use Native\Desktop\Http\Middleware\PreventRegularBrowserAccess;
 
 /**
@@ -18,11 +18,13 @@ use Native\Desktop\Http\Middleware\PreventRegularBrowserAccess;
  * same install — every other injected value (storage/database/user paths) is
  * install-stable. Both are read through `config('nativephp-internal.*')`:
  *
- *   - {@see Client} signs every native API call with the
- *     secret and targets the API URL, and
- *   - {@see PreventRegularBrowserAccess} compares
- *     the secret on the `_native/api/booted` / `_native/api/events` requests that
- *     drive the window and native events.
+ *   - {@see Client} signs every native API call with the secret and targets the
+ *     API URL — and {@see EventWatcher} constructs a long-lived Client during
+ *     NativePHP's package registration, capturing both values at that moment for
+ *     every custom `nativephp`-channel broadcast it later posts, and
+ *   - {@see PreventRegularBrowserAccess} compares the secret on the
+ *     `_native/api/booted` / `_native/api/events` requests that drive the window
+ *     and native events.
  *
  * A version-cached config froze those two values at cache time, so without this
  * the launch would have to re-run `config:cache` to re-bake them. Because they
@@ -31,8 +33,10 @@ use Native\Desktop\Http\Middleware\PreventRegularBrowserAccess;
  * keeps the persisted config valid and lets the startup patch skip the
  * per-launch `config:cache` boot entirely (see scripts/patch-native-server.php).
  *
- * Run from {@see AppServiceProvider::register()} so it lands
- * before any provider boots and before the request middleware runs.
+ * Run from a `beforeBootstrapping(RegisterProviders)` hook in bootstrap/app.php
+ * so it lands after the config is loaded but BEFORE any provider registers —
+ * NativePHP builds {@see EventWatcher}'s Client during package registration, so
+ * an app provider (which registers after package providers) would be too late.
  */
 final readonly class RehydrateNativeRuntimeConfigAction
 {

--- a/app/Console/Commands/StartupBenchCommand.php
+++ b/app/Console/Commands/StartupBenchCommand.php
@@ -61,7 +61,14 @@ class StartupBenchCommand extends Command
             $stockBoot = $this->median(['rfa:startup-bench', '--noop'], [], $samples, $warmup);
             $patchedBoot = $this->median(['rfa:startup-bench', '--noop'], $opcache, $samples, $warmup);
             $stockCache = $this->median(['optimize'], [], $samples, $warmup);
-            $patchedCache = $this->median(['config:cache'], $opcache, $samples, $warmup);
+            // Stock NativePHP runs `optimize` on every launch; the patched warm
+            // launch skips the cache step entirely (the version-cached config
+            // persists and the per-launch port/secret are re-read from the live
+            // environment at runtime). Still measure what a `config:cache` boot —
+            // the step the previous patch revision paid every launch — would cost,
+            // so the saving is visible, but the warm-launch cache step is 0.
+            $skippedConfigCache = $this->median(['config:cache'], $opcache, $samples, $warmup);
+            $patchedCache = 0.0;
         } finally {
             File::deleteDirectory($cacheDir);
             // Restore the un-optimized dev state the bench started from.
@@ -71,12 +78,21 @@ class StartupBenchCommand extends Command
         $report = $this->summarize($stockBoot, $patchedBoot, $stockCache, $patchedCache, $opcacheAvailable);
 
         if ((bool) $this->option('json')) {
-            $this->line((string) json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+            $this->line((string) json_encode(
+                [...$report, 'skipped_config_cache_ms' => round($skippedConfigCache, 1)],
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES,
+            ));
 
             return self::SUCCESS;
         }
 
         $this->renderReport($report);
+
+        $this->info(sprintf(
+            'Warm same-version launches now skip the cache step entirely (the previous patch '
+            .'revision still paid a ~%sms config:cache boot every launch).',
+            number_format(round($skippedConfigCache, 1), 1),
+        ));
 
         return self::SUCCESS;
     }
@@ -101,7 +117,7 @@ class StartupBenchCommand extends Command
     ): array {
         $rows = [
             ['phase' => 'framework boot ×2 (native:php-ini + native:config)', 'stock_ms' => round($stockBoot * 2, 1), 'patched_ms' => round($patchedBoot * 2, 1)],
-            ['phase' => 'cache step (optimize → config:cache)', 'stock_ms' => round($stockCache, 1), 'patched_ms' => round($patchedCache, 1)],
+            ['phase' => 'cache step (optimize → skipped on warm launch)', 'stock_ms' => round($stockCache, 1), 'patched_ms' => round($patchedCache, 1)],
         ];
 
         $stockTotal = round($stockBoot * 2 + $stockCache, 1);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
-use App\Actions\RehydrateNativeRuntimeConfigAction;
 use App\Services\GitFileContentService;
 use App\Services\ReviewConfigService;
 use App\Support\LocalAsset;
@@ -21,13 +20,6 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->mergeConfigFrom(base_path('config/rfa.php'), 'rfa');
-
-        // Point the (version-cached) config at THIS launch's native API port and
-        // IPC secret. NativePHP injects them fresh per launch, so this lets the
-        // startup patch keep the cached config across launches and skip the
-        // per-launch config:cache boot. Runs in register() so it lands before any
-        // provider boots and before PreventRegularBrowserAccess checks the secret.
-        (new RehydrateNativeRuntimeConfigAction)->handle();
 
         // Singleton so hashAt() memoization survives across every caller in a
         // single request. RFA runs as NativePHP / built-in server (shared-nothing),

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Actions\RehydrateNativeRuntimeConfigAction;
 use App\Services\GitFileContentService;
 use App\Services\ReviewConfigService;
 use App\Support\LocalAsset;
@@ -20,6 +21,13 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->mergeConfigFrom(base_path('config/rfa.php'), 'rfa');
+
+        // Point the (version-cached) config at THIS launch's native API port and
+        // IPC secret. NativePHP injects them fresh per launch, so this lets the
+        // startup patch keep the cached config across launches and skip the
+        // per-launch config:cache boot. Runs in register() so it lands before any
+        // provider boots and before PreventRegularBrowserAccess checks the secret.
+        (new RehydrateNativeRuntimeConfigAction)->handle();
 
         // Singleton so hashAt() memoization survives across every caller in a
         // single request. RFA runs as NativePHP / built-in server (shared-nothing),

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,10 +1,12 @@
 <?php
 
+use App\Actions\RehydrateNativeRuntimeConfigAction;
 use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Bootstrap\RegisterProviders;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 
-return Application::configure(basePath: dirname(__DIR__))
+$app = Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
     )
@@ -14,3 +16,17 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withExceptions(function (Exceptions $exceptions): void {
         //
     })->create();
+
+// Point the (version-cached) config at THIS launch's native API port and IPC
+// secret before ANY provider registers. NativePHP's package provider runs
+// before app providers and, during registration, constructs a long-lived
+// Client (EventWatcher) from config('nativephp-internal.*') — so a version-
+// cached config must be corrected here, not in a provider, or that retained
+// client would post broadcasts to the previous launch's port/secret. Config is
+// already loaded by the time RegisterProviders runs; the action no-ops unless
+// the config is cached (a packaged build). See RehydrateNativeRuntimeConfigAction.
+$app->beforeBootstrapping(RegisterProviders::class, function (): void {
+    (new RehydrateNativeRuntimeConfigAction)->handle();
+});
+
+return $app;

--- a/scripts/patch-native-server.php
+++ b/scripts/patch-native-server.php
@@ -98,6 +98,49 @@ JS;
         }
 JS;
 
+    // The optimize block as the PREVIOUS RFA revision left it: a same-version
+    // launch re-ran `config:cache` via an rfaCommand ternary (no config.php
+    // probe). The stock find above no longer matches such a file, so without
+    // this an already-patched vendor copy would keep paying config:cache every
+    // warm launch. Replacing the whole old block upgrades it to the current
+    // skip-entirely shape, byte-identical to a fresh patch.
+    $oldOptimizeFind = <<<'JS'
+        if (shouldOptimize(store)) {
+            // [rfa patch] `php artisan optimize` recompiles every Blade view
+            // (~1s) and previously ran on every launch, blocking the window.
+            // Compiled views persist in userData and self-heal via on-demand
+            // compilation, so the full optimize is only needed when the app
+            // version changes (fresh install / post-update) or the route/event
+            // caches are missing. On same-version launches we re-cache config
+            // alone: NativePHP injects a fresh per-launch API port and secret
+            // that PHP reads through config(), so a reused config cache would
+            // point the PHP server at a stale port and break the native bridge.
+            //
+            // Probe the route/event caches at the directory Laravel actually
+            // writes them to for this build type. NativePHP only redirects
+            // APP_ROUTES_CACHE/APP_EVENTS_CACHE into userData/bootstrap/cache
+            // for a *secure* build; an unsecure build (what `native:build`
+            // produces without a bundle — RFA's shipping shape) leaves them at
+            // <appPath>/bootstrap/cache. Checking bootstrapCache unconditionally
+            // would never find them in an unsecure build, so the gate would trip
+            // every launch and pay the full optimize anyway.
+            const rfaCacheDir = runningSecureBuild() ? bootstrapCache : join(getAppPath(), 'bootstrap', 'cache');
+            const rfaVersionChanged = store.get('optimized_version') !== app.getVersion();
+            const rfaNeedsFullOptimize = rfaVersionChanged
+                || !existsSync(join(rfaCacheDir, 'routes-v7.php'))
+                || !existsSync(join(rfaCacheDir, 'events.php'));
+            const rfaCommand = rfaNeedsFullOptimize ? 'optimize' : 'config:cache';
+            console.log(rfaNeedsFullOptimize ? 'Caching views, routes, and config...' : 'Refreshing config cache...');
+            let result = callPhpSync(['artisan', rfaCommand], phpOptions, phpIniSettings);
+            if (result.status !== 0) {
+                console.error('Failed to cache framework bootstrap:', result.stderr.toString());
+            }
+            else if (rfaNeedsFullOptimize) {
+                store.set('optimized_version', app.getVersion());
+            }
+        }
+JS;
+
     // Create the opcache file-cache directory at module load, before any PHP
     // call runs. opcache will not create it itself, and the pre-flight calls
     // below need it to already exist.
@@ -129,6 +172,13 @@ JS;
         $patched = str_replace($optimizeFind, $optimizeReplace, $patched);
     }
 
+    // Upgrade a file left patched by the previous RFA revision in place. Only one
+    // of these two finds can match (stock OR old-patched), so this never double-
+    // applies; on the current shape neither matches.
+    if (str_contains($patched, $oldOptimizeFind)) {
+        $patched = str_replace($oldOptimizeFind, $optimizeReplace, $patched);
+    }
+
     if (str_contains($patched, $mkdirFind) && ! str_contains($patched, "'framework', 'opcache'")) {
         $patched = str_replace($mkdirFind, $mkdirReplace, $patched);
     }
@@ -138,11 +188,15 @@ JS;
         $patched = str_replace($preflightFind, $preflightReplace, $patched);
     }
 
-    // Only report success when every edit is present in the result. Checking the
-    // optimize marker alone would mis-report a half-applied file (e.g. NativePHP
-    // changed one block's shape) as already_patched, silently dropping the
-    // opcache optimization. The pre-flight edit lands in both retrieve* helpers.
-    $fullyPatched = str_contains($patched, 'rfaNeedsFullOptimize')
+    // Only report success when every edit is present in the result. The config.php
+    // probe is the marker UNIQUE to the current skip-entirely shape — requiring it
+    // (not just `rfaNeedsFullOptimize`, which the previous revision also had) means
+    // a file still carrying the old config:cache warm-launch branch is treated as
+    // not-yet-patched rather than mis-reported as already_patched. The opcache
+    // markers guard against a half-applied file; the pre-flight edit lands in both
+    // retrieve* helpers.
+    $fullyPatched = str_contains($patched, "existsSync(join(rfaCacheDir, 'config.php'))")
+        && str_contains($patched, 'rfaNeedsFullOptimize')
         && str_contains($patched, "'framework', 'opcache'")
         && substr_count($patched, '[rfa opcache] reuse compiled opcode') === 2;
 

--- a/scripts/patch-native-server.php
+++ b/scripts/patch-native-server.php
@@ -7,15 +7,17 @@
  * `electron-vite build` bundles directly — it does not run the plugin's `tsc`
  * step):
  *
- *  1. Optimize once per version. NativePHP runs `php artisan optimize`
- *     synchronously before the PHP server starts, on every launch. That
- *     recompiles all Blade views (~1s) and blocks the window. Compiled views
- *     persist in userData and self-heal via on-demand compilation, so the full
- *     optimize is only needed on a version change (fresh install / post-update)
- *     or when the route/event caches are missing. On same-version launches we
- *     re-cache config alone, because NativePHP injects a fresh per-launch API
- *     port and secret that PHP reads through config() — a reused config cache
- *     would point the PHP server at a stale port and break the native bridge.
+ *  1. Optimize once per version, then skip the cache step on warm launches.
+ *     NativePHP runs `php artisan optimize` synchronously before the PHP server
+ *     starts, on every launch. That recompiles all Blade views and re-caches
+ *     config/routes/events (~1s) and blocks the window. The compiled caches
+ *     persist in the build's bootstrap/cache, so the full optimize is only
+ *     needed on a version change (fresh install / post-update) or when a cache
+ *     file is missing. On same-version launches the cache step is skipped
+ *     ENTIRELY: the only per-launch-varying config (the native API port and IPC
+ *     secret) is re-read from the live process environment at runtime by
+ *     RehydrateNativeRuntimeConfigAction, so the persisted config stays valid
+ *     without a per-launch config:cache boot.
  *
  *  2. Warm opcode for the launch-time `php artisan` calls. NativePHP shells out
  *     to `native:php-ini` and `native:config` before the server starts, each a
@@ -55,37 +57,43 @@ JS;
 
     $optimizeReplace = <<<'JS'
         if (shouldOptimize(store)) {
-            // [rfa patch] `php artisan optimize` recompiles every Blade view
-            // (~1s) and previously ran on every launch, blocking the window.
-            // Compiled views persist in userData and self-heal via on-demand
-            // compilation, so the full optimize is only needed when the app
-            // version changes (fresh install / post-update) or the route/event
-            // caches are missing. On same-version launches we re-cache config
-            // alone: NativePHP injects a fresh per-launch API port and secret
-            // that PHP reads through config(), so a reused config cache would
-            // point the PHP server at a stale port and break the native bridge.
+            // [rfa patch] `php artisan optimize` recompiles every Blade view and
+            // re-caches config/routes/events (~1s) and previously ran on every
+            // launch, blocking the window. The compiled caches persist in the
+            // build's bootstrap/cache, so the full optimize is only needed when
+            // the app version changes (fresh install / post-update) or a cache
+            // file is missing.
             //
-            // Probe the route/event caches at the directory Laravel actually
-            // writes them to for this build type. NativePHP only redirects
-            // APP_ROUTES_CACHE/APP_EVENTS_CACHE into userData/bootstrap/cache
-            // for a *secure* build; an unsecure build (what `native:build`
-            // produces without a bundle — RFA's shipping shape) leaves them at
-            // <appPath>/bootstrap/cache. Checking bootstrapCache unconditionally
-            // would never find them in an unsecure build, so the gate would trip
-            // every launch and pay the full optimize anyway.
+            // On a same-version launch we skip the cache step ENTIRELY — including
+            // the config:cache the earlier RFA patch ran for the fresh per-launch
+            // API port and IPC secret. Those two values are the only per-launch
+            // config that varies, and the app now re-reads them from the live
+            // process environment at runtime (RehydrateNativeRuntimeConfigAction
+            // in AppServiceProvider), so the persisted version-cached config stays
+            // valid and we avoid a full framework boot on every warm launch.
+            //
+            // Probe the caches at the directory Laravel actually writes them to
+            // for this build type. NativePHP only redirects APP_*_CACHE into
+            // userData/bootstrap/cache for a *secure* build; an unsecure build
+            // (what `native:build` produces without a bundle — RFA's shipping
+            // shape) leaves them at <appPath>/bootstrap/cache. Checking
+            // bootstrapCache unconditionally would never find them in an unsecure
+            // build, so the gate would trip every launch and pay the full optimize.
             const rfaCacheDir = runningSecureBuild() ? bootstrapCache : join(getAppPath(), 'bootstrap', 'cache');
             const rfaVersionChanged = store.get('optimized_version') !== app.getVersion();
             const rfaNeedsFullOptimize = rfaVersionChanged
+                || !existsSync(join(rfaCacheDir, 'config.php'))
                 || !existsSync(join(rfaCacheDir, 'routes-v7.php'))
                 || !existsSync(join(rfaCacheDir, 'events.php'));
-            const rfaCommand = rfaNeedsFullOptimize ? 'optimize' : 'config:cache';
-            console.log(rfaNeedsFullOptimize ? 'Caching views, routes, and config...' : 'Refreshing config cache...');
-            let result = callPhpSync(['artisan', rfaCommand], phpOptions, phpIniSettings);
-            if (result.status !== 0) {
-                console.error('Failed to cache framework bootstrap:', result.stderr.toString());
-            }
-            else if (rfaNeedsFullOptimize) {
-                store.set('optimized_version', app.getVersion());
+            if (rfaNeedsFullOptimize) {
+                console.log('Caching views, routes, and config...');
+                let result = callPhpSync(['artisan', 'optimize'], phpOptions, phpIniSettings);
+                if (result.status !== 0) {
+                    console.error('Failed to cache framework bootstrap:', result.stderr.toString());
+                }
+                else {
+                    store.set('optimized_version', app.getVersion());
+                }
             }
         }
 JS;

--- a/scripts/patch-native-server.php
+++ b/scripts/patch-native-server.php
@@ -325,6 +325,167 @@ JS;
     return 'patched';
 }
 
+/**
+ * Show an early splash window in the compiled main bootstrap (`dist/index.js`).
+ *
+ * NativePHP creates no window until the very end of the launch chain: Electron
+ * boots, the PHP server starts, the `_native/api/booted` round-trip fires,
+ * NativeAppServiceProvider::boot() calls Window::open, Electron then creates the
+ * real BrowserWindow (show:false) and only `.show()`s it on `did-finish-load`.
+ * So the user stares at a blank screen for the entire Electron-boot + PHP-boot +
+ * first-render duration — the screen is dark until everything is ready.
+ *
+ * This opens a lightweight, frameless splash the instant `app.whenReady()`
+ * resolves — before the PHP server boots — giving immediate visual feedback, and
+ * hands off seamlessly: the splash closes the moment the real window finishes
+ * loading (the first non-splash window created, via Window::open). The splash is
+ * a self-contained `data:` URL so there is nothing extra to bundle, and the
+ * whole thing is fail-open — any error just means no splash, i.e. today's
+ * behaviour. On macOS (RFA's only desktop target) closing the splash while it is
+ * the only window does not quit the app: `window-all-closed` is darwin-guarded.
+ *
+ * @return 'patched'|'already_patched'|'block_not_found'|'not_found'
+ */
+function patchNativeSplashWindow(string $indexPath): string
+{
+    if (! file_exists($indexPath)) {
+        return 'not_found';
+    }
+
+    $content = file_get_contents($indexPath);
+
+    // 1. Pull BrowserWindow into the electron import so the splash can create one.
+    $importFind = 'import { app, session, powerMonitor } from "electron";';
+    $importReplace = 'import { app, session, powerMonitor, BrowserWindow } from "electron";';
+
+    // 2. The splash markup, embedded as a module-level const (no asset to ship).
+    $htmlAnchor = 'const { autoUpdater } = electronUpdater;';
+    $htmlConst = <<<'JS'
+// [rfa splash] Self-contained splash markup — inline styles only, no external
+// resources, so it loads instantly from a data: URL with nothing to bundle.
+const RFA_SPLASH_HTML = `<!doctype html><html><head><meta charset="utf-8"><style>html,body{margin:0;height:100%;background:#0d1117;overflow:hidden}.wrap{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#e6edf3;-webkit-user-select:none;user-select:none}.name{font-size:22px;font-weight:600;letter-spacing:.4px;opacity:.92}.spinner{margin-top:18px;width:26px;height:26px;border:3px solid rgba(230,237,243,.18);border-top-color:#58a6ff;border-radius:50%;animation:rfaspin .8s linear infinite}@keyframes rfaspin{to{transform:rotate(360deg)}}</style></head><body><div class="wrap"><div class="name">rfa</div><div class="spinner"></div></div></body></html>`;
+JS;
+
+    // 3. The splash lifecycle methods, injected as class members.
+    $methodsAnchor = '    bootstrapApp(app) {';
+    $methods = <<<'JS'
+    rfaShowSplash() {
+        // [rfa splash] Open a lightweight window the instant Electron is ready —
+        // before the PHP server boots and the real window is created — so the
+        // launch shows immediate feedback instead of a blank screen. Fail-open:
+        // any error just leaves no splash (today's behaviour).
+        try {
+            const splash = new BrowserWindow({
+                width: 480,
+                height: 320,
+                frame: false,
+                resizable: false,
+                movable: false,
+                center: true,
+                show: false,
+                skipTaskbar: true,
+                backgroundColor: '#0d1117',
+                title: 'rfa',
+            });
+            this.rfaSplash = splash;
+            splash.once('ready-to-show', () => {
+                try {
+                    if (!splash.isDestroyed()) {
+                        splash.show();
+                    }
+                }
+                catch (rfaError) { }
+            });
+            splash.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(RFA_SPLASH_HTML));
+            // Seamless handoff: the first non-splash window created is the main
+            // window (opened via Window::open once PHP has booted). Close the
+            // splash on that window's `show` — which NativePHP fires only after
+            // `did-finish-load` — so the real window is painted before the splash
+            // disappears, leaving no blank frame in between.
+            const rfaOnCreated = (_, window) => {
+                if (window === this.rfaSplash) {
+                    return;
+                }
+                app.removeListener('browser-window-created', rfaOnCreated);
+                window.once('show', () => this.rfaCloseSplash());
+            };
+            app.on('browser-window-created', rfaOnCreated);
+            // Safety net: never leave a spinner stuck if no window ever opens.
+            this.rfaSplashTimer = setTimeout(() => this.rfaCloseSplash(), 60000);
+        }
+        catch (rfaError) {
+            this.rfaSplash = null;
+        }
+    }
+    rfaCloseSplash() {
+        try {
+            if (this.rfaSplashTimer) {
+                clearTimeout(this.rfaSplashTimer);
+                this.rfaSplashTimer = null;
+            }
+        }
+        catch (rfaError) { }
+        const splash = this.rfaSplash;
+        this.rfaSplash = null;
+        try {
+            if (splash && !splash.isDestroyed()) {
+                splash.close();
+            }
+        }
+        catch (rfaError) { }
+    }
+    bootstrapApp(app) {
+JS;
+
+    // 4. Fire the splash the instant Electron is ready, before any PHP boot.
+    $callFind = <<<'JS'
+            yield app.whenReady();
+            const config = yield this.loadConfig();
+JS;
+    $callReplace = <<<'JS'
+            yield app.whenReady();
+            this.rfaShowSplash(); // [rfa splash] instant feedback before PHP boots
+            const config = yield this.loadConfig();
+JS;
+
+    $patched = $content;
+
+    if (str_contains($patched, $importFind) && ! str_contains($patched, 'powerMonitor, BrowserWindow')) {
+        $patched = str_replace($importFind, $importReplace, $patched);
+    }
+
+    if (str_contains($patched, $htmlAnchor) && ! str_contains($patched, 'const RFA_SPLASH_HTML')) {
+        $patched = str_replace($htmlAnchor, $htmlAnchor."\n".$htmlConst, $patched);
+    }
+
+    if (str_contains($patched, $methodsAnchor) && ! str_contains($patched, 'rfaShowSplash() {')) {
+        $patched = str_replace($methodsAnchor, $methods, $patched);
+    }
+
+    if (str_contains($patched, $callFind) && ! str_contains($patched, 'this.rfaShowSplash()')) {
+        $patched = str_replace($callFind, $callReplace, $patched);
+    }
+
+    // Only success when every edit is present, so a NativePHP bump that reshapes
+    // one anchor can't half-apply (e.g. a splash that is created but never shown).
+    $fullyPatched = str_contains($patched, 'powerMonitor, BrowserWindow')
+        && str_contains($patched, 'const RFA_SPLASH_HTML')
+        && str_contains($patched, 'rfaShowSplash() {')
+        && str_contains($patched, 'this.rfaShowSplash()');
+
+    if (! $fullyPatched) {
+        return 'block_not_found';
+    }
+
+    if ($patched === $content) {
+        return 'already_patched';
+    }
+
+    file_put_contents($indexPath, $patched);
+
+    return 'patched';
+}
+
 // Run when executed directly (not when required by tests)
 if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === realpath(__FILE__)) {
     $electronPlugin = __DIR__.'/../vendor/nativephp/desktop/resources/electron/electron-plugin/dist';
@@ -351,13 +512,22 @@ if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === realpath(__FILE__)) {
         'not_found' => null,
     };
 
+    $splashResult = patchNativeSplashWindow($electronPlugin.'/index.js');
+
+    match ($splashResult) {
+        'patched' => print "  NativePHP splash window added: instant feedback before PHP boots.\n",
+        'already_patched' => print "  NativePHP splash window already present.\n",
+        'block_not_found' => fwrite(STDERR, "  ERROR: NativePHP main bootstrap changed shape — splash window NOT applied. Update scripts/patch-native-server.php to match the new dist/index.js.\n"),
+        'not_found' => null,
+    };
+
     // Fail the composer hook only when a vendored file is present but no longer
     // matches (block_not_found): a NativePHP bump that reshaped the bootstrap must
     // not silently ship without the startup optimizations. `not_found` is NOT
     // fatal — the release build re-runs this hook via `composer install --no-dev`
     // on a pruned copy where the dist legitimately isn't at this path, and that
     // must not break the build (the bundled dist was already patched on install).
-    if ($result === 'block_not_found' || $preflightResult === 'block_not_found') {
+    if ($result === 'block_not_found' || $preflightResult === 'block_not_found' || $splashResult === 'block_not_found') {
         exit(1);
     }
 }

--- a/scripts/patch-native-server.php
+++ b/scripts/patch-native-server.php
@@ -68,9 +68,11 @@ JS;
             // the config:cache the earlier RFA patch ran for the fresh per-launch
             // API port and IPC secret. Those two values are the only per-launch
             // config that varies, and the app now re-reads them from the live
-            // process environment at runtime (RehydrateNativeRuntimeConfigAction
-            // in AppServiceProvider), so the persisted version-cached config stays
-            // valid and we avoid a full framework boot on every warm launch.
+            // process environment at runtime (RehydrateNativeRuntimeConfigAction,
+            // wired in bootstrap/app.php via a beforeBootstrapping(RegisterProviders)
+            // hook that runs before any provider registers), so the persisted
+            // version-cached config stays valid and we avoid a full framework boot
+            // on every warm launch.
             //
             // Probe the caches at the directory Laravel actually writes them to
             // for this build type. NativePHP only redirects APP_*_CACHE into
@@ -179,7 +181,7 @@ JS;
         $patched = str_replace($oldOptimizeFind, $optimizeReplace, $patched);
     }
 
-    if (str_contains($patched, $mkdirFind) && ! str_contains($patched, "'framework', 'opcache'")) {
+    if (str_contains($patched, $mkdirFind) && ! str_contains($patched, '[rfa opcache] persistent opcode cache dir')) {
         $patched = str_replace($mkdirFind, $mkdirReplace, $patched);
     }
 
@@ -192,12 +194,16 @@ JS;
     // probe is the marker UNIQUE to the current skip-entirely shape — requiring it
     // (not just `rfaNeedsFullOptimize`, which the previous revision also had) means
     // a file still carrying the old config:cache warm-launch branch is treated as
-    // not-yet-patched rather than mis-reported as already_patched. The opcache
-    // markers guard against a half-applied file; the pre-flight edit lands in both
-    // retrieve* helpers.
+    // not-yet-patched rather than mis-reported as already_patched. The two opcache
+    // markers are each UNIQUE to their edit: the mkdir comment proves the cache
+    // directory is created, and the pre-flight banner (×2) proves both retrieve*
+    // helpers reuse it. (`'framework', 'opcache'` alone would be ambiguous — the
+    // pre-flight `opcache.file_cache=…` path contains that same substring, so a
+    // file with only the pre-flight edit could mis-report as fully patched while
+    // the cache directory is never created.)
     $fullyPatched = str_contains($patched, "existsSync(join(rfaCacheDir, 'config.php'))")
         && str_contains($patched, 'rfaNeedsFullOptimize')
-        && str_contains($patched, "'framework', 'opcache'")
+        && str_contains($patched, '[rfa opcache] persistent opcode cache dir')
         && substr_count($patched, '[rfa opcache] reuse compiled opcode') === 2;
 
     if (! $fullyPatched) {
@@ -408,16 +414,25 @@ function patchNativeSplashWindow(string $indexPath): string
 
     $content = file_get_contents($indexPath);
 
-    // 1. Pull BrowserWindow into the electron import so the splash can create one.
+    // 1. Pull BrowserWindow + nativeTheme into the electron import so the splash
+    //    can create a window and tint it to the OS light/dark appearance.
     $importFind = 'import { app, session, powerMonitor } from "electron";';
-    $importReplace = 'import { app, session, powerMonitor, BrowserWindow } from "electron";';
+    $importReplace = 'import { app, session, powerMonitor, BrowserWindow, nativeTheme } from "electron";';
 
     // 2. The splash markup, embedded as a module-level const (no asset to ship).
+    //    Colors mirror RFA's own light/dark tokens (config/theme.php) and the
+    //    splash themes ITSELF via `prefers-color-scheme`: an Electron data: URL
+    //    follows nativeTheme (default themeSource 'system'), so on a light OS the
+    //    media query stays unmatched (light palette) and on a dark OS it flips to
+    //    the dark palette — matching RFA, which follows the system appearance by
+    //    default. No JS in the page; the native window backgroundColor is tinted
+    //    to the same appearance below so there is no wrong-color flash on open.
     $htmlAnchor = 'const { autoUpdater } = electronUpdater;';
     $htmlConst = <<<'JS'
 // [rfa splash] Self-contained splash markup — inline styles only, no external
-// resources, so it loads instantly from a data: URL with nothing to bundle.
-const RFA_SPLASH_HTML = `<!doctype html><html><head><meta charset="utf-8"><style>html,body{margin:0;height:100%;background:#0d1117;overflow:hidden}.wrap{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#e6edf3;-webkit-user-select:none;user-select:none}.name{font-size:22px;font-weight:600;letter-spacing:.4px;opacity:.92}.spinner{margin-top:18px;width:26px;height:26px;border:3px solid rgba(230,237,243,.18);border-top-color:#58a6ff;border-radius:50%;animation:rfaspin .8s linear infinite}@keyframes rfaspin{to{transform:rotate(360deg)}}</style></head><body><div class="wrap"><div class="name">rfa</div><div class="spinner"></div></div></body></html>`;
+// resources, so it loads instantly from a data: URL with nothing to bundle. It
+// theme-matches the OS (and thus RFA's default appearance) via prefers-color-scheme.
+const RFA_SPLASH_HTML = `<!doctype html><html><head><meta charset="utf-8"><style>:root{--rfa-bg:#ffffff;--rfa-fg:#09090b;--rfa-track:rgba(9,9,11,.14);--rfa-accent:#3b82f6}@media (prefers-color-scheme:dark){:root{--rfa-bg:#09090b;--rfa-fg:#fafafa;--rfa-track:rgba(250,250,250,.18);--rfa-accent:#60a5fa}}html,body{margin:0;height:100%;background:var(--rfa-bg);overflow:hidden}.wrap{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:var(--rfa-fg);-webkit-user-select:none;user-select:none}.name{font-size:22px;font-weight:600;letter-spacing:.4px;opacity:.92}.spinner{margin-top:18px;width:26px;height:26px;border:3px solid var(--rfa-track);border-top-color:var(--rfa-accent);border-radius:50%;animation:rfaspin .8s linear infinite}@keyframes rfaspin{to{transform:rotate(360deg)}}</style></head><body><div class="wrap"><div class="name">rfa</div><div class="spinner"></div></div></body></html>`;
 JS;
 
     // 3. The splash lifecycle methods, injected as class members.
@@ -438,7 +453,10 @@ JS;
                 center: true,
                 show: false,
                 skipTaskbar: true,
-                backgroundColor: '#0d1117',
+                // Tint the native window fill to the OS appearance so the frame
+                // shown before the data: URL paints matches the splash content
+                // (and RFA's default system-following theme) — no light/dark flash.
+                backgroundColor: nativeTheme.shouldUseDarkColors ? '#09090b' : '#ffffff',
                 title: 'rfa',
             });
             this.rfaSplash = splash;
@@ -461,8 +479,14 @@ JS;
                     return;
                 }
                 app.removeListener('browser-window-created', rfaOnCreated);
+                this.rfaSplashListener = null;
+                // Close on `show` (painted — the seamless handoff) and on `closed`
+                // (a window torn down before it ever shows — e.g. a failed load —
+                // must not strand the splash until the 60s timer).
                 window.once('show', () => this.rfaCloseSplash());
+                window.once('closed', () => this.rfaCloseSplash());
             };
+            this.rfaSplashListener = rfaOnCreated;
             app.on('browser-window-created', rfaOnCreated);
             // Safety net: never leave a spinner stuck if no window ever opens.
             this.rfaSplashTimer = setTimeout(() => this.rfaCloseSplash(), 60000);
@@ -476,6 +500,17 @@ JS;
             if (this.rfaSplashTimer) {
                 clearTimeout(this.rfaSplashTimer);
                 this.rfaSplashTimer = null;
+            }
+        }
+        catch (rfaError) { }
+        try {
+            // Drop the browser-window-created listener if the handoff never ran
+            // (no main window was ever created — e.g. PHP boot failed). Otherwise
+            // the closure, and the App instance it captures, leaks for the life of
+            // the process.
+            if (this.rfaSplashListener) {
+                app.removeListener('browser-window-created', this.rfaSplashListener);
+                this.rfaSplashListener = null;
             }
         }
         catch (rfaError) { }
@@ -504,7 +539,7 @@ JS;
 
     $patched = $content;
 
-    if (str_contains($patched, $importFind) && ! str_contains($patched, 'powerMonitor, BrowserWindow')) {
+    if (str_contains($patched, $importFind) && ! str_contains($patched, 'BrowserWindow, nativeTheme')) {
         $patched = str_replace($importFind, $importReplace, $patched);
     }
 
@@ -520,10 +555,59 @@ JS;
         $patched = str_replace($callFind, $callReplace, $patched);
     }
 
+    // -- Upgrade a file left splash-patched by the PREVIOUS RFA revision in place --
+    // The earlier splash was dark-only (fixed #0d1117, no nativeTheme). A plain
+    // `composer install` re-runs this hook over such a vendor copy; the guards above
+    // skip when their markers exist, so the themed edits would never reach it AND
+    // the success gate below (which now requires nativeTheme) would reject it and
+    // fail the hook. These three finds are unique to the old shape — each is a no-op
+    // on stock (handled above) and on an already-themed file — so re-patching
+    // converges to a result byte-identical to a fresh stock patch.
+
+    // a) Add nativeTheme to an old BrowserWindow-only import.
+    $oldSplashImport = 'import { app, session, powerMonitor, BrowserWindow } from "electron";';
+    if (str_contains($patched, $oldSplashImport) && ! str_contains($patched, 'BrowserWindow, nativeTheme')) {
+        $patched = str_replace($oldSplashImport, $importReplace, $patched);
+    }
+
+    // b) Swap the dark-only splash markup for the OS-following themed markup.
+    $oldSplashHtmlBlock = <<<'JS'
+// [rfa splash] Self-contained splash markup — inline styles only, no external
+// resources, so it loads instantly from a data: URL with nothing to bundle.
+const RFA_SPLASH_HTML = `<!doctype html><html><head><meta charset="utf-8"><style>html,body{margin:0;height:100%;background:#0d1117;overflow:hidden}.wrap{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#e6edf3;-webkit-user-select:none;user-select:none}.name{font-size:22px;font-weight:600;letter-spacing:.4px;opacity:.92}.spinner{margin-top:18px;width:26px;height:26px;border:3px solid rgba(230,237,243,.18);border-top-color:#58a6ff;border-radius:50%;animation:rfaspin .8s linear infinite}@keyframes rfaspin{to{transform:rotate(360deg)}}</style></head><body><div class="wrap"><div class="name">rfa</div><div class="spinner"></div></div></body></html>`;
+JS;
+    if (str_contains($patched, $oldSplashHtmlBlock)) {
+        $patched = str_replace($oldSplashHtmlBlock, $htmlConst, $patched);
+    }
+
+    // c) Tint the native window fill to the OS appearance instead of a fixed dark.
+    //    The replacement must stay byte-identical to the same lines baked into
+    //    $methods above (so an upgraded file equals a fresh stock patch).
+    $oldSplashBgBlock = <<<'JS'
+                show: false,
+                skipTaskbar: true,
+                backgroundColor: '#0d1117',
+                title: 'rfa',
+JS;
+    $newSplashBgBlock = <<<'JS'
+                show: false,
+                skipTaskbar: true,
+                // Tint the native window fill to the OS appearance so the frame
+                // shown before the data: URL paints matches the splash content
+                // (and RFA's default system-following theme) — no light/dark flash.
+                backgroundColor: nativeTheme.shouldUseDarkColors ? '#09090b' : '#ffffff',
+                title: 'rfa',
+JS;
+    if (str_contains($patched, $oldSplashBgBlock)) {
+        $patched = str_replace($oldSplashBgBlock, $newSplashBgBlock, $patched);
+    }
+
     // Only success when every edit is present, so a NativePHP bump that reshapes
-    // one anchor can't half-apply (e.g. a splash that is created but never shown).
-    $fullyPatched = str_contains($patched, 'powerMonitor, BrowserWindow')
+    // one anchor can't half-apply (e.g. a splash that is created but never shown,
+    // or themed markup without the nativeTheme import that tints the window).
+    $fullyPatched = str_contains($patched, 'BrowserWindow, nativeTheme')
         && str_contains($patched, 'const RFA_SPLASH_HTML')
+        && str_contains($patched, 'nativeTheme.shouldUseDarkColors')
         && str_contains($patched, 'rfaShowSplash() {')
         && str_contains($patched, 'this.rfaShowSplash()');
 

--- a/tests/Unit/Actions/RehydrateNativeRuntimeConfigActionTest.php
+++ b/tests/Unit/Actions/RehydrateNativeRuntimeConfigActionTest.php
@@ -1,9 +1,18 @@
 <?php
 
 use App\Actions\RehydrateNativeRuntimeConfigAction;
+use Illuminate\Foundation\Bootstrap\RegisterProviders;
 use Tests\TestCase;
 
 uses(TestCase::class);
+
+test('is wired in bootstrap to run before any provider registers', function () {
+    // bootstrap/app.php hooks the rehydration onto beforeBootstrapping(
+    // RegisterProviders) — i.e. after the config loads but before NativePHP's
+    // package provider builds EventWatcher's Client from cached config. Asserting
+    // the listener exists guards that wiring (an app provider would be too late).
+    expect(app('events')->hasListeners('bootstrapping: '.RegisterProviders::class))->toBeTrue();
+});
 
 /**
  * configurationIsCached() returns the bound `config_loaded_from_cache` flag, so

--- a/tests/Unit/Actions/RehydrateNativeRuntimeConfigActionTest.php
+++ b/tests/Unit/Actions/RehydrateNativeRuntimeConfigActionTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Actions\RehydrateNativeRuntimeConfigAction;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+/**
+ * configurationIsCached() returns the bound `config_loaded_from_cache` flag, so
+ * bind it directly to model a packaged (cached) vs dev (uncached) runtime
+ * without touching the shared bootstrap/cache that parallel workers depend on.
+ */
+function setConfigurationCached(bool $cached): void
+{
+    app()->instance('config_loaded_from_cache', $cached);
+}
+
+afterEach(function () {
+    foreach (['NATIVEPHP_API_URL', 'NATIVEPHP_SECRET'] as $key) {
+        putenv($key);
+        unset($_ENV[$key], $_SERVER[$key]);
+    }
+});
+
+test('rehydrates the per-launch api url and secret from the live environment when config is cached', function () {
+    setConfigurationCached(true);
+
+    // Simulate a stale version-cached config and the fresh per-launch values
+    // Electron injects into the process environment.
+    config([
+        'nativephp-internal.api_url' => 'http://localhost:4000/api/',
+        'nativephp-internal.secret' => 'stale-secret',
+    ]);
+    $_SERVER['NATIVEPHP_API_URL'] = 'http://localhost:52111/api/';
+    $_SERVER['NATIVEPHP_SECRET'] = 'fresh-launch-secret';
+
+    (new RehydrateNativeRuntimeConfigAction)->handle();
+
+    expect(config('nativephp-internal.api_url'))->toBe('http://localhost:52111/api/')
+        ->and(config('nativephp-internal.secret'))->toBe('fresh-launch-secret');
+});
+
+test('is a no-op when the configuration is not cached', function () {
+    setConfigurationCached(false);
+
+    // A dev / browser / test runtime reads these straight from env() in the
+    // config file, so they are already live and must be left untouched.
+    config([
+        'nativephp-internal.api_url' => 'http://localhost:4000/api/',
+        'nativephp-internal.secret' => 'config-file-secret',
+    ]);
+    $_SERVER['NATIVEPHP_API_URL'] = 'http://localhost:52111/api/';
+    $_SERVER['NATIVEPHP_SECRET'] = 'fresh-launch-secret';
+
+    (new RehydrateNativeRuntimeConfigAction)->handle();
+
+    expect(config('nativephp-internal.api_url'))->toBe('http://localhost:4000/api/')
+        ->and(config('nativephp-internal.secret'))->toBe('config-file-secret');
+});
+
+test('keeps the cached value when the environment variable is absent', function () {
+    setConfigurationCached(true);
+
+    config([
+        'nativephp-internal.api_url' => 'http://localhost:4000/api/',
+        'nativephp-internal.secret' => 'cached-secret',
+    ]);
+    // Only the port is injected this launch; the secret env var is missing.
+    $_SERVER['NATIVEPHP_API_URL'] = 'http://localhost:52111/api/';
+
+    (new RehydrateNativeRuntimeConfigAction)->handle();
+
+    expect(config('nativephp-internal.api_url'))->toBe('http://localhost:52111/api/')
+        // Never blanked: the existing value survives a missing env var.
+        ->and(config('nativephp-internal.secret'))->toBe('cached-secret');
+});

--- a/tests/Unit/Scripts/PatchNativeServerTest.php
+++ b/tests/Unit/Scripts/PatchNativeServerTest.php
@@ -321,6 +321,113 @@ test('the vendored NativePHP main bootstrap carries the pre-flight cache', funct
         ->toContain('import Store from "electron-store"; // [rfa preflight cache]');
 })->skip(fn () => ! file_exists(dirname(__DIR__, 3).'/vendor/nativephp/desktop/resources/electron/electron-plugin/dist/index.js'), 'NativePHP desktop electron plugin not installed');
 
+// -- Splash window (dist/index.js) --
+
+function stockIndexForSplash(): string
+{
+    return <<<'JS'
+import { app, session, powerMonitor } from "electron";
+import electronUpdater from 'electron-updater';
+const { autoUpdater } = electronUpdater;
+class NativePHP {
+    registerListeners(app) {
+        app.on("browser-window-created", (_, window) => {
+            optimizer.watchWindowShortcuts(window);
+        });
+    }
+    bootstrapApp(app) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield app.whenReady();
+            const config = yield this.loadConfig();
+            yield this.startPhpApp();
+            yield notifyLaravel("booted");
+        });
+    }
+}
+JS;
+}
+
+test('splash: returns not_found when index file does not exist', function () {
+    expect(patchNativeSplashWindow(tempServer()))->toBe('not_found');
+});
+
+test('splash: returns block_not_found when the bootstrap anchors are missing', function () {
+    $path = tempServer('const x = 1;');
+
+    expect(patchNativeSplashWindow($path))->toBe('block_not_found');
+    expect(file_get_contents($path))->toBe('const x = 1;');
+});
+
+test('splash: opens an early window before PHP boots, hands off, and is fail-open', function () {
+    $path = tempServer(stockIndexForSplash());
+
+    expect(patchNativeSplashWindow($path))->toBe('patched');
+
+    $content = file_get_contents($path);
+
+    expect($content)
+        // BrowserWindow is pulled into the electron import so the splash can open.
+        ->toContain('import { app, session, powerMonitor, BrowserWindow } from "electron";')
+        // The markup is embedded as a self-contained data URL — nothing to bundle.
+        ->toContain('const RFA_SPLASH_HTML')
+        ->toContain("loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(RFA_SPLASH_HTML))")
+        // Fired the instant Electron is ready, before any PHP boot.
+        ->toContain('this.rfaShowSplash(); // [rfa splash] instant feedback before PHP boots')
+        // Seamless handoff: the splash closes once the real window is shown.
+        ->toContain("window.once('show', () => this.rfaCloseSplash())")
+        // Fail-open: splash creation is wrapped so any error just means no splash.
+        ->toContain('catch (rfaError)');
+
+    // The splash fires before the first PHP boot (loadConfig), not after.
+    expect(strpos($content, 'this.rfaShowSplash()'))
+        ->toBeLessThan(strpos($content, 'const config = yield this.loadConfig()'));
+
+    // Each edit lands exactly once.
+    expect(substr_count($content, 'powerMonitor, BrowserWindow'))->toBe(1)
+        ->and(substr_count($content, 'rfaShowSplash() {'))->toBe(1)
+        ->and(substr_count($content, 'const RFA_SPLASH_HTML'))->toBe(1);
+});
+
+test('splash: preserves the existing browser-window-created listener', function () {
+    $path = tempServer(stockIndexForSplash());
+
+    patchNativeSplashWindow($path);
+
+    // The patch adds its own handoff listener without clobbering NativePHP's.
+    expect(file_get_contents($path))
+        ->toContain('optimizer.watchWindowShortcuts(window)');
+});
+
+test('splash: is idempotent', function () {
+    $path = tempServer(stockIndexForSplash());
+
+    patchNativeSplashWindow($path);
+    $first = file_get_contents($path);
+
+    expect(patchNativeSplashWindow($path))->toBe('already_patched');
+    expect(file_get_contents($path))->toBe($first);
+});
+
+test('splash: returns block_not_found when only the import anchor is present (partial)', function () {
+    // A NativePHP bump that reshaped the class but left the electron import. The
+    // import edit alone must not report success with the splash half-applied, and
+    // the file must be left untouched.
+    $importOnly = 'import { app, session, powerMonitor } from "electron";';
+    $path = tempServer($importOnly);
+
+    expect(patchNativeSplashWindow($path))->toBe('block_not_found');
+    expect(file_get_contents($path))->toBe($importOnly);
+});
+
+test('the vendored NativePHP main bootstrap carries the splash window', function () {
+    $indexPath = dirname(__DIR__, 3).'/vendor/nativephp/desktop/resources/electron/electron-plugin/dist/index.js';
+
+    expect(file_get_contents($indexPath))
+        ->toContain('powerMonitor, BrowserWindow')
+        ->toContain('const RFA_SPLASH_HTML')
+        ->toContain('this.rfaShowSplash()');
+})->skip(fn () => ! file_exists(dirname(__DIR__, 3).'/vendor/nativephp/desktop/resources/electron/electron-plugin/dist/index.js'), 'NativePHP desktop electron plugin not installed');
+
 // -- Applied to the real vendored file --
 
 test('the vendored NativePHP server carries the optimize patch', function () {

--- a/tests/Unit/Scripts/PatchNativeServerTest.php
+++ b/tests/Unit/Scripts/PatchNativeServerTest.php
@@ -121,12 +121,17 @@ test('patches the optimize block and returns patched', function () {
     expect($content)
         ->toContain('[rfa patch]')
         ->toContain('const rfaNeedsFullOptimize')
-        ->toContain("rfaNeedsFullOptimize ? 'optimize' : 'config:cache'")
+        // The full optimize only runs behind the version/cache gate; the warm
+        // path falls through with no cache step at all.
+        ->toContain('if (rfaNeedsFullOptimize) {')
         // The cache dir is build-type aware: userData/bootstrap/cache for a
         // secure build, <appPath>/bootstrap/cache for an unsecure one. Probing
         // bootstrapCache unconditionally would never trip the gate in an
         // unsecure build (RFA's shipping shape), paying the full optimize.
         ->toContain("const rfaCacheDir = runningSecureBuild() ? bootstrapCache : join(getAppPath(), 'bootstrap', 'cache')")
+        // The config cache is probed too: skipping config:cache on warm launches
+        // is only safe while a persisted config.php is present to fall back on.
+        ->toContain("existsSync(join(rfaCacheDir, 'config.php'))")
         ->toContain("existsSync(join(rfaCacheDir, 'routes-v7.php'))")
         ->toContain("existsSync(join(rfaCacheDir, 'events.php'))");
 });
@@ -146,16 +151,21 @@ test('warms the pre-flight artisan calls with a persistent opcache file cache', 
     expect(substr_count($content, '[rfa opcache] reuse compiled opcode'))->toBe(2);
 });
 
-test('the unconditional every-launch optimize call is gone after patching', function () {
+test('the cache step only runs behind the version gate after patching', function () {
     $path = tempServer(stockServer());
 
     patchNativeServerOptimize($path);
     $content = file_get_contents($path);
 
-    // The stock build always ran the full `optimize`; after patching the only
-    // unconditional command is the version-gated choice, never a bare optimize.
-    expect($content)->not->toContain("callPhpSync(['artisan', 'optimize']");
-    expect($content)->toContain("callPhpSync(['artisan', rfaCommand]");
+    // The stock build ran `optimize` unconditionally on every launch. After
+    // patching the only `optimize` call lives inside `if (rfaNeedsFullOptimize)`,
+    // and the warm path runs no cache step at all — not even config:cache (which
+    // the previous patch revision still paid every launch).
+    expect($content)
+        ->toContain('if (rfaNeedsFullOptimize) {')
+        ->toContain("callPhpSync(['artisan', 'optimize'], phpOptions, phpIniSettings)")
+        ->not->toContain("'artisan', 'config:cache'")
+        ->not->toContain('rfaCommand');
 });
 
 // -- Idempotency --

--- a/tests/Unit/Scripts/PatchNativeServerTest.php
+++ b/tests/Unit/Scripts/PatchNativeServerTest.php
@@ -151,6 +151,26 @@ test('warms the pre-flight artisan calls with a persistent opcache file cache', 
     expect(substr_count($content, '[rfa opcache] reuse compiled opcode'))->toBe(2);
 });
 
+test('fails loudly when the opcache cache-dir mkdir anchor is reshaped, despite the pre-flight substring matching', function () {
+    // Simulate a NativePHP bump that reshapes the `framework/testing` mkdir anchor
+    // so the cache-dir mkdir edit can no longer land, while the pre-flight anchors
+    // still match and inject `opcache.file_cache=…join(storagePath,'framework','opcache')`.
+    // That path CONTAINS the literal "'framework', 'opcache'", so a success check
+    // keyed on that ambiguous substring would mis-report this half-applied file as
+    // fully patched — shipping a build whose opcache file-cache directory is never
+    // created. The gate keys on the mkdir line's UNIQUE marker, so it must fail loudly.
+    $reshaped = str_replace(
+        "mkdirpSync(join(storagePath, 'framework', 'testing'));",
+        "mkdirpSync(join(storagePath, 'framework', 'cache'));",
+        stockServer(),
+    );
+    $path = tempServer($reshaped);
+
+    expect(patchNativeServerOptimize($path))->toBe('block_not_found');
+    // block_not_found must not leave a half-applied file on disk.
+    expect(file_get_contents($path))->toBe($reshaped);
+});
+
 test('the cache step only runs behind the version gate after patching', function () {
     $path = tempServer(stockServer());
 
@@ -188,9 +208,11 @@ function currentServerOptimizeBlock(): string
             // the config:cache the earlier RFA patch ran for the fresh per-launch
             // API port and IPC secret. Those two values are the only per-launch
             // config that varies, and the app now re-reads them from the live
-            // process environment at runtime (RehydrateNativeRuntimeConfigAction
-            // in AppServiceProvider), so the persisted version-cached config stays
-            // valid and we avoid a full framework boot on every warm launch.
+            // process environment at runtime (RehydrateNativeRuntimeConfigAction,
+            // wired in bootstrap/app.php via a beforeBootstrapping(RegisterProviders)
+            // hook that runs before any provider registers), so the persisted
+            // version-cached config stays valid and we avoid a full framework boot
+            // on every warm launch.
             //
             // Probe the caches at the directory Laravel actually writes them to
             // for this build type. NativePHP only redirects APP_*_CACHE into
@@ -512,8 +534,9 @@ test('splash: opens an early window before PHP boots, hands off, and is fail-ope
     $content = file_get_contents($path);
 
     expect($content)
-        // BrowserWindow is pulled into the electron import so the splash can open.
-        ->toContain('import { app, session, powerMonitor, BrowserWindow } from "electron";')
+        // BrowserWindow + nativeTheme are pulled into the electron import so the
+        // splash can open and tint itself to the OS appearance.
+        ->toContain('import { app, session, powerMonitor, BrowserWindow, nativeTheme } from "electron";')
         // The markup is embedded as a self-contained data URL — nothing to bundle.
         ->toContain('const RFA_SPLASH_HTML')
         ->toContain("loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(RFA_SPLASH_HTML))")
@@ -534,6 +557,114 @@ test('splash: opens an early window before PHP boots, hands off, and is fail-ope
         ->and(substr_count($content, 'const RFA_SPLASH_HTML'))->toBe(1);
 });
 
+test('splash: follows the OS light/dark appearance (matches RFA, which follows the system)', function () {
+    $path = tempServer(stockIndexForSplash());
+
+    patchNativeSplashWindow($path);
+
+    expect(file_get_contents($path))
+        // nativeTheme is imported so the native window fill can be tinted.
+        ->toContain('powerMonitor, BrowserWindow, nativeTheme')
+        // The native window backgroundColor tracks the OS appearance (no flash):
+        // dark fill on a dark OS, light fill on a light OS.
+        ->toContain("backgroundColor: nativeTheme.shouldUseDarkColors ? '#09090b' : '#ffffff'")
+        // The splash content themes ITSELF via prefers-color-scheme — a data: URL
+        // follows nativeTheme, so the page flips palette with the OS automatically.
+        ->toContain('@media (prefers-color-scheme:dark)')
+        // Light palette is the default (RFA's light tokens); dark overrides it.
+        ->toContain('--rfa-bg:#ffffff')
+        ->toContain('--rfa-bg:#09090b')
+        // The old hardcoded GitHub-dark fill is gone (it matched neither RFA mode).
+        ->not->toContain('#0d1117');
+});
+
+// -- Upgrading a file left splash-patched by the previous (dark-only) revision --
+
+// Reconstruct a file exactly as the pre-theme splash revision left it: patch
+// stock, then reverse the three theme edits back to the dark-only shape.
+function oldThemedSplashServer(): string
+{
+    $path = tempServer(stockIndexForSplash());
+    patchNativeSplashWindow($path);
+    $themed = file_get_contents($path);
+
+    $newHtmlBlock = <<<'JS'
+// [rfa splash] Self-contained splash markup — inline styles only, no external
+// resources, so it loads instantly from a data: URL with nothing to bundle. It
+// theme-matches the OS (and thus RFA's default appearance) via prefers-color-scheme.
+const RFA_SPLASH_HTML = `<!doctype html><html><head><meta charset="utf-8"><style>:root{--rfa-bg:#ffffff;--rfa-fg:#09090b;--rfa-track:rgba(9,9,11,.14);--rfa-accent:#3b82f6}@media (prefers-color-scheme:dark){:root{--rfa-bg:#09090b;--rfa-fg:#fafafa;--rfa-track:rgba(250,250,250,.18);--rfa-accent:#60a5fa}}html,body{margin:0;height:100%;background:var(--rfa-bg);overflow:hidden}.wrap{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:var(--rfa-fg);-webkit-user-select:none;user-select:none}.name{font-size:22px;font-weight:600;letter-spacing:.4px;opacity:.92}.spinner{margin-top:18px;width:26px;height:26px;border:3px solid var(--rfa-track);border-top-color:var(--rfa-accent);border-radius:50%;animation:rfaspin .8s linear infinite}@keyframes rfaspin{to{transform:rotate(360deg)}}</style></head><body><div class="wrap"><div class="name">rfa</div><div class="spinner"></div></div></body></html>`;
+JS;
+    $oldHtmlBlock = <<<'JS'
+// [rfa splash] Self-contained splash markup — inline styles only, no external
+// resources, so it loads instantly from a data: URL with nothing to bundle.
+const RFA_SPLASH_HTML = `<!doctype html><html><head><meta charset="utf-8"><style>html,body{margin:0;height:100%;background:#0d1117;overflow:hidden}.wrap{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#e6edf3;-webkit-user-select:none;user-select:none}.name{font-size:22px;font-weight:600;letter-spacing:.4px;opacity:.92}.spinner{margin-top:18px;width:26px;height:26px;border:3px solid rgba(230,237,243,.18);border-top-color:#58a6ff;border-radius:50%;animation:rfaspin .8s linear infinite}@keyframes rfaspin{to{transform:rotate(360deg)}}</style></head><body><div class="wrap"><div class="name">rfa</div><div class="spinner"></div></div></body></html>`;
+JS;
+    $newBg = <<<'JS'
+                show: false,
+                skipTaskbar: true,
+                // Tint the native window fill to the OS appearance so the frame
+                // shown before the data: URL paints matches the splash content
+                // (and RFA's default system-following theme) — no light/dark flash.
+                backgroundColor: nativeTheme.shouldUseDarkColors ? '#09090b' : '#ffffff',
+                title: 'rfa',
+JS;
+    $oldBg = <<<'JS'
+                show: false,
+                skipTaskbar: true,
+                backgroundColor: '#0d1117',
+                title: 'rfa',
+JS;
+
+    // Guard: if the current patch reshaped any of these, the reversal would
+    // silently no-op and the "old" fixture would actually be the new shape.
+    expect($themed)
+        ->toContain('powerMonitor, BrowserWindow, nativeTheme')
+        ->toContain($newHtmlBlock)
+        ->toContain($newBg);
+
+    $old = str_replace('powerMonitor, BrowserWindow, nativeTheme', 'powerMonitor, BrowserWindow', $themed);
+    $old = str_replace($newHtmlBlock, $oldHtmlBlock, $old);
+
+    return str_replace($newBg, $oldBg, $old);
+}
+
+test('splash: a dark-only patched file is NOT mistaken for fully patched (would fail the gate)', function () {
+    // The old splash carries BrowserWindow + rfaShowSplash but no nativeTheme, so
+    // the success gate must treat it as not-current rather than already_patched.
+    $old = oldThemedSplashServer();
+
+    expect($old)
+        ->toContain('#0d1117')
+        ->not->toContain('nativeTheme');
+});
+
+test('splash: upgrades a previously dark-only splash to the OS-following themed shape', function () {
+    $path = tempServer(oldThemedSplashServer());
+
+    expect(patchNativeSplashWindow($path))->toBe('patched');
+
+    $content = file_get_contents($path);
+
+    expect($content)
+        ->toContain('powerMonitor, BrowserWindow, nativeTheme')
+        ->toContain('@media (prefers-color-scheme:dark)')
+        ->toContain("backgroundColor: nativeTheme.shouldUseDarkColors ? '#09090b' : '#ffffff'")
+        ->not->toContain('#0d1117');
+
+    // The upgrade is byte-identical to a fresh stock → themed patch.
+    $fresh = tempServer(stockIndexForSplash());
+    patchNativeSplashWindow($fresh);
+    expect($content)->toBe(file_get_contents($fresh));
+});
+
+test('splash: upgrading a previously dark-only splash is idempotent', function () {
+    $path = tempServer(oldThemedSplashServer());
+
+    patchNativeSplashWindow($path);
+
+    expect(patchNativeSplashWindow($path))->toBe('already_patched');
+});
+
 test('splash: preserves the existing browser-window-created listener', function () {
     $path = tempServer(stockIndexForSplash());
 
@@ -542,6 +673,23 @@ test('splash: preserves the existing browser-window-created listener', function 
     // The patch adds its own handoff listener without clobbering NativePHP's.
     expect(file_get_contents($path))
         ->toContain('optimizer.watchWindowShortcuts(window)');
+});
+
+test('splash: cleans up its window-created listener and closes on a torn-down window', function () {
+    $path = tempServer(stockIndexForSplash());
+
+    patchNativeSplashWindow($path);
+
+    expect(file_get_contents($path))
+        // The handoff listener is retained on the instance so it can be removed…
+        ->toContain('this.rfaSplashListener = rfaOnCreated')
+        // …and rfaCloseSplash removes it on the timeout path (no main window ever
+        // opened), so the closure — and the App instance it captures — can't leak
+        // for the life of the process.
+        ->toContain("app.removeListener('browser-window-created', this.rfaSplashListener)")
+        // A window torn down before it ever fires `show` (e.g. a failed load) still
+        // hands off, instead of stranding the splash until the 60s safety timer.
+        ->toContain("window.once('closed', () => this.rfaCloseSplash())");
 });
 
 test('splash: is idempotent', function () {

--- a/tests/Unit/Scripts/PatchNativeServerTest.php
+++ b/tests/Unit/Scripts/PatchNativeServerTest.php
@@ -168,6 +168,152 @@ test('the cache step only runs behind the version gate after patching', function
         ->not->toContain('rfaCommand');
 });
 
+// -- Upgrading a file patched by the previous RFA revision --
+
+// The full optimize block the CURRENT patch injects (comment + code), and the
+// full block the PREVIOUS revision injected (config:cache warm branch). Used to
+// synthesize a faithfully old-patched file from the current patch output.
+function currentServerOptimizeBlock(): string
+{
+    return <<<'JS'
+        if (shouldOptimize(store)) {
+            // [rfa patch] `php artisan optimize` recompiles every Blade view and
+            // re-caches config/routes/events (~1s) and previously ran on every
+            // launch, blocking the window. The compiled caches persist in the
+            // build's bootstrap/cache, so the full optimize is only needed when
+            // the app version changes (fresh install / post-update) or a cache
+            // file is missing.
+            //
+            // On a same-version launch we skip the cache step ENTIRELY — including
+            // the config:cache the earlier RFA patch ran for the fresh per-launch
+            // API port and IPC secret. Those two values are the only per-launch
+            // config that varies, and the app now re-reads them from the live
+            // process environment at runtime (RehydrateNativeRuntimeConfigAction
+            // in AppServiceProvider), so the persisted version-cached config stays
+            // valid and we avoid a full framework boot on every warm launch.
+            //
+            // Probe the caches at the directory Laravel actually writes them to
+            // for this build type. NativePHP only redirects APP_*_CACHE into
+            // userData/bootstrap/cache for a *secure* build; an unsecure build
+            // (what `native:build` produces without a bundle — RFA's shipping
+            // shape) leaves them at <appPath>/bootstrap/cache. Checking
+            // bootstrapCache unconditionally would never find them in an unsecure
+            // build, so the gate would trip every launch and pay the full optimize.
+            const rfaCacheDir = runningSecureBuild() ? bootstrapCache : join(getAppPath(), 'bootstrap', 'cache');
+            const rfaVersionChanged = store.get('optimized_version') !== app.getVersion();
+            const rfaNeedsFullOptimize = rfaVersionChanged
+                || !existsSync(join(rfaCacheDir, 'config.php'))
+                || !existsSync(join(rfaCacheDir, 'routes-v7.php'))
+                || !existsSync(join(rfaCacheDir, 'events.php'));
+            if (rfaNeedsFullOptimize) {
+                console.log('Caching views, routes, and config...');
+                let result = callPhpSync(['artisan', 'optimize'], phpOptions, phpIniSettings);
+                if (result.status !== 0) {
+                    console.error('Failed to cache framework bootstrap:', result.stderr.toString());
+                }
+                else {
+                    store.set('optimized_version', app.getVersion());
+                }
+            }
+        }
+JS;
+}
+
+function previousRevisionServerOptimizeBlock(): string
+{
+    return <<<'JS'
+        if (shouldOptimize(store)) {
+            // [rfa patch] `php artisan optimize` recompiles every Blade view
+            // (~1s) and previously ran on every launch, blocking the window.
+            // Compiled views persist in userData and self-heal via on-demand
+            // compilation, so the full optimize is only needed when the app
+            // version changes (fresh install / post-update) or the route/event
+            // caches are missing. On same-version launches we re-cache config
+            // alone: NativePHP injects a fresh per-launch API port and secret
+            // that PHP reads through config(), so a reused config cache would
+            // point the PHP server at a stale port and break the native bridge.
+            //
+            // Probe the route/event caches at the directory Laravel actually
+            // writes them to for this build type. NativePHP only redirects
+            // APP_ROUTES_CACHE/APP_EVENTS_CACHE into userData/bootstrap/cache
+            // for a *secure* build; an unsecure build (what `native:build`
+            // produces without a bundle — RFA's shipping shape) leaves them at
+            // <appPath>/bootstrap/cache. Checking bootstrapCache unconditionally
+            // would never find them in an unsecure build, so the gate would trip
+            // every launch and pay the full optimize anyway.
+            const rfaCacheDir = runningSecureBuild() ? bootstrapCache : join(getAppPath(), 'bootstrap', 'cache');
+            const rfaVersionChanged = store.get('optimized_version') !== app.getVersion();
+            const rfaNeedsFullOptimize = rfaVersionChanged
+                || !existsSync(join(rfaCacheDir, 'routes-v7.php'))
+                || !existsSync(join(rfaCacheDir, 'events.php'));
+            const rfaCommand = rfaNeedsFullOptimize ? 'optimize' : 'config:cache';
+            console.log(rfaNeedsFullOptimize ? 'Caching views, routes, and config...' : 'Refreshing config cache...');
+            let result = callPhpSync(['artisan', rfaCommand], phpOptions, phpIniSettings);
+            if (result.status !== 0) {
+                console.error('Failed to cache framework bootstrap:', result.stderr.toString());
+            }
+            else if (rfaNeedsFullOptimize) {
+                store.set('optimized_version', app.getVersion());
+            }
+        }
+JS;
+}
+
+// Build a file exactly as the previous revision left it: the current patch
+// output (real opcache edits) with the optimize block reverted to old config:cache.
+function oldPatchedServer(): string
+{
+    $path = tempServer(stockServer());
+    patchNativeServerOptimize($path);
+    $current = file_get_contents($path);
+
+    // Guard: if the current patch reshaped, this revert would silently no-op and
+    // the "old" fixture would actually be the new shape. Assert it really swaps.
+    expect($current)->toContain(currentServerOptimizeBlock());
+
+    return str_replace(currentServerOptimizeBlock(), previousRevisionServerOptimizeBlock(), $current);
+}
+
+test('a file patched by the previous revision is NOT mistaken for already_patched', function () {
+    // The old block still carries `rfaNeedsFullOptimize` and the opcache markers,
+    // so the pre-config.php-probe check would have returned already_patched and
+    // left the config:cache-every-warm-launch branch in place.
+    $old = oldPatchedServer();
+
+    expect($old)
+        ->toContain('rfaCommand')
+        ->not->toContain("existsSync(join(rfaCacheDir, 'config.php'))");
+});
+
+test('upgrades a previously-patched file to the skip-entirely shape', function () {
+    $path = tempServer(oldPatchedServer());
+
+    expect(patchNativeServerOptimize($path))->toBe('patched');
+
+    $content = file_get_contents($path);
+
+    expect($content)
+        // The old config:cache warm-launch branch is gone…
+        ->not->toContain('rfaCommand')
+        ->not->toContain("'artisan', 'config:cache'")
+        // …replaced by the current skip-entirely gate.
+        ->toContain("existsSync(join(rfaCacheDir, 'config.php'))")
+        ->toContain('if (rfaNeedsFullOptimize) {');
+
+    // The upgrade is byte-identical to a fresh stock → current patch.
+    $fresh = tempServer(stockServer());
+    patchNativeServerOptimize($fresh);
+    expect($content)->toBe(file_get_contents($fresh));
+});
+
+test('upgrading a previously-patched file is idempotent', function () {
+    $path = tempServer(oldPatchedServer());
+
+    patchNativeServerOptimize($path);
+
+    expect(patchNativeServerOptimize($path))->toBe('already_patched');
+});
+
 // -- Idempotency --
 
 test('returns already_patched on second run', function () {


### PR DESCRIPTION
## Summary

Optimizes NativePHP startup by skipping the per-launch `config:cache` step on warm launches (same version), and adds an early splash window for immediate visual feedback during boot.

## Key Changes

**Startup Optimization**
- Modified `patchNativeServerOptimize()` to skip the entire cache step on warm launches instead of running `config:cache`
- Added `RehydrateNativeRuntimeConfigAction` to re-read the per-launch NativePHP API port and IPC secret from the live process environment at runtime, allowing the version-cached config to persist across launches without re-caching
- Integrated the rehydration action into `AppServiceProvider::register()` so it runs before any provider boots
- Updated the optimization gate to also check for `config.php` presence alongside route and event caches
- Updated startup benchmark command to measure the skipped `config:cache` cost separately

**Splash Window**
- Added `patchNativeSplashWindow()` to inject an early, lightweight splash window into the compiled Electron bootstrap (`dist/index.js`)
- The splash opens the instant `app.whenReady()` resolves (before PHP boots) and closes seamlessly when the real window finishes loading
- Splash markup is self-contained as a `data:` URL with inline styles only—nothing extra to bundle
- Implemented as fail-open: any error simply means no splash (today's behavior)

## Implementation Details

- The per-launch values (API port and secret) are injected by Electron into the PHP process environment, not `.env`, so they're readable via `env()` even under a cached config
- The rehydration action only runs when config is cached (packaged builds), making it a no-op in dev/browser/test environments where the config file re-evaluates `env()` on every boot
- The splash lifecycle is managed with event listeners: it closes on the first non-splash window's `show` event, with a 60-second safety timeout
- All patches are idempotent and fail-safe: if a NativePHP version bump reshapes the bootstrap, the patch returns `block_not_found` and prevents a half-applied state
- Added comprehensive unit tests for both the optimization logic and splash window injection

## Testing

- Added `RehydrateNativeRuntimeConfigActionTest` covering cached/uncached configs and missing environment variables
- Extended `PatchNativeServerTest` to verify the warm-launch cache skip and config.php probe
- Added `patchNativeSplashWindow` tests covering idempotency, fail-open behavior, and seamless handoff
- All existing tests pass; new tests verify the patches apply correctly to the vendored NativePHP files

https://claude.ai/code/session_019M6kPr6Ft892K6AB11s6dE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an early splash screen during app startup for a faster, more polished launch experience.
  * Native runtime settings now refresh from the current environment when configuration is cached.

* **Improvements**
  * Warm launches now skip unnecessary cache work when everything is already up to date.
  * Startup reporting now includes the skipped cache-step timing for clearer performance insights.

* **Bug Fixes**
  * Improved startup patch detection so partially applied changes are handled more reliably.
  * Better handling of missing runtime environment values preserves existing settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->