### PR TITLE
Add inline base-branch editor to branch picker

### DIFF
--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -148,10 +148,20 @@
                 return base.state === BranchBaseState.Ready;
             },
 
+            /**
+             * The configured base branch name, preferring the resolved snapshot
+             * value and falling back to the project setting. Empty when none is
+             * set. Single source of truth for the row label, the edit affordance,
+             * and the editor's initial draft.
+             */
+            get baseBranchName() {
+                const base = this.$wire.branchBase;
+                return (base && base.baseBranch) || this.$wire.defaultBaseBranch || '';
+            },
+
             /** True when a base branch is configured (drives the edit affordance label). */
             get hasBaseBranch() {
-                const base = this.$wire.branchBase;
-                return Boolean((base && base.baseBranch) || this.$wire.defaultBaseBranch);
+                return Boolean(this.baseBranchName);
             },
 
             /**
@@ -288,8 +298,6 @@
 
             closePanel() {
                 this.open = false;
-                this.baseEditing = false;
-                this.baseDraft = '';
                 if (Alpine.store('overlays').is('branch-explorer')) Alpine.store('overlays').close();
             },
 
@@ -687,8 +695,7 @@
 
             /** Reveal the inline editor, seeded with the current base, and focus it. */
             startEditBase() {
-                const base = this.$wire.branchBase;
-                this.baseDraft = (base && base.baseBranch) || this.$wire.defaultBaseBranch || '';
+                this.baseDraft = this.baseBranchName;
                 this.baseEditing = true;
                 this._clearSelectionError();
                 this.$nextTick(() => this.$refs.baseInput?.focus());

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -107,6 +107,10 @@
             activeDiffFrom: activeDiffFrom || 'HEAD',
             projectSlug,
             selectionError: '',
+            // Inline base-branch editor state for the "Since {base}" row. Lets the
+            // user set the project base without opening project settings.
+            baseEditing: false,
+            baseDraft: '',
             selectedHashes: [],
             workingTreeSelected: false,
             // Shift-click anchor. At most one is active at a time:
@@ -144,6 +148,12 @@
                 return base.state === BranchBaseState.Ready;
             },
 
