### PR TITLE
fix(review): keep diff chrome out of selection citations

### DIFF
--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -95,6 +95,48 @@
         return lines.map((line) => `> ${line}`).join('\n') + '\n\n';
     }
 
+    // Reconstructs the selected text from `range`, scoped to `root` (one diff
+    // file), reading only the source-text content cells. `Selection.toString()`
+    // serializes every Text node the range spans, including the line-number and
+    // +/- prefix gutters — which are `user-select: none` (so they never render
+    // as selected) yet still land in the string once a selection crosses a row
+    // boundary, leaking `6`/`+` chrome into a citation. Walking the
+    // `.diff-cell-content` cells instead keeps the quote to real source: each
+    // row contributes one line, clamped to the selection's start/end offsets,
+    // joined with newlines so the citation mirrors the source's own line breaks
+    // and indentation. Returns '' when the range covers no content cell.
+    function selectionSourceText(range, root) {
+        if (!range || !root) return '';
+        const doc = root.ownerDocument || (typeof document !== 'undefined' ? document : null);
+        if (!doc) return '';
+
+        const seenRows = new Set();
+        const pieces = [];
+        root.querySelectorAll('.diff-cell-content').forEach((cell) => {
+            if (!range.intersectsNode(cell)) return;
+            const row = cell.closest('.diff-line');
+            // A split-view context row carries the same text in its primary and
+            // mirror cells; keep the first that the range touches so the line
+            // isn't quoted twice.
+            if (row) {
+                if (seenRows.has(row)) return;
+                seenRows.add(row);
+            }
+
+            const cellRange = doc.createRange();
+            cellRange.selectNodeContents(cell);
+            if (cell.contains(range.startContainer)) {
+                cellRange.setStart(range.startContainer, range.startOffset);
+            }
+            if (cell.contains(range.endContainer)) {
+                cellRange.setEnd(range.endContainer, range.endOffset);
+            }
+            pieces.push(cellRange.toString());
+        });
+
+        return pieces.join('\n');
+    }
+
     // Walks up from a Selection/Range node to the `.diff-line` row it sits in.
     // Text nodes resolve through their parent element. Returns null when the
     // node isn't inside a diff row (e.g. a selection in a comment box).
@@ -564,14 +606,16 @@
                     createLinePoint(lineRange.endLine, lineRange.side),
                 );
                 this.lastClickedPoint = this.formEndPoint ? { ...this.formEndPoint } : null;
-                this._prefillCitation(formatCitation(selection.toString()));
+                this._prefillCitation(formatCitation(selectionSourceText(selection.getRangeAt(0), this.$el)));
                 this.showForm = true;
                 this.focusCommentInput();
             },
 
-            // Current text selection as a string, but only when it begins inside
-            // this file's diff rows — so a stray selection elsewhere (a comment,
-            // another file) never leaks into this file's citation. '' otherwise.
+            // Current text selection as source text, but only when it begins
+            // inside this file's diff rows — so a stray selection elsewhere (a
+            // comment, another file) never leaks into this file's citation. Reads
+            // through selectionSourceText so the diff chrome (line-number / +-
+            // prefix gutters) is excluded. '' otherwise.
             _selectionTextWithinFile() {
                 const selection = this._activeSelection();
                 if (!selection) return '';
@@ -580,7 +624,7 @@
                     return '';
                 }
 
