### PR TITLE
Auto-detect default base branch on project registration

### DIFF
--- a/app/Actions/RegisterProjectAction.php
+++ b/app/Actions/RegisterProjectAction.php
@@ -72,6 +72,9 @@ final readonly class RegisterProjectAction
             'branch' => $this->git->getCurrentBranch($directory),
             'remote_url' => $this->git->getRemoteUrl($path),
             'global_gitignore_path' => $this->git->resolveGlobalExcludesFile($path),
+            // Seed a sensible base only on first registration; once the project
+            // exists this is a user-editable setting we must not clobber.
+            'default_base_branch' => $this->git->detectDefaultBaseBranch($path),
         ];
 
         try {

--- a/app/Services/GitMetadataService.php
+++ b/app/Services/GitMetadataService.php
@@ -92,6 +92,24 @@ class GitMetadataService
     }
 
     /**
+     * Best-effort guess at the branch a review should diff against: a local
+     * `main`, else a local `master`. Favours `main` when both exist — it's the
+     * modern default, and the user can change it if the repo prefers otherwise.
+     * Returns null when neither is present so callers leave the base unset
+     * rather than committing to an arbitrary branch.
+     */
+    public function detectDefaultBaseBranch(string $directory): ?string
+    {
+        foreach (['main', 'master'] as $candidate) {
+            if ($this->branchExists($directory, $candidate) === true) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Read the URL configured for `origin`. Returns null when no origin is set
      * (e.g. repos with no remote, or remotes under a different name).
      */

--- a/app/Services/GitMetadataService.php
+++ b/app/Services/GitMetadataService.php
@@ -101,8 +101,17 @@ class GitMetadataService
     public function detectDefaultBaseBranch(string $directory): ?string
     {
         foreach (['main', 'master'] as $candidate) {
-            if ($this->branchExists($directory, $candidate) === true) {
+            $exists = $this->branchExists($directory, $candidate);
+
+            if ($exists === true) {
                 return $candidate;
+            }
+
+            // An indeterminate probe (timeout, lock) isn't a confirmed absence,
+            // so don't fall through to a lower-priority candidate and risk
+            // seeding `master` while `main` may well exist. Leave the base unset.
+            if ($exists === null) {
+                return null;
             }
         }
 

--- a/tests/Unit/Actions/RegisterProjectActionTest.php
+++ b/tests/Unit/Actions/RegisterProjectActionTest.php
@@ -41,6 +41,39 @@ test('seeds branch on first registration', function () {
     expect($project->branch)->toBe('main');
 });
 
+test('seeds default base branch from main on first registration', function () {
+    $project = app(RegisterProjectAction::class)->handle($this->testRepoPath);
+
+    expect($project->default_base_branch)->toBe('main');
+});
+
+test('seeds default base branch from master when the repo uses master', function () {
+    $this->runTestRepoCommand($this->testRepoPath, 'git branch -m main master');
+
+    $project = app(RegisterProjectAction::class)->handle($this->testRepoPath);
+
+    expect($project->default_base_branch)->toBe('master');
+});
+
+test('leaves default base branch unset when neither main nor master exists', function () {
+    $this->runTestRepoCommand($this->testRepoPath, 'git branch -m main trunk');
+
+    $project = app(RegisterProjectAction::class)->handle($this->testRepoPath);
+
+    expect($project->default_base_branch)->toBeNull();
+});
+
+test('does not overwrite a user-chosen base branch on re-registration', function () {
+    $project = app(RegisterProjectAction::class)->handle($this->testRepoPath);
+
+    // User narrows the review to a different base; re-registration must respect it.
+    $project->update(['default_base_branch' => 'develop']);
+
+    $refreshed = app(RegisterProjectAction::class)->handle($this->testRepoPath);
+
+    expect($refreshed->default_base_branch)->toBe('develop');
+});
+
 test('does not overwrite branch on re-registration', function () {
     app(RegisterProjectAction::class)->handle($this->testRepoPath);
 

--- a/tests/Unit/Services/GitMetadataServiceDetectDefaultBaseBranchTest.php
+++ b/tests/Unit/Services/GitMetadataServiceDetectDefaultBaseBranchTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Exceptions\GitCommandException;
 use App\Services\GitMetadataService;
 use App\Services\GitProcessService;
 use Illuminate\Support\Facades\File;
@@ -37,4 +38,23 @@ test('returns null when neither main nor master exists', function () {
     $this->runTestRepoCommand($this->tmpDir, 'git branch -m main trunk');
 
     expect($this->service->detectDefaultBaseBranch($this->tmpDir))->toBeNull();
+});
+
+test('does not fall through to master when the main probe is indeterminate', function () {
+    // `main` probe fails for an unknowable reason (exit 128 / timeout), while
+    // `master` definitively exists. We must not seed `master` off the back of an
+    // indeterminate `main` probe — `main` may well be there.
+    $service = new GitMetadataService(new class extends GitProcessService
+    {
+        public function run(string $repoPath, array $args): string
+        {
+            if (in_array('refs/heads/main', $args, true)) {
+                throw new GitCommandException(command: 'git '.implode(' ', $args), stderr: 'fatal: lock', exitCode: 128);
+            }
+
+            return '';
+        }
+    });
+
+    expect($service->detectDefaultBaseBranch('/tmp/whatever'))->toBeNull();
 });

--- a/tests/Unit/Services/GitMetadataServiceDetectDefaultBaseBranchTest.php
+++ b/tests/Unit/Services/GitMetadataServiceDetectDefaultBaseBranchTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Services\GitMetadataService;
+use App\Services\GitProcessService;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    $this->tmpDir = $this->createTempDirectory('rfa_detect_base_test_');
+    $this->initTestRepo($this->tmpDir);
+
+    File::put($this->tmpDir.'/file.txt', "ok\n");
+    $this->commitTestRepo($this->tmpDir, 'init');
+
+    $this->service = new GitMetadataService(new GitProcessService);
+});
+
+test('detects main when only main exists', function () {
+    expect($this->service->detectDefaultBaseBranch($this->tmpDir))->toBe('main');
+});
+
+test('detects master when only master exists', function () {
+    $this->runTestRepoCommand($this->tmpDir, 'git branch -m main master');
+
+    expect($this->service->detectDefaultBaseBranch($this->tmpDir))->toBe('master');
+});
+
+test('favours main when both main and master exist', function () {
+    $this->runTestRepoCommand($this->tmpDir, 'git branch master');
+
+    expect($this->service->detectDefaultBaseBranch($this->tmpDir))->toBe('main');
+});
+
+test('returns null when neither main nor master exists', function () {
+    $this->runTestRepoCommand($this->tmpDir, 'git branch -m main trunk');
+
+    expect($this->service->detectDefaultBaseBranch($this->tmpDir))->toBeNull();
+});


### PR DESCRIPTION
## Summary
Adds automatic detection of the default base branch when a project is first registered, seeding the `default_base_branch` field with either `main` or `master` based on what exists in the repository.

## Key Changes
- **New `GitMetadataService.detectDefaultBaseBranch()` method** — Intelligently detects the repository's default base branch by checking for `main` first (modern convention), then `master` as fallback. Returns `null` if neither exists, allowing callers to leave the field unset rather than committing to an arbitrary branch.
- **Updated `RegisterProjectAction`** — Seeds `default_base_branch` only on first registration via the new detection method. Respects user edits on re-registration by not overwriting an already-set value.
- **Comprehensive test coverage** — Added `GitMetadataServiceDetectDefaultBaseBranchTest` with four test cases covering all detection scenarios (main only, master only, both present, neither present). Extended `RegisterProjectActionTest` with four additional tests validating the seeding behavior and re-registration safety.

## Implementation Details
- Detection favors `main` when both branches exist—it's the modern default, and users can change it if their repo prefers otherwise.
- The action only sets `default_base_branch` during initial project creation; subsequent registrations preserve user customizations.
- Tests use temporary git repositories to validate behavior across different branch configurations.

https://claude.ai/code/session_01LD7RFVg2p6H3gT9isbFeGA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically detects and stores a project’s default base branch during first-time registration.
  * Supports common branch names and chooses the most likely review base branch when available.

* **Bug Fixes**
  * Preserves any manually updated default base branch when a project is registered again.
  * Leaves the default base branch unset when no suitable branch can be confirmed.

* **Tests**
  * Added coverage for branch detection and registration behavior across common branch setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->