### PR TITLE
Wide events audit 2026-08-04

### DIFF
--- a/reports/wide-events/2026-08-04.md
+++ b/reports/wide-events/2026-08-04.md
@@ -1,0 +1,74 @@
+# Wide Events Audit: 2026-08-04
+
+## Summary
+
+- Deterministic checks: fail (environment blocker, not a code failure)
+- Findings: 1 critical, 0 warning, 3 info
+- Files reviewed: 15 production files touching `Log::*` or `Context::*`
+
+## Deterministic Checks
+
+| Command | Result | Notes |
+|---|---|---|
+| `php artisan test --compact tests/Arch/LoggingConventionsTest.php` | fail | `[CRITICAL]` The audit environment cannot install dev composer dependencies (`Could not authenticate against github.com` for pest, larastan, and pest plugins). Prod-only install succeeds. Pest is not present so the arch suite could not be executed. This is an environment gap, not a code regression. Static replays of every mechanically checkable rule below (C1, C2, C3, C4, C5, C6, C7, C9) show no violations in the tree, and C8 is covered by `tests/Feature/LogChannelPostureTest.php` which is unchanged. |
+
+Static replay of the arch rules against the current tree:
+
+- C1 no `Log::debug()` in `app/` or `resources/views` — 0 matches
+- C2 every `Log::info()` passes a single event-name argument — verified across the 7 canonical calls
+- C3 every event name is a two-to-four segment lowercase dotted literal — verified for all `Log::info` / `warning` / `error`
+- C4 every static `Context` key starts with `rfa.` — 0 non-namespaced literal keys found
+- C5 every `Log::warning|error|critical` payload includes `reason` — verified across the 17 non-info calls
+- C6 static `rfa.outcome` values in vocabulary — all uses of `Context::add('rfa.outcome', ...)` and every `$outcome = '...'` literal fall inside `{completed, error, skipped, cancelled, rejected, partial}`
+- C7 no banned absolute-path key — verified
+- C9 no raw `$e->getMessage()` / `getTraceAsString()` / `stderr` in log payload or Context field — only sanitized `LogSanitizer::summary($e->stderr)` and `LogSanitizer::summary($event->message|$event->stack)` uses remain
+
+## Findings
+
+### [CRITICAL] Deterministic arch suite could not run in the audit environment
+
+- **File:** `tests/Arch/LoggingConventionsTest.php`
+- **Rule:** SKILL "If the deterministic test command fails, still write and open the report. Mark the failed command as `[CRITICAL]`."
+- **Evidence:** `composer install` fails on dev packages with `Could not authenticate against github.com` (pestphp/pest, pestphp/pest-plugin-browser, pestphp/pest-plugin-mutate). `vendor/bin/pest` is therefore absent and `php artisan test` cannot bootstrap Pest.
+- **Impact:** No enforcement signal from CI-equivalent checks during this audit run. Static replay in this report is a best-effort substitute, not a real test pass.
+- **Suggested fix:** Configure a GitHub token (or vendor-cached tarball) available to the routine's environment so `composer install` can complete. Then re-run the audit and confirm the arch suite passes.
+
+### [INFO] Console commands do not emit a canonical event for their unit of work
+
+- **File:** `app/Console/Commands/RegisterProjectCommand.php:16`, `app/Console/Commands/ScanDirectoryCommand.php:16`, `app/Console/Commands/LinkExternalPathCommand.php:16`
+- **Rule:** Agentic check "Logging Ownership" and A1. SKILL says "Console command owns the canonical event for the command unless it delegates to a logged action." The delegated actions (`RegisterProjectAction`, `ScanDirectoryAction`, `LinkExternalPathAction`) do not emit canonical events either.
+- **Evidence:** Neither `Log::info` nor `Context::flush` appears in `app/Console/Commands/` or in the three delegated actions. Errors surface only via `$this->error($e->getMessage())` to stdout.
+- **Impact:** Any CLI-driven registration, scan, or path link happens without a queryable outcome, duration, or reason record. Rare in day-to-day use, but the ownership rule expects coverage of these entry points.
+- **Suggested fix:** Wrap each command's `handle()` (or its delegated action) with the canonical pattern from the SKILL, setting `rfa.outcome`, `rfa.duration_ms`, and a small identifier set (project reference for register / link, scanned path hash for scan). Alternatively, document the exemption in the SKILL.
+
+### [INFO] Startup inbox processing lacks a canonical event
+
+- **File:** `app/Providers/NativeAppServiceProvider.php:297`
+- **Rule:** Agentic check "Logging Ownership" and A1. `processInbox()` opens a project on boot analogously to `HandleDeepLink`, which does emit `deeplink.opened`.
+- **Evidence:** `processInbox` calls `RecordRuntimeDiagnosticAction::handle('inbox.opened', ...)` (a JSONL breadcrumb, not a `Log::info` canonical event) and returns early with no owner event on the several other terminal paths (missing dir, empty glob, corrupt read, empty path, action returned null).
+- **Impact:** The outcome distribution for "app opened via inbox terminal helper" is unqueryable from the standard log channel, even though the deep-link and menu equivalents are.
+- **Suggested fix:** Add the canonical pattern (`Context::flush()`, `try/finally`, `rfa.outcome`, `rfa.duration_ms`) around the inbox flow with a `Log::info('inbox.opened')` owner event mirroring the shape of `HandleDeepLink`.
+
+### [INFO] Review-page write actions have no canonical event
+
+- **File:** `app/Concerns/ReviewPage/ManagesReviewTrash.php:59` (discardFileChanges), `app/Concerns/ReviewPage/ManagesReviewTrash.php:101` (restoreDiscardedFile), `app/Concerns/ReviewPage/ManagesReviewTrash.php:121` (permanentlyDeleteTrashed); plus the review-page comment writes and submit path (`resources/views/pages/⚡review-page.blade.php`).
+- **Rule:** Agentic check "Logging Ownership" and A1. The SKILL says the Livewire public method owns the canonical event when a side effect lives in the component; where the component delegates to an Action, that Action owns the canonical event.
+- **Evidence:** `discardFileChanges`, `restoreDiscardedFile`, and `permanentlyDeleteTrashed` are user-triggered mutations (file deletion / restore / trash purge) that delegate to Actions in `app/Actions/`. Neither the Livewire concerns nor those Actions emit a canonical `Log::info` event. Only `softRefresh` on this page is instrumented; only `createComment` on `context-page` is instrumented. Comment writes on the review page have no owner event either.
+- **Impact:** Consistency gap. Trash mutations are destructive-with-undo user actions that the SKILL's ownership heuristic would put in scope; they cannot be reasoned about in the log stream.
+- **Suggested fix:** Either widen instrumentation to match `context-page::createComment` and `review-page::softRefresh` (`review.discarded`, `review.discard.restored`, `review.trash.deleted`, `review.comment.written`, etc.), or codify the deliberate scope of "externally meaningful" in the SKILL so future readers see the boundary.
+
+## Clean Areas
+
+- **Canonical event shape.** All 7 `Log::info()` calls (`menu.item.clicked`, `deeplink.opened`, `updater.available`, `updater.downloaded`, `updater.failed`, `review.refreshed`, `context.comment.written`) carry `rfa.outcome` and `rfa.duration_ms` in the finally, use `Context::flush()` at the top of the owner, and use event names in the "domain.past_tense" convention.
+- **Listener-owned failure symmetry.** `UpdateError` in `NativeAppServiceProvider` emits both a diagnostic `Log::error('updater.failed', ...)` inside the try and a canonical `Log::info('updater.failed')` from the finally, matching the SKILL's listener-owned-unit rule. `Log::error` uses `LogSanitizer::summary($event->message|$event->stack)` for the sanitized detail.
+- **Owner / child correlation.** `OpenRepositoryDialogAction` and `OpenProjectFromPathAction` add `rfa.reason` and `rfa.error_class` on the Context so the calling owner (`HandleMenuItemClicked` and `HandleDeepLink`) can distinguish `rejected`, `cancelled`, and `error` from a plain null return. Neither child flushes context.
+- **Warning payload hygiene.** All 17 `Log::warning` / `Log::error` payloads include a stable `reason`. Git-command failures consistently use `exit_code` and `stderr_summary` via `LogSanitizer::summary($e->stderr)`. Generic exception paths use `error_class` (`$e::class`) rather than raw messages. `HandleDeepLink` hashes the raw deep-link path with xxh128 into `rfa.path_hash` instead of storing the path itself.
+- **Storage posture.** `config/logging.php` pins `LOG_CHANNEL=daily` with `LOG_LEVEL=info` and `LOG_DAILY_DAYS=7`. Remote scaffolding channels (slack, papertrail, syslog, errorlog) are defined but not part of the default channel or its resolved stack. `tests/Feature/LogChannelPostureTest.php` enforces this at runtime.
+- **Outcome vocabulary discipline.** Every static `rfa.outcome` literal and every `$outcome = '...'` local is in the approved set. `HandleDeepLink` even uses `Context::addIf('rfa.reason', 'not_a_project')` so the child's more specific reason wins when the action already set one.
+
+## Residual Risks
+
+- **No live CI signal for this run.** The static replay above is not a substitute for running the arch suite. Any regression the scanners would have caught this week is undetected until the environment can resolve dev composer dependencies.
+- **Absolute repo paths in warning payloads.** `GitMetadataService` and `EnsureRfaGitExcludeAction` warnings pass `'repo' => $repoPath` (the absolute path). The SKILL allows this when the path is the input being diagnosed, which it is for git subprocess failures, so this is not flagged. It still means anyone reading warning logs sees local filesystem layout.
+- **Semantic ownership boundary.** Whether every Livewire mutation on the review page constitutes an "externally meaningful operation" is a judgment call the SKILL delegates to reviewers. The finding above lists the concrete gaps but the team may deliberately want a narrower scope.
+- **Agentic review limits.** No call-graph analysis for stale-context bleed under real NativePHP long-lived-process traces; this review reasons per-file rather than per-request.


### PR DESCRIPTION
Automated weekly wide-events logging audit.

Artifact: `reports/wide-events/2026-08-04.md`

This PR is human-gated. It contains the report only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzwCPf1QzsWm84R88ize2V)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the August 4, 2026 wide-events audit report.
  * Documented test execution limitations, logging replay results, key findings, clean areas, and remaining risks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->