### PR TITLE
Refactor theme switcher to support light/dark/system modes

### DIFF
--- a/resources/CLAUDE.md
+++ b/resources/CLAUDE.md
@@ -43,9 +43,10 @@ When a path's text content is set client-side (e.g. `x-text` from a JS object), 
 - Prefer raw text `text-gh-green`/`text-gh-red` over `flux:badge` for +/- counts in headers
 
 ## Dark Mode
-- Managed by Flux's `@fluxAppearance` + `$flux.dark`
-- Toggle: `$flux.dark = ! $flux.dark`
-- System preference detection is automatic via Flux
+- Managed by Flux's `@fluxAppearance` + `$flux.appearance` (`'light' | 'dark' | 'system'`)
+- The `theme-switcher` SFC is a segmented `flux:radio.group` bound `x-model="$flux.appearance"` — three states: light, dark, and system (follows the OS via `prefers-color-scheme`). `system` is the default when the user hasn't chosen.
+- Flux applies/removes the `dark` class on `<html>` and tracks the OS in system mode; read the resolved state via `$flux.dark` when you only need the boolean.
+- The switcher also mirrors the *resolved* theme into the persistent `rfa_theme` cookie (`dark`/`light`, 1-year) so non-Livewire consumers can read it without JS. Keep that cookie write in sync if you change the switcher.
 
 ## Visual Style
 - Brutalist/raw aesthetic: bold type, dramatic scale contrast, generous whitespace in chrome

--- a/resources/CLAUDE.md
+++ b/resources/CLAUDE.md
@@ -45,8 +45,8 @@ When a path's text content is set client-side (e.g. `x-text` from a JS object), 
 ## Dark Mode
 - Managed by Flux's `@fluxAppearance` + `$flux.appearance` (`'light' | 'dark' | 'system'`)
 - The `theme-switcher` SFC is a segmented `flux:radio.group` bound `x-model="$flux.appearance"` — three states: light, dark, and system (follows the OS via `prefers-color-scheme`). `system` is the default when the user hasn't chosen.
-- Flux applies/removes the `dark` class on `<html>` and tracks the OS in system mode; read the resolved state via `$flux.dark` when you only need the boolean.
-- The switcher also mirrors the *resolved* theme into the persistent `rfa_theme` cookie (`dark`/`light`, 1-year) so non-Livewire consumers can read it without JS. Keep that cookie write in sync if you change the switcher.
+- Flux applies/removes the `dark` class on `<html>` and tracks the OS in system mode; read the resolved boolean via `$flux.dark` (reactive to both explicit picks and OS changes while in system mode).
+- The switcher mirrors that `$flux.dark` value into the persistent `rfa_theme` cookie (`dark`/`light`, 1-year) via a single `x-effect`, so non-Livewire consumers can read the resolved theme without JS.
 
 ## Visual Style
 - Brutalist/raw aesthetic: bold type, dramatic scale contrast, generous whitespace in chrome

--- a/resources/views/livewire/⚡theme-switcher.blade.php
+++ b/resources/views/livewire/⚡theme-switcher.blade.php
@@ -7,18 +7,10 @@ new class extends Component {};
 
 <div
     x-data
-    x-effect="
-        document.cookie = 'rfa_theme=' + (
-            ($flux.appearance === 'dark' || ($flux.appearance === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)) ? 'dark' : 'light'
-        ) + ';path=/;max-age=31536000;SameSite=Lax';
-    "
-    x-init="
-        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-            if ($flux.appearance === 'system') {
-                document.cookie = 'rfa_theme=' + (e.matches ? 'dark' : 'light') + ';path=/;max-age=31536000;SameSite=Lax';
-            }
-        });
-    "
+    {{-- Mirror the resolved theme into the rfa_theme cookie. $flux.dark is reactive
+         to both explicit picks and OS changes while in system mode, so this single
+         effect covers all three states without a separate matchMedia listener. --}}
+    x-effect="document.cookie = 'rfa_theme=' + ($flux.dark ? 'dark' : 'light') + ';path=/;max-age=31536000;SameSite=Lax'"
 >
     <flux:radio.group x-model="$flux.appearance" variant="segmented" size="sm" aria-label="Theme">
         <flux:tooltip content="Light">

--- a/resources/views/livewire/⚡theme-switcher.blade.php
+++ b/resources/views/livewire/⚡theme-switcher.blade.php
@@ -7,27 +7,28 @@ new class extends Component {};
 
 <div
     x-data
+    x-effect="
+        document.cookie = 'rfa_theme=' + (
+            ($flux.appearance === 'dark' || ($flux.appearance === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)) ? 'dark' : 'light'
+        ) + ';path=/;max-age=31536000;SameSite=Lax';
+    "
     x-init="
