### PR TITLE
Settle divergence banners through islands instead of page morphs

### DIFF
--- a/app/Concerns/ReviewPage/ReviewsBranchDivergence.php
+++ b/app/Concerns/ReviewPage/ReviewsBranchDivergence.php
@@ -25,9 +25,9 @@ use Livewire\Attributes\On;
  *
  * Component state read/written: $divergenceState, $divergenceContext,
  * $dismissedAtHead, $dismissedAtBranch, $divergenceChecked, $projectBranch,
- * $projectId, $repoPath. Calls into the coordinator spine (isCommitMode,
- * softRefresh, rehydrateForTarget) and the render pipeline (skipRender,
- * dispatch).
+ * $projectId, $repoPath, $files. Calls into the coordinator spine
+ * (isCommitMode, softRefresh, rehydrateForTarget) and the render pipeline
+ * (skipRender, forceRender, renderIsland, dispatch).
  */
 trait ReviewsBranchDivergence
 {
@@ -37,9 +37,64 @@ trait ReviewsBranchDivergence
     #[On('head-divergence-transitioned')]
     public function checkHeadDivergence(): void
     {
+        $branchBefore = $this->projectBranch;
+
         if (! $this->refreshDivergenceState()) {
             $this->skipRender();
+
+            return;
         }
+
+        if ($this->divergenceNeedsFullRender($branchBefore)) {
+            return;
+        }
+
+        $this->skipRender();
+        $this->renderDivergenceIslands();
+    }
+
+    /**
+     * Re-check divergence from inside a comment write without settling the
+     * page render, which the mutation's flags own. A transition surfacing
+     * mid-write still refreshes the divergence islands: the poller sees the
+     * state as already applied on its next tick, so a skipRender mutation
+     * that swallowed the repaint would strand a stale banner.
+     */
+    private function recheckDivergenceDuringCommentWrite(): void
+    {
+        $branchBefore = $this->projectBranch;
+
+        if (! $this->refreshDivergenceState()) {
+            return;
+        }
+
+        if ($this->divergenceNeedsFullRender($branchBefore)) {
+            // Pin the render before the mutation's skipRender flag latches.
+            $this->forceRender();
+
+            return;
+        }
+
+        $this->renderDivergenceIslands();
+    }
+
+    /**
+     * Banner-only transitions settle through the divergence islands because
+     * a parent render re-hydrates every diff-file child. Two transitions
+     * still need the whole page: an auto-follow re-pointed the review and
+     * replaced the file list, and an empty file list, whose divergence
+     * empty-state message lives outside the islands (that morph is
+     * cheap: there are no children).
+     */
+    private function divergenceNeedsFullRender(string $branchBefore): bool
+    {
+        return $this->projectBranch !== $branchBefore || $this->files === [];
+    }
+
+    private function renderDivergenceIslands(): void
+    {
+        $this->renderIsland('divergence-marker');
+        $this->renderIsland('divergence-missing-bar');
     }
 
     /**

--- a/app/DTOs/ReviewCommentMutation.php
+++ b/app/DTOs/ReviewCommentMutation.php
@@ -52,8 +52,9 @@ final readonly class ReviewCommentMutation
 
     /**
      * A comment was removed: refresh its file when the id is known, offer undo
-     * when the deleted row was loaded, and re-check divergence. Renders the
-     * parent so the sidebar and empty states reflect the removal.
+     * when the deleted row was loaded, and re-check divergence. The removal
+     * reaches its child through comment-updated, so the parent render
+     * is skipped.
      *
      * @param  array<int, array<string, mixed>>  $comments
      * @param  array<string, mixed>|null  $deletedComment
@@ -67,13 +68,15 @@ final readonly class ReviewCommentMutation
                 ? ['type' => 'delete', 'payload' => [$deletedComment], 'message' => 'Comment deleted']
                 : null,
             checksDivergence: true,
-            skipsRender: false,
+            skipsRender: true,
         );
     }
 
     /**
      * Every loaded comment was cleared: refresh the affected files, offer undo
-     * with the cleared rows, and re-check divergence. Renders the parent.
+     * with the cleared rows, and re-check divergence. The clears reach their
+     * children through comment-updated events, so the parent render
+     * is skipped.
      *
      * @param  array<int, array<string, mixed>>  $comments
      * @param  list<string>  $affectedFileIds
@@ -88,21 +91,22 @@ final readonly class ReviewCommentMutation
             $affectedFileIds,
             ['type' => 'clear-all', 'payload' => $clearedComments, 'message' => 'Cleared '.$count.' comment'.($count === 1 ? '' : 's')],
             checksDivergence: true,
-            skipsRender: false,
+            skipsRender: true,
         );
     }
 
     /**
      * Removed comments were restored (the undo path): refresh the affected
-     * files and re-check divergence. Carries no undo of its own and renders the
-     * parent so the sidebar and empty states reflect the restored comments.
+     * files and re-check divergence. Carries no undo of its own; the restored
+     * rows reach their children through comment-updated events, so the
+     * parent render is skipped.
      *
      * @param  array<int, array<string, mixed>>  $comments
      * @param  list<string>  $affectedFileIds
      */
     public static function restored(array $comments, array $affectedFileIds): self
     {
-        return new self($comments, $affectedFileIds, null, checksDivergence: true, skipsRender: false);
+        return new self($comments, $affectedFileIds, null, checksDivergence: true, skipsRender: true);
     }
 
     /**

--- a/resources/CLAUDE.md
+++ b/resources/CLAUDE.md
@@ -199,6 +199,10 @@ ReviewPage (`resources/views/pages/⚡review-page.blade.php`) renders N DiffFile
 | `rfa-hide-reviewed` | `reviewed-toggle` island button `$dispatch` (window) | ReviewPage root Alpine `@window` -> queued `$wire.hideReviewedFiles` | none |
 | `rfa-show-all-files` | `reviewed-toggle` island button `$dispatch` (window) | ReviewPage root Alpine `@window` -> queued `$wire.showAllFiles` | none |
 | `rfa-clear-recently-reviewed` | Recently-reviewed "Clear" button `$dispatch` (window) | ReviewPage root Alpine `@window` -> queued `$wire.clearRecentlyReviewed` | none |
+| `rfa-keep-reviewing` | divergence marker popover button `$dispatch` (window; the marker lives in the `divergence-marker` island, so a wire:click would settle only that island) | ReviewPage root Alpine `@window` -> `$wire.keepReviewing` | none |
+| `rfa-switch-review-to-head` | divergence marker popover + missing-target bar buttons `$dispatch` (window) | ReviewPage root Alpine `@window` -> `$wire.switchReviewToHead` | none |
+| `rfa-dismiss-detached-banner` | divergence marker popover button `$dispatch` (window) | ReviewPage root Alpine `@window` -> `$wire.dismissDetachedBanner` | none |
+| `rfa-dismiss-missing-target` | missing-target bar button `$dispatch` (window; the bar lives in the `divergence-missing-bar` island) | ReviewPage root Alpine `@window` -> `$wire.dismissMissingTarget` | none |
 | `rfa-comment-selection` | ReviewPage Alpine `$dispatch` (window), fired by the `review.comment-selection` shortcut (`c`); resolves the selection's owning file id from its `[data-file-id]` ancestor | DiffFile Alpine `@window` -> `if ($event.detail.fileId === fileId) commentOnSelection()` | `{fileId}` |
 | `comment-updated` | ReviewPage PHP dispatch | DiffFile Alpine `@window` | `{fileId, comments}` |
 | `copy-to-clipboard` | DiffFile Alpine/PHP, ReviewPage PHP, comment-display, comments-drawer, branch-explorer | layout `<body>` Alpine `@window` | `{text, toast?}` (if `toast` string is set, a success toast with that text shows on success) |

--- a/resources/CLAUDE.md
+++ b/resources/CLAUDE.md
@@ -182,6 +182,7 @@ ReviewPage (`resources/views/pages/⚡review-page.blade.php`) renders N DiffFile
 | `toggleReviewed` | Yes | Always skips the parent render; refreshes the `reviewed-toggle`, `reviewed-counter`, and `file-list` islands, plus the visibility islands (`source-diff-list`, `file-count`, `file-list-header`, `status-strip-copy-paths`) in Hide-reviewed mode where the toggle drops the file from the visible set. |
 | `hideReviewedFiles` / `showAllFiles` | Yes | Skip the parent render; refresh `reviewed-toggle`, `reviewed-counter`, `file-list`, and the visibility islands as files drop in/out of the visible set. |
 | `clearRecentlyReviewed` | Yes | Skip the parent render; refresh `file-list` only in Hide-reviewed mode (where the Recently-reviewed group shows). |
+| `checkHeadDivergence` | Yes | Poller transitions settle through the `divergence-marker` and `divergence-missing-bar` islands instead of morphing the page. Renders the page only when auto-follow rehydrated the file list, or when the file list is empty (the divergence empty-state message lives outside the islands and there are no children to re-hydrate). |
 | `submitReview` | No | Replaces entire submit bar UI (submitted state) |
 | `discardFileChanges` | No | Structural change: file removed from list, trash updated |
 | `restoreDiscardedFile` | No | Structural change: file reappears in list |

--- a/resources/views/components/divergence/marker.blade.php
+++ b/resources/views/components/divergence/marker.blade.php
@@ -7,7 +7,11 @@
     where its cause does. Only shows for the quiet, recoverable states
     (Diverged / Detached); MissingTarget is a blocking bar (<x-divergence.missing-bar>).
 
-    Buttons call ReviewPage actions directly (this is rendered inside its DOM).
+    Rendered inside the review page's `divergence-marker` island, where a
+    wire:click would scope its render to the island. Buttons instead
+    `$dispatch` bubbling `rfa-*` window events that the page-root
+    Alpine forwards to `$wire`, so the actions settle the whole
+    page (see the event schema in resources/CLAUDE.md).
 --}}
 @props(['state', 'context' => []])
 
@@ -80,10 +84,10 @@
 
             <div class="flex items-center justify-end gap-1 px-3 py-2.5 border-t border-gh-border bg-gh-surface/50">
                 @if($isDiverged)
-                    <button type="button" wire:click="keepReviewing" @click="open = false" class="text-xs font-medium text-gh-muted hover:text-gh-text px-2.5 py-1.5 rounded-md transition-colors">Keep reviewing</button>
-                    <button type="button" wire:click="switchReviewToHead" @click="open = false" class="text-xs font-medium font-display rounded-md px-3 py-1.5 bg-gh-accent text-gh-bg hover:opacity-90 transition-opacity">Switch review here</button>
+                    <button type="button" @click="open = false; $dispatch('rfa-keep-reviewing')" class="text-xs font-medium text-gh-muted hover:text-gh-text px-2.5 py-1.5 rounded-md transition-colors">Keep reviewing</button>
+                    <button type="button" @click="open = false; $dispatch('rfa-switch-review-to-head')" class="text-xs font-medium font-display rounded-md px-3 py-1.5 bg-gh-accent text-gh-bg hover:opacity-90 transition-opacity">Switch review here</button>
                 @else
-                    <button type="button" wire:click="dismissDetachedBanner" @click="open = false" class="text-xs font-medium text-gh-muted hover:text-gh-text px-2.5 py-1.5 rounded-md transition-colors">Dismiss</button>
+                    <button type="button" @click="open = false; $dispatch('rfa-dismiss-detached-banner')" class="text-xs font-medium text-gh-muted hover:text-gh-text px-2.5 py-1.5 rounded-md transition-colors">Dismiss</button>
                 @endif
             </div>
         </div>

--- a/resources/views/components/divergence/missing-bar.blade.php
+++ b/resources/views/components/divergence/missing-bar.blade.php
@@ -5,7 +5,10 @@
     longer exists (deleted / renamed / mid-rebase). Unlike Diverged/Detached
     (quiet header marker), this stays a full-width bar — but on-brand (house
     pattern from update-banner, gh-* tokens) rather than a stock-Flux callout,
-    and now dismissible. Buttons call ReviewPage actions directly.
+    and now dismissible. Rendered inside the review page's
+    `divergence-missing-bar` island, where a wire:click would scope its
+    render to the island: buttons instead `$dispatch` bubbling `rfa-*`
+    window events that the page-root Alpine forwards to `$wire`.
 --}}
 @props(['state', 'context' => []])
 
@@ -28,9 +31,9 @@
                 </p>
             </div>
             <div class="flex items-center gap-1 shrink-0">
-                <button type="button" wire:click="dismissMissingTarget" class="text-xs font-medium text-gh-muted hover:text-gh-text px-2.5 py-1.5 rounded-md transition-colors">Dismiss</button>
+                <button type="button" @click="$dispatch('rfa-dismiss-missing-target')" class="text-xs font-medium text-gh-muted hover:text-gh-text px-2.5 py-1.5 rounded-md transition-colors">Dismiss</button>
                 @if($currentBranch)
-                    <button type="button" wire:click="switchReviewToHead" class="text-xs font-medium font-display rounded-md px-3 py-1.5 bg-gh-accent text-gh-bg hover:opacity-90 transition-opacity">Switch review here</button>
+                    <button type="button" @click="$dispatch('rfa-switch-review-to-head')" class="text-xs font-medium font-display rounded-md px-3 py-1.5 bg-gh-accent text-gh-bg hover:opacity-90 transition-opacity">Switch review here</button>
                 @endif
             </div>
         </div>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -696,8 +696,9 @@ new #[Layout('layouts.app')] class extends Component
      * The new comment reaches its child through the event, so the parent skips
      * its own render where the mutation allows. That avoids re-hydrating every
      * diff-file child (the TooManyComponentsException hazard) and keeps the 1+N
-     * contract. Divergence transitions surface through the head-divergence
-     * poller, not by piggybacking on comment writes.
+     * contract. A divergence transition caught by the write's re-check settles
+     * through the divergence islands, so the banner stays current even when
+     * the mutation skips the parent render.
      */
     private function applyCommentMutation(?ReviewCommentMutation $mutation): void
     {
@@ -721,7 +722,7 @@ new #[Layout('layouts.app')] class extends Component
         }
 
         if ($mutation->checksDivergence) {
-            $this->checkHeadDivergence();
+            $this->recheckDivergenceDuringCommentWrite();
         }
 
         if ($mutation->skipsRender) {
@@ -1337,7 +1338,11 @@ new #[Layout('layouts.app')] class extends Component
                         :default-base-branch="$defaultBaseBranch"
                     />
                     @if(! $this->isCommitMode())
-                        <x-divergence.marker :state="$divergenceState" :context="$divergenceContext" />
+                        {{-- Island so a banner-only divergence transition repaints the
+                             marker without morphing the page (see renderDivergenceIslands). --}}
+                        @island(name: 'divergence-marker', always: true)
+                            <x-divergence.marker :state="$divergenceState" :context="$divergenceContext" />
+                        @endisland
                     @endif
                 @endif
                 <livewire:comments-drawer :repo-path="$repoPath" :project-id="$projectId ?: null" />
@@ -1498,7 +1503,9 @@ new #[Layout('layouts.app')] class extends Component
             :target="$projectBranch"
         />
 
-        <x-divergence.missing-bar :state="$divergenceState" :context="$divergenceContext" />
+        @island(name: 'divergence-missing-bar', always: true)
+            <x-divergence.missing-bar :state="$divergenceState" :context="$divergenceContext" />
+        @endisland
     @endif
 
     @if($commitInfo)

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1217,6 +1217,14 @@ new #[Layout('layouts.app')] class extends Component
     x-on:rfa-hide-reviewed.window="hideReviewedFiles()"
     x-on:rfa-show-all-files.window="showAllFiles()"
     x-on:rfa-clear-recently-reviewed.window="clearRecentlyReviewed()"
+    {{-- Divergence banner buttons sit inside the divergence islands, where a
+         wire:click would scope its render to that island. They bridge through
+         these window events so the actions run at page scope: switching and
+         keep/dismiss all settle more than the banner they were clicked in. --}}
+    x-on:rfa-keep-reviewing.window="$wire.keepReviewing()"
+    x-on:rfa-switch-review-to-head.window="$wire.switchReviewToHead()"
+    x-on:rfa-dismiss-detached-banner.window="$wire.dismissDetachedBanner()"
+    x-on:rfa-dismiss-missing-target.window="$wire.dismissMissingTarget()"
     {{-- Filter/file/commit shortcuts are registered through the keymap store
          (see registerShortcuts() in review-page.js). Only the in-input Escape
          that clears the file filter stays here, since the store suppresses

--- a/tests/Unit/Actions/ReviewCommentWorkflowActionTest.php
+++ b/tests/Unit/Actions/ReviewCommentWorkflowActionTest.php
@@ -102,7 +102,7 @@ test('update returns null when no row matches the id', function () {
 
 // -- delete --
 
-test('delete removes the comment and offers undo while rendering the parent', function () {
+test('delete removes the comment and offers undo while skipping the parent render', function () {
     $added = ($this->add)([])->comments;
     $commentId = $added[0]['id'];
 
@@ -115,7 +115,7 @@ test('delete removes the comment and offers undo while rendering the parent', fu
         ->and($mutation->undo['payload'][0]['id'])->toBe($commentId)
         ->and($mutation->undo['message'])->toBe('Comment deleted')
         ->and($mutation->checksDivergence)->toBeTrue()
-        ->and($mutation->skipsRender)->toBeFalse();
+        ->and($mutation->skipsRender)->toBeTrue();
 
     expect(Comment::find($commentId))->toBeNull();
 });
@@ -134,12 +134,12 @@ test('delete of a valid id absent from the pool offers no undo and refreshes no 
         ->and($mutation->affectedFileIds)->toBe([])
         ->and($mutation->undo)->toBeNull()
         ->and($mutation->checksDivergence)->toBeTrue()
-        ->and($mutation->skipsRender)->toBeFalse();
+        ->and($mutation->skipsRender)->toBeTrue();
 });
 
 // -- clearAll --
 
-test('clearAll deletes every comment and offers undo while rendering the parent', function () {
+test('clearAll deletes every comment and offers undo while skipping the parent render', function () {
     $first = ($this->add)([], 'file-abc', 'one')->comments;
     $both = ($this->add)($first, 'file-def', 'two')->comments;
 
@@ -152,7 +152,7 @@ test('clearAll deletes every comment and offers undo while rendering the parent'
         ->and($mutation->undo['payload'])->toHaveCount(2)
         ->and($mutation->undo['message'])->toBe('Cleared 2 comments')
         ->and($mutation->checksDivergence)->toBeTrue()
-        ->and($mutation->skipsRender)->toBeFalse();
+        ->and($mutation->skipsRender)->toBeTrue();
 
     expect(Comment::count())->toBe(0);
 });
@@ -182,7 +182,7 @@ test('restore re-persists a removed comment and re-checks divergence without off
         ->and($mutation->affectedFileIds)->toBe(['file-abc'])
         ->and($mutation->undo)->toBeNull()
         ->and($mutation->checksDivergence)->toBeTrue()
-        ->and($mutation->skipsRender)->toBeFalse();
+        ->and($mutation->skipsRender)->toBeTrue();
 
     expect(Comment::where('id', $commentId)->exists())->toBeTrue();
 });

--- a/tests/Unit/Livewire/ReviewPageBranchDivergenceTest.php
+++ b/tests/Unit/Livewire/ReviewPageBranchDivergenceTest.php
@@ -17,6 +17,13 @@ use Tests\TestCase;
 
 uses(TestCase::class, LazilyRefreshDatabase::class);
 
+function divergenceIslandFragments(mixed $component, string $name): string
+{
+    return collect($component->effects['islandFragments'] ?? [])
+        ->filter(fn (string $fragment): bool => str_contains($fragment, "name={$name}|"))
+        ->implode("\n");
+}
+
 /**
  * Install a controllable GetCurrentHeadAction fake in the container.
  * Tests mutate `$fake->result` to simulate a HEAD move across poll ticks.
@@ -169,7 +176,8 @@ test('missing_target banner shown when the target vanishes mid-review', function
     expect($component->get('divergenceState'))->toBe(DivergenceState::MissingTarget);
     expect($component->get('divergenceContext.target'))->toBe('main');
     expect($component->get('divergenceContext.currentBranch'))->toBe('feature-x');
-    $component->assertSeeHtml('data-testid="divergence-banner-missing"');
+    // The bar arrives through its island: the transition skips the page morph.
+    expect(divergenceIslandFragments($component, 'divergence-missing-bar'))->toContain('divergence-banner-missing');
 });
 
 test('initial open auto-follows the checked-out branch when the stored target is gone', function () {
@@ -388,6 +396,171 @@ test('switchReviewToHead is undoable and undo restores the original target', fun
     // HEAD is still on feature-x, so restoring the main target must re-surface
     // divergence — the head poller won't fire on an unchanged HEAD identity.
     expect($component->get('divergenceState'))->toBe(DivergenceState::Diverged);
+});
+
+test('banner-only transition skips the parent render and paints the divergence islands', function () {
+    Comment::create([
+        'id' => 'c1',
+        'project_id' => $this->project->id,
+        'repo_path' => $this->project->path,
+        'origin_ref' => 'main',
+        'file_path' => 'src/Foo.php',
+        'side' => 'new',
+        'start_line' => 1,
+        'end_line' => 1,
+        'file_content_hash' => 'mock-hash',
+        'body' => 'hello',
+        'is_draft' => false,
+        'submitted_at' => now(),
+    ]);
+
+    $fake = bindFakeCurrentHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
+
+    $component = Livewire::test('pages::review-page', ['slug' => 'divergence-test']);
+    expect($component->get('divergenceState'))->toBe(DivergenceState::Aligned);
+
+    $fake->result = new CurrentHeadResult(branch: 'feature-x', sha: 'b'.str_repeat('0', 39), detached: false, targetExists: true);
+    $component->call('checkHeadDivergence');
+
+    expect($component->get('divergenceState'))->toBe(DivergenceState::Diverged);
+    // A page morph would re-hydrate every diff-file child, so the banner must
+    // travel through its island instead.
+    expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue();
+    expect(divergenceIslandFragments($component, 'divergence-marker'))->toContain('divergence-banner-diverged');
+});
+
+test('unchanged divergence skips the parent render without painting islands', function () {
+    $fake = bindFakeCurrentHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
+
+    $component = Livewire::test('pages::review-page', ['slug' => 'divergence-test']);
+
+    $component->call('checkHeadDivergence');
+
+    expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue();
+    expect(divergenceIslandFragments($component, 'divergence-marker'))->toBe('');
+    expect(divergenceIslandFragments($component, 'divergence-missing-bar'))->toBe('');
+});
+
+test('auto-follow transition renders the whole page because the file list was rehydrated', function () {
+    // No comments, so a HEAD move silently re-points the review.
+    $fake = bindFakeCurrentHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
+
+    $component = Livewire::test('pages::review-page', ['slug' => 'divergence-test']);
+
+    $fake->result = new CurrentHeadResult(branch: 'feature-x', sha: 'b'.str_repeat('0', 39), detached: false, targetExists: true);
+    $component->call('checkHeadDivergence');
+
+    expect($component->get('projectBranch'))->toBe('feature-x');
+    expect(\Livewire\store($component->instance())->get('skipRender', false))->toBeFalse();
+});
+
+test('a transition with no files renders the page so the divergence empty state updates', function () {
+    // The divergence empty-state message lives outside the islands; with no
+    // diff-file children the full morph is the cheap and correct path.
+    app()->bind(GetFileListAction::class, fn () => new class
+    {
+        public function handle(string $repoPath, bool $clearCache = true, ?int $projectId = null, ?string $globalGitignorePath = null, ?DiffTarget $target = null): array
+        {
+            return [];
+        }
+    });
+
+    Comment::create([
+        'id' => 'c1',
+        'project_id' => $this->project->id,
+        'repo_path' => $this->project->path,
+        'origin_ref' => 'main',
+        'file_path' => 'src/Foo.php',
+        'side' => 'new',
+        'start_line' => 1,
+        'end_line' => 1,
+        'file_content_hash' => 'mock-hash',
+        'body' => 'hello',
+        'is_draft' => false,
+        'submitted_at' => now(),
+    ]);
+
+    $fake = bindFakeCurrentHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
+
+    $component = Livewire::test('pages::review-page', ['slug' => 'divergence-test']);
+
+    $fake->result = new CurrentHeadResult(branch: 'feature-x', sha: 'b'.str_repeat('0', 39), detached: false, targetExists: true);
+    $component->call('checkHeadDivergence');
+
+    expect($component->get('divergenceState'))->toBe(DivergenceState::Diverged);
+    expect(\Livewire\store($component->instance())->get('skipRender', false))->toBeFalse();
+    $component->assertSeeHtml('Nothing to review on');
+});
+
+test('deleting a comment skips the parent render when divergence is unchanged', function () {
+    Comment::create([
+        'id' => 'c-1',
+        'project_id' => $this->project->id,
+        'repo_path' => $this->project->path,
+        'origin_ref' => 'main',
+        'file_path' => 'src/Foo.php',
+        'side' => 'new',
+        'start_line' => 1,
+        'end_line' => 1,
+        'file_content_hash' => 'mock-hash',
+        'body' => 'hello',
+        'is_draft' => false,
+        'submitted_at' => now(),
+    ]);
+
+    bindFakeCurrentHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
+
+    $component = Livewire::test('pages::review-page', ['slug' => 'divergence-test']);
+
+    $component->set('comments', [[
+        'id' => 'c-1',
+        'fileId' => 'abc123',
+        'file' => 'src/Foo.php',
+        'side' => 'new',
+        'startLine' => 1,
+        'endLine' => 1,
+        'body' => 'hello',
+        'isDraft' => false,
+    ]]);
+    $component->call('deleteComment', 'c-1');
+
+    // The mutation's flag owns the skip; the unchanged divergence re-check
+    // must neither paint islands nor decide the render.
+    expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue();
+    expect(divergenceIslandFragments($component, 'divergence-marker'))->toBe('');
+    expect(divergenceIslandFragments($component, 'divergence-missing-bar'))->toBe('');
+});
+
+test('a divergence transition caught during a comment write paints the divergence islands', function () {
+    Comment::create([
+        'id' => 'c1',
+        'project_id' => $this->project->id,
+        'repo_path' => $this->project->path,
+        'origin_ref' => 'main',
+        'file_path' => 'src/Foo.php',
+        'side' => 'new',
+        'start_line' => 1,
+        'end_line' => 1,
+        'file_content_hash' => 'mock-hash',
+        'body' => 'hello',
+        'is_draft' => false,
+        'submitted_at' => now(),
+    ]);
+
+    $fake = bindFakeCurrentHeadAction(new CurrentHeadResult(branch: 'main', sha: 'a'.str_repeat('0', 39), detached: false, targetExists: true));
+
+    $component = Livewire::test('pages::review-page', ['slug' => 'divergence-test']);
+    expect($component->get('divergenceState'))->toBe(DivergenceState::Aligned);
+
+    // HEAD moves between poller ticks; the write's re-check catches it first.
+    // The poller will see the state as already applied, so the banner must
+    // paint now, through the islands, despite the mutation's skipRender.
+    $fake->result = new CurrentHeadResult(branch: 'feature-x', sha: 'b'.str_repeat('0', 39), detached: false, targetExists: true);
+    $component->call('addComment', 'abc123', 'right', 1, 1, 'another note');
+
+    expect($component->get('divergenceState'))->toBe(DivergenceState::Diverged);
+    expect(\Livewire\store($component->instance())->get('skipRender'))->toBeTrue();
+    expect(divergenceIslandFragments($component, 'divergence-marker'))->toContain('divergence-banner-diverged');
 });
 
 test('dismissMissingTarget suppresses the missing-target banner for that branch', function () {

--- a/tests/Unit/Livewire/ReviewPageBranchDivergenceTest.php
+++ b/tests/Unit/Livewire/ReviewPageBranchDivergenceTest.php
@@ -151,6 +151,14 @@ test('diverged banner shown when HEAD differs and a comment exists', function ()
     expect($component->get('divergenceContext.commentCount'))->toBe(1);
     expect($component->get('projectBranch'))->toBe('main');
     $component->assertSeeHtml('data-testid="divergence-banner-diverged"');
+
+    // The banner sits inside the divergence-marker island, where a wire:click
+    // would settle only that island. Its actions must bridge through window
+    // events that the page root forwards to $wire at page scope.
+    $component->assertSeeHtml("\$dispatch('rfa-switch-review-to-head')");
+    $component->assertSeeHtml("\$dispatch('rfa-keep-reviewing')");
+    $component->assertSeeHtml('x-on:rfa-switch-review-to-head.window');
+    $component->assertSeeHtml('x-on:rfa-keep-reviewing.window');
 });
 
 test('detached banner shown when HEAD is detached', function () {
@@ -205,6 +213,12 @@ test('initial open keeps the banner and does not retarget when branch existence 
     expect($component->get('projectBranch'))->toBe('main');
     expect($this->project->fresh()->branch)->toBe('main');
     $component->assertSeeHtml('data-testid="divergence-banner-missing"');
+
+    // The bar sits inside the divergence-missing-bar island; its actions
+    // bridge through window events so they run at page scope.
+    $component->assertSeeHtml("\$dispatch('rfa-dismiss-missing-target')");
+    $component->assertSeeHtml('x-on:rfa-dismiss-missing-target.window');
+    $component->assertSeeHtml('x-on:rfa-dismiss-detached-banner.window');
 });
 
 test('keepReviewing suppresses the banner for that branch, even across new commits', function () {


### PR DESCRIPTION
## Summary

Implements the one presently actionable proposal from #104: divergence chrome now settles through explicit Livewire islands instead of full-page morphs.

- A HEAD-divergence transition from the poller used to re-render the whole review page, re-hydrating every diff-file child (the 1+N cost the page avoids everywhere else) even when only banner chrome changed. The header marker and the missing-target bar now live in `divergence-marker` / `divergence-missing-bar` islands that `checkHeadDivergence` refreshes under `skipRender()`, mirroring the reviewed-state settle pattern.
- The page still morphs for the two transitions that need it: an auto-follow that rehydrated the file list, and an empty file list, whose divergence empty-state message lives outside the islands (that morph is cheap: no children to re-hydrate).
- Comment writes now re-check divergence through `recheckDivergenceDuringCommentWrite()`, which leaves the page-render decision to the mutation's flags. That fixes two latent defects:
  1. A divergence transition caught mid-write painted nothing (the mutation's `skipRender` suppressed it), and the poller then saw the state as already applied and never repainted, stranding a stale banner until an unrelated full render.
  2. The unchanged-divergence path latched `skipRender()` over mutations whose flag asked for a render, so the flag was never effective.
- `ReviewCommentMutation::deleted()` / `cleared()` / `restored()` now declare `skipsRender: true`, matching their tested and shipped behavior (the `ReviewPageTest` "skips render" tests and the CLAUDE.md skipRender table); their previous `false` flag was always overridden by that latch, and no parent-rendered markup depends on comment state.

### Why the other five #104 proposals are not implemented

Each is conditional on a trigger that does not exist yet, or its concern is already covered: `applySelection` is already the server authority and rejects stale `snapshotKey`s; expand-context/expand-gap have no batching or keyboard-repeat controls and Livewire serializes same-component calls; bulk copy-paths is already server-computed (`copyVisiblePaths`); the context-page comment bridge and the review-page comment burst queue are gated on comment controls moving into islands or burst-firing toolbars, which has not happened. Building those queues and coordinators now would add mechanisms nothing exercises.

## Validation

- `vendor/bin/pint --dirty --format agent`
- `composer test:types` (PHPStan, clean)
- `composer test` — 1650/1653 pass; the 3 failures are `PatchNativeServerTest` vendored-NativePHP assertions that also fail on clean `main` in this environment
- New/updated coverage in `ReviewPageBranchDivergenceTest`: banner-only transition paints islands and skips the parent render, unchanged divergence paints nothing, auto-follow and empty-file-list transitions still morph the page, a transition caught during a comment write paints the islands, and comment deletion skips via its mutation flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5BYb5cTR149b9ahJFYNTm

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5BYb5cTR149b9ahJFYNTm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review page divergence indicators now update more smoothly, with banner and missing-target states refreshing independently when possible.
  * Comment actions can now update the review view without a full page rerender in more cases.

* **Bug Fixes**
  * Improved handling of branch divergence changes so the page fully refreshes only when needed.
  * Fixed mid-write comment updates so divergence notices stay current during transitions.

* **Documentation**
  * Updated review-page behavior notes to reflect the new update flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->