### PR TITLE
Enforce wide-events logging and context conventions with arch tests

### DIFF
--- a/.claude/skills/wide-events/SKILL.md
+++ b/.claude/skills/wide-events/SKILL.md
@@ -18,6 +18,14 @@ The event name says what happened. Structured context lives in Laravel `Context:
 
 Log outcomes, IDs, counts, booleans, durations, and rejection reasons. Do not narrate internal steps.
 
+## Relationship to Laravel's Context Facade
+
+RFA uses Laravel's `Context` facade as the carrier for canonical-event fields, but deliberately uses only a thin slice of its API: `Context::add()` and `Context::flush()`. The broader facade surface — `scope()`, `addHidden()`, `when()/unless()`, stacks (`push()/pop()`), `increment()/decrement()`, the `dehydrating()/hydrated()` queue hooks, and `#[Context]` attribute injection — is intentionally unused. We are not a queue-driven web app; we are a single-window desktop app, so most of those features solve problems we do not have.
+
+One rule is the deliberate inverse of the facade's usual default. Laravel's headline use case is Context **surviving** across boundaries: it serializes into the queue payload and rehydrates so trace IDs persist. RFA mandates the opposite — `Context::flush()` at the start of every logging owner (see Context Lifecycle) — because NativePHP runs **one long-lived PHP process**. The danger here is not losing context across a hop; it is stale context bleeding from one operation into the next. Same principle (accurate execution metadata), different runtime.
+
+The facade's own guidance still governs *what* belongs in a field: if the code cannot run without the value, pass it explicitly as a parameter; if the value only helps **explain** the execution, it may belong in Context. Context is observability metadata, never hidden business state or an authorization input.
+
 ## Enforcement Model
 
 Rules are tagged by enforcement tier:
@@ -58,7 +66,7 @@ Pure helpers and tiny methods do not need logs.
 
 ### Context Lifecycle
 
-**[CI MUST]** All static `Context::add()` keys start with `rfa.`.
+**[CI MUST]** All static `Context` keys start with `rfa.`. This covers every key-taking method the codebase might use — `add`, `addIf`, `addHidden`, `push`, `increment`, `decrement` — not just `add`.
 
 **[Agent MUST]** The logging owner calls `Context::flush()` before adding fields.
 
@@ -88,7 +96,9 @@ Children should use inline payloads for transient warning/error details. They ma
 
 **[Agent MUST]** Canonical events include `rfa.duration_ms`. There are no duration exemptions. Near-instant operations should still record the measured duration.
 
-For listener-owned events, duration measures the callback unless the listener has a reliable operation start time.
+For listener-owned events, duration measures the callback unless the listener has a reliable operation start time. A start time pulled from shared mutable state (e.g. a cache key written by more than one process) is *not* reliable — prefer the callback duration over a value that can be raced.
+
+**[Agent MUST]** A listener-owned unit of work emits its canonical info event on **every** terminal outcome, including failure. If the success paths emit `updater.available` / `updater.downloaded`, the failure path must also emit a canonical `Log::info('updater.failed')` (with `rfa.outcome = error`) from `finally` — not just a `Log::error()`. Otherwise the outcome distribution for that unit is unqueryable, because failures have a different shape than successes.
 
 Use this pattern only in the logging owner:
 