-        document.cookie = 'rfa_theme=' + (document.documentElement.classList.contains('dark') ? 'dark' : 'light') + ';path=/;max-age=31536000;SameSite=Lax';
         window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-            if (!localStorage.getItem('flux.appearance')) {
+            if ($flux.appearance === 'system') {
                 document.cookie = 'rfa_theme=' + (e.matches ? 'dark' : 'light') + ';path=/;max-age=31536000;SameSite=Lax';
             }
         });
     "
 >
-    <flux:tooltip content="Switch to dark mode">
-        <flux:button
-            x-on:click="$flux.dark = !$flux.dark; document.cookie = 'rfa_theme=' + ($flux.dark ? 'dark' : 'light') + ';path=/;max-age=31536000;SameSite=Lax'"
-            variant="ghost" size="sm" aria-label="Switch to dark mode"
-            icon="moon" icon:variant="outline" x-show="!$flux.dark" x-cloak
-        />
-    </flux:tooltip>
-    <flux:tooltip content="Switch to light mode">
-        <flux:button
-            x-on:click="$flux.dark = !$flux.dark; document.cookie = 'rfa_theme=' + ($flux.dark ? 'dark' : 'light') + ';path=/;max-age=31536000;SameSite=Lax'"
-            variant="ghost" size="sm" aria-label="Switch to light mode"
-            icon="sun" icon:variant="outline" x-show="$flux.dark"
-        />
-    </flux:tooltip>
+    <flux:radio.group x-model="$flux.appearance" variant="segmented" size="sm" aria-label="Theme">
+        <flux:tooltip content="Light">
+            <flux:radio value="light" icon="sun" icon:variant="outline" aria-label="Light theme" />
+        </flux:tooltip>
+        <flux:tooltip content="Dark">
+            <flux:radio value="dark" icon="moon" icon:variant="outline" aria-label="Dark theme" />
+        </flux:tooltip>
+        <flux:tooltip content="Match system">
+            <flux:radio value="system" icon="computer-desktop" icon:variant="outline" aria-label="Match system theme" />
+        </flux:tooltip>
+    </flux:radio.group>
 </div>

--- a/tests/Feature/View/ThemeSwitcherComponentTest.php
+++ b/tests/Feature/View/ThemeSwitcherComponentTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use Livewire\Livewire;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+test('offers light, dark, and system as the three theme states', function () {
+    Livewire::test('theme-switcher')
+        ->assertSeeHtml('value="light"')
+        ->assertSeeHtml('value="dark"')
+        ->assertSeeHtml('value="system"');
+});
+
+test('binds the segmented control to the flux appearance state', function () {
+    Livewire::test('theme-switcher')
+        ->assertSeeHtml('x-model="$flux.appearance"')
+        ->assertSeeHtml('data-flux-radio-group-segmented');
+});
+
+test('mirrors the resolved theme into the rfa_theme cookie', function () {
+    Livewire::test('theme-switcher')
+        ->assertSeeHtml('rfa_theme');
+});


### PR DESCRIPTION
## Summary
Upgrades the theme switcher from a binary dark/light toggle to a three-state segmented control that supports light, dark, and system (OS preference) modes. Aligns the component with Flux's `$flux.appearance` state model and improves cookie persistence logic.

## Key Changes
- **UI Refactor**: Replaced two toggle buttons with a `flux:radio.group` segmented control offering three options: light, dark, and system
- **State Management**: Migrated from `$flux.dark` boolean toggle to `$flux.appearance` enum (`'light' | 'dark' | 'system'`)
- **Cookie Persistence**: 
  - Moved cookie write logic from click handlers to `x-effect` to reactively sync the *resolved* theme (accounting for system preference when in system mode)
  - Simplified system preference detection: only updates cookie on OS change if user is in system mode
- **Documentation**: Updated CLAUDE.md to document the new three-state model, cookie behavior, and how to read the resolved boolean via `$flux.dark` when needed
- **Tests**: Added feature test covering the three radio options, segmented binding, and cookie presence

## Implementation Details
- The `x-effect` watches `$flux.appearance` and writes the resolved theme to `rfa_theme` cookie (1-year expiry, SameSite=Lax)
- System mode respects `prefers-color-scheme: dark` media query; cookie updates when OS preference changes and user hasn't manually selected a theme
- Non-Livewire consumers can read the persistent `rfa_theme` cookie without JavaScript

https://claude.ai/code/session_01Dx7BzW5FjG2VQnKCukoYXU