+            /** True when a base branch is configured (drives the edit affordance label). */
+            get hasBaseBranch() {
+                const base = this.$wire.branchBase;
+                return Boolean((base && base.baseBranch) || this.$wire.defaultBaseBranch);
+            },
+
             /**
              * One-line explanation under the "Since {base}" row. For the ready
              * state it's the scope summary; otherwise it names why the row can't
@@ -167,7 +177,7 @@
                     case BranchBaseState.OnBaseBranch:
                         return "you're on the base branch";
                     case BranchBaseState.NotConfigured:
-                        return 'set a base branch in project settings';
+                        return 'set a base branch to compare';
                     default:
                         return '';
                 }
@@ -261,6 +271,8 @@
                 this.open = true;
                 this.search = '';
                 this.selectedIndex = 0;
+                this.baseEditing = false;
+                this.baseDraft = '';
                 this._clearSelectionError();
                 Alpine.store('overlays').open('branch-explorer');
 
@@ -276,6 +288,8 @@
 
             closePanel() {
                 this.open = false;
+                this.baseEditing = false;
+                this.baseDraft = '';
                 if (Alpine.store('overlays').is('branch-explorer')) Alpine.store('overlays').close();
             },
 
@@ -654,6 +668,47 @@
                         variant: 'info',
                     });
                 }
+            },
+
+            /**
+             * Row click router for the "Since {base}" row body. With a usable
+             * base it applies the since-base diff (the row body's default
+             * one-click path); otherwise it opens the inline editor - the only
+             * thing the user can do here when no base resolves.
+             */
+            onSinceBaseRowClick() {
+                if (this.baseEditing) return;
+                if (this.sinceBaseActionable) {
+                    this.viewSinceBase();
+                    return;
+                }
+                this.startEditBase();
+            },
+
+            /** Reveal the inline editor, seeded with the current base, and focus it. */
+            startEditBase() {
+                const base = this.$wire.branchBase;
+                this.baseDraft = (base && base.baseBranch) || this.$wire.defaultBaseBranch || '';
+                this.baseEditing = true;
+                this._clearSelectionError();
+                this.$nextTick(() => this.$refs.baseInput?.focus());
+            },
+
+            /**
+             * Persist the typed base branch through the component, which re-resolves
+             * the "Since {base}" row in place and syncs the page. An empty value
+             * clears the base (mirrors the settings input).
+             */
+            async saveBase() {
+                const value = this.baseDraft.trim();
+                this.baseEditing = false;
+                this._clearSelectionError();
+                await this.$wire.setDefaultBaseBranch(value);
+            },
+
+            cancelEditBase() {
+                this.baseEditing = false;
+                this.baseDraft = '';
             },
 
             /**

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -681,7 +681,7 @@
             /**
              * Row click router for the "Since {base}" row body. With a usable
              * base it applies the since-base diff (the row body's default
-             * one-click path); otherwise it opens the inline editor - the only
+             * one-click path). Otherwise it opens the inline editor, the only
              * thing the user can do here when no base resolves.
              */
             onSinceBaseRowClick() {

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -2,6 +2,7 @@
 
 use App\Actions\LoadBranchExplorerSnapshotAction;
 use App\Actions\ResolveBranchExplorerSelectionAction;
+use App\Actions\UpdateProjectSettingAction;
 use App\DTOs\BranchExplorerSnapshot;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\Renderless;
@@ -10,6 +11,9 @@ use Livewire\Component;
 new class extends Component {
     #[Locked]
     public string $repoPath = '';
+
+    #[Locked]
+    public int $projectId = 0;
 
     #[Locked]
     public string $currentBranch = '';
@@ -77,6 +81,31 @@ new class extends Component {
         );
 
         $this->hydrateSnapshot($snapshot);
+    }
+
+    /**
+     * Persist the project's base branch from inside the picker and re-resolve
+     * the snapshot in place, so the "Since {base}" row reflects the new base
+     * without remounting (a remount would close the open panel). Mirrors the
+     * settings dropdown's {@see updatedDefaultBaseBranch}; the page is kept in
+     * sync via the dispatched event so both entry points agree.
+     */
+    #[Renderless]
+    public function setDefaultBaseBranch(string $branch): void
+    {
+        $value = trim($branch);
+        $this->defaultBaseBranch = $value;
+
+        app(UpdateProjectSettingAction::class)->handle($this->projectId, [
+            'default_base_branch' => $value === '' ? null : $value,
+        ]);
+
+        $this->loadSnapshot(
+            $this->snapshotBranch !== '' ? $this->snapshotBranch : $this->currentBranch,
+            count($this->commits),
+        );
+
+        $this->dispatch('default-base-branch-changed', value: $value);
     }
 
     #[Renderless]
@@ -380,23 +409,24 @@ new class extends Component {
                         </div>
 
                         {{-- "Since {base}" row: always present so its position never
-                             shifts. Clickable when the base is configured, resolved,
-                             and HEAD is ahead; otherwise disabled with a reason that
-                             names why it can't be used right now. --}}
+                             shifts. With a usable base (configured, resolved, HEAD
+                             ahead) the row toggles the since-base selection; otherwise
+                             a reason names why, and clicking the row — or the pencil —
+                             opens an inline editor to set the base without leaving the
+                             picker. The project-settings input does the same thing. --}}
                         <div
                             data-testid="since-base-row"
                             class="px-4 py-2.5 border-b border-gh-border/50 group"
                             :class="{
-                                'cursor-pointer hover:bg-gh-border/20 transition-colors': sinceBaseActionable,
-                                'opacity-60 cursor-not-allowed': !sinceBaseActionable,
-                                'bg-gh-link/5 border-l-2 border-l-gh-link': sinceBaseActionable && sinceBaseSelected,
-                                'bg-gh-text/5 border-l-2 border-l-gh-text': sinceBaseActionable && sinceBaseActive && !sinceBaseSelected,
+                                'cursor-pointer hover:bg-gh-border/20 transition-colors': !baseEditing,
+                                'bg-gh-link/5 border-l-2 border-l-gh-link': !baseEditing && sinceBaseActionable && sinceBaseSelected,
+                                'bg-gh-text/5 border-l-2 border-l-gh-text': !baseEditing && sinceBaseActionable && sinceBaseActive && !sinceBaseSelected,
                             }"
-                            :aria-disabled="sinceBaseActionable ? null : 'true'"
                             :aria-current="sinceBaseActionable && sinceBaseActive ? 'true' : null"
-                            @click="sinceBaseActionable && viewSinceBase()"
+                            @click="onSinceBaseRowClick()"
                         >
-                            <div class="flex items-start gap-2">
+                            {{-- Display mode --}}
+                            <div class="flex items-start gap-2" x-show="!baseEditing">
                                 <button
                                     type="button"
                                     data-testid="since-base-select-toggle"
@@ -420,10 +450,61 @@ new class extends Component {
                                 </button>
                                 <div class="min-w-0 flex-1">
                                     <div class="text-xs text-gh-text truncate font-medium tracking-tight">
-                                        Since <span class="font-mono" x-text="($wire.branchBase && $wire.branchBase.baseBranch) || 'base branch'"></span>
+                                        Since <span class="font-mono" x-text="(($wire.branchBase && $wire.branchBase.baseBranch) || $wire.defaultBaseBranch) || 'base branch'"></span>
                                     </div>
                                     <span class="block mt-0.5 text-[10px] font-mono text-gh-muted" x-text="sinceBaseReason"></span>
                                 </div>
+                                {{-- Set / change the base branch without leaving the picker. --}}
+                                <button
+                                    type="button"
+                                    data-testid="since-base-edit"
+                                    @click.stop="startEditBase()"
+                                    class="shrink-0 flex items-center justify-center size-6 rounded-md text-gh-muted hover:text-gh-text hover:bg-gh-border/40 transition-all cursor-pointer opacity-0 group-hover:opacity-100"
+                                    :class="{ '!opacity-100': !hasBaseBranch }"
+                                    :title="hasBaseBranch ? 'Change base branch' : 'Set base branch'"
+                                    :aria-label="hasBaseBranch ? 'Change base branch' : 'Set base branch'"
+                                >
+                                    <flux:icon icon="pencil-square" variant="outline" class="!size-3.5" />
+                                </button>
+                            </div>
+
+                            {{-- Edit mode: type a branch name to set the project base. --}}
+                            <div class="flex items-start gap-2" x-show="baseEditing" x-cloak @click.stop>
+                                <span class="mt-0.5 size-4 shrink-0" aria-hidden="true"></span>
+                                <div class="min-w-0 flex-1">
+                                    <flux:input
+                                        x-ref="baseInput"
+                                        x-model="baseDraft"
+                                        @keydown.enter.stop.prevent="saveBase()"
+                                        @keydown.escape.stop.prevent="cancelEditBase()"
+                                        placeholder="dev, master, main..."
+                                        size="sm"
+                                        variant="filled"
+                                        class="!font-mono text-xs"
+                                        data-testid="since-base-input"
+                                    />
+                                    <span class="block mt-1 text-[10px] font-mono text-gh-muted">Enter to save &middot; Esc to cancel</span>
+                                </div>
+                                <button
+                                    type="button"
+                                    data-testid="since-base-save"
+                                    @click.stop="saveBase()"
+                                    class="shrink-0 flex items-center justify-center size-6 rounded-md text-gh-link hover:bg-gh-link/15 transition-colors cursor-pointer"
+                                    title="Save base branch"
+                                    aria-label="Save base branch"
+                                >
+                                    <flux:icon icon="check" variant="outline" class="!size-3.5" />
+                                </button>
+                                <button
+                                    type="button"
+                                    data-testid="since-base-cancel"
+                                    @click.stop="cancelEditBase()"
+                                    class="shrink-0 flex items-center justify-center size-6 rounded-md text-gh-muted hover:text-gh-text hover:bg-gh-border/40 transition-colors cursor-pointer"
+                                    title="Cancel"
+                                    aria-label="Cancel"
+                                >
+                                    <flux:icon icon="x-mark" variant="outline" class="!size-3.5" />
+                                </button>
                             </div>
                         </div>
 

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -87,16 +87,15 @@ new class extends Component {
      * Persist the project's base branch from inside the picker and re-resolve
      * the snapshot in place, so the "Since {base}" row reflects the new base
      * without remounting (a remount would close the open panel). Mirrors the
-     * settings dropdown's {@see updatedDefaultBaseBranch}; the page is kept in
-     * sync via the dispatched event so both entry points agree.
+     * settings dropdown's {@see updatedDefaultBaseBranch}. The dispatched event
+     * keeps the page in sync so both entry points agree.
      */
     #[Renderless]
     public function setDefaultBaseBranch(string $branch): void
     {
         $value = trim($branch);
 
-        // A no-op save (same base) would still hit the DB and re-resolve the
-        // snapshot for no visible change - skip the whole round-trip.
+        // Skip the DB write and snapshot reload when the base is unchanged.
         if ($value === $this->defaultBaseBranch) {
             return;
         }
@@ -417,10 +416,11 @@ new class extends Component {
 
                         {{-- "Since {base}" row: always present so its position never
                              shifts. With a usable base (configured, resolved, HEAD
-                             ahead) the row toggles the since-base selection; otherwise
-                             a reason names why, and clicking the row — or the pencil —
-                             opens an inline editor to set the base without leaving the
-                             picker. The project-settings input does the same thing. --}}
+                             ahead) the row body applies the since-base diff and the
+                             checkbox seeds the selection. Without one, a reason names
+                             why, and clicking the row (or the pencil) opens an inline
+                             editor to set the base without leaving the picker. The
+                             project-settings input does the same thing. --}}
                         <div
                             data-testid="since-base-row"
                             class="px-4 py-2.5 border-b border-gh-border/50 group"

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -94,6 +94,13 @@ new class extends Component {
     public function setDefaultBaseBranch(string $branch): void
     {
         $value = trim($branch);
+
+        // A no-op save (same base) would still hit the DB and re-resolve the
+        // snapshot for no visible change - skip the whole round-trip.
+        if ($value === $this->defaultBaseBranch) {
+            return;
+        }
+
         $this->defaultBaseBranch = $value;
 
         app(UpdateProjectSettingAction::class)->handle($this->projectId, [
@@ -450,7 +457,7 @@ new class extends Component {
                                 </button>
                                 <div class="min-w-0 flex-1">
                                     <div class="text-xs text-gh-text truncate font-medium tracking-tight">
-                                        Since <span class="font-mono" x-text="(($wire.branchBase && $wire.branchBase.baseBranch) || $wire.defaultBaseBranch) || 'base branch'"></span>
+                                        Since <span class="font-mono" x-text="baseBranchName || 'base branch'"></span>
                                     </div>
                                     <span class="block mt-0.5 text-[10px] font-mono text-gh-muted" x-text="sinceBaseReason"></span>
                                 </div>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -409,9 +409,9 @@ new #[Layout('layouts.app')] class extends Component
     /**
      * Mirror a base-branch change made inside the branch picker back onto the
      * page so the settings input and the "Since {base}" header label stay in
-     * sync. The picker already persisted it and re-resolved its own snapshot;
-     * we skip the render so the picker (keyed on `defaultBaseBranch`) isn't
-     * remounted out from under the open panel.
+     * sync. The picker already persisted it and re-resolved its own snapshot.
+     * Skipping the render keeps the picker (keyed on `defaultBaseBranch`) from
+     * remounting out from under the open panel.
      */
     #[On('default-base-branch-changed')]
     public function syncDefaultBaseBranch(string $value): void

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -406,6 +406,21 @@ new #[Layout('layouts.app')] class extends Component
         $this->isSinceBaseView = $this->detectSinceBaseView();
     }
 
+    /**
+     * Mirror a base-branch change made inside the branch picker back onto the
+     * page so the settings input and the "Since {base}" header label stay in
+     * sync. The picker already persisted it and re-resolved its own snapshot;
+     * we skip the render so the picker (keyed on `defaultBaseBranch`) isn't
+     * remounted out from under the open panel.
+     */
+    #[On('default-base-branch-changed')]
+    public function syncDefaultBaseBranch(string $value): void
+    {
+        $this->defaultBaseBranch = trim($value);
+        $this->isSinceBaseView = $this->detectSinceBaseView();
+        $this->skipRender();
+    }
+
     public function addExternalPath(): void
     {
         $this->pickAndLinkExternalPath(isFile: false);
@@ -1311,6 +1326,7 @@ new #[Layout('layouts.app')] class extends Component
                     <livewire:branch-explorer
                         :key="'branch-explorer-'.$projectId.'-'.md5($projectBranch.'|'.$defaultBaseBranch)"
                         :repo-path="$repoPath"
+                        :project-id="$projectId"
                         :current-branch="$projectBranch"
                         :project-slug="$projectSlug"
                         :active-commit-hash="$diffTo"

--- a/tests/Js/branch-explorer.test.js
+++ b/tests/Js/branch-explorer.test.js
@@ -657,7 +657,7 @@ describe('since-base row predictability', () => {
         expect(withBase(BranchBaseState.UpToDate).sinceBaseReason).toBe('no commits ahead');
         expect(withBase(BranchBaseState.MissingRef).sinceBaseReason).toBe('base ref not found locally (run git fetch)');
         expect(withBase(BranchBaseState.OnBaseBranch).sinceBaseReason).toBe("you're on the base branch");
-        expect(withBase(BranchBaseState.NotConfigured).sinceBaseReason).toBe('set a base branch in project settings');
+        expect(withBase(BranchBaseState.NotConfigured).sinceBaseReason).toBe('set a base branch to compare');
     });
 
     it('explains the off-branch case with the current branch name', () => {
@@ -726,6 +726,100 @@ describe('since-base auto-apply (row body)', () => {
         expect(makeForView({ activeCommitHash: 'basesha', activeDiffFrom: 'basesha', branchBase: readyBase }).sinceBaseActive).toBe(false);
         expect(makeForView({ activeCommitHash: null, activeDiffFrom: 'basesha', branchBase: readyBase, branch: 'feature/x' }).sinceBaseActive).toBe(false);
         expect(makeForView({ activeCommitHash: null, activeDiffFrom: 'basesha', branchBase: null }).sinceBaseActive).toBe(false);
+    });
+});
+
+describe('inline base-branch editor', () => {
+    function makeEditable({ branchBase = null, defaultBaseBranch = '' } = {}) {
+        const a = makeForView({ branchBase });
+        a.$wire.defaultBaseBranch = defaultBaseBranch;
+        a.$wire.setDefaultBaseBranch = vi.fn(async () => {});
+        a.$wire.applySelection = vi.fn(async () => {});
+        a.$wire.snapshotKey = 'snap-1';
+        a.$nextTick = (cb) => cb && cb();
+        a.$refs = { baseInput: { focus: vi.fn() } };
+        return a;
+    }
+
+    it('hasBaseBranch reflects the configured base from branchBase or the prop', () => {
+        expect(makeEditable().hasBaseBranch).toBe(false);
+        expect(makeEditable({ defaultBaseBranch: 'dev' }).hasBaseBranch).toBe(true);
+        expect(makeEditable({ branchBase: { state: BranchBaseState.MissingRef, baseBranch: 'dev' } }).hasBaseBranch).toBe(true);
+    });
+
+    it('startEditBase seeds the draft from the configured base and focuses the input', () => {
+        const a = makeEditable({ branchBase: { state: BranchBaseState.Ready, baseBranch: 'dev', hashesInRange: [] } });
+
+        a.startEditBase();
+
+        expect(a.baseEditing).toBe(true);
+        expect(a.baseDraft).toBe('dev');
+        expect(a.$refs.baseInput.focus).toHaveBeenCalledTimes(1);
+    });
+
+    it('startEditBase falls back to the defaultBaseBranch prop when branchBase has no name', () => {
+        const a = makeEditable({ defaultBaseBranch: 'main' });
+
+        a.startEditBase();
+
+        expect(a.baseDraft).toBe('main');
+    });
+
+    it('saveBase trims the draft, persists through the wire, and closes the editor', async () => {
+        const a = makeEditable();
+        a.baseEditing = true;
+        a.baseDraft = '  dev  ';
+
+        await a.saveBase();
+
+        expect(a.$wire.setDefaultBaseBranch).toHaveBeenCalledWith('dev');
+        expect(a.baseEditing).toBe(false);
+    });
+
+    it('saveBase passes an empty string to clear the base', async () => {
+        const a = makeEditable({ defaultBaseBranch: 'dev' });
+        a.baseEditing = true;
+        a.baseDraft = '   ';
+
+        await a.saveBase();
+
+        expect(a.$wire.setDefaultBaseBranch).toHaveBeenCalledWith('');
+    });
+
+    it('cancelEditBase closes the editor and discards the draft', () => {
+        const a = makeEditable();
+        a.baseEditing = true;
+        a.baseDraft = 'typed-but-discarded';
+
+        a.cancelEditBase();
+
+        expect(a.baseEditing).toBe(false);
+        expect(a.baseDraft).toBe('');
+    });
+
+    it('row click applies since-base when actionable, otherwise opens the editor', () => {
+        const ready = makeEditable({ branchBase: { state: BranchBaseState.Ready, baseBranch: 'dev', baseSha: 'base', hashesInRange: ['aaa1'] } });
+        ready.$wire.commits = commits;
+        ready.onSinceBaseRowClick();
+        // Actionable row body routes through the auto-apply path, not the editor.
+        expect(ready.baseEditing).toBe(false);
+        expect(ready.workingTreeSelected).toBe(true);
+        expect(ready.$wire.applySelection).toHaveBeenCalled();
+
+        const unset = makeEditable();
+        unset.onSinceBaseRowClick();
+        expect(unset.baseEditing).toBe(true);
+        expect(unset.$wire.applySelection).not.toHaveBeenCalled();
+    });
+
+    it('row click is a no-op while the editor is open', () => {
+        const a = makeEditable({ branchBase: { state: BranchBaseState.Ready, baseBranch: 'dev', baseSha: 'base', hashesInRange: ['aaa1'] } });
+        a.baseEditing = true;
+
+        a.onSinceBaseRowClick();
+
+        expect(a.workingTreeSelected).toBe(false);
+        expect(a.$wire.applySelection).not.toHaveBeenCalled();
     });
 });
 

--- a/tests/Unit/Livewire/BranchExplorerTest.php
+++ b/tests/Unit/Livewire/BranchExplorerTest.php
@@ -193,6 +193,21 @@ test('setDefaultBaseBranch persists the base, reloads the snapshot, and notifies
         ->and($component->get('branchBase')['baseBranch'])->toBe('dev');
 });
 
+test('setDefaultBaseBranch is a no-op when the base is unchanged', function () {
+    fakeGitMetadata();
+
+    $project = Project::factory()->create(['default_base_branch' => 'dev']);
+
+    Livewire::test('branch-explorer', [
+        'repoPath' => '/tmp/repo',
+        'projectId' => $project->id,
+        'currentBranch' => 'main',
+        'defaultBaseBranch' => 'dev',
+    ])
+        ->call('setDefaultBaseBranch', '  dev  ')
+        ->assertNotDispatched('default-base-branch-changed');
+});
+
 test('setDefaultBaseBranch with a blank value clears the project base', function () {
     fakeGitMetadata();
 

--- a/tests/Unit/Livewire/BranchExplorerTest.php
+++ b/tests/Unit/Livewire/BranchExplorerTest.php
@@ -2,11 +2,13 @@
 
 use App\DTOs\BranchEntry;
 use App\DTOs\CommitEntry;
+use App\Models\Project;
 use App\Services\GitMetadataService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-uses(TestCase::class);
+uses(TestCase::class, RefreshDatabase::class);
 
 function fakeGitMetadata(array $branches = ['local' => [], 'remote' => []], array $commits = []): GitMetadataService
 {
@@ -162,6 +164,50 @@ test('applySelection dispatches an inline error for non-contiguous commits', fun
         ->assertDispatched('branch-explorer-selection-error', function (string $event, array $params): bool {
             return str_contains($params['message'] ?? '', 'pick every commit');
         });
+});
+
+test('setDefaultBaseBranch persists the base, reloads the snapshot, and notifies the page', function () {
+    $mock = fakeGitMetadata(commits: [
+        new CommitEntry('h1', 'h1', 'tip commit', 'me', '1m', '2026-01-01'),
+    ]);
+    // Resolved ref but no merge base keeps resolution off the real git binary
+    // while still proving the reload picked up the newly-configured base.
+    $mock->shouldReceive('getMergeBase')->andReturn(null);
+
+    $project = Project::factory()->create(['default_base_branch' => null]);
+
+    $component = Livewire::test('branch-explorer', [
+        'repoPath' => '/tmp/repo',
+        'projectId' => $project->id,
+        'currentBranch' => 'main',
+    ])->call('loadSnapshot', 'main');
+
+    expect($component->get('branchBase')['state'])->toBe('not_configured');
+
+    $component
+        ->call('setDefaultBaseBranch', '  dev  ')
+        ->assertSet('defaultBaseBranch', 'dev')
+        ->assertDispatched('default-base-branch-changed', value: 'dev');
+
+    expect($project->fresh()->default_base_branch)->toBe('dev')
+        ->and($component->get('branchBase')['baseBranch'])->toBe('dev');
+});
+
+test('setDefaultBaseBranch with a blank value clears the project base', function () {
+    fakeGitMetadata();
+
+    $project = Project::factory()->create(['default_base_branch' => 'dev']);
+
+    $component = Livewire::test('branch-explorer', [
+        'repoPath' => '/tmp/repo',
+        'projectId' => $project->id,
+        'currentBranch' => 'main',
+        'defaultBaseBranch' => 'dev',
+    ])->call('setDefaultBaseBranch', '   ');
+
+    $component->assertSet('defaultBaseBranch', '');
+
+    expect($project->fresh()->default_base_branch)->toBeNull();
 });
 
 test('applySelection refreshes and dispatches stale when the snapshot key changed', function () {


### PR DESCRIPTION
## Summary
Adds an inline editor to the "Since {base}" row in the branch explorer picker, allowing users to set or change the project's base branch without leaving the picker or opening project settings. The editor is triggered by clicking the row (when no base is configured) or a pencil icon (always available), and persists changes through a new `setDefaultBaseBranch` Livewire action that re-resolves the snapshot in place.

## Key Changes

- **New Livewire action** (`setDefaultBaseBranch`): Persists the base branch to the project, re-resolves the snapshot without remounting, and dispatches an event to sync the page. Includes a no-op guard to skip DB round-trips when the base is unchanged.

- **New page listener** (`syncDefaultBaseBranch`): Mirrors base-branch changes from the picker back to the review page, keeping the settings input and header label in sync while skipping render to avoid remounting the picker.

- **Inline editor UI**: Added display/edit mode toggle to the "Since {base}" row:
  - Display mode shows the current base with a pencil icon (visible on hover, always visible when no base is set)
  - Edit mode reveals a text input with Enter/Esc shortcuts and save/cancel buttons
  - Row click routes to toggle selection (when actionable) or open the editor (when base is not configured)

- **Alpine state management**: New `baseEditing`, `baseDraft`, `baseBranchName`, and `hasBaseBranch` properties; new methods `onSinceBaseRowClick()`, `startEditBase()`, `saveBase()`, and `cancelEditBase()`.

- **Updated messaging**: Changed "set a base branch in project settings" to "set a base branch to compare" to reflect the new inline affordance.

- **Component wiring**: Added `projectId` locked property to branch-explorer and passed it from the review page so the action can persist settings.

- **Test coverage**: Added comprehensive unit tests for the new action (persistence, no-op guard, clearing) and JS tests for the editor state machine (focus, draft seeding, save/cancel, row click routing).

https://claude.ai/code/session_01WV83YCwhreJ9eEidqBNpCy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline editing for the base branch in the “Since {base}” row, including save and cancel actions.
  * The base branch selection now updates the page state immediately when changed.

* **Bug Fixes**
  * Improved the “Since {base}” row behavior so clicks either open the editor or apply the range as expected.
  * Updated the fallback message shown when no base branch is configured.
  * Trimming and clearing the base branch now works correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->