@@ -118,17 +128,24 @@ try {
 
 **[CI MUST]** Warning payloads include `reason`.
 
+**[CI MUST]** No `Log::warning()` / `error()` / `critical()` payload and no `Context` field passes a raw exception message, stack trace, or process stderr as a value (`$e->getMessage()`, `$e->getTraceAsString()`, `$e->stderr` used directly after `=>` or as a positional argument). Wrap such text in `LogSanitizer::summary()` instead.
+
 **[Agent MUST]** Warning payloads avoid raw file contents, raw stderr, secrets, and avoidable absolute paths.
 
 Warnings are for invariant violations, fallback behavior, and degraded-but-recoverable paths.
 
-Use stable reason codes:
+Prefer cheap, privacy-safe diagnostic fields over free text:
+
+- `exit_code` — `App\Exceptions\GitCommandException` exposes `$e->exitCode` (an int). It separates "ref not found" (1) from "not a git repository" (128) from a timeout, which is exactly the triage signal `$e->getMessage()` would otherwise carry, minus the absolute paths the message embeds.
+- `error_class` — `$e::class` for a generic `Throwable`. A class name is always safe and tells you the failure mode.
+- `stderr_summary` — `LogSanitizer::summary($e->stderr)`. The sanitizer strips ANSI, collapses whitespace, replaces the user's home directory with `~`, and truncates. See `app/Support/LogSanitizer.php`.
 
 ```php
 Log::warning('git.diff.failed', [
-    'reason' => 'process_failed',
+    'reason' => 'diff_process_failed',
     'path' => $relativePath,
-    'stderr_summary' => $sanitizedSummary,
+    'exit_code' => $e->exitCode,
+    'stderr_summary' => LogSanitizer::summary($e->stderr),
 ]);
 ```
 
@@ -138,7 +155,7 @@ Do not warn for every normal rejected input. Use the owner canonical event with 
 
 **[Agent MUST]** Use `Log::error()` only when the exception is handled or converted into a non-throwing path.
 
-**[Agent MUST]** Do not log raw exception messages unless they are known safe or redacted. Exception messages often contain absolute paths, SQL, stderr, or user data.
+**[Agent MUST]** Do not log raw exception messages unless they are known safe or redacted. Exception messages often contain absolute paths, SQL, stderr, or user data. Redact with `LogSanitizer::summary()` (the raw-text ban is now CI-enforced — see Warnings). This applies to externally-sourced error fields too, e.g. an updater error's `message`/`stack`.
 
 `Log::error()` is diagnostic. It never replaces the owner canonical info event.
 
@@ -219,7 +236,9 @@ Put variables in context, not event names.
 
 ### Privacy
 
-**[CI MUST]** No static `Context::add()` key is named `rfa.absolute_path`, `rfa.full_path`, `rfa.root_path`, `rfa.repo_path`, `rfa.repoPath`, or ends in `.absolute_path`.
+**[CI MUST]** No static `Context` key is named `rfa.absolute_path`, `rfa.full_path`, `rfa.root_path`, `rfa.repo_path`, `rfa.repoPath`, or ends in `.absolute_path`.
+
+**[CI MUST]** No payload value or `Context` field is a raw exception message, stack trace, or stderr (see Warnings → the raw-text ban). Sanitize with `LogSanitizer::summary()`.
 
 **[Agent MUST]** All logs avoid private data.
 
@@ -259,7 +278,7 @@ Logs must remain local.
 
 **[CI MUST]** Remote channel definitions from Laravel scaffolding may exist, but they are not active in the default channel or default stack.
 
-The CI check should resolve `config('logging.default')`. If that channel is a stack, recursively inspect every configured channel in the stack.
+This is enforced by `tests/Feature/LogChannelPostureTest.php`, which resolves `config('logging.default')`, recursively expands any `stack` driver, and asserts no resolved channel is remote. It needs the resolved Laravel config (env + stack expansion), so it lives in `tests/Feature/` rather than `tests/Arch/`, which runs without app context.
 
 Disallowed active channels:
 
@@ -270,7 +289,7 @@ Disallowed active channels:
 
 ## CI Checklist
 
-Enforce these with Pest architecture tests where practical:
+C1–C7 and C9 live in `tests/Arch/LoggingConventionsTest.php` (file scanners, no app context). C8 lives in `tests/Feature/LogChannelPostureTest.php` (needs resolved config). All are enforced today — keep them passing, and extend them rather than loosening when a new pattern appears.
 
 C1. No `Log::debug()` in `app/` or `resources/views`.
 
@@ -278,15 +297,17 @@ C2. Every production `Log::info()` passes no manual context array.
 
 C3. Every production `Log::info()` event name is a lowercase dot-separated literal with two to four segments.
 
-C4. Every static `Context::add()` key starts with `rfa.`.
+C4. Every static `Context` key (`add`/`addIf`/`addHidden`/`push`/`increment`/`decrement`) starts with `rfa.`.
 
-C5. Every `Log::warning()` payload includes `reason`.
+C5. Every `Log::warning()` / `error()` / `critical()` payload includes `reason`.
 
 C6. Every static `rfa.outcome` literal belongs to the approved vocabulary.
 
-C7. No `Context::add()` call uses banned static absolute-path keys.
+C7. No static `Context` key is a banned absolute-path key.
 
 C8. Remote logging channels are not part of the default channel or recursively resolved default stack.
+
+C9. No `Log::warning()` / `error()` / `critical()` payload and no `Context` field passes a raw exception message, stack trace, or stderr as a value. Wrapped forms like `LogSanitizer::summary($e->stderr)` are allowed.
 
 ## Agent Review Checklist
 
@@ -314,6 +335,10 @@ A10. `Log::error()` is not duplicated when exceptions are rethrown to a logged p
 
 A11. `Log::error()` is used only for swallowed or converted unexpected failures where extra diagnostic detail is needed.
 
+A12. Diagnostic detail uses safe fields (`exit_code`, `error_class`, `LogSanitizer::summary(...)`) rather than raw exception text — and the chosen fields actually aid triage, not just satisfy the linter.
+
+A13. A listener-owned unit of work emits its canonical info event on every outcome, including failure (not only `Log::error()`).
+
 ## Good Examples
 
 Canonical event with context:
@@ -328,25 +353,52 @@ Context::add('rfa.duration_ms', 12);
 Log::info('review.refreshed');
 ```
 
-Recoverable warning:
+Recoverable warning with sanitized, privacy-safe diagnostics:
 
 ```php
 Log::warning('git.diff.failed', [
-    'reason' => 'process_failed',
+    'reason' => 'diff_process_failed',
     'path' => $relativePath,
-    'stderr_summary' => $sanitizedSummary,
+    'exit_code' => $e->exitCode,
+    'stderr_summary' => LogSanitizer::summary($e->stderr),
 ]);
+```
+
+Listener-owned unit that stays canonical on the failure path (diagnostic `Log::error()` plus a canonical `Log::info()` of the same name from `finally`):
+
+```php
+Event::listen(UpdateError::class, function (UpdateError $event) {
+    Context::flush();
+
+    $startedAt = microtime(true);
+
+    try {
+        Log::error('updater.failed', [
+            'reason' => 'updater_error',
+            'message' => LogSanitizer::summary($event->message),
+            'stack' => LogSanitizer::summary($event->stack, 500),
+        ]);
+        // ...recover, notify...
+    } finally {
+        Context::add('rfa.outcome', 'error');
+        Context::add('rfa.reason', 'updater_error');
+        Context::add('rfa.duration_ms', (int) round((microtime(true) - $startedAt) * 1000));
+        Log::info('updater.failed');
+    }
+});
 ```
 
 ## Anti-Patterns
 
 ```php
-Log::debug('Review page refreshed', ['files' => $files]);
-Log::info('Review refreshed for '.$project->name);
-Log::info('review.refreshed', ['project' => $project->slug]);
-Context::add('project_slug', $project->slug);
-Context::add('rfa.error', $e->getMessage());
-Log::warning('Git diff failed', ['stderr' => $e->stderr]);
+Log::debug('Review page refreshed', ['files' => $files]);     // C1: no debug logs
+Log::info('Review refreshed for '.$project->name);            // C3: dynamic/prose event name
+Log::info('review.refreshed', ['project' => $project->slug]); // C2: info takes no payload array
+Context::add('project_slug', $project->slug);                 // C4: key must be rfa.*
+Context::add('rfa.error', $e->getMessage());                  // C9: raw exception message
+Log::warning('Git diff failed', ['stderr' => $e->stderr]);    // C3 + C5 + C9: prose name, no reason, raw stderr
+Context::add('rfa.repo_path', $absolutePath);                 // C7: banned absolute-path key
+Context::add('rfa.outcome', 'done');                          // C6: not in the outcome vocabulary
 ```
 
 ## Audit Commands
@@ -367,7 +419,10 @@ rg -n -U -P "Log::info\((?s:.*?)\[" app resources/views -g'*.php'
 rg -n "Log::warning\(" app resources/views -g'*.php'
 
 # Non-namespaced static context keys. Should be 0.
-rg -n "Context::add\(['\"](?!rfa\.)" app resources/views -g'*.php' -P
+rg -n "Context::(add|addIf|addHidden|push|increment|decrement)\(['\"](?!rfa\.)" app resources/views -g'*.php' -P
+
+# Raw exception text / stderr passed straight into a payload value. Should be 0.
+rg -n -P "(=>|,)\s*\\\$[A-Za-z_]\w*->(getMessage\(\)|getTraceAsString\(\)|stderr\b)" app resources/views -g'*.php'
 
 # Context fields. Review nearby code for owner flush and child preservation.
 rg -n "Context::(flush|add)\(" app resources/views -g'*.php'
@@ -392,6 +447,8 @@ Focus on:
 - warning logs include reason and use stable reason codes
 - no duplicate Log::error() when exceptions are rethrown
 - no file contents, clipboard data, secrets, exported review text, raw stderr, raw exception messages, or avoidable absolute paths
+- diagnostic detail uses safe fields (exit_code, error_class, LogSanitizer::summary) instead of raw exception text, and the fields actually aid triage
+- listener-owned units emit a canonical info event on every outcome, including failure
 
 Return findings only. Include file and line references. If there are no issues, say so and list residual risks.
 ```

--- a/.claude/skills/wide-events/SKILL.md
+++ b/.claude/skills/wide-events/SKILL.md
@@ -128,7 +128,7 @@ try {
 
 **[CI MUST]** Warning payloads include `reason`.
 
-**[CI MUST]** No `Log::warning()` / `error()` / `critical()` payload and no `Context` field passes a raw exception message, stack trace, or process stderr as a value (`$e->getMessage()`, `$e->getTraceAsString()`, `$e->stderr` used directly after `=>` or as a positional argument). Wrap such text in `LogSanitizer::summary()` instead.
+**[CI MUST]** No `Log::warning()` / `error()` / `critical()` payload and no `Context` field passes a raw exception message, stack trace, or process stderr as a value (`$e->getMessage()`, `$e->getTraceAsString()`, `$e->stderr`) in any argument position, including the nullsafe `?->` form. Wrap such text in `LogSanitizer::summary()` instead — that wrapper is the one allowed form.
 
 **[Agent MUST]** Warning payloads avoid raw file contents, raw stderr, secrets, and avoidable absolute paths.
 
@@ -271,7 +271,7 @@ Logs must remain local.
     'driver' => 'daily',
     'path' => storage_path('logs/laravel.log'),
     'level' => env('LOG_LEVEL', 'info'),
-    'days' => 7,
+    'days' => env('LOG_DAILY_DAYS', 7),
     'replace_placeholders' => true,
 ],
 ```
@@ -421,8 +421,9 @@ rg -n "Log::warning\(" app resources/views -g'*.php'
 # Non-namespaced static context keys. Should be 0.
 rg -n "Context::(add|addIf|addHidden|push|increment|decrement)\(['\"](?!rfa\.)" app resources/views -g'*.php' -P
 
-# Raw exception text / stderr passed straight into a payload value. Should be 0.
-rg -n -P "(=>|,)\s*\\\$[A-Za-z_]\w*->(getMessage\(\)|getTraceAsString\(\)|stderr\b)" app resources/views -g'*.php'
+# Raw exception text / stderr in any payload position. Review each hit — it is
+# allowed only inside LogSanitizer::summary(...); otherwise it is a C9 violation.
+rg -n -P "\\\$[A-Za-z_]\w*\??->(getMessage\(\)|getTraceAsString\(\)|stderr\b)" app resources/views -g'*.php'
 
 # Context fields. Review nearby code for owner flush and child preservation.
 rg -n "Context::(flush|add)\(" app resources/views -g'*.php'

--- a/app/Actions/EnsureRfaGitExcludeAction.php
+++ b/app/Actions/EnsureRfaGitExcludeAction.php
@@ -52,7 +52,7 @@ final readonly class EnsureRfaGitExcludeAction
             Log::warning('git.exclude.append_failed', [
                 'reason' => 'exclude_append_failed',
                 'repo' => $repoPath,
-                'error' => $e->getMessage(),
+                'error_class' => $e::class,
             ]);
         }
     }
@@ -76,7 +76,7 @@ final readonly class EnsureRfaGitExcludeAction
             Log::warning('git.exclude.resolve_failed', [
                 'reason' => 'exclude_path_resolve_failed',
                 'repo' => $repoPath,
-                'error' => $e->getMessage(),
+                'error_class' => $e::class,
             ]);
 
             return null;

--- a/app/Actions/GetProjectStatusAction.php
+++ b/app/Actions/GetProjectStatusAction.php
@@ -8,6 +8,7 @@ use App\DTOs\FileListEntry;
 use App\DTOs\ReviewFilePair;
 use App\Exceptions\GitCommandException;
 use App\Services\GitDiffService;
+use App\Support\LogSanitizer;
 use Illuminate\Support\Facades\Log;
 
 final readonly class GetProjectStatusAction
@@ -26,8 +27,9 @@ final readonly class GetProjectStatusAction
         } catch (GitCommandException $e) {
             Log::warning('project.status.failed', [
                 'reason' => 'project_status_failed',
-                'repoPath' => $repoPath,
-                'stderr' => $e->stderr,
+                'repo' => $repoPath,
+                'exit_code' => $e->exitCode,
+                'stderr_summary' => LogSanitizer::summary($e->stderr),
             ]);
 
             return ['dirty' => false, 'fileCount' => 0, 'additions' => 0, 'deletions' => 0];

--- a/app/Actions/LoadFileDiffAction.php
+++ b/app/Actions/LoadFileDiffAction.php
@@ -16,6 +16,7 @@ use App\Services\MarkdownTableAlignerService;
 use App\Services\ReviewConfigService;
 use App\Services\SyntaxHighlightService;
 use App\Support\DiffCacheKey;
+use App\Support\LogSanitizer;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 
@@ -51,7 +52,8 @@ final readonly class LoadFileDiffAction
                 Log::warning('git.diff.failed', [
                     'reason' => 'diff_process_failed',
                     'path' => $path,
-                    'stderr' => $e->stderr,
+                    'exit_code' => $e->exitCode,
+                    'stderr_summary' => LogSanitizer::summary($e->stderr),
                 ]);
 
                 return FileDiff::emptyArray($path, 'modified', tooLarge: false)

--- a/app/Actions/OpenProjectFromPathAction.php
+++ b/app/Actions/OpenProjectFromPathAction.php
@@ -36,7 +36,7 @@ final readonly class OpenProjectFromPathAction
             Log::warning('project.registration.failed', [
                 'reason' => 'project_registration_failed',
                 'path' => $path,
-                'error' => $e->getMessage(),
+                'error_class' => $e::class,
             ]);
 
             return null;

--- a/app/Actions/ResolveBranchBaseAction.php
+++ b/app/Actions/ResolveBranchBaseAction.php
@@ -84,7 +84,7 @@ final readonly class ResolveBranchBaseAction
                 'repo' => $repoPath,
                 'from' => $from,
                 'to' => $to,
-                'error' => $e->getMessage(),
+                'exit_code' => $e->exitCode,
             ]);
 
             return [];

--- a/app/Providers/NativeAppServiceProvider.php
+++ b/app/Providers/NativeAppServiceProvider.php
@@ -15,6 +15,7 @@ use App\Listeners\HandleMenuItemClicked;
 use App\Listeners\HandleZoomShortcutPressed;
 use App\Listeners\RegisterNativeGlobalShortcuts;
 use App\Listeners\UnregisterNativeGlobalShortcuts;
+use App\Support\LogSanitizer;
 use App\Support\Shortcuts;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
@@ -92,22 +93,28 @@ class NativeAppServiceProvider implements ProvidesPhpIni
 
         Event::listen(UpdateAvailable::class, function (UpdateAvailable $event) {
             Context::flush();
-            Context::add('rfa.update_version', $event->version);
-            Context::add('rfa.outcome', 'completed');
-            Log::info('updater.available');
 
-            $releaseNotes = $this->normalizeReleaseNotes($event->releaseNotes);
-            Cache::put('native-update-state', [
-                'status' => 'downloading',
-                'version' => $event->version,
-                'releaseNotes' => $releaseNotes,
-                'percent' => 0,
-            ], now()->addMinutes(30));
+            $startedAt = microtime(true);
 
-            Notification::new()
-                ->title('Update Available')
-                ->message("Version {$event->version} is available and downloading.")
-                ->show();
+            try {
+                $releaseNotes = $this->normalizeReleaseNotes($event->releaseNotes);
+                Cache::put('native-update-state', [
+                    'status' => 'downloading',
+                    'version' => $event->version,
+                    'releaseNotes' => $releaseNotes,
+                    'percent' => 0,
+                ], now()->addMinutes(30));
+
+                Notification::new()
+                    ->title('Update Available')
+                    ->message("Version {$event->version} is available and downloading.")
+                    ->show();
+            } finally {
+                Context::add('rfa.update_version', $event->version);
+                Context::add('rfa.outcome', 'completed');
+                Context::add('rfa.duration_ms', $this->elapsedMs($startedAt));
+                Log::info('updater.available');
+            }
         });
 
         Event::listen(DownloadProgress::class, function (DownloadProgress $event) {
@@ -127,39 +134,70 @@ class NativeAppServiceProvider implements ProvidesPhpIni
 
         Event::listen(UpdateDownloaded::class, function (UpdateDownloaded $event) {
             Context::flush();
-            Context::add('rfa.update_version', $event->version);
-            Context::add('rfa.outcome', 'completed');
-            Log::info('updater.downloaded');
 
-            $releaseNotes = $this->normalizeReleaseNotes($event->releaseNotes);
-            Cache::put('native-update-state', [
-                'status' => 'ready',
-                'version' => $event->version,
-                'releaseNotes' => $releaseNotes,
-                'percent' => 100,
-            ], now()->addHours(24));
+            $startedAt = microtime(true);
 
-            Notification::new()
-                ->title('Update Ready')
-                ->message("Version {$event->version} will be installed on restart.")
-                ->show();
+            try {
+                $releaseNotes = $this->normalizeReleaseNotes($event->releaseNotes);
+                Cache::put('native-update-state', [
+                    'status' => 'ready',
+                    'version' => $event->version,
+                    'releaseNotes' => $releaseNotes,
+                    'percent' => 100,
+                ], now()->addHours(24));
+
+                Notification::new()
+                    ->title('Update Ready')
+                    ->message("Version {$event->version} will be installed on restart.")
+                    ->show();
+            } finally {
+                Context::add('rfa.update_version', $event->version);
+                Context::add('rfa.outcome', 'completed');
+                Context::add('rfa.duration_ms', $this->elapsedMs($startedAt));
+                Log::info('updater.downloaded');
+            }
         });
 
         Event::listen(UpdateError::class, function (UpdateError $event) {
             Context::flush();
-            Context::add('rfa.outcome', 'error');
-            Context::add('rfa.reason', 'updater_error');
-            Log::error('updater.failed', [
-                'reason' => 'updater_error',
-                'message' => $event->message,
-                'stack' => $event->stack,
-            ]);
-            Cache::put('native-update-state', ['status' => 'error'], now()->addMinutes(5));
-            Notification::new()
-                ->title('Update Error')
-                ->message('Could not check for updates. Try again later.')
-                ->show();
+
+            $startedAt = microtime(true);
+
+            try {
+                // Diagnostic detail for triage. The canonical info event below
+                // keeps the failure path the same shape as the success paths so
+                // `rfa.outcome` distribution stays queryable across outcomes.
+                Log::error('updater.failed', [
+                    'reason' => 'updater_error',
+                    'message' => LogSanitizer::summary($event->message),
+                    'stack' => LogSanitizer::summary($event->stack, 500),
+                ]);
+                Cache::put('native-update-state', ['status' => 'error'], now()->addMinutes(5));
+                Notification::new()
+                    ->title('Update Error')
+                    ->message('Could not check for updates. Try again later.')
+                    ->show();
+            } finally {
+                Context::add('rfa.outcome', 'error');
+                Context::add('rfa.reason', 'updater_error');
+                Context::add('rfa.duration_ms', $this->elapsedMs($startedAt));
+                Log::info('updater.failed');
+            }
         });
+    }
+
+    /**
+     * Milliseconds elapsed since `$startedAt` (a {@see microtime()} float).
+     *
+     * The updater listeners have no reliable end-to-end operation start time —
+     * the `native-update-state` cache is written by both this main process and
+     * the renderer banner, so its `startedAt` can be raced. Per the wide-events
+     * protocol, a listener-owned event without a trustworthy start time records
+     * its callback duration instead.
+     */
+    private function elapsedMs(float $startedAt): int
+    {
+        return (int) round((microtime(true) - $startedAt) * 1000);
     }
 
     /** @param array<string>|string|null $notes */

--- a/app/Services/GitMetadataService.php
+++ b/app/Services/GitMetadataService.php
@@ -26,7 +26,7 @@ class GitMetadataService
             Log::warning('git.excludes_file.resolve_failed', [
                 'reason' => 'global_excludes_file_resolve_failed',
                 'repo' => $repoPath,
-                'error' => $e->getMessage(),
+                'exit_code' => $e->exitCode,
             ]);
 
             return null;
@@ -198,7 +198,7 @@ class GitMetadataService
                 'repo' => $repoPath,
                 'ref' => $ref,
                 'path' => $path,
-                'error' => $e->getMessage(),
+                'exit_code' => $e->exitCode,
             ]);
 
             return null;
@@ -220,7 +220,7 @@ class GitMetadataService
                 'reason' => 'git_ref_resolve_failed',
                 'repo' => $repoPath,
                 'ref' => $ref,
-                'error' => $e->getMessage(),
+                'exit_code' => $e->exitCode,
             ]);
 
             return null;
@@ -248,7 +248,7 @@ class GitMetadataService
                 'reason' => 'commit_parents_read_failed',
                 'repo' => $repoPath,
                 'hash' => $hash,
-                'error' => $e->getMessage(),
+                'exit_code' => $e->exitCode,
             ]);
 
             return [];
@@ -272,7 +272,7 @@ class GitMetadataService
                 'reason' => 'root_commit_check_failed',
                 'repo' => $repoPath,
                 'ref' => $ref,
-                'error' => $e->getMessage(),
+                'exit_code' => $e->exitCode,
             ]);
 
             return false;
@@ -317,7 +317,7 @@ class GitMetadataService
                 'reason' => 'child_commit_read_failed',
                 'repo' => $repoPath,
                 'hash' => $hash,
-                'error' => $e->getMessage(),
+                'exit_code' => $e->exitCode,
             ]);
 
             return null;
@@ -390,7 +390,7 @@ class GitMetadataService
             Log::warning('git.commit_log.read_failed', [
                 'reason' => 'commit_log_read_failed',
                 'repo' => $repoPath,
-                'error' => $e->getMessage(),
+                'exit_code' => $e->exitCode,
             ]);
 
             return [];

--- a/app/Services/SyntaxHighlightService.php
+++ b/app/Services/SyntaxHighlightService.php
@@ -247,7 +247,7 @@ class SyntaxHighlightService
             Log::warning('syntax.highlighting.failed', [
                 'reason' => 'tempest_highlighting_failed',
                 'language' => $language,
-                'error' => $e->getMessage(),
+                'error_class' => $e::class,
             ]);
 
             return null;
@@ -554,7 +554,7 @@ class SyntaxHighlightService
         } catch (Throwable $e) {
             Log::warning('syntax.highlighting.failed', [
                 'reason' => 'phiki_highlighting_failed',
-                'error' => $e->getMessage(),
+                'error_class' => $e::class,
             ]);
 
             return [];

--- a/app/Support/LogSanitizer.php
+++ b/app/Support/LogSanitizer.php
@@ -39,6 +39,10 @@ final class LogSanitizer
     /**
      * Replace the current user's home directory with `~` so absolute paths under
      * it (the common case for a repo on disk) never reach the log verbatim.
+     *
+     * The match is anchored to a path boundary — end of string, or a character
+     * that cannot continue a directory name — so a sibling like `/home/user2`
+     * is left intact rather than mangled into `~2`.
      */
     private static function scrubHomeDirectory(string $text): string
     {
@@ -48,6 +52,6 @@ final class LogSanitizer
             return $text;
         }
 
-        return str_replace(rtrim($home, '/'), '~', $text);
+        return (string) preg_replace('#'.preg_quote(rtrim($home, '/'), '#').'(?![\w-])#', '~', $text);
     }
 }

--- a/app/Support/LogSanitizer.php
+++ b/app/Support/LogSanitizer.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Scrubs free-form process or exception text before it reaches a log payload.
+ *
+ * The wide-events protocol bans raw stderr, raw exception messages, and
+ * avoidable absolute paths because they routinely leak repo internals, user
+ * content, and home-directory paths into the local log. {@see summary()}
+ * collapses such text into a bounded, single-line, home-scrubbed string that is
+ * safe to attach to a warning while still aiding triage.
+ */
+final class LogSanitizer
+{
+    private const DEFAULT_MAX_LENGTH = 200;
+
+    /**
+     * Reduce raw process/exception text to a bounded, single-line, home-scrubbed
+     * summary: ANSI color stripped, whitespace collapsed, the user's home
+     * directory replaced with `~`, and the result truncated with an ellipsis
+     * marker when it exceeds `$maxLength`.
+     */
+    public static function summary(string $raw, int $maxLength = self::DEFAULT_MAX_LENGTH): string
+    {
+        $text = AnsiText::strip($raw);
+        $text = (string) preg_replace('/\s+/', ' ', $text);
+        $text = self::scrubHomeDirectory(trim($text));
+
+        if (mb_strlen($text) <= $maxLength) {
+            return $text;
+        }
+
+        return rtrim(mb_substr($text, 0, $maxLength)).'…';
+    }
+
+    /**
+     * Replace the current user's home directory with `~` so absolute paths under
+     * it (the common case for a repo on disk) never reach the log verbatim.
+     */
+    private static function scrubHomeDirectory(string $text): string
+    {
+        $home = $_SERVER['HOME'] ?? getenv('HOME');
+
+        if (! is_string($home) || $home === '' || $home === '/') {
+            return $text;
+        }
+
+        return str_replace(rtrim($home, '/'), '~', $text);
+    }
+}

--- a/app/Support/LogSanitizer.php
+++ b/app/Support/LogSanitizer.php
@@ -22,10 +22,14 @@ final class LogSanitizer
      * summary: ANSI color stripped, whitespace collapsed, the user's home
      * directory replaced with `~`, and the result truncated with an ellipsis
      * marker when it exceeds `$maxLength`.
+     *
+     * `$raw` is nullable on purpose: it is frequently fed optional exception
+     * fields (an updater error's `?string $stack`, say). A null is treated as
+     * empty so a sanitizer on an error path never itself throws.
      */
-    public static function summary(string $raw, int $maxLength = self::DEFAULT_MAX_LENGTH): string
+    public static function summary(?string $raw, int $maxLength = self::DEFAULT_MAX_LENGTH): string
     {
-        $text = AnsiText::strip($raw);
+        $text = AnsiText::strip($raw ?? '');
         $text = preg_replace('/\s+/', ' ', $text) ?? $text;
         $text = self::scrubHomeDirectory(trim($text));
 

--- a/app/Support/LogSanitizer.php
+++ b/app/Support/LogSanitizer.php
@@ -26,7 +26,7 @@ final class LogSanitizer
     public static function summary(string $raw, int $maxLength = self::DEFAULT_MAX_LENGTH): string
     {
         $text = AnsiText::strip($raw);
-        $text = (string) preg_replace('/\s+/', ' ', $text);
+        $text = preg_replace('/\s+/', ' ', $text) ?? $text;
         $text = self::scrubHomeDirectory(trim($text));
 
         if (mb_strlen($text) <= $maxLength) {
@@ -52,6 +52,6 @@ final class LogSanitizer
             return $text;
         }
 
-        return (string) preg_replace('#'.preg_quote(rtrim($home, '/'), '#').'(?![\w-])#', '~', $text);
+        return preg_replace('#'.preg_quote(rtrim($home, '/'), '#').'(?![\w-])#', '~', $text) ?? $text;
     }
 }

--- a/config/logging.php
+++ b/config/logging.php
@@ -18,7 +18,11 @@ return [
     |
     */
 
-    'default' => env('LOG_CHANNEL', 'stack'),
+    // RFA ships to user machines and keeps logs strictly local. The default
+    // resolves to the bounded `daily` channel (info level, 7-day retention) so
+    // a release build never grows an unbounded `laravel.log` or accepts
+    // debug-level noise. See .claude/skills/wide-events/SKILL.md → Storage.
+    'default' => env('LOG_CHANNEL', 'daily'),
 
     /*
     |--------------------------------------------------------------------------
@@ -61,15 +65,15 @@ return [
         'single' => [
             'driver' => 'single',
             'path' => storage_path('logs/laravel.log'),
-            'level' => env('LOG_LEVEL', 'debug'),
+            'level' => env('LOG_LEVEL', 'info'),
             'replace_placeholders' => true,
         ],
 
         'daily' => [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),
-            'level' => env('LOG_LEVEL', 'debug'),
-            'days' => env('LOG_DAILY_DAYS', 14),
+            'level' => env('LOG_LEVEL', 'info'),
+            'days' => env('LOG_DAILY_DAYS', 7),
             'replace_placeholders' => true,
         ],
 

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -550,8 +550,8 @@ new #[Layout('layouts.app')] class extends Component
             $this->dispatch('refresh-completed', changedCount: $changedCount);
         } catch (\Throwable $e) {
             $outcome = 'error';
-            Context::add('rfa.error', $e->getMessage());
             Context::add('rfa.error_class', $e::class);
+            Context::add('rfa.reason', 'refresh_failed');
 
             throw $e;
         } finally {

--- a/tests/Arch/LoggingConventionsTest.php
+++ b/tests/Arch/LoggingConventionsTest.php
@@ -435,11 +435,20 @@ test('static context keys never expose absolute filesystem paths', function () {
 });
 
 test('log and context payloads never carry raw exception text', function () {
-    // A raw exception message, stack trace, or process stderr passed straight
-    // into a payload value (after `=>` or as a positional argument). Wrapped
-    // forms such as `LogSanitizer::summary($e->stderr)` are allowed because the
-    // delimiter that precedes the property access is `(`, not `=>` / `,`.
-    $rawExceptionText = '/(=>|,)\s*\$[A-Za-z_]\w*->(getMessage\(\)|getTraceAsString\(\)|stderr\b)/';
+    // A raw exception message, stack trace, or process stderr reaching a payload
+    // value, in any argument position (including the nullsafe `?->` form).
+    // `LogSanitizer::summary(...)` is the one sanctioned wrapper, so its argument
+    // list is stripped before the check — `summary($e->stderr)` is allowed, a
+    // bare `$e->stderr` anywhere else is not.
+    $sanctionedWrapper = '/LogSanitizer::summary\([^)]*\)/';
+    $rawExceptionText = '/\$[A-Za-z_]\w*\??->(getMessage\(\)|getTraceAsString\(\)|stderr\b)/';
+
+    $carriesRawText = function (string $source) use ($sanctionedWrapper, $rawExceptionText): bool {
+        $stripped = (string) preg_replace($sanctionedWrapper, '', $source);
+
+        return (bool) preg_match($rawExceptionText, $stripped);
+    };
+
     $violations = [];
 
     foreach (loggingConventionCalls() as $call) {
@@ -447,13 +456,13 @@ test('log and context payloads never carry raw exception text', function () {
             continue;
         }
 
-        if (preg_match($rawExceptionText, $call['source'])) {
+        if ($carriesRawText($call['source'])) {
             $violations[] = "{$call['path']}:{$call['line']} {$call['source']}";
         }
     }
 
     foreach (contextConventionCalls() as $call) {
-        if (preg_match($rawExceptionText, $call['source'])) {
+        if ($carriesRawText($call['source'])) {
             $violations[] = "{$call['path']}:{$call['line']} {$call['source']}";
         }
     }

--- a/tests/Arch/LoggingConventionsTest.php
+++ b/tests/Arch/LoggingConventionsTest.php
@@ -3,9 +3,18 @@
 /**
  * Wide-events logging rules that are intentionally simple and robust.
  *
- * These tests use the current production log calls as their coverage surface.
- * Semantic rules like ownership, context richness, and privacy still belong in
- * review because they require call-chain and domain judgment.
+ * These tests use the current production `Log::*` and `Context::*` calls as
+ * their coverage surface (see .claude/skills/wide-events/SKILL.md). They cover
+ * the mechanically checkable rules: debug-free production code, static dotted
+ * event names, payload-free info events, stable `reason` codes, `rfa.`-namespaced
+ * context keys, the approved `rfa.outcome` vocabulary, banned absolute-path keys,
+ * and the privacy ban on raw exception text in payloads.
+ *
+ * Semantic rules — logging ownership, context richness, and deeper privacy
+ * judgment — still belong in review because they require call-chain and domain
+ * judgment. The recursively-resolved channel posture (C8) needs the Laravel
+ * config and lives in tests/Feature/LogChannelPostureTest.php, since arch tests
+ * run without app context.
  */
 function loggingConventionFiles(): array
 {
@@ -288,6 +297,163 @@ test('warning and error logs include a stable reason payload', function () {
         $payload = $arguments[1] ?? '';
 
         if (! preg_match('/[\'"]reason[\'"]\s*=>/', $payload)) {
+            $violations[] = "{$call['path']}:{$call['line']} {$call['source']}";
+        }
+    }
+
+    expect($violations)->toBeEmpty();
+});
+
+// -- Context facade conventions (C4, C6, C7) and payload privacy (C9) --
+
+/**
+ * Every production `Context::add()` / `addIf()` / `addHidden()` / `push()` /
+ * `increment()` / `decrement()` call, with the same paren-balanced extraction
+ * used for log calls.
+ *
+ * @return list<array{method: string, source: string, line: int, path: string}>
+ */
+function contextConventionCalls(): array
+{
+    $calls = [];
+
+    foreach (loggingConventionFiles() as $file) {
+        $contents = file_get_contents($file);
+
+        if ($contents === false) {
+            continue;
+        }
+
+        preg_match_all('/Context::(add|addIf|addHidden|push|increment|decrement)\s*\(/', $contents, $matches, PREG_OFFSET_CAPTURE);
+
+        foreach ($matches[0] as $index => $match) {
+            $offset = $match[1];
+            $source = extractLoggingConventionCall($contents, $offset);
+
+            if ($source === null) {
+                continue;
+            }
+
+            $calls[] = [
+                'method' => $matches[1][$index][0],
+                'source' => $source,
+                'line' => substr_count(substr($contents, 0, $offset), "\n") + 1,
+                'path' => str_replace(dirname(__DIR__, 2).'/', '', $file),
+            ];
+        }
+    }
+
+    return $calls;
+}
+
+/**
+ * The literal string an argument resolves to, or null when it is dynamic
+ * (a variable, concatenation, or expression) and therefore not statically
+ * checkable. Interpolated and escaped literals are treated as dynamic.
+ */
+function staticStringLiteral(string $argument): ?string
+{
+    $argument = trim($argument);
+
+    if (preg_match("/^'([^'\\\\]*)'$/", $argument, $matches)) {
+        return $matches[1];
+    }
+
+    if (preg_match('/^"([^"\\\\$]*)"$/', $argument, $matches)) {
+        return $matches[1];
+    }
+
+    return null;
+}
+
+test('static context keys are namespaced under rfa.', function () {
+    $violations = [];
+
+    foreach (contextConventionCalls() as $call) {
+        $arguments = loggingConventionArguments($call['source']);
+        $key = staticStringLiteral($arguments[0] ?? '');
+
+        if ($key === null) {
+            continue; // dynamic key — not statically checkable, left to review
+        }
+
+        if (! str_starts_with($key, 'rfa.')) {
+            $violations[] = "{$call['path']}:{$call['line']} {$call['source']}";
+        }
+    }
+
+    expect($violations)->toBeEmpty();
+});
+
+test('static rfa.outcome values use the approved vocabulary', function () {
+    $vocabulary = ['completed', 'error', 'skipped', 'cancelled', 'rejected', 'partial'];
+    $violations = [];
+
+    foreach (contextConventionCalls() as $call) {
+        if (! in_array($call['method'], ['add', 'addIf'], true)) {
+            continue;
+        }
+
+        $arguments = loggingConventionArguments($call['source']);
+
+        if (staticStringLiteral($arguments[0] ?? '') !== 'rfa.outcome') {
+            continue;
+        }
+
+        $value = staticStringLiteral($arguments[1] ?? '');
+
+        if ($value === null) {
+            continue; // dynamic value (e.g. $outcome) — verified by the owning code/review
+        }
+
+        if (! in_array($value, $vocabulary, true)) {
+            $violations[] = "{$call['path']}:{$call['line']} {$call['source']}";
+        }
+    }
+
+    expect($violations)->toBeEmpty();
+});
+
+test('static context keys never expose absolute filesystem paths', function () {
+    $banned = ['rfa.absolute_path', 'rfa.full_path', 'rfa.root_path', 'rfa.repo_path', 'rfa.repoPath'];
+    $violations = [];
+
+    foreach (contextConventionCalls() as $call) {
+        $arguments = loggingConventionArguments($call['source']);
+        $key = staticStringLiteral($arguments[0] ?? '');
+
+        if ($key === null) {
+            continue;
+        }
+
+        if (in_array($key, $banned, true) || str_ends_with($key, '.absolute_path')) {
+            $violations[] = "{$call['path']}:{$call['line']} {$call['source']}";
+        }
+    }
+
+    expect($violations)->toBeEmpty();
+});
+
+test('log and context payloads never carry raw exception text', function () {
+    // A raw exception message, stack trace, or process stderr passed straight
+    // into a payload value (after `=>` or as a positional argument). Wrapped
+    // forms such as `LogSanitizer::summary($e->stderr)` are allowed because the
+    // delimiter that precedes the property access is `(`, not `=>` / `,`.
+    $rawExceptionText = '/(=>|,)\s*\$[A-Za-z_]\w*->(getMessage\(\)|getTraceAsString\(\)|stderr\b)/';
+    $violations = [];
+
+    foreach (loggingConventionCalls() as $call) {
+        if (! in_array($call['level'], ['warning', 'error', 'critical'], true)) {
+            continue;
+        }
+
+        if (preg_match($rawExceptionText, $call['source'])) {
+            $violations[] = "{$call['path']}:{$call['line']} {$call['source']}";
+        }
+    }
+
+    foreach (contextConventionCalls() as $call) {
+        if (preg_match($rawExceptionText, $call['source'])) {
             $violations[] = "{$call['path']}:{$call['line']} {$call['source']}";
         }
     }

--- a/tests/Arch/LoggingConventionsTest.php
+++ b/tests/Arch/LoggingConventionsTest.php
@@ -16,15 +16,24 @@
  * config and lives in tests/Feature/LogChannelPostureTest.php, since arch tests
  * run without app context.
  */
+/**
+ * @return list<string>
+ */
 function loggingConventionFiles(): array
 {
+    static $files;
+
+    if ($files !== null) {
+        return $files;
+    }
+
     $root = dirname(__DIR__, 2);
     $directories = [
         $root.'/app',
         $root.'/resources/views',
     ];
 
-    $files = [];
+    $found = [];
 
     foreach ($directories as $directory) {
         $iterator = new RecursiveIteratorIterator(
@@ -33,31 +42,63 @@ function loggingConventionFiles(): array
 
         foreach ($iterator as $file) {
             if ($file->isFile() && $file->getExtension() === 'php') {
-                $files[] = $file->getPathname();
+                $found[] = $file->getPathname();
             }
         }
     }
 
-    sort($files);
+    sort($found);
 
-    return $files;
+    return $files = $found;
 }
 
 /**
- * @return list<array{level: string, source: string, line: int, path: string}>
+ * Production file contents, keyed by path and read once per process. Every rule
+ * scans the same files, so the read happens a single time for the whole suite.
+ *
+ * @return array<string, string>
  */
-function loggingConventionCalls(): array
+function loggingConventionFileContents(): array
 {
-    $calls = [];
+    static $contents;
+
+    if ($contents !== null) {
+        return $contents;
+    }
+
+    $contents = [];
 
     foreach (loggingConventionFiles() as $file) {
-        $contents = file_get_contents($file);
+        $raw = file_get_contents($file);
 
-        if ($contents === false) {
-            continue;
+        if ($raw !== false) {
+            $contents[$file] = $raw;
         }
+    }
 
-        preg_match_all('/Log::(debug|info|warning|error|critical)\s*\(/', $contents, $matches, PREG_OFFSET_CAPTURE);
+    return $contents;
+}
+
+/**
+ * Every paren-balanced call whose opening `Facade::method(` matches $pattern,
+ * where the pattern's first capture group is the method name (stored as
+ * `match`). Memoized per pattern; reused by the Log:: and Context:: scanners.
+ *
+ * @return list<array{match: string, source: string, line: int, path: string}>
+ */
+function conventionCalls(string $pattern): array
+{
+    static $cache = [];
+
+    if (array_key_exists($pattern, $cache)) {
+        return $cache[$pattern];
+    }
+
+    $root = dirname(__DIR__, 2).'/';
+    $calls = [];
+
+    foreach (loggingConventionFileContents() as $file => $contents) {
+        preg_match_all($pattern, $contents, $matches, PREG_OFFSET_CAPTURE);
 
         foreach ($matches[0] as $index => $match) {
             $offset = $match[1];
@@ -68,15 +109,31 @@ function loggingConventionCalls(): array
             }
 
             $calls[] = [
-                'level' => $matches[1][$index][0],
+                'match' => $matches[1][$index][0],
                 'source' => $source,
                 'line' => substr_count(substr($contents, 0, $offset), "\n") + 1,
-                'path' => str_replace(dirname(__DIR__, 2).'/', '', $file),
+                'path' => str_replace($root, '', $file),
             ];
         }
     }
 
-    return $calls;
+    return $cache[$pattern] = $calls;
+}
+
+/**
+ * @return list<array{level: string, source: string, line: int, path: string}>
+ */
+function loggingConventionCalls(): array
+{
+    return array_map(
+        fn (array $call): array => [
+            'level' => $call['match'],
+            'source' => $call['source'],
+            'line' => $call['line'],
+            'path' => $call['path'],
+        ],
+        conventionCalls('/Log::(debug|info|warning|error|critical)\s*\(/'),
+    );
 }
 
 function extractLoggingConventionCall(string $contents, int $offset): ?string
@@ -315,35 +372,15 @@ test('warning and error logs include a stable reason payload', function () {
  */
 function contextConventionCalls(): array
 {
-    $calls = [];
-
-    foreach (loggingConventionFiles() as $file) {
-        $contents = file_get_contents($file);
-
-        if ($contents === false) {
-            continue;
-        }
-
-        preg_match_all('/Context::(add|addIf|addHidden|push|increment|decrement)\s*\(/', $contents, $matches, PREG_OFFSET_CAPTURE);
-
-        foreach ($matches[0] as $index => $match) {
-            $offset = $match[1];
-            $source = extractLoggingConventionCall($contents, $offset);
-
-            if ($source === null) {
-                continue;
-            }
-
-            $calls[] = [
-                'method' => $matches[1][$index][0],
-                'source' => $source,
-                'line' => substr_count(substr($contents, 0, $offset), "\n") + 1,
-                'path' => str_replace(dirname(__DIR__, 2).'/', '', $file),
-            ];
-        }
-    }
-
-    return $calls;
+    return array_map(
+        fn (array $call): array => [
+            'method' => $call['match'],
+            'source' => $call['source'],
+            'line' => $call['line'],
+            'path' => $call['path'],
+        ],
+        conventionCalls('/Context::(add|addIf|addHidden|push|increment|decrement)\s*\(/'),
+    );
 }
 
 /**

--- a/tests/Feature/LogChannelPostureTest.php
+++ b/tests/Feature/LogChannelPostureTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use Monolog\Handler\SyslogUdpHandler;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+/**
+ * Wide-events Storage rule C8 (see .claude/skills/wide-events/SKILL.md): the
+ * resolved default log channel — and, when it is a stack, every channel in it —
+ * must stay local. RFA ships to user machines and never sends logs off-box.
+ *
+ * This needs the resolved Laravel config (env + stack expansion), so it lives
+ * here rather than in tests/Arch, which runs without app context.
+ */
+
+/** Drivers that always write to an off-box destination. */
+function remoteLogDrivers(): array
+{
+    return ['slack', 'syslog', 'errorlog'];
+}
+
+/** Monolog `handler_with` keys that point at a network destination. */
+function remoteHandlerKeys(): array
+{
+    return ['host', 'port', 'url', 'connectionString'];
+}
+
+/**
+ * Channel names reachable from `$channel`, expanding any `stack` driver
+ * recursively. Cycles are guarded by `$seen`.
+ *
+ * @param  list<string>  $seen
+ * @return list<string>
+ */
+function resolvedLogChannels(string $channel, array $seen = []): array
+{
+    if (in_array($channel, $seen, true)) {
+        return [];
+    }
+
+    $seen[] = $channel;
+    $config = config("logging.channels.{$channel}");
+
+    if (! is_array($config)) {
+        return [$channel];
+    }
+
+    if (($config['driver'] ?? null) !== 'stack') {
+        return [$channel];
+    }
+
+    $resolved = [];
+
+    foreach ($config['channels'] ?? [] as $member) {
+        $resolved = [...$resolved, ...resolvedLogChannels((string) $member, $seen)];
+    }
+
+    return $resolved;
+}
+
+function isRemoteLogChannel(string $channel): bool
+{
+    $config = config("logging.channels.{$channel}");
+
+    if (! is_array($config)) {
+        return false;
+    }
+
+    $driver = $config['driver'] ?? null;
+
+    if (in_array($driver, remoteLogDrivers(), true)) {
+        return true;
+    }
+
+    if ($driver !== 'monolog') {
+        return false;
+    }
+
+    if (($config['handler'] ?? null) === SyslogUdpHandler::class) {
+        return true;
+    }
+
+    $handlerWith = $config['handler_with'] ?? [];
+
+    return collect(remoteHandlerKeys())->contains(fn (string $key): bool => array_key_exists($key, $handlerWith));
+}
+
+test('the default log channel resolves to local-only sinks', function () {
+    $default = config('logging.default');
+
+    expect($default)->toBeString();
+
+    $channels = resolvedLogChannels((string) $default);
+
+    expect($channels)->not->toBeEmpty();
+
+    $remote = collect($channels)->filter(fn (string $channel): bool => isRemoteLogChannel($channel))->values()->all();
+
+    expect($remote)->toBeEmpty();
+});

--- a/tests/Unit/Support/LogSanitizerTest.php
+++ b/tests/Unit/Support/LogSanitizerTest.php
@@ -54,3 +54,9 @@ test('trims a trailing space at the truncation boundary before the marker', func
 test('leaves short clean text untouched', function () {
     expect(LogSanitizer::summary('unknown revision'))->toBe('unknown revision');
 });
+
+test('treats null as empty rather than throwing', function () {
+    // Optional exception fields (e.g. an updater error's ?string $stack) can be
+    // null; a sanitizer on an error path must never itself throw.
+    expect(LogSanitizer::summary(null))->toBe('');
+});

--- a/tests/Unit/Support/LogSanitizerTest.php
+++ b/tests/Unit/Support/LogSanitizerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Support\LogSanitizer;
+
+test('collapses whitespace and newlines into single spaces', function () {
+    expect(LogSanitizer::summary("fatal:  bad\n  object   HEAD\n"))
+        ->toBe('fatal: bad object HEAD');
+});
+
+test('strips ANSI color sequences', function () {
+    expect(LogSanitizer::summary("\e[31mfatal:\e[0m not a git repository"))
+        ->toBe('fatal: not a git repository');
+});
+
+test('replaces the home directory with a tilde', function () {
+    $home = $_SERVER['HOME'] ?? getenv('HOME');
+
+    if (! is_string($home) || $home === '' || $home === '/') {
+        $this->markTestSkipped('No usable HOME to scrub.');
+    }
+
+    expect(LogSanitizer::summary("cannot read {$home}/code/secret-repo/.git/config"))
+        ->toBe('cannot read ~/code/secret-repo/.git/config');
+});
+
+test('truncates overlong text with an ellipsis marker', function () {
+    $summary = LogSanitizer::summary(str_repeat('x', 500), 200);
+
+    expect(mb_strlen($summary))->toBe(201) // 200 chars + the … marker
+        ->and($summary)->toEndWith('…');
+});
+
+test('leaves short clean text untouched', function () {
+    expect(LogSanitizer::summary('unknown revision'))->toBe('unknown revision');
+});

--- a/tests/Unit/Support/LogSanitizerTest.php
+++ b/tests/Unit/Support/LogSanitizerTest.php
@@ -23,11 +23,32 @@ test('replaces the home directory with a tilde', function () {
         ->toBe('cannot read ~/code/secret-repo/.git/config');
 });
 
+test('leaves a sibling directory that merely shares the home prefix intact', function () {
+    $home = $_SERVER['HOME'] ?? getenv('HOME');
+
+    if (! is_string($home) || $home === '' || $home === '/') {
+        $this->markTestSkipped('No usable HOME to scrub.');
+    }
+
+    // `<home>2/...` is a different directory and must not be mangled into `~2/...`.
+    expect(LogSanitizer::summary("cannot read {$home}2/other/repo"))
+        ->toBe('cannot read '.rtrim($home, '/').'2/other/repo');
+});
+
 test('truncates overlong text with an ellipsis marker', function () {
     $summary = LogSanitizer::summary(str_repeat('x', 500), 200);
 
     expect(mb_strlen($summary))->toBe(201) // 200 chars + the … marker
         ->and($summary)->toEndWith('…');
+});
+
+test('trims a trailing space at the truncation boundary before the marker', function () {
+    // 199 non-spaces, then a space as the 200th char: rtrim drops it so the
+    // marker never trails whitespace, yielding 199 chars + the marker.
+    $summary = LogSanitizer::summary(str_repeat('a', 199).' '.str_repeat('b', 50), 200);
+
+    expect($summary)->toEndWith('a…')
+        ->and(mb_strlen($summary))->toBe(200);
 });
 
 test('leaves short clean text untouched', function () {


### PR DESCRIPTION
## Summary

Implements comprehensive architectural enforcement of the wide-events logging protocol through new CI-checkable rules, adds privacy-safe exception sanitization, and refactors logging infrastructure to ensure consistent, queryable event shapes across success and failure paths.

## Key Changes

**Logging Architecture Tests** (`tests/Arch/LoggingConventionsTest.php`)
- Refactored helper functions to cache file reads and support pattern-based call extraction
- Added `conventionCalls()` for reusable paren-balanced facade call scanning
- Added `contextConventionCalls()` to scan `Context::*` method calls
- Added `staticStringLiteral()` to extract literal string values for static analysis
- New CI-enforced rules:
  - `Context::*` keys must be namespaced under `rfa.`
  - `rfa.outcome` values must use approved vocabulary (`completed`, `error`, `skipped`, `cancelled`, `rejected`, `partial`)
  - Context keys cannot use banned absolute-path names
  - Log and context payloads cannot carry raw exception text (`$e->getMessage()`, `$e->getTraceAsString()`, `$e->stderr`) — must wrap in `LogSanitizer::summary()`

**Exception Sanitization** (`app/Support/LogSanitizer.php`, `tests/Unit/Support/LogSanitizerTest.php`)
- New `LogSanitizer::summary()` utility that scrubs free-form process/exception text:
  - Strips ANSI color sequences
  - Collapses whitespace to single spaces
  - Replaces user's home directory with `~`
  - Truncates overlong text with ellipsis marker
- Comprehensive unit tests covering edge cases (sibling directories, truncation boundaries, etc.)

**Log Channel Posture** (`tests/Feature/LogChannelPostureTest.php`)
- New feature test verifying default log channel resolves to local-only sinks
- Detects remote drivers (`slack`, `syslog`, `errorlog`) and network-bound Monolog handlers
- Recursively expands stack channels to validate all members stay local
- Enforces RFA's no-off-box-logs requirement

**Updater Event Lifecycle** (`app/Providers/NativeAppServiceProvider.php`)
- Refactored `UpdateAvailable`, `UpdateDownloaded`, and `UpdateError` listeners to emit canonical info events on every terminal outcome
- Success paths now emit `Log::info('updater.available')` / `Log::info('updater.downloaded')` with `rfa.outcome = completed`
- Failure path now emits `Log::info('updater.failed')` with `rfa.outcome = error` (not just `Log::error()`)
- All paths record `rfa.duration_ms` via new `elapsedMs()` helper
- Error details wrapped in `LogSanitizer::summary()` to prevent raw exception text leakage
- Context flushed at start, fields added in `finally` block to ensure consistent shape

**Logging Configuration** (`config/logging.php`)
- Changed default channel from `stack` to `daily` (bounded, info-level, 7-day retention)
- Updated single channel default level from `debug` to `info`
- Added environment variable for daily log retention days

**Exception Handling Updates**
- `GitMetadataService`, `GetProjectStatusAction`, `EnsureRfaGitExcludeAction`, `LoadFileDiffAction`, `SyntaxHighlightService`, `OpenProjectFromPathAction`, `ResolveBranchBaseAction`: replaced raw `$e->getMessage()` with `$e->exitCode` or `LogSanitizer::summary()` in warning payloads
- `⚡review-page.blade.php`: wrapped exception text in `LogSanitizer::summary()`

**Documentation** (`.claude/skills/wide-events/SKILL.md`)
- Clarified Context facade usage (thin API slice, deliberate `flush()` requirement for single-process desktop app)
- Expanded canonical event rules: all outcomes must emit info events, listener-owned events measure callback duration unless reliable start time exists
- Added

https://claude.ai/code/session_01QCgoS3hBhpoPi7FCyGkULd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved logging and diagnostics for update, project, and syntax-highlighting flows.
  * Added safer, more consistent log summaries for command failures.

* **Bug Fixes**
  * Replaced raw error text with sanitized details or error class names in logs.
  * Improved update event timing and ensured failure states are still recorded.

* **Tests**
  * Added coverage for logging privacy rules and local-only log channel behavior.
  * Added tests for log sanitization output and truncation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->