### PR TITLE
Rename settings dropdown to project settings for clarity

### DIFF
--- a/resources/views/pages/partials/review-settings-dropdown.blade.php
+++ b/resources/views/pages/partials/review-settings-dropdown.blade.php
@@ -1,11 +1,17 @@
-{{-- Settings dropdown for the review page: global .gitignore toggle, default base branch, and linked external paths. Rendered inside the page, so wire: bindings and component props resolve against it. The caller guards on isCommitMode(). --}}
+{{-- Project settings dropdown for the review page: global .gitignore toggle, default base branch, and linked external paths. Rendered inside the page, so wire: bindings and component props resolve against it. The caller guards on isCommitMode(). --}}
 
 <flux:dropdown position="bottom" align="end">
-    <flux:tooltip content="Settings">
+    <flux:tooltip content="Project settings">
         <flux:button variant="ghost" size="sm" icon="cog-6-tooth" icon:variant="outline"
-            aria-label="Settings" />
+            aria-label="Project settings" />
     </flux:tooltip>
     <flux:menu>
+        <div class="px-3 pt-2 pb-1">
+            <span class="section-label text-[10px] font-display font-semibold uppercase tracking-brutal text-gh-muted">
+                Project settings
+            </span>
+        </div>
+        <flux:menu.separator />
         <flux:menu.item keep-open>
             <flux:checkbox wire:model.live="respectGlobalGitignore" label="Global .gitignore" class="text-xs whitespace-nowrap" />
         </flux:menu.item>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1412,7 +1412,7 @@ new #[Layout('layouts.app')] class extends Component
                     </div>
                 @endif
 
-                {{-- Settings --}}
+                {{-- Project settings --}}
                 @if(! $this->isCommitMode())
                     @include('pages.partials.review-settings-dropdown')
                 @endif


### PR DESCRIPTION
## Summary
Updated the review page settings dropdown to be explicitly labeled as "Project settings" throughout the UI and code comments, improving clarity about what settings are being configured.

## Key Changes
- Updated dropdown tooltip and button aria-label from "Settings" to "Project settings"
- Added a section header label inside the dropdown menu to clearly identify it as "Project settings"
- Updated code comments to reflect "Project settings" instead of generic "Settings"
- Added visual separator after the section header for better menu organization

## Implementation Details
- The dropdown now includes a styled section label (`section-label`) with appropriate typography and spacing
- A `flux:menu.separator` provides visual distinction between the header and menu items
- All user-facing text and accessibility labels now consistently use "Project settings" terminology
- Changes are isolated to the review page settings dropdown component and its parent template

https://claude.ai/code/session_01AN7WHyqPeJzNaVUqtbDjXt