### PR TITLE
Wide events audit 2026-06-30

### DIFF
--- a/reports/wide-events/2026-06-30.md
+++ b/reports/wide-events/2026-06-30.md
@@ -1,0 +1,102 @@
+# Wide Events Audit: 2026-06-30
+
+## Summary
+
+- Deterministic checks: pass
+- Findings: 0 critical, 7 warning, 2 info
+- Files reviewed: 9 production files emitting `Log::*` or `Context::*`
+
+## Deterministic Checks
+
+| Command | Result | Notes |
+|---|---|---|
+| `php artisan test --compact tests/Arch/LoggingConventionsTest.php` | pass | 4 tests, 4 assertions, 47ms |
+
+## Findings
+
+### [WARNING] Raw exception message stored in Context
+
+- **File:** `resources/views/pages/⚡review-page.blade.php:538`
+- **Rule:** Privacy (A9), Anti-Pattern in SKILL.md
+- **Evidence:** `Context::add('rfa.error', $e->getMessage())` inside the `softRefresh()` catch block. SKILL.md lists this exact line as an anti-pattern under "Anti-Patterns".
+- **Impact:** Exception messages frequently leak absolute paths, SQL fragments, stderr, or user data into the canonical `review.refreshed` event. The same block already adds `rfa.error_class`, so the raw message adds risk without adding diagnostic value.
+- **Suggested fix:** Drop `Context::add('rfa.error', ...)`. Keep `rfa.error_class` and add a stable `rfa.reason` literal (for example `refresh_failed`) so failures stay queryable.
+
+### [WARNING] Updater listener for `updater.failed` has no canonical info event
+
+- **File:** `app/Providers/NativeAppServiceProvider.php:148`
+- **Rule:** Logging Ownership (A1), Errors And Criticals ("Log::error() never replaces the owner canonical info event")
+- **Evidence:** The `UpdateError` listener calls `Log::error('updater.failed', [...])` but never emits a canonical `Log::info()` for the listener-owned unit of work.
+- **Impact:** Success paths emit `updater.available` and `updater.downloaded`, but the failure path emits only an error event. Querying "what happened on this updater attempt" returns inconsistent shape across outcomes and breaks `rfa.outcome` distribution analysis.
+- **Suggested fix:** Pattern the listener after the standard's try/finally template. Keep `Log::error('updater.failed', ...)` for diagnostic detail, then add a canonical `Log::info('updater.failed')` from `finally` with `rfa.outcome = error`, `rfa.reason = updater_error`, and `rfa.duration_ms`.
+
+### [WARNING] Canonical updater events missing `rfa.duration_ms`
+
+- **File:** `app/Providers/NativeAppServiceProvider.php:93-97`, `app/Providers/NativeAppServiceProvider.php:128-132`
+- **Rule:** Canonical Event Fields (A6, "There are no duration exemptions")
+- **Evidence:** `Log::info('updater.available')` and `Log::info('updater.downloaded')` add `rfa.update_version` and `rfa.outcome` but no `rfa.duration_ms`.
+- **Impact:** Owner canonical events are required to carry `rfa.duration_ms` so latency baselines and regressions are visible. Updater events currently cannot answer "how long did the download take" without joining other sources.
+- **Suggested fix:** Either record the listener callback duration, or pull a reliable operation start time from the `native-update-state` cache entry written by `CheckingForUpdate` and `UpdateAvailable`, then add `rfa.duration_ms` before emitting the canonical event.
+
+### [WARNING] Raw stderr in `git.diff.failed` warning payload
+
+- **File:** `app/Actions/LoadFileDiffAction.php:54`
+- **Rule:** Warnings ("avoid raw file contents, raw stderr, secrets, and avoidable absolute paths")
+- **Evidence:** `'stderr' => $e->stderr` in the `Log::warning('git.diff.failed', ...)` payload.
+- **Impact:** Raw git stderr can carry absolute paths, repo internals, or user content from rejected diffs. The standard explicitly bans raw stderr in favor of `stderr_summary`.
+- **Suggested fix:** Replace with `'stderr_summary' => trim(substr($e->stderr, 0, 200))` or a domain-specific sanitizer that strips paths and trims length.
+
+### [WARNING] Raw stderr in `project.status.failed` warning payload
+
+- **File:** `app/Actions/GetProjectStatusAction.php:30`
+- **Rule:** Warnings ("avoid raw stderr")
+- **Evidence:** `'stderr' => $e->stderr` in `Log::warning('project.status.failed', ...)`.
+- **Impact:** Same as above. `GetProjectStatusAction` runs on every project status refresh, so the noisy payload accumulates fast in `laravel.log`.
+- **Suggested fix:** Sanitize and rename to `stderr_summary`. Consider also dropping the absolute `repoPath` in favor of a project slug if a project context is available at the call site.
+
+### [WARNING] Raw exception messages on git-flavored warnings
+
+- **File:** `app/Services/GitMetadataService.php:29,174,196,224,248,293,366`, `app/Actions/EnsureRfaGitExcludeAction.php:55,79`, `app/Actions/OpenProjectFromPathAction.php:39`, `app/Actions/ResolveBranchBaseAction.php:87`
+- **Rule:** Privacy (A9, "logs avoid raw exception messages")
+- **Evidence:** Nine `Log::warning(...)` calls pass `'error' => $e->getMessage()` from `GitCommandException` or `Throwable` paths.
+- **Impact:** Git error strings regularly include absolute paths, repo internals, or stderr fragments. The stable `reason` field is already present, so the raw message adds privacy risk and log noise without aiding triage.
+- **Suggested fix:** Drop `'error' => $e->getMessage()` from these payloads. If diagnostic detail is needed, add a sanitized `error_class` and a domain-specific `error_summary` (truncated and path-scrubbed). Prefer enriching `reason` codes over storing exception text.
+
+### [WARNING] Default log channel is the scaffolding `stack` with unbounded retention
+
+- **File:** `config/logging.php:21`
+- **Rule:** Storage ("local retention is unbounded" check, [Review SHOULD])
+- **Evidence:** `'default' => env('LOG_CHANNEL', 'stack')`, where the `stack` driver loads `env('LOG_STACK', 'single')`. The `single` channel writes to `storage/logs/laravel.log` with no retention policy and `LOG_LEVEL` defaults to `debug`.
+- **Impact:** SKILL.md prescribes a `daily` default with `days => 7` and `info` level. The current default lets `laravel.log` grow unbounded and accepts debug-level entries should any leak in (today C1 is enforced, but the channel posture is not defensive). For a NativePHP app shipped to user machines, this can quietly fill the user data directory.
+- **Suggested fix:** Adopt the recommended posture: `'default' => env('LOG_CHANNEL', 'daily')` and align the `daily` channel level default to `info` with `days => 7`.
+
+### [INFO] No CI architecture test for storage rule C8
+
+- **File:** `tests/Arch/LoggingConventionsTest.php`
+- **Rule:** Enforcement Model ("Add or update Pest architecture tests when practical" for `[CI MUST]` rules)
+- **Evidence:** SKILL.md C8 is `[CI MUST]`: "Remote logging channels are not part of the default channel or recursively resolved default stack." The arch test file enforces C1, C2, C3, and `reason` payloads but does not resolve `config('logging.default')` and walk the stack.
+- **Impact:** A regression that flips `LOG_STACK` to include `slack`, `papertrail`, `syslog`, `errorlog`, or a Monolog handler with `host`/`url`/`connectionString` would not be caught at CI.
+- **Suggested fix:** Add a fifth test that requires Laravel app context, reads `config('logging.default')`, recursively walks any `stack` driver, and asserts that no resolved channel matches the disallowed driver or handler list.
+
+### [INFO] No CI architecture test for outcome vocabulary, namespaced keys, or banned path keys
+
+- **File:** `tests/Arch/LoggingConventionsTest.php`
+- **Rule:** Enforcement Model (C4, C6, C7 are `[CI MUST]`)
+- **Evidence:** C4 (`rfa.` namespace on `Context::add` keys), C6 (`rfa.outcome` literal belongs to the approved vocabulary), and C7 (banned absolute-path keys) have no corresponding Pest test.
+- **Impact:** All three rules are mechanically enforceable and today's production code passes them, but the standard expects CI coverage so regressions are caught before review.
+- **Suggested fix:** Extend `LoggingConventionsTest.php` with file-scanning tests for the three rules. The scan can reuse the existing `loggingConventionFiles()` helper and a regex over `Context::add\(['\"]...['\"]`.
+
+## Clean Areas
+
+- `softRefresh()` in `resources/views/pages/⚡review-page.blade.php` follows the canonical try/catch/finally template: clean `Context::flush()` at the top, owner context populated in `finally`, `rfa.outcome` and `rfa.duration_ms` always set, error and success branches both reach `Log::info('review.refreshed')`.
+- Every `Log::warning(...)` payload in production code carries a stable `reason` literal that matches the warning's failure mode. The C5 arch test confirms this mechanically.
+- Event names across the codebase (`review.refreshed`, `updater.available`, `updater.downloaded`, `git.diff.failed`, `git.commit_range.list_failed`, `context.comment.rejected`, and the rest) are lowercase dot-separated past-tense literals within the two-to-four segment rule.
+- No `Log::debug(...)` calls anywhere under `app/` or `resources/views/`. C1 holds.
+- `Log::info(...)` calls pass no inline payload anywhere in production code. C2 holds.
+
+## Residual Risks
+
+- The audit reviewed `app/` and `resources/views/` source. Test-only or vendor logging was not in scope.
+- The agentic review of "enough IDs and counts to debug the operation" is judgment-based and may miss missing context fields that the page's domain owners would consider important.
+- Ownership analysis assumed the documented Layer pattern: Action owns when delegated to. Some small data-fetching Actions (`LoadFileDiffAction`, `GetProjectStatusAction`) emit no canonical info event. SKILL.md exempts "pure helpers and tiny methods" so these were not flagged, but a reviewer who treats them as operation boundaries might disagree.
+- Storage finding for the default channel is based on `config/logging.php` defaults. Packaged builds may set `LOG_CHANNEL` and `LOG_STACK` in `.env` that this audit did not inspect.


### PR DESCRIPTION
Automated weekly wide-events logging audit.

Artifact: `reports/wide-events/2026-06-30.md`

This PR is human-gated. It contains the report only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRJ6L5FEVtLfbpU8G28Gsv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new audit report for Wide Events, including pass/fail checks, findings, clean areas, and residual risks.
  * Captured several warning and info items related to logging consistency, event formatting, and retention settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->