-                return selection.toString();
+                return selectionSourceText(selection.getRangeAt(0), this.$el);
             },
 
             submitComment(isDraft = false) {
@@ -740,6 +784,7 @@
         areLinePointsEqual,
         rowContainsLinePoint,
         formatCitation,
+        selectionSourceText,
         closestDiffLine,
         selectionLineRange,
         createDiffFile,

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -107,8 +107,7 @@
     // and indentation. Returns '' when the range covers no content cell.
     function selectionSourceText(range, root) {
         if (!range || !root) return '';
-        const doc = root.ownerDocument || (typeof document !== 'undefined' ? document : null);
-        if (!doc) return '';
+        const doc = root.ownerDocument;
 
         const seenRows = new Set();
         const pieces = [];

--- a/tests/Js/diff-file.test.js
+++ b/tests/Js/diff-file.test.js
@@ -9,6 +9,7 @@ const {
     areLinePointsEqual,
     rowContainsLinePoint,
     formatCitation,
+    selectionSourceText,
     closestDiffLine,
     selectionLineRange,
     createDiffFile,
@@ -634,6 +635,97 @@ describe('formatCitation', () => {
     });
 });
 
+describe('selectionSourceText', () => {
+    let root;
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    // Builds a Range from the first occurrence of `startStr` in the start cell's
+    // text to the end of the first occurrence of `endStr` in the end cell's text.
+    function rangeFromText(startSelector, startStr, endSelector, endStr) {
+        const startNode = document.querySelector(startSelector).firstChild;
+        const endNode = document.querySelector(endSelector).firstChild;
+        const range = document.createRange();
+        range.setStart(startNode, startNode.textContent.indexOf(startStr));
+        range.setEnd(endNode, endNode.textContent.indexOf(endStr) + endStr.length);
+        return range;
+    }
+
+    it('excludes the line-number and +/- prefix gutters when a selection crosses a row', () => {
+        // The reported bug: selecting "Otwell … Porzio)" across a hard-wrapped
+        // markdown paragraph dragged the line-number (6) and add-marker (+)
+        // gutter cells of the second row into the citation.
+        document.body.innerHTML = `
+            <div id="file-root">
+                <div class="diff-line" data-line-new="5"><div class="diff-cell-num"></div><div class="diff-cell-num">5</div><div class="diff-cell-prefix">+</div><div class="diff-cell-content">standards and the simplification panel (Otwell, DHH, Wathan,</div></div>
+                <div class="diff-line" data-line-new="6"><div class="diff-cell-num"></div><div class="diff-cell-num">6</div><div class="diff-cell-prefix">+</div><div class="diff-cell-content">   Porzio), merged into one prioritized list.</div></div>
+            </div>
+        `;
+        root = document.getElementById('file-root');
+        const range = rangeFromText(
+            '[data-line-new="5"] .diff-cell-content', 'Otwell',
+            '[data-line-new="6"] .diff-cell-content', 'Porzio)',
+        );
+
+        const text = selectionSourceText(range, root);
+
+        // Real source only — no `5`, `6`, or `+` chrome — with each row's own
+        // line break and indentation preserved.
+        expect(text).toBe('Otwell, DHH, Wathan,\n   Porzio)');
+        expect(formatCitation(text)).toBe('> Otwell, DHH, Wathan,\n>    Porzio)\n\n');
+    });
+
+    it('returns the clamped substring for a selection within a single line', () => {
+        document.body.innerHTML = `
+            <div id="file-root">
+                <div class="diff-line" data-line-new="9"><div class="diff-cell-num">9</div><div class="diff-cell-prefix"> </div><div class="diff-cell-content">    const value = compute(input);</div></div>
+            </div>
+        `;
+        root = document.getElementById('file-root');
+        const range = rangeFromText(
+            '[data-line-new="9"] .diff-cell-content', 'compute',
+            '[data-line-new="9"] .diff-cell-content', 'compute',
+        );
+
+        expect(selectionSourceText(range, root)).toBe('compute');
+    });
+
+    it('preserves the leading indentation of a whole-line selection', () => {
+        document.body.innerHTML = `
+            <div id="file-root">
+                <div class="diff-line" data-line-new="9"><div class="diff-cell-num">9</div><div class="diff-cell-prefix">+</div><div class="diff-cell-content">    indented();</div></div>
+            </div>
+        `;
+        root = document.getElementById('file-root');
+        const cell = document.querySelector('.diff-cell-content');
+        const range = document.createRange();
+        range.selectNodeContents(cell);
+
+        expect(selectionSourceText(range, root)).toBe('    indented();');
+    });
+
+    it('quotes a split-view context row once, not once per mirror cell', () => {
+        document.body.innerHTML = `
+            <div id="file-root">
+                <div class="diff-line" data-line-old="3" data-line-new="3"><div class="diff-cell-num">3</div><div class="diff-cell-content">shared context</div><div class="diff-cell-content diff-cell-content-mirror" aria-hidden="true">shared context</div></div>
+            </div>
+        `;
+        root = document.getElementById('file-root');
+        const cell = document.querySelector('.diff-cell-content:not(.diff-cell-content-mirror)');
+        const range = document.createRange();
+        range.selectNodeContents(cell);
+
+        expect(selectionSourceText(range, root)).toBe('shared context');
+    });
+
+    it('returns an empty string when the range or root is missing', () => {
+        expect(selectionSourceText(null, document.body)).toBe('');
+        expect(selectionSourceText(document.createRange(), null)).toBe('');
+    });
+});
+
 describe('closestDiffLine', () => {
     afterEach(() => {
         document.body.innerHTML = '';
@@ -779,8 +871,8 @@ describe('comment on text selection', () => {
         globalThis.Alpine = { store: () => ({ collapseAll: false }) };
         document.body.innerHTML = `
             <div id="file-root">
-                <div class="diff-line" data-line-new="13"><div class="diff-cell-content">> Identify the single most undeniable paper cut</div></div>
-                <div class="diff-line" data-line-new="14"><div class="diff-cell-content">more context</div></div>
+                <div class="diff-line" data-line-new="13"><div class="diff-cell-num"></div><div class="diff-cell-num">13</div><div class="diff-cell-prefix">+</div><div class="diff-cell-content">Identify the single most undeniable paper cut</div></div>
+                <div class="diff-line" data-line-new="14"><div class="diff-cell-num"></div><div class="diff-cell-num">14</div><div class="diff-cell-prefix">+</div><div class="diff-cell-content">more context</div></div>
             </div>
         `;
         root = document.getElementById('file-root');
@@ -834,10 +926,10 @@ describe('comment on text selection', () => {
         expect(component.$refs.commentInput.focus).toHaveBeenCalled();
     });
 
-    it('anchors a multi-line selection across the spanned rows', () => {
+    it('anchors a multi-line selection across the spanned rows and excludes the gutter chrome', () => {
         const component = makeComponent();
         stubSelection({
-            text: 'line thirteen\nline fourteen',
+            text: 'ignored — citation reads source text from the DOM, not toString()',
             startSelector: '[data-line-new="13"] .diff-cell-content',
             endSelector: '[data-line-new="14"] .diff-cell-content',
         });
@@ -846,7 +938,9 @@ describe('comment on text selection', () => {
 
         expect(component.formLine).toBe(13);
         expect(component.formEndLine).toBe(14);
-        expect(component.formBody).toBe('> line thirteen\n> line fourteen\n\n');
+        // The line-number (13/14) and `+` prefix cells the range spans never
+        // leak into the quote — each row contributes only its source line.
+        expect(component.formBody).toBe('> Identify the single most undeniable paper cut\n> more context\n\n');
     });
 
     it('does nothing when the selection is collapsed', () => {


### PR DESCRIPTION
A text selection that crossed a diff row pulled the line-number and +/-
prefix gutter cells into the quoted citation (e.g. `> 6` / `> +` between
the real lines). Those cells are `user-select: none` so they never render
as selected, but Selection.toString() still serializes them once a range
spans rows.

Rebuild the citation from the source-text content cells only, via a new
selectionSourceText() helper: each row contributes one line, clamped to
the selection's start/end offsets and joined with newlines, so the quote
respects the source's own line breaks and indentation while dropping the
diff chrome.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J9LXdR2VM3DTXQSDHoqUbc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quoted text when commenting on selected diff content, so copied text now excludes line numbers and +/- gutter symbols.
  * Multi-line selections now use the visible source text from the file, preserving the correct lines and indentation.
  * Split-view context rows are no longer duplicated in quoted selections.
  * Selections outside file content now return empty text instead of partial UI text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->