### PR TITLE
fix(review): stop Escape in other inputs from clearing the files filter

### DIFF
--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1227,12 +1227,16 @@ new #[Layout('layouts.app')] class extends Component
     x-on:rfa-dismiss-missing-target.window="$wire.dismissMissingTarget()"
     {{-- Filter/file/commit shortcuts are registered through the keymap store
          (see registerShortcuts() in review-page.js). Only the in-input Escape
-         that clears the file filter stays here, since the store suppresses
-         shortcuts while focus is in an input. --}}
+         stays here, since the store suppresses shortcuts while focus is in an
+         input. It blurs whichever non-comment input has focus, but only
+         clears the file filter when Escape came from the filter input itself —
+         clearing it from other inputs (branch picker, settings, global
+         comment) silently threw away the user's filter text. --}}
     @keydown.escape.window="
         if (($event.target.tagName === 'TEXTAREA' || $event.target.tagName === 'INPUT')
             && !$event.target.closest('[data-comment-form]')) {
-            $wire.clearFileFilter(); $event.target.blur(); $event.preventDefault();
+            if ($event.target.closest('[data-testid=file-filter]')) { $wire.clearFileFilter(); }
+            $event.target.blur(); $event.preventDefault();
         }
     "
 >
@@ -1587,8 +1591,8 @@ new #[Layout('layouts.app')] class extends Component
                     size="sm"
                     variant="filled"
                     class="mb-3"
+                    data-testid="file-filter"
                     x-ref="fileFilterInput"
-                    @keydown.escape="$wire.clearFileFilter(); $el.blur()"
                 />
                 {{-- File list as an island so a reviewed mark/un-mark refreshes the
                      sidebar checkmarks and recovery group without a full page render.

--- a/tests/Browser/FileInteractionTest.php
+++ b/tests/Browser/FileInteractionTest.php
@@ -526,6 +526,34 @@ test('right-click copy full paths prepends repo path to each entry', function ()
         ->each(fn (string $line) => expect($line)->toStartWith($expectedRepoPath.'/'));
 });
 
+test('escape inside the files filter clears it', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $filter = $page->page()->getByPlaceholder('Filter files...');
+    $filter->fill('hello');
+    $page->page()->getByText('utils.php')->first()->waitFor(['state' => 'hidden']);
+
+    $filter->press('Escape');
+
+    $page->page()->getByText('utils.php')->first()->waitFor();
+    expect($page->page()->getByPlaceholder('Filter files...')->inputValue())->toBe('');
+});
+
+test('escape in another input keeps the files filter text', function () {
+    $page = $this->visit($this->projectUrl());
+
+    $filter = $page->page()->getByPlaceholder('Filter files...');
+    $filter->fill('hello');
+    $page->page()->getByText('utils.php')->first()->waitFor(['state' => 'hidden']);
+
+    $globalComment = $page->page()->getByPlaceholder('Overall review comment (optional)');
+    $globalComment->click();
+    $globalComment->press('Escape');
+
+    expect($page->page()->getByPlaceholder('Filter files...')->inputValue())->toBe('hello');
+    expect($page->page()->getByText('utils.php')->count())->toBe(0);
+});
+
 test('copy menu hides when filter excludes all files', function () {
     $page = $this->visit($this->projectUrl());
 


### PR DESCRIPTION
https://claude.ai/code/session_01M3Jts3UrUJYfdJFjvqnJZy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Escape-key behavior on the review page.
  * Pressing Escape in the file filter now clears the filter and restores all file results.
  * Pressing Escape in another input no longer changes the file filter or its results.

* **Tests**
  * Added browser coverage for both file-filter Escape-key scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->