### PR TITLE
Canonical wide events for deep links, menu clicks, updater outcomes, and context comment writes

### DIFF
--- a/app/Actions/OpenProjectFromPathAction.php
+++ b/app/Actions/OpenProjectFromPathAction.php
@@ -22,13 +22,19 @@ final readonly class OpenProjectFromPathAction
         $realPath = realpath($path);
 
         if ($realPath === false || ! File::isDirectory($realPath)) {
+            Context::add('rfa.reason', 'path_not_found');
+
             return null;
         }
 
         try {
             return $this->register->handle($realPath);
         } catch (NotAGitRepositoryException) {
-            // Expected: the deep-linked path simply isn't a git repo. No-op.
+            // Expected: the deep-linked path simply isn't a git repo. The
+            // Context field carries the rejection reason to the calling
+            // owner's canonical event.
+            Context::add('rfa.reason', 'not_a_git_repository');
+
             return null;
         } catch (Throwable $e) {
             // Unexpected (e.g. a database error). Log it as a real failure rather

--- a/app/Actions/OpenProjectFromPathAction.php
+++ b/app/Actions/OpenProjectFromPathAction.php
@@ -6,6 +6,7 @@ namespace App\Actions;
 
 use App\Exceptions\NotAGitRepositoryException;
 use App\Models\Project;
+use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
 use Throwable;
@@ -32,7 +33,12 @@ final readonly class OpenProjectFromPathAction
         } catch (Throwable $e) {
             // Unexpected (e.g. a database error). Log it as a real failure rather
             // than silently treating it as "not a git repository", and still avoid
-            // crashing the deep-link/menu handler.
+            // crashing the deep-link/menu handler. The Context fields surface the
+            // failure on the calling owner's canonical event so a swallowed error
+            // doesn't masquerade as a plain rejection there.
+            Context::add('rfa.reason', 'project_registration_failed');
+            Context::add('rfa.error_class', $e::class);
+
             Log::warning('project.registration.failed', [
                 'reason' => 'project_registration_failed',
                 'path' => $path,

--- a/app/Actions/OpenRepositoryDialogAction.php
+++ b/app/Actions/OpenRepositoryDialogAction.php
@@ -6,6 +6,7 @@ namespace App\Actions;
 
 use App\Exceptions\NotAGitRepositoryException;
 use App\Models\Project;
+use Illuminate\Support\Facades\Context;
 use Native\Desktop\Dialog;
 use Native\Desktop\Facades\Alert;
 use Throwable;
@@ -30,6 +31,10 @@ final readonly class OpenRepositoryDialogAction
         try {
             return $this->register->handle($path);
         } catch (NotAGitRepositoryException) {
+            // The Context fields let the calling owner's canonical event tell a
+            // rejected pick apart from a dismissed dialog (both return null).
+            Context::add('rfa.reason', 'not_a_git_repository');
+
             Alert::new()
                 ->type('warning')
                 ->title('Not a Git Repository')
@@ -39,6 +44,9 @@ final readonly class OpenRepositoryDialogAction
         } catch (Throwable $e) {
             // A real failure (e.g. a database error) — don't mislabel it as
             // "not a git repository".
+            Context::add('rfa.reason', 'project_registration_failed');
+            Context::add('rfa.error_class', $e::class);
+
             Alert::new()
                 ->type('warning')
                 ->title('Could Not Open Repository')

--- a/app/Listeners/HandleDeepLink.php
+++ b/app/Listeners/HandleDeepLink.php
@@ -41,33 +41,35 @@ final readonly class HandleDeepLink
                 return;
             }
 
-            Context::add('rfa.mode', is_string($query['mode'] ?? null) ? $query['mode'] : null);
-            Context::add('rfa.path_hash', hash('xxh128', $path));
+            $mode = is_string($query['mode'] ?? null) ? $query['mode'] : null;
+            $pathHash = hash('xxh128', $path);
+
+            Context::add('rfa.mode', $mode);
+            Context::add('rfa.path_hash', $pathHash);
 
             app(RecordRuntimeDiagnosticAction::class)->handle('deeplink.received', [
-                'mode' => is_string($query['mode'] ?? null) ? $query['mode'] : null,
-                'path_hash' => hash('xxh128', $path),
+                'mode' => $mode,
+                'path_hash' => $pathHash,
             ]);
 
             $project = app(OpenProjectFromPathAction::class)->handle($path);
 
             if (! $project) {
-                // The action swallows unexpected registration failures and marks
-                // them via Context (rfa.reason = project_registration_failed);
-                // only a genuinely non-project path is a rejection.
-                if (Context::get('rfa.reason') === 'project_registration_failed') {
-                    $outcome = 'error';
-                } else {
-                    $outcome = 'rejected';
-                    Context::add('rfa.reason', 'not_a_project');
-                }
+                // The action marks why it returned null via Context: an
+                // unexpected registration failure is an error, everything
+                // else (missing path, not a repo) is a rejection.
+                $outcome = Context::get('rfa.reason') === 'project_registration_failed'
+                    ? 'error'
+                    : 'rejected';
+
+                Context::addIf('rfa.reason', 'not_a_project');
 
                 return;
             }
 
             // Fail open on junk mode values: anything that isn't 'context' lands
             // on review-page rather than failing the whole open.
-            $routeName = (($query['mode'] ?? null) === 'context') ? 'context-page' : 'review-page';
+            $routeName = ($mode === 'context') ? 'context-page' : 'review-page';
 
             Context::add('rfa.route', $routeName);
             Context::add('rfa.project_id', $project->id);

--- a/app/Listeners/HandleDeepLink.php
+++ b/app/Listeners/HandleDeepLink.php
@@ -52,8 +52,15 @@ final readonly class HandleDeepLink
             $project = app(OpenProjectFromPathAction::class)->handle($path);
 
             if (! $project) {
-                $outcome = 'rejected';
-                Context::add('rfa.reason', 'not_a_project');
+                // The action swallows unexpected registration failures and marks
+                // them via Context (rfa.reason = project_registration_failed);
+                // only a genuinely non-project path is a rejection.
+                if (Context::get('rfa.reason') === 'project_registration_failed') {
+                    $outcome = 'error';
+                } else {
+                    $outcome = 'rejected';
+                    Context::add('rfa.reason', 'not_a_project');
+                }
 
                 return;
             }

--- a/app/Listeners/HandleDeepLink.php
+++ b/app/Listeners/HandleDeepLink.php
@@ -6,47 +6,84 @@ namespace App\Listeners;
 
 use App\Actions\OpenProjectFromPathAction;
 use App\Actions\RecordRuntimeDiagnosticAction;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Log;
 use Native\Desktop\Events\App\OpenedFromURL;
 use Native\Desktop\Facades\Window;
+use Throwable;
 
 final readonly class HandleDeepLink
 {
     public function handle(OpenedFromURL $event): void
     {
-        $parsed = parse_url($event->url);
+        Context::flush();
 
-        if (! is_array($parsed) || ($parsed['scheme'] ?? '') !== 'rfa' || ($parsed['host'] ?? '') !== 'open') {
-            return;
+        $startedAt = microtime(true);
+        $outcome = 'completed';
+
+        try {
+            $parsed = parse_url($event->url);
+
+            if (! is_array($parsed) || ($parsed['scheme'] ?? '') !== 'rfa' || ($parsed['host'] ?? '') !== 'open') {
+                $outcome = 'rejected';
+                Context::add('rfa.reason', 'unsupported_url');
+
+                return;
+            }
+
+            parse_str($parsed['query'] ?? '', $query);
+            $path = $query['path'] ?? null;
+
+            if (! is_string($path) || $path === '') {
+                $outcome = 'rejected';
+                Context::add('rfa.reason', 'missing_path');
+
+                return;
+            }
+
+            Context::add('rfa.mode', is_string($query['mode'] ?? null) ? $query['mode'] : null);
+            Context::add('rfa.path_hash', hash('xxh128', $path));
+
+            app(RecordRuntimeDiagnosticAction::class)->handle('deeplink.received', [
+                'mode' => is_string($query['mode'] ?? null) ? $query['mode'] : null,
+                'path_hash' => hash('xxh128', $path),
+            ]);
+
+            $project = app(OpenProjectFromPathAction::class)->handle($path);
+
+            if (! $project) {
+                $outcome = 'rejected';
+                Context::add('rfa.reason', 'not_a_project');
+
+                return;
+            }
+
+            // Fail open on junk mode values: anything that isn't 'context' lands
+            // on review-page rather than failing the whole open.
+            $routeName = (($query['mode'] ?? null) === 'context') ? 'context-page' : 'review-page';
+
+            Context::add('rfa.route', $routeName);
+            Context::add('rfa.project_id', $project->id);
+            Context::add('rfa.project_slug', $project->slug);
+
+            app(RecordRuntimeDiagnosticAction::class)->handle('deeplink.opened', [
+                'route' => $routeName,
+                'project_id' => $project->id,
+                'project_slug' => $project->slug,
+            ]);
+
+            Window::get('main')->url(route($routeName, ['slug' => $project->slug]));
+        } catch (Throwable $e) {
+            $outcome = 'error';
+            Context::add('rfa.error_class', $e::class);
+            Context::add('rfa.reason', 'deeplink_open_failed');
+
+            throw $e;
+        } finally {
+            Context::add('rfa.outcome', $outcome);
+            Context::add('rfa.duration_ms', (int) round((microtime(true) - $startedAt) * 1000));
+
+            Log::info('deeplink.opened');
         }
-
-        parse_str($parsed['query'] ?? '', $query);
-        $path = $query['path'] ?? null;
-
-        if (! is_string($path) || $path === '') {
-            return;
-        }
-
-        app(RecordRuntimeDiagnosticAction::class)->handle('deeplink.received', [
-            'mode' => is_string($query['mode'] ?? null) ? $query['mode'] : null,
-            'path_hash' => hash('xxh128', $path),
-        ]);
-
-        $project = app(OpenProjectFromPathAction::class)->handle($path);
-
-        if (! $project) {
-            return;
-        }
-
-        // Fail open on junk mode values: anything that isn't 'context' lands
-        // on review-page rather than failing the whole open.
-        $routeName = (($query['mode'] ?? null) === 'context') ? 'context-page' : 'review-page';
-
-        app(RecordRuntimeDiagnosticAction::class)->handle('deeplink.opened', [
-            'route' => $routeName,
-            'project_id' => $project->id,
-            'project_slug' => $project->slug,
-        ]);
-
-        Window::get('main')->url(route($routeName, ['slug' => $project->slug]));
     }
 }

--- a/app/Listeners/HandleMenuItemClicked.php
+++ b/app/Listeners/HandleMenuItemClicked.php
@@ -132,6 +132,7 @@ final readonly class HandleMenuItemClicked
     {
         $cachedId = Cache::get(self::ACTIVE_PROJECT_CACHE_KEY);
         $project = is_int($cachedId) ? app(ResolveProjectByIdAction::class)->handle($cachedId) : null;
+        $usedCachedProject = $project !== null;
 
         if (! $project) {
             $project = app(OpenRepositoryDialogAction::class)->handle();
@@ -143,12 +144,12 @@ final readonly class HandleMenuItemClicked
 
         Context::add('rfa.project_id', $project->id);
         Context::add('rfa.project_slug', $project->slug);
-        Context::add('rfa.used_cached_project', is_int($cachedId));
+        Context::add('rfa.used_cached_project', $usedCachedProject);
 
         app(RecordRuntimeDiagnosticAction::class)->handle($diagnostic, [
             'project_id' => $project->id,
             'project_slug' => $project->slug,
-            'used_cached_project' => is_int($cachedId),
+            'used_cached_project' => $usedCachedProject,
         ]);
 
         Window::get('main')->url(route($routeName, ['slug' => $project->slug]));

--- a/app/Listeners/HandleMenuItemClicked.php
+++ b/app/Listeners/HandleMenuItemClicked.php
@@ -106,7 +106,7 @@ final readonly class HandleMenuItemClicked
         $project = app(OpenRepositoryDialogAction::class)->handle();
 
         if (! $project) {
-            return $this->outcomeForDismissedPicker();
+            return $this->outcomeForNullProject();
         }
 
         Context::add('rfa.project_id', $project->id);
@@ -138,7 +138,7 @@ final readonly class HandleMenuItemClicked
         }
 
         if (! $project) {
-            return $this->outcomeForDismissedPicker();
+            return $this->outcomeForNullProject();
         }
 
         Context::add('rfa.project_id', $project->id);
@@ -157,13 +157,12 @@ final readonly class HandleMenuItemClicked
     }
 
     /**
-     * A null project from OpenRepositoryDialogAction can mean three things:
-     * the user dismissed the picker (cancelled), picked a non-repo folder
-     * (rejected, rfa.reason = not_a_git_repository), or registration blew up
-     * (error, rfa.reason = project_registration_failed). The action marks the
-     * last two via Context so the canonical outcome stays truthful here.
+     * Map a null project from OpenRepositoryDialogAction to its outcome.
+     *
+     * The action marks non-dismissal causes via Context (rfa.reason), so
+     * a plain dismissal is the only null left unmarked.
      */
-    private function outcomeForDismissedPicker(): string
+    private function outcomeForNullProject(): string
     {
         return match (Context::get('rfa.reason')) {
             'project_registration_failed' => 'error',

--- a/app/Listeners/HandleMenuItemClicked.php
+++ b/app/Listeners/HandleMenuItemClicked.php
@@ -10,9 +10,12 @@ use App\Actions\ResolveProjectByIdAction;
 use App\Actions\ScanDirectoryDialogAction;
 use App\Events\ShowShortcutsRequested;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Log;
 use Native\Desktop\Events\Menu\MenuItemClicked;
 use Native\Desktop\Facades\AutoUpdater;
 use Native\Desktop\Facades\Window;
+use Throwable;
 
 final readonly class HandleMenuItemClicked
 {
@@ -25,24 +28,44 @@ final readonly class HandleMenuItemClicked
 
     public function handle(MenuItemClicked $event): void
     {
-        $id = $event->item['id'] ?? null;
+        Context::flush();
 
-        app(RecordRuntimeDiagnosticAction::class)->handle('menu.clicked', [
-            'id' => $id,
-        ]);
+        $startedAt = microtime(true);
+        $outcome = 'skipped';
 
-        match ($id) {
-            'open-repo' => $this->handleOpenRepo(),
-            'scan-directory' => app(ScanDirectoryDialogAction::class)->handle(),
-            'check-updates' => $this->handleCheckUpdates(),
-            'show-context' => $this->navigateToActiveProject('context-page', 'menu.show_context.completed'),
-            'review-code' => $this->navigateToActiveProject('review-page', 'menu.review_code.completed'),
-            'show-shortcuts' => ShowShortcutsRequested::dispatch(),
-            default => null,
-        };
+        try {
+            $id = $event->item['id'] ?? null;
+
+            Context::add('rfa.menu_id', $id);
+
+            app(RecordRuntimeDiagnosticAction::class)->handle('menu.clicked', [
+                'id' => $id,
+            ]);
+
+            $outcome = match ($id) {
+                'open-repo' => $this->handleOpenRepo(),
+                'scan-directory' => app(ScanDirectoryDialogAction::class)->handle() ? 'completed' : 'cancelled',
+                'check-updates' => $this->handleCheckUpdates(),
+                'show-context' => $this->navigateToActiveProject('context-page', 'menu.show_context.completed'),
+                'review-code' => $this->navigateToActiveProject('review-page', 'menu.review_code.completed'),
+                'show-shortcuts' => $this->handleShowShortcuts(),
+                default => 'skipped',
+            };
+        } catch (Throwable $e) {
+            $outcome = 'error';
+            Context::add('rfa.error_class', $e::class);
+            Context::add('rfa.reason', 'menu_click_failed');
+
+            throw $e;
+        } finally {
+            Context::add('rfa.outcome', $outcome);
+            Context::add('rfa.duration_ms', (int) round((microtime(true) - $startedAt) * 1000));
+
+            Log::info('menu.item.clicked');
+        }
     }
 
-    private function handleCheckUpdates(): void
+    private function handleCheckUpdates(): string
     {
         Cache::put('native-update-state', [
             'status' => 'checking',
@@ -51,20 +74,36 @@ final readonly class HandleMenuItemClicked
         ], now()->addMinutes(2));
 
         AutoUpdater::checkForUpdates();
+
+        return 'completed';
     }
 
-    private function handleOpenRepo(): void
+    private function handleShowShortcuts(): string
+    {
+        ShowShortcutsRequested::dispatch();
+
+        return 'completed';
+    }
+
+    private function handleOpenRepo(): string
     {
         $project = app(OpenRepositoryDialogAction::class)->handle();
 
-        if ($project) {
-            app(RecordRuntimeDiagnosticAction::class)->handle('menu.open_repo.completed', [
-                'project_id' => $project->id,
-                'project_slug' => $project->slug,
-            ]);
-
-            Window::get('main')->url(route('review-page', ['slug' => $project->slug]));
+        if (! $project) {
+            return 'cancelled';
         }
+
+        Context::add('rfa.project_id', $project->id);
+        Context::add('rfa.project_slug', $project->slug);
+
+        app(RecordRuntimeDiagnosticAction::class)->handle('menu.open_repo.completed', [
+            'project_id' => $project->id,
+            'project_slug' => $project->slug,
+        ]);
+
+        Window::get('main')->url(route('review-page', ['slug' => $project->slug]));
+
+        return 'completed';
     }
 
     /**
@@ -73,7 +112,7 @@ final readonly class HandleMenuItemClicked
      * picker when the cache is empty or stale (project deleted, or user is on
      * select-repo-page which forgets the key).
      */
-    private function navigateToActiveProject(string $routeName, string $diagnostic): void
+    private function navigateToActiveProject(string $routeName, string $diagnostic): string
     {
         $cachedId = Cache::get(self::ACTIVE_PROJECT_CACHE_KEY);
         $project = is_int($cachedId) ? app(ResolveProjectByIdAction::class)->handle($cachedId) : null;
@@ -82,14 +121,22 @@ final readonly class HandleMenuItemClicked
             $project = app(OpenRepositoryDialogAction::class)->handle();
         }
 
-        if ($project) {
-            app(RecordRuntimeDiagnosticAction::class)->handle($diagnostic, [
-                'project_id' => $project->id,
-                'project_slug' => $project->slug,
-                'used_cached_project' => is_int($cachedId),
-            ]);
-
-            Window::get('main')->url(route($routeName, ['slug' => $project->slug]));
+        if (! $project) {
+            return 'cancelled';
         }
+
+        Context::add('rfa.project_id', $project->id);
+        Context::add('rfa.project_slug', $project->slug);
+        Context::add('rfa.used_cached_project', is_int($cachedId));
+
+        app(RecordRuntimeDiagnosticAction::class)->handle($diagnostic, [
+            'project_id' => $project->id,
+            'project_slug' => $project->slug,
+            'used_cached_project' => is_int($cachedId),
+        ]);
+
+        Window::get('main')->url(route($routeName, ['slug' => $project->slug]));
+
+        return 'completed';
     }
 }

--- a/app/Listeners/HandleMenuItemClicked.php
+++ b/app/Listeners/HandleMenuItemClicked.php
@@ -44,7 +44,7 @@ final readonly class HandleMenuItemClicked
 
             $outcome = match ($id) {
                 'open-repo' => $this->handleOpenRepo(),
-                'scan-directory' => app(ScanDirectoryDialogAction::class)->handle() ? 'completed' : 'cancelled',
+                'scan-directory' => $this->handleScanDirectory(),
                 'check-updates' => $this->handleCheckUpdates(),
                 'show-context' => $this->navigateToActiveProject('context-page', 'menu.show_context.completed'),
                 'review-code' => $this->navigateToActiveProject('review-page', 'menu.review_code.completed'),
@@ -78,6 +78,22 @@ final readonly class HandleMenuItemClicked
         return 'completed';
     }
 
+    private function handleScanDirectory(): string
+    {
+        $result = app(ScanDirectoryDialogAction::class)->handle();
+
+        if (! $result) {
+            return 'cancelled';
+        }
+
+        Context::add('rfa.repos_found', $result->found);
+        Context::add('rfa.repos_registered', $result->registered);
+        Context::add('rfa.repos_already_tracked', $result->alreadyTracked);
+        Context::add('rfa.repos_failed', $result->failed);
+
+        return $result->failed > 0 ? 'partial' : 'completed';
+    }
+
     private function handleShowShortcuts(): string
     {
         ShowShortcutsRequested::dispatch();
@@ -90,7 +106,7 @@ final readonly class HandleMenuItemClicked
         $project = app(OpenRepositoryDialogAction::class)->handle();
 
         if (! $project) {
-            return 'cancelled';
+            return $this->outcomeForDismissedPicker();
         }
 
         Context::add('rfa.project_id', $project->id);
@@ -122,7 +138,7 @@ final readonly class HandleMenuItemClicked
         }
 
         if (! $project) {
-            return 'cancelled';
+            return $this->outcomeForDismissedPicker();
         }
 
         Context::add('rfa.project_id', $project->id);
@@ -138,5 +154,21 @@ final readonly class HandleMenuItemClicked
         Window::get('main')->url(route($routeName, ['slug' => $project->slug]));
 
         return 'completed';
+    }
+
+    /**
+     * A null project from OpenRepositoryDialogAction can mean three things:
+     * the user dismissed the picker (cancelled), picked a non-repo folder
+     * (rejected, rfa.reason = not_a_git_repository), or registration blew up
+     * (error, rfa.reason = project_registration_failed). The action marks the
+     * last two via Context so the canonical outcome stays truthful here.
+     */
+    private function outcomeForDismissedPicker(): string
+    {
+        return match (Context::get('rfa.reason')) {
+            'project_registration_failed' => 'error',
+            'not_a_git_repository' => 'rejected',
+            default => 'cancelled',
+        };
     }
 }

--- a/app/Providers/NativeAppServiceProvider.php
+++ b/app/Providers/NativeAppServiceProvider.php
@@ -39,6 +39,7 @@ use Native\Desktop\Facades\App;
 use Native\Desktop\Facades\Menu;
 use Native\Desktop\Facades\Window;
 use Native\Desktop\Notification;
+use Throwable;
 
 class NativeAppServiceProvider implements ProvidesPhpIni
 {
@@ -95,6 +96,7 @@ class NativeAppServiceProvider implements ProvidesPhpIni
             Context::flush();
 
             $startedAt = microtime(true);
+            $outcome = 'completed';
 
             try {
                 $releaseNotes = $this->normalizeReleaseNotes($event->releaseNotes);
@@ -109,9 +111,15 @@ class NativeAppServiceProvider implements ProvidesPhpIni
                     ->title('Update Available')
                     ->message("Version {$event->version} is available and downloading.")
                     ->show();
+            } catch (Throwable $e) {
+                $outcome = 'error';
+                Context::add('rfa.error_class', $e::class);
+                Context::add('rfa.reason', 'update_available_handling_failed');
+
+                throw $e;
             } finally {
                 Context::add('rfa.update_version', $event->version);
-                Context::add('rfa.outcome', 'completed');
+                Context::add('rfa.outcome', $outcome);
                 Context::add('rfa.duration_ms', $this->elapsedMs($startedAt));
                 Log::info('updater.available');
             }
@@ -136,6 +144,7 @@ class NativeAppServiceProvider implements ProvidesPhpIni
             Context::flush();
 
             $startedAt = microtime(true);
+            $outcome = 'completed';
 
             try {
                 $releaseNotes = $this->normalizeReleaseNotes($event->releaseNotes);
@@ -150,9 +159,15 @@ class NativeAppServiceProvider implements ProvidesPhpIni
                     ->title('Update Ready')
                     ->message("Version {$event->version} will be installed on restart.")
                     ->show();
+            } catch (Throwable $e) {
+                $outcome = 'error';
+                Context::add('rfa.error_class', $e::class);
+                Context::add('rfa.reason', 'update_downloaded_handling_failed');
+
+                throw $e;
             } finally {
                 Context::add('rfa.update_version', $event->version);
-                Context::add('rfa.outcome', 'completed');
+                Context::add('rfa.outcome', $outcome);
                 Context::add('rfa.duration_ms', $this->elapsedMs($startedAt));
                 Log::info('updater.downloaded');
             }

--- a/resources/views/pages/⚡context-page.blade.php
+++ b/resources/views/pages/⚡context-page.blade.php
@@ -271,11 +271,15 @@ new #[Layout('layouts.app')] class extends Component
                     'end_line' => $endLine,
                 ]);
 
+                $this->skipRender();
+
                 return;
             }
 
             if (! $comment) {
                 $outcome = 'skipped';
+
+                $this->skipRender();
 
                 return;
             }

--- a/resources/views/pages/⚡context-page.blade.php
+++ b/resources/views/pages/⚡context-page.blade.php
@@ -14,6 +14,7 @@ use App\Events\HardReloadShortcutPressed;
 use App\Events\RefreshShortcutPressed;
 use App\Listeners\HandleMenuItemClicked;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Context;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Locked;
@@ -235,43 +236,69 @@ new #[Layout('layouts.app')] class extends Component
 
     private function createComment(string $fileId, string $side, ?int $startLine, ?int $endLine, string $body, ?string $lineSnippet, bool $isDraft): void
     {
+        Context::flush();
+
+        $startedAt = microtime(true);
+        $outcome = 'completed';
+
         try {
-            $comment = app(ContextCommentWorkflowAction::class)->handle(
-                $this->repoPath,
-                $this->projectId ?: null,
-                $this->contextFiles,
-                $fileId,
-                $side,
-                $startLine,
-                $endLine,
-                $body,
-                $isDraft,
-                $lineSnippet,
-            );
-        } catch (\App\Exceptions\ContextCommentRejectedException $e) {
-            // Stale or malformed payload (renderer state drifted from
-            // the actual file). Log the named reason for diagnostics
-            // and treat the action as a no-op so the page never
-            // crashes on a bad screen state.
-            \Illuminate\Support\Facades\Log::warning('context.comment.rejected', [
-                'reason' => $e->reason->value,
-                'fileId' => $fileId,
-                'side' => $side,
-                'startLine' => $startLine,
-                'endLine' => $endLine,
-            ]);
+            try {
+                $comment = app(ContextCommentWorkflowAction::class)->handle(
+                    $this->repoPath,
+                    $this->projectId ?: null,
+                    $this->contextFiles,
+                    $fileId,
+                    $side,
+                    $startLine,
+                    $endLine,
+                    $body,
+                    $isDraft,
+                    $lineSnippet,
+                );
+            } catch (\App\Exceptions\ContextCommentRejectedException $e) {
+                // Stale or malformed payload (renderer state drifted from
+                // the actual file). Log the named reason for diagnostics
+                // and treat the action as a no-op so the page never
+                // crashes on a bad screen state.
+                $outcome = 'rejected';
+                Context::add('rfa.reason', $e->reason->value);
 
-            return;
+                \Illuminate\Support\Facades\Log::warning('context.comment.rejected', [
+                    'reason' => $e->reason->value,
+                    'file_id' => $fileId,
+                    'side' => $side,
+                    'start_line' => $startLine,
+                    'end_line' => $endLine,
+                ]);
+
+                return;
+            }
+
+            if (! $comment) {
+                $outcome = 'skipped';
+
+                return;
+            }
+
+            $this->comments[] = $comment;
+            $this->dispatchFileComments($fileId);
+            $this->dispatchSidebarSummary();
+            $this->skipRender();
+        } catch (\Throwable $e) {
+            $outcome = 'error';
+            Context::add('rfa.error_class', $e::class);
+            Context::add('rfa.reason', 'comment_write_failed');
+
+            throw $e;
+        } finally {
+            Context::add('rfa.project_slug', $this->projectSlug);
+            Context::add('rfa.file_id', $fileId);
+            Context::add('rfa.is_draft', $isDraft);
+            Context::add('rfa.outcome', $outcome);
+            Context::add('rfa.duration_ms', (int) round((microtime(true) - $startedAt) * 1000));
+
+            \Illuminate\Support\Facades\Log::info('context.comment.written');
         }
-
-        if (! $comment) {
-            return;
-        }
-
-        $this->comments[] = $comment;
-        $this->dispatchFileComments($fileId);
-        $this->dispatchSidebarSummary();
-        $this->skipRender();
     }
 
     #[On('update-comment')]

--- a/tests/Feature/Listeners/HandleDeepLinkTest.php
+++ b/tests/Feature/Listeners/HandleDeepLinkTest.php
@@ -4,6 +4,8 @@ use App\Actions\OpenProjectFromPathAction;
 use App\Listeners\HandleDeepLink;
 use App\Models\Project;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Log;
 use Native\Desktop\Events\App\OpenedFromURL;
 use Native\Desktop\Facades\Window;
 use Tests\TestCase;
@@ -68,6 +70,46 @@ test('ignores empty path values', function () {
     app(HandleDeepLink::class)->handle(new OpenedFromURL('rfa://open?path='));
 
     expect($this->capturedUrl)->toBeNull();
+});
+
+test('emits a canonical deeplink.opened event with completed outcome on success', function () {
+    Log::spy();
+
+    app(HandleDeepLink::class)->handle(new OpenedFromURL('rfa://open?path=/some/repo'));
+
+    Log::shouldHaveReceived('info')->once()->with('deeplink.opened');
+    expect(Context::get('rfa.outcome'))->toBe('completed')
+        ->and(Context::get('rfa.route'))->toBe('review-page')
+        ->and(Context::get('rfa.project_slug'))->toBe('rfa')
+        ->and(Context::get('rfa.duration_ms'))->toBeInt();
+});
+
+test('emits a canonical deeplink.opened event with rejected outcome for non-rfa urls', function () {
+    Log::spy();
+
+    app(HandleDeepLink::class)->handle(new OpenedFromURL('https://example.com/anything'));
+
+    Log::shouldHaveReceived('info')->once()->with('deeplink.opened');
+    expect(Context::get('rfa.outcome'))->toBe('rejected')
+        ->and(Context::get('rfa.reason'))->toBe('unsupported_url');
+});
+
+test('emits a canonical deeplink.opened event with rejected outcome when the path is not a project', function () {
+    app()->bind(OpenProjectFromPathAction::class, fn () => new class
+    {
+        public function handle(string $path): ?Project
+        {
+            return null;
+        }
+    });
+
+    Log::spy();
+
+    app(HandleDeepLink::class)->handle(new OpenedFromURL('rfa://open?path=/some/repo'));
+
+    Log::shouldHaveReceived('info')->once()->with('deeplink.opened');
+    expect(Context::get('rfa.outcome'))->toBe('rejected')
+        ->and(Context::get('rfa.reason'))->toBe('not_a_project');
 });
 
 test('routes to review-page when OpenProjectFromPathAction returns null', function () {

--- a/tests/Feature/Listeners/HandleDeepLinkTest.php
+++ b/tests/Feature/Listeners/HandleDeepLinkTest.php
@@ -112,6 +112,28 @@ test('emits a canonical deeplink.opened event with rejected outcome when the pat
         ->and(Context::get('rfa.reason'))->toBe('not_a_project');
 });
 
+test('emits a canonical deeplink.opened event with error outcome when registration fails unexpectedly', function () {
+    app()->bind(OpenProjectFromPathAction::class, fn () => new class
+    {
+        public function handle(string $path): ?Project
+        {
+            // Mirrors the real action's swallowed-Throwable branch.
+            Context::add('rfa.reason', 'project_registration_failed');
+            Context::add('rfa.error_class', RuntimeException::class);
+
+            return null;
+        }
+    });
+
+    Log::spy();
+
+    app(HandleDeepLink::class)->handle(new OpenedFromURL('rfa://open?path=/some/repo'));
+
+    Log::shouldHaveReceived('info')->once()->with('deeplink.opened');
+    expect(Context::get('rfa.outcome'))->toBe('error')
+        ->and(Context::get('rfa.reason'))->toBe('project_registration_failed');
+});
+
 test('routes to review-page when OpenProjectFromPathAction returns null', function () {
     app()->bind(OpenProjectFromPathAction::class, fn () => new class
     {

--- a/tests/Feature/Listeners/HandleMenuItemClickedTest.php
+++ b/tests/Feature/Listeners/HandleMenuItemClickedTest.php
@@ -8,7 +8,9 @@ use App\Listeners\HandleMenuItemClicked;
 use App\Models\Project;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
 use Native\Desktop\Events\Menu\MenuItemClicked;
 use Native\Desktop\Facades\Window;
 use Tests\TestCase;
@@ -184,4 +186,46 @@ test('unknown menu item ids are ignored', function () {
     app(HandleMenuItemClicked::class)->handle(new MenuItemClicked(['id' => 'whatever']));
 
     expect($this->capturedUrl)->toBeNull();
+});
+
+test('emits a canonical menu.item.clicked event with completed outcome when open-repo picks a project', function () {
+    $project = Project::factory()->create(['slug' => 'opened']);
+
+    bindOpenRepositoryDialogAction($project);
+    bindResolveProjectByIdAction(null);
+
+    Log::spy();
+
+    app(HandleMenuItemClicked::class)->handle(new MenuItemClicked(['id' => 'open-repo']));
+
+    Log::shouldHaveReceived('info')->once()->with('menu.item.clicked');
+    expect(Context::get('rfa.outcome'))->toBe('completed')
+        ->and(Context::get('rfa.menu_id'))->toBe('open-repo')
+        ->and(Context::get('rfa.project_slug'))->toBe('opened')
+        ->and(Context::get('rfa.duration_ms'))->toBeInt();
+});
+
+test('emits a canonical menu.item.clicked event with cancelled outcome when the open-repo dialog is dismissed', function () {
+    bindOpenRepositoryDialogAction(null);
+    bindResolveProjectByIdAction(null);
+
+    Log::spy();
+
+    app(HandleMenuItemClicked::class)->handle(new MenuItemClicked(['id' => 'open-repo']));
+
+    Log::shouldHaveReceived('info')->once()->with('menu.item.clicked');
+    expect(Context::get('rfa.outcome'))->toBe('cancelled');
+});
+
+test('emits a canonical menu.item.clicked event with skipped outcome for unknown ids', function () {
+    bindOpenRepositoryDialogAction(null);
+    bindResolveProjectByIdAction(null);
+
+    Log::spy();
+
+    app(HandleMenuItemClicked::class)->handle(new MenuItemClicked(['id' => 'whatever']));
+
+    Log::shouldHaveReceived('info')->once()->with('menu.item.clicked');
+    expect(Context::get('rfa.outcome'))->toBe('skipped')
+        ->and(Context::get('rfa.menu_id'))->toBe('whatever');
 });

--- a/tests/Feature/Listeners/HandleMenuItemClickedTest.php
+++ b/tests/Feature/Listeners/HandleMenuItemClickedTest.php
@@ -3,6 +3,7 @@
 use App\Actions\OpenRepositoryDialogAction;
 use App\Actions\ResolveProjectByIdAction;
 use App\Actions\ScanDirectoryDialogAction;
+use App\DTOs\ScanDirectoryResult;
 use App\Events\ShowShortcutsRequested;
 use App\Listeners\HandleMenuItemClicked;
 use App\Models\Project;
@@ -215,6 +216,90 @@ test('emits a canonical menu.item.clicked event with cancelled outcome when the 
 
     Log::shouldHaveReceived('info')->once()->with('menu.item.clicked');
     expect(Context::get('rfa.outcome'))->toBe('cancelled');
+});
+
+test('emits a canonical menu.item.clicked event with rejected outcome when the picked folder is not a repo', function () {
+    app()->bind(OpenRepositoryDialogAction::class, fn () => new class
+    {
+        public function handle(): ?Project
+        {
+            // Mirrors the real action's NotAGitRepositoryException branch.
+            Context::add('rfa.reason', 'not_a_git_repository');
+
+            return null;
+        }
+    });
+    bindResolveProjectByIdAction(null);
+
+    Log::spy();
+
+    app(HandleMenuItemClicked::class)->handle(new MenuItemClicked(['id' => 'open-repo']));
+
+    Log::shouldHaveReceived('info')->once()->with('menu.item.clicked');
+    expect(Context::get('rfa.outcome'))->toBe('rejected');
+});
+
+test('emits a canonical menu.item.clicked event with error outcome when registration fails unexpectedly', function () {
+    app()->bind(OpenRepositoryDialogAction::class, fn () => new class
+    {
+        public function handle(): ?Project
+        {
+            // Mirrors the real action's swallowed-Throwable branch.
+            Context::add('rfa.reason', 'project_registration_failed');
+            Context::add('rfa.error_class', RuntimeException::class);
+
+            return null;
+        }
+    });
+    bindResolveProjectByIdAction(null);
+
+    Log::spy();
+
+    app(HandleMenuItemClicked::class)->handle(new MenuItemClicked(['id' => 'open-repo']));
+
+    Log::shouldHaveReceived('info')->once()->with('menu.item.clicked');
+    expect(Context::get('rfa.outcome'))->toBe('error');
+});
+
+test('emits a canonical menu.item.clicked event with partial outcome when a scan has failed registrations', function () {
+    app()->bind(ScanDirectoryDialogAction::class, fn () => new class
+    {
+        public function handle(): ScanDirectoryResult
+        {
+            return new ScanDirectoryResult(found: 3, registered: 2, alreadyTracked: 0, failed: 1);
+        }
+    });
+    bindOpenRepositoryDialogAction(null);
+    bindResolveProjectByIdAction(null);
+
+    Log::spy();
+
+    app(HandleMenuItemClicked::class)->handle(new MenuItemClicked(['id' => 'scan-directory']));
+
+    Log::shouldHaveReceived('info')->once()->with('menu.item.clicked');
+    expect(Context::get('rfa.outcome'))->toBe('partial')
+        ->and(Context::get('rfa.repos_found'))->toBe(3)
+        ->and(Context::get('rfa.repos_registered'))->toBe(2)
+        ->and(Context::get('rfa.repos_failed'))->toBe(1);
+});
+
+test('emits a canonical menu.item.clicked event with completed outcome when a scan registers cleanly', function () {
+    app()->bind(ScanDirectoryDialogAction::class, fn () => new class
+    {
+        public function handle(): ScanDirectoryResult
+        {
+            return new ScanDirectoryResult(found: 2, registered: 2, alreadyTracked: 0, failed: 0);
+        }
+    });
+    bindOpenRepositoryDialogAction(null);
+    bindResolveProjectByIdAction(null);
+
+    Log::spy();
+
+    app(HandleMenuItemClicked::class)->handle(new MenuItemClicked(['id' => 'scan-directory']));
+
+    Log::shouldHaveReceived('info')->once()->with('menu.item.clicked');
+    expect(Context::get('rfa.outcome'))->toBe('completed');
 });
 
 test('emits a canonical menu.item.clicked event with skipped outcome for unknown ids', function () {

--- a/tests/Feature/Listeners/HandleMenuItemClickedTest.php
+++ b/tests/Feature/Listeners/HandleMenuItemClickedTest.php
@@ -65,7 +65,8 @@ test('show-context with cached active-project navigates to context-page for that
 
     app(HandleMenuItemClicked::class)->handle(new MenuItemClicked(['id' => 'show-context']));
 
-    expect($this->capturedUrl)->toBe(route('context-page', ['slug' => 'rfa']));
+    expect($this->capturedUrl)->toBe(route('context-page', ['slug' => 'rfa']))
+        ->and(Context::get('rfa.used_cached_project'))->toBeTrue();
 });
 
 test('show-context with cache miss falls back to the file-picker flow', function () {
@@ -89,7 +90,8 @@ test('show-context with stale cached id (project deleted) falls back to the file
 
     app(HandleMenuItemClicked::class)->handle(new MenuItemClicked(['id' => 'show-context']));
 
-    expect($this->capturedUrl)->toBe(route('context-page', ['slug' => 'picked']));
+    expect($this->capturedUrl)->toBe(route('context-page', ['slug' => 'picked']))
+        ->and(Context::get('rfa.used_cached_project'))->toBeFalse();
 });
 
 test('show-context with no cached id and no project picked navigates nowhere', function () {

--- a/tests/Unit/Actions/OpenProjectFromPathActionTest.php
+++ b/tests/Unit/Actions/OpenProjectFromPathActionTest.php
@@ -3,6 +3,7 @@
 use App\Actions\OpenProjectFromPathAction;
 use App\Models\Project;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
 
@@ -25,7 +26,8 @@ test('returns the registered project for a real git directory', function () {
 test('returns null when path does not exist', function () {
     $missing = sys_get_temp_dir().'/rfa_definitely_not_here_'.uniqid();
 
-    expect(app(OpenProjectFromPathAction::class)->handle($missing))->toBeNull();
+    expect(app(OpenProjectFromPathAction::class)->handle($missing))->toBeNull()
+        ->and(Context::get('rfa.reason'))->toBe('path_not_found');
 });
 
 test('returns null when path is a file rather than a directory', function () {
@@ -37,7 +39,8 @@ test('returns null when path is a file rather than a directory', function () {
 test('returns null and swallows the exception when registration fails', function () {
     $nonGit = $this->createTempDirectory('rfa_open_path_nongit_');
 
-    expect(app(OpenProjectFromPathAction::class)->handle($nonGit))->toBeNull();
+    expect(app(OpenProjectFromPathAction::class)->handle($nonGit))->toBeNull()
+        ->and(Context::get('rfa.reason'))->toBe('not_a_git_repository');
 
     expect(Project::count())->toBe(0);
 });

--- a/tests/Unit/Livewire/ContextPageTest.php
+++ b/tests/Unit/Livewire/ContextPageTest.php
@@ -246,8 +246,46 @@ test('addComment records a rejected outcome and keeps the diagnostic warning whe
     Livewire::test('pages::context-page', ['slug' => 'test-project'])
         ->call('addComment', 'nope', 'file', null, null, 'hello');
 
-    Log::shouldHaveReceived('warning')->once();
+    Log::shouldHaveReceived('warning')->once()->with('context.comment.rejected', Mockery::type('array'));
     Log::shouldHaveReceived('info')->once()->with('context.comment.written');
     expect(Context::get('rfa.outcome'))->toBe('rejected')
         ->and(Context::get('rfa.reason'))->toBe(ContextCommentRejection::UnknownFileId->value);
+});
+
+test('addComment records a skipped outcome when the workflow produces no comment', function () {
+    app()->bind(ContextCommentWorkflowAction::class, fn () => new class
+    {
+        public function handle(mixed ...$args): ?array
+        {
+            return null;
+        }
+    });
+
+    Log::spy();
+
+    Livewire::test('pages::context-page', ['slug' => 'test-project'])
+        ->call('addComment', 'file-1', 'file', null, null, '');
+
+    Log::shouldHaveReceived('info')->once()->with('context.comment.written');
+    expect(Context::get('rfa.outcome'))->toBe('skipped');
+});
+
+test('addComment records an error outcome and rethrows on unexpected failure', function () {
+    app()->bind(ContextCommentWorkflowAction::class, fn () => new class
+    {
+        public function handle(mixed ...$args): never
+        {
+            throw new RuntimeException('boom');
+        }
+    });
+
+    Log::spy();
+
+    expect(fn () => Livewire::test('pages::context-page', ['slug' => 'test-project'])
+        ->call('addComment', 'file-1', 'file', null, null, 'hello'))
+        ->toThrow(RuntimeException::class);
+
+    Log::shouldHaveReceived('info')->once()->with('context.comment.written');
+    expect(Context::get('rfa.outcome'))->toBe('error')
+        ->and(Context::get('rfa.reason'))->toBe('comment_write_failed');
 });

--- a/tests/Unit/Livewire/ContextPageTest.php
+++ b/tests/Unit/Livewire/ContextPageTest.php
@@ -1,14 +1,19 @@
 <?php
 
+use App\Actions\ContextCommentWorkflowAction;
 use App\Actions\DiscoverAgentContextFilesAction;
 use App\Actions\LoadContextCommentsAction;
 use App\Actions\ResolveProjectAction;
+use App\Enums\ContextCommentRejection;
 use App\Events\HardReloadShortcutPressed;
 use App\Events\RefreshShortcutPressed;
+use App\Exceptions\ContextCommentRejectedException;
 use App\Models\Comment;
 use App\Models\Project;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Log;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -194,4 +199,55 @@ test('clearAllComments dispatches a clear-all undo event with every removed row'
         ->assertDispatched('undo-available', type: 'clear-all', message: 'Cleared 2 comments');
 
     expect(Comment::whereIn('id', array_column($payload, 'id'))->count())->toBe(0);
+});
+
+test('addComment emits a canonical context.comment.written event with completed outcome', function () {
+    app()->bind(ContextCommentWorkflowAction::class, fn () => new class
+    {
+        /** @return array<string, mixed> */
+        public function handle(mixed ...$args): array
+        {
+            return [
+                'id' => 'c1',
+                'fileId' => 'file-1',
+                'side' => 'file',
+                'startLine' => null,
+                'endLine' => null,
+                'body' => 'hello',
+                'isDraft' => false,
+                'lineSnippet' => null,
+            ];
+        }
+    });
+
+    Log::spy();
+
+    Livewire::test('pages::context-page', ['slug' => 'test-project'])
+        ->call('addComment', 'file-1', 'file', null, null, 'hello');
+
+    Log::shouldHaveReceived('info')->once()->with('context.comment.written');
+    expect(Context::get('rfa.outcome'))->toBe('completed')
+        ->and(Context::get('rfa.file_id'))->toBe('file-1')
+        ->and(Context::get('rfa.is_draft'))->toBeFalse()
+        ->and(Context::get('rfa.duration_ms'))->toBeInt();
+});
+
+test('addComment records a rejected outcome and keeps the diagnostic warning when the payload is rejected', function () {
+    app()->bind(ContextCommentWorkflowAction::class, fn () => new class
+    {
+        public function handle(mixed ...$args): never
+        {
+            throw new ContextCommentRejectedException(ContextCommentRejection::UnknownFileId);
+        }
+    });
+
+    Log::spy();
+
+    Livewire::test('pages::context-page', ['slug' => 'test-project'])
+        ->call('addComment', 'nope', 'file', null, null, 'hello');
+
+    Log::shouldHaveReceived('warning')->once();
+    Log::shouldHaveReceived('info')->once()->with('context.comment.written');
+    expect(Context::get('rfa.outcome'))->toBe('rejected')
+        ->and(Context::get('rfa.reason'))->toBe(ContextCommentRejection::UnknownFileId->value);
 });


### PR DESCRIPTION
Addresses the warning-level findings from the 2026-07-14 (#136) and 2026-07-21 (#137) wide-events audits.

## Changes

- **`HandleDeepLink`** now owns a canonical `deeplink.opened` event emitted on every terminal outcome — `completed`, `rejected` (`unsupported_url` / `missing_path` / `not_a_project`), or `error` — with `rfa.mode`, `rfa.route`, `rfa.path_hash`, project id/slug, and `rfa.duration_ms`. Existing JSONL breadcrumbs are unchanged.
- **`HandleMenuItemClicked`** now owns a canonical `menu.item.clicked` event with `rfa.menu_id`, outcome, and duration. Sub-handlers return their outcome (`completed` / `cancelled` when a dialog is dismissed) instead of `void`; unknown ids report `skipped`, throws report `error`. Project context is added to `Context` where a navigation resolves.
- **Updater listeners** (`UpdateAvailable` / `UpdateDownloaded` in `NativeAppServiceProvider`) no longer hardcode `rfa.outcome = 'completed'` in `finally`: a `catch` flips the outcome to `error` with `rfa.error_class` and a stable reason before rethrowing, matching the `softRefresh()` reference pattern.
- **Context-page comment writes** (`createComment`) own a canonical `context.comment.written` event with `completed` / `rejected` / `skipped` / `error` outcomes plus file id, draft flag, and duration. The diagnostic `context.comment.rejected` warning stays on the rejected branch; its payload keys move to snake_case to match surrounding convention.

## Tests

- `HandleDeepLinkTest`: canonical event + outcome/reason assertions for success, non-rfa URLs, and unresolvable paths.
- `HandleMenuItemClickedTest`: completed (open-repo), cancelled (dialog dismissed), and skipped (unknown id) outcomes.
- `ContextPageTest`: completed and rejected paths for `context.comment.written`, including the retained warning.

The updater catch-path has no direct test (NativePHP `Notification::new()` isn't cheaply fakeable); the logging arch tests cover the vocabulary and shape rules it must satisfy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3Jts3UrUJYfdJFjvqnJZy

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3Jts3UrUJYfdJFjvqnJZy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid/unsupported deep links, missing paths, non-project paths, repository registration issues, update failures, and comment-write failures with clearer failure reasons.

* **Reliability**
  * Standardized outcome tracking (completed/rejected/cancelled/error) across deep links, menu actions, repository opening/scanning, auto-updates, and comment writing.
  * Added consistent canonical event logging for successful operations.

* **Tests**
  * Expanded feature/unit tests to verify deep-link/menu/comment event reporting and the associated outcome metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->