### PR TITLE
Refactor theme switcher from segmented radio to dropdown menu

### DIFF
--- a/resources/CLAUDE.md
+++ b/resources/CLAUDE.md
@@ -44,7 +44,7 @@ When a path's text content is set client-side (e.g. `x-text` from a JS object), 
 
 ## Dark Mode
 - Managed by Flux's `@fluxAppearance` + `$flux.appearance` (`'light' | 'dark' | 'system'`)
-- The `theme-switcher` SFC is a segmented `flux:radio.group` bound `x-model="$flux.appearance"` — three states: light, dark, and system (follows the OS via `prefers-color-scheme`). `system` is the default when the user hasn't chosen.
+- The `theme-switcher` SFC is a `flux:dropdown`: a square ghost trigger whose icon mirrors the current mode (sun/moon/computer-desktop, swapped via `x-show="$flux.appearance === …"`), opening a `flux:menu.radio.group` bound `x-model="$flux.appearance"` with the three states — light, dark, and system (follows the OS via `prefers-color-scheme`). The active state carries the menu check. `system` is the default when the user hasn't chosen.
 - Flux applies/removes the `dark` class on `<html>` and tracks the OS in system mode; read the resolved boolean via `$flux.dark` (reactive to both explicit picks and OS changes while in system mode).
 - The switcher mirrors that `$flux.dark` value into the persistent `rfa_theme` cookie (`dark`/`light`, 1-year) via a single `x-effect`, so non-Livewire consumers can read the resolved theme without JS.
 

--- a/resources/views/livewire/⚡theme-switcher.blade.php
+++ b/resources/views/livewire/⚡theme-switcher.blade.php
@@ -21,19 +21,21 @@ new class extends Component {};
             <flux:icon.computer-desktop variant="outline" class="size-5" x-show="$flux.appearance === 'system'" x-cloak />
         </flux:button>
 
-        <flux:menu>
+        {{-- Hug the content instead of Flux's default min-w-48, which leaves a
+             wide empty gutter to the right of these short labels. --}}
+        <flux:menu class="min-w-0">
             <flux:menu.radio.group x-model="$flux.appearance">
                 <flux:menu.radio value="light">
-                    <flux:icon.sun variant="outline" class="size-4 me-2" />
-                    Light
+                    <flux:icon.sun variant="outline" class="size-4 me-2.5" />
+                    <span class="pe-2">Light</span>
                 </flux:menu.radio>
                 <flux:menu.radio value="dark">
-                    <flux:icon.moon variant="outline" class="size-4 me-2" />
-                    Dark
+                    <flux:icon.moon variant="outline" class="size-4 me-2.5" />
+                    <span class="pe-2">Dark</span>
                 </flux:menu.radio>
                 <flux:menu.radio value="system">
-                    <flux:icon.computer-desktop variant="outline" class="size-4 me-2" />
-                    System
+                    <flux:icon.computer-desktop variant="outline" class="size-4 me-2.5" />
+                    <span class="pe-2">System</span>
                 </flux:menu.radio>
             </flux:menu.radio.group>
         </flux:menu>

--- a/resources/views/livewire/⚡theme-switcher.blade.php
+++ b/resources/views/livewire/⚡theme-switcher.blade.php
@@ -14,8 +14,13 @@ new class extends Component {};
 >
     <flux:dropdown position="bottom" align="end">
         {{-- Trigger mirrors the current appearance: the icon swaps to whichever
-             mode is active so the collapsed control always reads as "current mode". --}}
-        <flux:button variant="ghost" size="sm" square aria-label="Theme" data-testid="theme-switcher-trigger">
+             mode is active so the collapsed control always reads as "current mode".
+             The accessible name tracks the same state so assistive tech announces
+             the active theme without opening the menu (static label is the
+             pre-hydration fallback). --}}
+        <flux:button variant="ghost" size="sm" square data-testid="theme-switcher-trigger"
+            aria-label="Theme"
+            x-bind:aria-label="'Theme: ' + { light: 'Light', dark: 'Dark', system: 'System' }[$flux.appearance]">
             <flux:icon.sun variant="outline" class="size-5" x-show="$flux.appearance === 'light'" x-cloak />
             <flux:icon.moon variant="outline" class="size-5" x-show="$flux.appearance === 'dark'" x-cloak />
             <flux:icon.computer-desktop variant="outline" class="size-5" x-show="$flux.appearance === 'system'" x-cloak />

--- a/resources/views/livewire/⚡theme-switcher.blade.php
+++ b/resources/views/livewire/⚡theme-switcher.blade.php
@@ -12,15 +12,30 @@ new class extends Component {};
          effect covers all three states without a separate matchMedia listener. --}}
     x-effect="document.cookie = 'rfa_theme=' + ($flux.dark ? 'dark' : 'light') + ';path=/;max-age=31536000;SameSite=Lax'"
 >
