### PR TITLE
Wide events audit 2026-07-21

### DIFF
--- a/reports/wide-events/2026-07-21.md
+++ b/reports/wide-events/2026-07-21.md
@@ -1,0 +1,78 @@
+# Wide Events Audit: 2026-07-21
+
+## Summary
+
+- Deterministic checks: pass
+- Findings: 0 critical, 2 warning, 2 info
+- Files reviewed: 19
+
+## Deterministic Checks
+
+| Command | Result | Notes |
+|---|---|---|
+| `php artisan test --compact tests/Arch/LoggingConventionsTest.php` | pass | 8 tests, 8 assertions, 68ms |
+| `php artisan test --compact tests/Feature/LogChannelPostureTest.php` | pass | Default channel resolves to bounded local `daily`. Ran as a companion check for C8 storage posture. |
+
+Production log inventory (from the standard `rg` sweep):
+
+- Canonical `Log::info()` events: 4 (`review.refreshed`, `updater.available`, `updater.downloaded`, `updater.failed`)
+- `Log::warning()` calls: 12
+- `Log::error()` calls: 1 (`updater.failed` diagnostic, paired with the canonical info in `finally`)
+- `Log::critical()` calls: 0
+- `Log::debug()` calls: 0
+- `Context::flush()` call sites: 4 (all owners, no child)
+- `Context::add()` call sites: 21 (all keys `rfa.*`)
+
+## Findings
+
+### [WARNING] Deep-link listener has no canonical info event
+
+- **File:** `app/Listeners/HandleDeepLink.php:14`
+- **Rule:** Scope + Logging Ownership. The wide-events skill lists NativePHP listeners for deep links, menu events, and updater events as in scope, and says the listener owns the canonical event unless it delegates to a logged action.
+- **Evidence:** `HandleDeepLink::handle()` parses the URL, records two breadcrumbs through `RecordRuntimeDiagnosticAction`, calls `OpenProjectFromPathAction` (which logs only on unexpected failure), then swaps the window URL. No `Log::info()` is emitted on any terminal outcome. `RecordRuntimeDiagnosticAction` writes to a separate JSONL file through `RuntimeDiagnosticsService`, not the Laravel Log channel.
+- **Impact:** Deep-link opens do not appear in the canonical `rfa.outcome` distribution. Invalid scheme rejections, "not a git repo" outcomes, and successful navigations are indistinguishable from a query over the Log channel. The updater listeners in `NativeAppServiceProvider` set the precedent for how a listener-owned unit should emit even on failure.
+- **Suggested fix:** Wrap the handler body in the owner pattern (flush context, capture `microtime(true)`, `try`/`finally`, emit `deeplink.opened` with `rfa.outcome` in `completed`/`rejected`/`error`, plus `rfa.mode`, `rfa.route`, `rfa.path_hash`, `rfa.project_slug` where resolvable).
+
+### [WARNING] Menu-click listener has no canonical info event
+
+- **File:** `app/Listeners/HandleMenuItemClicked.php:26`
+- **Rule:** Scope + Logging Ownership. Same as above.
+- **Evidence:** `HandleMenuItemClicked::handle()` fires a breadcrumb, then dispatches by menu id to one of five handlers. The success paths call `RecordRuntimeDiagnosticAction` with names like `menu.open_repo.completed`, but nothing reaches `Log::info()`. Unknown menu ids and the check-updates path emit nothing.
+- **Impact:** Menu-driven navigations, "check for updates" clicks, and the show-shortcuts event never produce a canonical event. Failure modes (project cache stale, dialog cancelled, unknown id) are not observable through the Log channel.
+- **Suggested fix:** Emit `menu.item.clicked` from the top-level `handle()` in `finally`, with `rfa.menu_id`, `rfa.outcome`, and `rfa.duration_ms`. Sub-handlers that already have their own canonical event should not double-emit, matching the owner heuristic.
+
+### [INFO] Canonical events missing for several externally meaningful user operations
+
+- **File:** `resources/views/pages/⚡review-page.blade.php:576` (only `review.refreshed` in this cluster), plus absent from `app/Concerns/ReviewPage/ExportsReview.php`, `app/Actions/ExportReviewAction.php`, `app/Actions/ExportReviewSnapshotAction.php`, `app/Actions/DiscardFileChangesAction.php`, `app/Actions/RegisterProjectAction.php`, `app/Actions/ContextCommentWorkflowAction.php`, `app/Actions/ReviewCommentWorkflowAction.php`, `app/Actions/ToggleReviewedAction.php`, `app/Actions/ScanDirectoryAction.php`.
+- **Rule:** Scope + Doctrine. The skill lists Actions and Livewire methods with side effects as owners, and doctrine says one externally meaningful unit of work gets one canonical `Log::info()` event.
+- **Evidence:** Outside `review.refreshed` and the three updater events, no production canonical events exist. Submitting a review, exporting a snapshot, discarding a file, registering or removing a project, saving a comment, and toggling reviewed all touch DB or filesystem state without emitting a canonical event. `RecordRuntimeDiagnosticAction` breadcrumbs cover some of these but do not go through the Log channel.
+- **Impact:** The `rfa.outcome` distribution for user-driven work is dominated by refreshes and updater callbacks, so real usage patterns and failure rates for submit, export, discard, register, and comment writes are invisible when the Log channel is the source. Some of these paths are the first place you would look when a user reports "my review didn't submit."
+- **Suggested fix:** Pick the operations where the answer to "what happened to this unit of work?" is worth having in the Log channel and add the owner pattern (Action or Livewire method) with a chosen event name. `review.submitted`, `review.snapshot.exported`, `review.file.discarded`, `project.registered`, `comment.saved`, `file.reviewed` are candidates.
+
+### [INFO] `git.*` and repo-registration warnings expose the absolute repo path
+
+- **File:** `app/Services/GitMetadataService.php:28`, `196`, `219`, `247`, `271`, `316`, `390`; `app/Actions/EnsureRfaGitExcludeAction.php:52`, `76`; `app/Actions/GetProjectStatusAction.php:28`; `app/Actions/ResolveBranchBaseAction.php:82`; `app/Actions/OpenProjectFromPathAction.php:36` (uses `path`, the caller-supplied absolute path).
+- **Rule:** Privacy. The skill says: prefer project slugs, relative file paths, hashes, counts, booleans, and stable reason codes. Absolute paths are allowed in warning payloads only when no project context can resolve a relative path or when the path itself is the failed input being diagnosed.
+- **Evidence:** Each of these warnings sets `'repo' => $repoPath` where `$repoPath` is the absolute repo root. The services take `$repoPath` as a bare parameter, so the project id and slug are not in scope at the call site. For most of these the path is not itself the failed input, so the exception in the privacy rule does not obviously apply.
+- **Impact:** Warning payloads leak the user's home-directory-anchored absolute paths. Not a secret, but avoidable, and inconsistent with the canonical events' preference for `rfa.project_slug`. `OpenProjectFromPathAction` is the outlier where the path genuinely is the input being diagnosed (a deep-link path might not be a repo at all), so its `path` field is defensible.
+- **Suggested fix:** Where a caller can plumb a project id or slug alongside `$repoPath`, add `project_slug`/`project_id` to the payload and drop `repo`. Where the callee is inherently repo-path-first (`GitMetadataService`), consider hashing the path (`hash('xxh128', $repoPath)`) as the correlation field.
+
+## Clean Areas
+
+- Every canonical `Log::info()` call carries a static lowercase dot-separated event name, no manual payload, and is emitted from a `finally` block by its owner.
+- Every canonical event owner calls `Context::flush()` before adding fields. No child site flushes.
+- `rfa.outcome` values in code are all in the approved vocabulary (`completed`, `error`).
+- `rfa.duration_ms` is present on all four canonical events, including the updater failure path.
+- The updater failure path is the reference implementation for a listener-owned unit that stays canonical on failure: diagnostic `Log::error('updater.failed', [...])` plus a canonical `Log::info('updater.failed')` from `finally`.
+- Every warning and error payload includes a static `reason` key with a stable snake-case code.
+- No warning or error payload passes raw `getMessage()`, `getTraceAsString()`, or `->stderr` outside `LogSanitizer::summary(...)`. `GetProjectStatusAction` and `LoadFileDiffAction` demonstrate the sanctioned wrapper.
+- `git.*` warnings prefer `exit_code` (from `GitCommandException::$exitCode`) over free text for triage.
+- `config/logging.php` default resolves to bounded local `daily` (7-day retention, `info` level). Remote channel scaffolding (`slack`, `papertrail`) is defined but not activated in the default channel or default stack. `LogChannelPostureTest` confirms this.
+- No `Log::debug()` in production, no manual info payloads, and every static `Context` key starts with `rfa.`.
+
+## Residual Risks
+
+- The `EnsureRfaGitExcludeAction` catch block is a broad `\Throwable`, so the payload carries `error_class` but not `exit_code`. A rescue-then-catch would let a `GitCommandException` add `exit_code`. Not a rule violation, but a triage improvement.
+- `context.comment.rejected` (`resources/views/pages/⚡context-page.blade.php:256`) uses camelCase payload keys (`fileId`, `startLine`, `endLine`) rather than snake_case. Inline warning payloads are exempt from `rfa.` namespacing, and the CI check only enforces `reason`, so this is not a violation, but it drifts from the surrounding convention (see `git.diff.failed`'s snake_case fields).
+- Whether every listed action or Livewire side effect deserves a canonical event is a judgment call the audit cannot make from the code alone. The [INFO] finding surfaces the coverage gap so maintainers can pick per operation.
+- Agentic review looked at file contents and call sites, not runtime behavior. A path that only fires under specific data (e.g. an updater error with an unexpected stack shape) may still surprise `LogSanitizer::summary()` in ways only fuzzing would surface.


### PR DESCRIPTION
Automated weekly wide-events logging audit.

Artifact: `reports/wide-events/2026-07-21.md`

This PR is human-gated. It contains the report only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYCbsumpVgsThCVBHepRC4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an audit report covering production logging and event canonicalization checks.
  * Documented test results, logging usage metrics, categorized findings, clean areas, and residual risks.
  * Highlighted listener handlers and repository-related warnings requiring attention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->