-    <flux:radio.group x-model="$flux.appearance" variant="segmented" size="sm" aria-label="Theme">
-        <flux:tooltip content="Light">
-            <flux:radio value="light" icon="sun" icon:variant="outline" aria-label="Light theme" />
-        </flux:tooltip>
-        <flux:tooltip content="Dark">
-            <flux:radio value="dark" icon="moon" icon:variant="outline" aria-label="Dark theme" />
-        </flux:tooltip>
-        <flux:tooltip content="Match system">
-            <flux:radio value="system" icon="computer-desktop" icon:variant="outline" aria-label="Match system theme" />
-        </flux:tooltip>
-    </flux:radio.group>
+    <flux:dropdown position="bottom" align="end">
+        {{-- Trigger mirrors the current appearance: the icon swaps to whichever
+             mode is active so the collapsed control always reads as "current mode". --}}
+        <flux:button variant="ghost" size="sm" square aria-label="Theme" data-testid="theme-switcher-trigger">
+            <flux:icon.sun variant="outline" class="size-5" x-show="$flux.appearance === 'light'" x-cloak />
+            <flux:icon.moon variant="outline" class="size-5" x-show="$flux.appearance === 'dark'" x-cloak />
+            <flux:icon.computer-desktop variant="outline" class="size-5" x-show="$flux.appearance === 'system'" x-cloak />
+        </flux:button>
+
+        <flux:menu>
+            <flux:menu.radio.group x-model="$flux.appearance">
+                <flux:menu.radio value="light">
+                    <flux:icon.sun variant="outline" class="size-4 me-2" />
+                    Light
+                </flux:menu.radio>
+                <flux:menu.radio value="dark">
+                    <flux:icon.moon variant="outline" class="size-4 me-2" />
+                    Dark
+                </flux:menu.radio>
+                <flux:menu.radio value="system">
+                    <flux:icon.computer-desktop variant="outline" class="size-4 me-2" />
+                    System
+                </flux:menu.radio>
+            </flux:menu.radio.group>
+        </flux:menu>
+    </flux:dropdown>
 </div>

--- a/tests/Feature/View/ThemeSwitcherComponentTest.php
+++ b/tests/Feature/View/ThemeSwitcherComponentTest.php
@@ -27,6 +27,11 @@ test('collapses into a dropdown whose trigger reflects the current mode', functi
         ->assertSeeHtml("x-show=\"\$flux.appearance === 'system'\"");
 });
 
+test('announces the active theme in the trigger accessible name', function () {
+    Livewire::test('theme-switcher')
+        ->assertSeeHtml("x-bind:aria-label=\"'Theme: ' + { light: 'Light', dark: 'Dark', system: 'System' }[\$flux.appearance]\"");
+});
+
 test('mirrors the resolved theme into the rfa_theme cookie', function () {
     Livewire::test('theme-switcher')
         ->assertSeeHtml('rfa_theme');

--- a/tests/Feature/View/ThemeSwitcherComponentTest.php
+++ b/tests/Feature/View/ThemeSwitcherComponentTest.php
@@ -12,10 +12,19 @@ test('offers light, dark, and system as the three theme states', function () {
         ->assertSeeHtml('value="system"');
 });
 
-test('binds the segmented control to the flux appearance state', function () {
+test('binds the radio menu to the flux appearance state', function () {
     Livewire::test('theme-switcher')
         ->assertSeeHtml('x-model="$flux.appearance"')
-        ->assertSeeHtml('data-flux-radio-group-segmented');
+        ->assertSeeHtml('data-flux-menu-radio-group');
+});
+
+test('collapses into a dropdown whose trigger reflects the current mode', function () {
+    Livewire::test('theme-switcher')
+        ->assertSeeHtml('data-testid="theme-switcher-trigger"')
+        ->assertSeeHtml('data-flux-menu')
+        ->assertSeeHtml("x-show=\"\$flux.appearance === 'light'\"")
+        ->assertSeeHtml("x-show=\"\$flux.appearance === 'dark'\"")
+        ->assertSeeHtml("x-show=\"\$flux.appearance === 'system'\"");
 });
 
 test('mirrors the resolved theme into the rfa_theme cookie', function () {


### PR DESCRIPTION
## Summary
Converts the theme switcher component from a segmented radio group to a compact dropdown menu, improving UI density while maintaining full functionality.

## Changes
- **Component structure**: Replaced `flux:radio.group` (segmented variant) with `flux:dropdown` containing a `flux:menu.radio.group`
- **Trigger button**: Added a square ghost button that dynamically displays the current theme icon (sun/moon/computer-desktop) via `x-show` conditionals, making the active mode immediately visible when collapsed
- **Menu styling**: Applied `min-w-0` to the menu to eliminate excess padding and align with the short label widths
- **Icons**: Integrated Flux icon components with consistent sizing (size-5 for trigger, size-4 for menu items)
- **Accessibility**: Maintained `aria-label` on trigger and preserved radio semantics in the menu
- **Tests**: Updated test assertions to verify dropdown structure (`data-flux-menu`, `data-flux-menu-radio-group`) and added new test confirming the trigger icon swaps based on `$flux.appearance` state
- **Documentation**: Updated CLAUDE.md to reflect the new dropdown + menu radio pattern

## Implementation Details
- The trigger icon uses Alpine's `x-show` with `x-cloak` to prevent flash of unstyled content
- Cookie persistence and Flux appearance binding remain unchanged
- The dropdown maintains the same three theme options (light, dark, system) with identical behavior

https://claude.ai/code/session_01VpaeM9XZmSggwLqqwngkP7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the theme switcher to use a dropdown menu with Light, Dark, and System options.
  * The trigger now shows an icon that reflects the active theme.

* **Documentation**
  * Revised the Dark Mode docs to match the updated theme switcher experience.

* **Tests**
  * Added coverage for the new dropdown behavior and active-theme display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->