### PR TITLE
Resolve wide-events audit findings (2026-08-11)

### DIFF
--- a/.claude/skills/wide-events/SKILL.md
+++ b/.claude/skills/wide-events/SKILL.md
@@ -289,7 +289,7 @@ Disallowed active channels:
 
 ## CI Checklist
 
-C1–C7 and C9 live in `tests/Arch/LoggingConventionsTest.php` (file scanners, no app context). C8 lives in `tests/Feature/LogChannelPostureTest.php` (needs resolved config). All are enforced today — keep them passing, and extend them rather than loosening when a new pattern appears.
+C1–C7 and C9–C10 live in `tests/Arch/LoggingConventionsTest.php` (file scanners, no app context). C8 lives in `tests/Feature/LogChannelPostureTest.php` (needs resolved config). All are enforced today — keep them passing, and extend them rather than loosening when a new pattern appears.
 
 C1. No `Log::debug()` in `app/` or `resources/views`.
 
@@ -308,6 +308,8 @@ C7. No static `Context` key is a banned absolute-path key.
 C8. Remote logging channels are not part of the default channel or recursively resolved default stack.
 
 C9. No `Log::warning()` / `error()` / `critical()` payload and no `Context` field passes a raw exception message, stack trace, or stderr as a value. Wrapped forms like `LogSanitizer::summary($e->stderr)` are allowed.
+
+C10. No `Log::warning()` / `error()` / `critical()` payload passes the absolute repository root variable `$repoPath`. Use owner `Context`, relative paths, hashes, counts, or stable reason codes instead.
 
 ## Agent Review Checklist
 

--- a/app/Actions/EnsureRfaGitExcludeAction.php
+++ b/app/Actions/EnsureRfaGitExcludeAction.php
@@ -51,7 +51,6 @@ final readonly class EnsureRfaGitExcludeAction
         } catch (\Throwable $e) {
             Log::warning('git.exclude.append_failed', [
                 'reason' => 'exclude_append_failed',
-                'repo' => $repoPath,
                 'error_class' => $e::class,
             ]);
         }
@@ -75,7 +74,6 @@ final readonly class EnsureRfaGitExcludeAction
         } catch (\Throwable $e) {
             Log::warning('git.exclude.resolve_failed', [
                 'reason' => 'exclude_path_resolve_failed',
-                'repo' => $repoPath,
                 'error_class' => $e::class,
             ]);
 

--- a/app/Actions/GetProjectStatusAction.php
+++ b/app/Actions/GetProjectStatusAction.php
@@ -27,7 +27,6 @@ final readonly class GetProjectStatusAction
         } catch (GitCommandException $e) {
             Log::warning('project.status.failed', [
                 'reason' => 'project_status_failed',
-                'repo' => $repoPath,
                 'exit_code' => $e->exitCode,
                 'stderr_summary' => LogSanitizer::summary($e->stderr),
             ]);

--- a/app/Actions/ResolveBranchBaseAction.php
+++ b/app/Actions/ResolveBranchBaseAction.php
@@ -81,7 +81,6 @@ final readonly class ResolveBranchBaseAction
         } catch (GitCommandException $e) {
             Log::warning('git.commit_range.list_failed', [
                 'reason' => 'commit_range_list_failed',
-                'repo' => $repoPath,
                 'from' => $from,
                 'to' => $to,
                 'exit_code' => $e->exitCode,

--- a/app/Providers/NativeAppServiceProvider.php
+++ b/app/Providers/NativeAppServiceProvider.php
@@ -132,12 +132,30 @@ class NativeAppServiceProvider implements ProvidesPhpIni
             Cache::put('native-update-state', $state, now()->addMinutes(30));
         });
 
-        Event::listen(UpdateNotAvailable::class, function () {
-            Cache::put('native-update-state', ['status' => 'up-to-date'], now()->addSeconds(10));
-            Notification::new()
-                ->title('No Updates')
-                ->message('You are running the latest version.')
-                ->show();
+        Event::listen(UpdateNotAvailable::class, function (UpdateNotAvailable $event) {
+            Context::flush();
+
+            $startedAt = microtime(true);
+            $outcome = 'completed';
+
+            try {
+                Cache::put('native-update-state', ['status' => 'up-to-date'], now()->addSeconds(10));
+                Notification::new()
+                    ->title('No Updates')
+                    ->message('You are running the latest version.')
+                    ->show();
+            } catch (Throwable $e) {
+                $outcome = 'error';
+                Context::add('rfa.error_class', $e::class);
+                Context::add('rfa.reason', 'update_not_available_handling_failed');
+
+                throw $e;
+            } finally {
+                Context::add('rfa.update_version', $event->version);
+                Context::add('rfa.outcome', $outcome);
+                Context::add('rfa.duration_ms', $this->elapsedMs($startedAt));
+                Log::info('updater.current');
+            }
         });
 
         Event::listen(UpdateDownloaded::class, function (UpdateDownloaded $event) {

--- a/app/Services/GitMetadataService.php
+++ b/app/Services/GitMetadataService.php
@@ -25,7 +25,6 @@ class GitMetadataService
         } catch (GitCommandException $e) {
             Log::warning('git.excludes_file.resolve_failed', [
                 'reason' => 'global_excludes_file_resolve_failed',
-                'repo' => $repoPath,
                 'exit_code' => $e->exitCode,
             ]);
 
@@ -195,7 +194,6 @@ class GitMetadataService
         } catch (GitCommandException $e) {
             Log::warning('git.file_content.read_failed', [
                 'reason' => 'file_content_read_failed',
-                'repo' => $repoPath,
                 'ref' => $ref,
                 'path' => $path,
                 'exit_code' => $e->exitCode,
@@ -218,7 +216,6 @@ class GitMetadataService
         } catch (GitCommandException $e) {
             Log::warning('git.ref.resolve_failed', [
                 'reason' => 'git_ref_resolve_failed',
-                'repo' => $repoPath,
                 'ref' => $ref,
                 'exit_code' => $e->exitCode,
             ]);
@@ -246,7 +243,6 @@ class GitMetadataService
         } catch (GitCommandException $e) {
             Log::warning('git.commit_parents.read_failed', [
                 'reason' => 'commit_parents_read_failed',
-                'repo' => $repoPath,
                 'hash' => $hash,
                 'exit_code' => $e->exitCode,
             ]);
@@ -270,7 +266,6 @@ class GitMetadataService
         } catch (GitCommandException $e) {
             Log::warning('git.root_commit.check_failed', [
                 'reason' => 'root_commit_check_failed',
-                'repo' => $repoPath,
                 'ref' => $ref,
                 'exit_code' => $e->exitCode,
             ]);
@@ -315,7 +310,6 @@ class GitMetadataService
         } catch (GitCommandException $e) {
             Log::warning('git.child_commit.read_failed', [
                 'reason' => 'child_commit_read_failed',
-                'repo' => $repoPath,
                 'hash' => $hash,
                 'exit_code' => $e->exitCode,
             ]);
@@ -389,7 +383,6 @@ class GitMetadataService
         } catch (GitCommandException $e) {
             Log::warning('git.commit_log.read_failed', [
                 'reason' => 'commit_log_read_failed',
-                'repo' => $repoPath,
                 'exit_code' => $e->exitCode,
             ]);
 

--- a/reports/wide-events/2026-08-11.md
+++ b/reports/wide-events/2026-08-11.md
@@ -1,0 +1,58 @@
+# Wide Events Audit: 2026-08-11
+
+## Summary
+
+- Deterministic checks: pass
+- Findings: 0 critical, 0 warning, 3 info
+- Files reviewed: 15
+
+## Deterministic Checks
+
+| Command | Result | Notes |
+|---|---|---|
+| `php artisan test --compact tests/Arch/LoggingConventionsTest.php` | pass | 8 tests, 8 assertions, ~45ms |
+| `php artisan test --compact tests/Feature/LogChannelPostureTest.php` | pass | Resolved default channel and stack stay local (C8) |
+
+## Findings
+
+### [INFO] Warning payloads embed absolute repo paths where slug context is available
+
+- **File:** `app/Services/GitMetadataService.php:26`, `196`, `219`, `247`, `271`, `316`, `390`; `app/Actions/EnsureRfaGitExcludeAction.php:52`, `76`; `app/Actions/GetProjectStatusAction.php:28`; `app/Actions/ResolveBranchBaseAction.php:82`
+- **Rule:** Agent Review Checklist A9, Privacy → "Prefer project slugs, relative file paths, hashes, counts, booleans, and stable reason codes."
+- **Evidence:** Each warning payload carries `'repo' => $repoPath` where `$repoPath` is the absolute filesystem root of the repository. The standard permits absolute paths in warning payloads when no project context can resolve a relative path or when the path itself is the failed input being diagnosed. The callers of these services and actions are typically owners that already carry `rfa.project_id` and `rfa.project_slug` in `Context`, so the absolute value duplicates identity that owner context already provides.
+- **Impact:** Low. Correlation is still possible through the owner canonical event. The redundant absolute string adds a stable but privacy-noisier field to warning payloads and expands the surface area of paths that later log-scrubbing would need to handle.
+- **Suggested fix:** Where a caller already has a `Project`, pass a `$projectSlug` or `$projectId` alongside `$repoPath` and use that in the warning payload. Where only the path is available (e.g. a raw deep-link input), the current absolute value remains inside the allowed carve-out.
+
+### [INFO] `handleCheckUpdates` records `completed` before the update result is known
+
+- **File:** `app/Listeners/HandleMenuItemClicked.php:68`
+- **Rule:** Agent Review Checklist A5, Outcome Semantics → `completed` means the requested work finished.
+- **Evidence:** `handleCheckUpdates()` writes an in-progress `native-update-state` cache entry, calls `AutoUpdater::checkForUpdates()`, and returns `'completed'`. The actual check runs asynchronously and lands later through `UpdateAvailable` / `UpdateNotAvailable` / `UpdateError` listeners, each of which owns its own canonical event.
+- **Impact:** Low. The click was dispatched, so treating the menu-click unit as completed is defensible. The subtle risk is that a reader querying `menu.item.clicked` for `rfa.menu_id = check-updates` may mistake `completed` for "update-check succeeded" rather than "click was accepted and handed off."
+- **Suggested fix:** Optional. Consider a `partial` or a dedicated `dispatched` semantic if that queryability matters. Otherwise document in the SKILL that a listener that fires and forgets to a downstream owner records `completed` for the dispatch itself.
+
+### [INFO] `context.comment.rejected` warning restates fields already on the owner canonical event
+
+- **File:** `resources/views/pages/⚡context-page.blade.php:270`
+- **Rule:** Agent Review Checklist A2, A11, Warnings → "Do not warn for every normal rejected input. Use the owner canonical event with `rfa.outcome = rejected`. Add a warning only when the rejection is unexpected, security-relevant, or indicates degraded behavior."
+- **Evidence:** On `ContextCommentRejectedException` the owner sets `rfa.outcome = rejected` and `rfa.reason = $e->reason->value`, and additionally emits `Log::warning('context.comment.rejected', ['reason' => ..., 'file_id' => ..., 'side' => ..., 'start_line' => ..., 'end_line' => ...])`. The warning is justified by the comment as a stale-renderer-state signal (degraded behavior), so it qualifies under the SKILL exception. The `file_id` / `side` / line fields do add diagnostic detail beyond what the canonical event carries.
+- **Impact:** Low. The distinction between "expected user rejection" and "renderer drifted out of sync with the file" is precisely the case the SKILL allows a warning for. Left as-is this is fine; the note is here so a future reviewer does not read the pair as a violation.
+- **Suggested fix:** Optional. Either leave both in place (current state) or promote the extra fields onto owner `Context` and drop the warning. If left as-is, add a short code comment tying it to the SKILL's degraded-behavior carve-out so intent is legible without a git-blame walk.
+
+## Clean Areas
+
+- Every canonical `Log::info()` has a single clear owner and lives in the correct layer (listener for deep-link and menu, provider closures for updater events, Livewire page methods for review-refresh and comment-write). Child services and actions never duplicate a parent canonical event.
+- `Context::flush()` runs first in every owner (`HandleDeepLink::handle`, `HandleMenuItemClicked::handle`, all three updater listeners in `NativeAppServiceProvider`, `⚡review-page::softRefresh`, `⚡context-page::createComment`). Child services and actions add `rfa.reason` / `rfa.error_class` without flushing, preserving owner correlation.
+- Every canonical event includes `rfa.outcome` and `rfa.duration_ms`. Context carries structured IDs, slugs, counts, and booleans that make the operations queryable without reading code (e.g. `rfa.repos_found`, `rfa.repos_registered`, `rfa.repos_already_tracked`, `rfa.repos_failed` on scan; `rfa.changed_count`, `rfa.changed_file_ids`, `rfa.file_count_before` / `_after` on review refresh).
+- `rfa.outcome` values follow the standard vocabulary and the decision tree. `deeplink.opened` uses `rejected` for `unsupported_url` and `missing_path`, `error` only when the swallowed exception is `project_registration_failed`, and `completed` on the success path.
+- The listener-owned `updater.failed` unit emits both a diagnostic `Log::error()` and the canonical `Log::info()` from `finally`, satisfying A13 so failure and success paths of the updater share one queryable shape.
+- Warning payloads use stable reason codes plus safe diagnostic fields (`exit_code`, `error_class`, `LogSanitizer::summary`) rather than raw exception text. No payload passes `$e->getMessage()`, `$e->getTraceAsString()`, or raw `$e->stderr`.
+- No banned absolute-path keys are set on `Context`. Where a path appears on a warning it is either a relative path (`LoadFileDiffAction`) or a raw deep-link input value being diagnosed (`OpenProjectFromPathAction`).
+- Storage stays local. `config/logging.php` resolves `default` to `daily` (or the stack of `single`), retention is bounded via `LOG_DAILY_DAYS`, and `LogChannelPostureTest` confirms no active resolved channel is `slack`, `papertrail`, `syslog`, `errorlog`, or a remote Monolog handler.
+
+## Residual Risks
+
+- Agentic review reads code, not runtime traffic. Dynamic `Context::add()` values (e.g. `rfa.reason` from an exception's `reason->value`) are only spot-checked against the vocabulary. A future reason enum entry could drift from the approved outcome set without the arch tests catching it.
+- `LoadFileDiffAction` runs per-file on lazy render and does not emit a canonical info event. This is a scope judgment (per-file diff render is not an externally meaningful user operation) rather than a rule violation, but a reviewer disagreeing on that boundary would raise it.
+- The routine reads only files listed under Data Sources and never runs the app or replays JSONL diagnostics, so runtime-only regressions (e.g. a listener that never actually reaches `finally` under a real Electron crash) are outside its detection surface.
+- `OpenRepositoryDialogAction::handle` passes `$e->getMessage()` into `Alert::show()` for the user-facing error dialog. This is a UI surface, not a `Log::` or `Context::` payload, so it is outside the SKILL's raw-exception ban, but it is worth noting that the exception text does leave the app boundary.

--- a/reports/wide-events/2026-08-11.md
+++ b/reports/wide-events/2026-08-11.md
@@ -3,33 +3,34 @@
 ## Summary
 
 - Deterministic checks: pass
-- Findings: 0 critical, 0 warning, 3 info
+- Findings: 0 critical, 2 warning (both resolved), 2 info
 - Files reviewed: 15
 
 ## Deterministic Checks
 
 | Command | Result | Notes |
 |---|---|---|
-| `php artisan test --compact tests/Arch/LoggingConventionsTest.php` | pass | 8 tests, 8 assertions, ~45ms |
+| `php artisan test --compact tests/Arch/LoggingConventionsTest.php` | pass | Includes C10 regression coverage for absolute repository roots |
 | `php artisan test --compact tests/Feature/LogChannelPostureTest.php` | pass | Resolved default channel and stack stay local (C8) |
+| `php artisan test --compact tests/Unit/Providers/NativeAppServiceProviderTest.php` | pass | Covers completed and error outcomes for the no-update listener |
 
 ## Findings
 
-### [INFO] Warning payloads embed absolute repo paths where slug context is available
+### [WARNING] [RESOLVED] Warning payloads embedded absolute repo paths where owner context is available
 
 - **File:** `app/Services/GitMetadataService.php:26`, `196`, `219`, `247`, `271`, `316`, `390`; `app/Actions/EnsureRfaGitExcludeAction.php:52`, `76`; `app/Actions/GetProjectStatusAction.php:28`; `app/Actions/ResolveBranchBaseAction.php:82`
 - **Rule:** Agent Review Checklist A9, Privacy → "Prefer project slugs, relative file paths, hashes, counts, booleans, and stable reason codes."
 - **Evidence:** Each warning payload carries `'repo' => $repoPath` where `$repoPath` is the absolute filesystem root of the repository. The standard permits absolute paths in warning payloads when no project context can resolve a relative path or when the path itself is the failed input being diagnosed. The callers of these services and actions are typically owners that already carry `rfa.project_id` and `rfa.project_slug` in `Context`, so the absolute value duplicates identity that owner context already provides.
 - **Impact:** Low. Correlation is still possible through the owner canonical event. The redundant absolute string adds a stable but privacy-noisier field to warning payloads and expands the surface area of paths that later log-scrubbing would need to handle.
-- **Suggested fix:** Where a caller already has a `Project`, pass a `$projectSlug` or `$projectId` alongside `$repoPath` and use that in the warning payload. Where only the path is available (e.g. a raw deep-link input), the current absolute value remains inside the allowed carve-out.
+- **Resolution:** Removed the redundant `repo` field from all 11 warning payloads. Added C10 to the wide-events rules and `LoggingConventionsTest` so diagnostic payloads cannot pass `$repoPath` again. Relative paths, refs, hashes, exit codes, error classes, and owner `Context` retain the useful diagnostic data.
 
 ### [INFO] `handleCheckUpdates` records `completed` before the update result is known
 
 - **File:** `app/Listeners/HandleMenuItemClicked.php:68`
 - **Rule:** Agent Review Checklist A5, Outcome Semantics → `completed` means the requested work finished.
-- **Evidence:** `handleCheckUpdates()` writes an in-progress `native-update-state` cache entry, calls `AutoUpdater::checkForUpdates()`, and returns `'completed'`. The actual check runs asynchronously and lands later through `UpdateAvailable` / `UpdateNotAvailable` / `UpdateError` listeners, each of which owns its own canonical event.
+- **Evidence:** `handleCheckUpdates()` writes an in-progress `native-update-state` cache entry, calls `AutoUpdater::checkForUpdates()`, and returns `'completed'`. The actual check runs asynchronously and lands later through terminal updater listeners, each of which owns its canonical event.
 - **Impact:** Low. The click was dispatched, so treating the menu-click unit as completed is defensible. The subtle risk is that a reader querying `menu.item.clicked` for `rfa.menu_id = check-updates` may mistake `completed` for "update-check succeeded" rather than "click was accepted and handed off."
-- **Suggested fix:** Optional. Consider a `partial` or a dedicated `dispatched` semantic if that queryability matters. Otherwise document in the SKILL that a listener that fires and forgets to a downstream owner records `completed` for the dispatch itself.
+- **Disposition:** Leave as-is. The menu listener owns dispatch, not the asynchronous updater result. `completed` accurately means that the click was accepted and the update check was started. The terminal updater listener records the result separately.
 
 ### [INFO] `context.comment.rejected` warning restates fields already on the owner canonical event
 
@@ -37,17 +38,25 @@
 - **Rule:** Agent Review Checklist A2, A11, Warnings → "Do not warn for every normal rejected input. Use the owner canonical event with `rfa.outcome = rejected`. Add a warning only when the rejection is unexpected, security-relevant, or indicates degraded behavior."
 - **Evidence:** On `ContextCommentRejectedException` the owner sets `rfa.outcome = rejected` and `rfa.reason = $e->reason->value`, and additionally emits `Log::warning('context.comment.rejected', ['reason' => ..., 'file_id' => ..., 'side' => ..., 'start_line' => ..., 'end_line' => ...])`. The warning is justified by the comment as a stale-renderer-state signal (degraded behavior), so it qualifies under the SKILL exception. The `file_id` / `side` / line fields do add diagnostic detail beyond what the canonical event carries.
 - **Impact:** Low. The distinction between "expected user rejection" and "renderer drifted out of sync with the file" is precisely the case the SKILL allows a warning for. Left as-is this is fine; the note is here so a future reviewer does not read the pair as a violation.
-- **Suggested fix:** Optional. Either leave both in place (current state) or promote the extra fields onto owner `Context` and drop the warning. If left as-is, add a short code comment tying it to the SKILL's degraded-behavior carve-out so intent is legible without a git-blame walk.
+- **Disposition:** Leave as-is. The existing code comment identifies stale or malformed renderer state as the reason for the warning. The extra file and line fields provide diagnostic detail that the canonical event does not carry.
+
+### [WARNING] [RESOLVED] `UpdateNotAvailable` lacked a canonical terminal event
+
+- **File:** `app/Providers/NativeAppServiceProvider.php:135`
+- **Rule:** Agent Review Checklist A3, A5, A6, A13.
+- **Evidence:** The listener updated cache state and showed a notification without flushing context or emitting an info event. The common no-update result was absent from the updater outcome distribution.
+- **Impact:** Successful update checks with no available release could not be queried through the canonical event stream. Exceptions in that listener also had no terminal outcome.
+- **Resolution:** Added `updater.current` with `rfa.update_version`, `rfa.outcome`, and `rfa.duration_ms`. The exception path adds `rfa.error_class` and `rfa.reason`, rethrows, and still emits the canonical event from `finally`. Provider tests cover both outcomes.
 
 ## Clean Areas
 
 - Every canonical `Log::info()` has a single clear owner and lives in the correct layer (listener for deep-link and menu, provider closures for updater events, Livewire page methods for review-refresh and comment-write). Child services and actions never duplicate a parent canonical event.
-- `Context::flush()` runs first in every owner (`HandleDeepLink::handle`, `HandleMenuItemClicked::handle`, all three updater listeners in `NativeAppServiceProvider`, `⚡review-page::softRefresh`, `⚡context-page::createComment`). Child services and actions add `rfa.reason` / `rfa.error_class` without flushing, preserving owner correlation.
+- `Context::flush()` runs first in every owner (`HandleDeepLink::handle`, `HandleMenuItemClicked::handle`, all four terminal updater listeners in `NativeAppServiceProvider`, `⚡review-page::softRefresh`, `⚡context-page::createComment`). Child services and actions add `rfa.reason` / `rfa.error_class` without flushing, preserving owner correlation.
 - Every canonical event includes `rfa.outcome` and `rfa.duration_ms`. Context carries structured IDs, slugs, counts, and booleans that make the operations queryable without reading code (e.g. `rfa.repos_found`, `rfa.repos_registered`, `rfa.repos_already_tracked`, `rfa.repos_failed` on scan; `rfa.changed_count`, `rfa.changed_file_ids`, `rfa.file_count_before` / `_after` on review refresh).
 - `rfa.outcome` values follow the standard vocabulary and the decision tree. `deeplink.opened` uses `rejected` for `unsupported_url` and `missing_path`, `error` only when the swallowed exception is `project_registration_failed`, and `completed` on the success path.
-- The listener-owned `updater.failed` unit emits both a diagnostic `Log::error()` and the canonical `Log::info()` from `finally`, satisfying A13 so failure and success paths of the updater share one queryable shape.
+- The updater terminal listeners emit canonical events from `finally`. `updater.failed` also emits a sanitized diagnostic error. No-update success and exception paths share the `updater.current` event shape.
 - Warning payloads use stable reason codes plus safe diagnostic fields (`exit_code`, `error_class`, `LogSanitizer::summary`) rather than raw exception text. No payload passes `$e->getMessage()`, `$e->getTraceAsString()`, or raw `$e->stderr`.
-- No banned absolute-path keys are set on `Context`. Where a path appears on a warning it is either a relative path (`LoadFileDiffAction`) or a raw deep-link input value being diagnosed (`OpenProjectFromPathAction`).
+- No banned absolute-path keys are set on `Context`, and warning payloads no longer receive repository roots through `$repoPath`. Remaining warning paths are relative (`LoadFileDiffAction`) or the failed raw deep-link input (`OpenProjectFromPathAction`).
 - Storage stays local. `config/logging.php` resolves `default` to `daily` (or the stack of `single`), retention is bounded via `LOG_DAILY_DAYS`, and `LogChannelPostureTest` confirms no active resolved channel is `slack`, `papertrail`, `syslog`, `errorlog`, or a remote Monolog handler.
 
 ## Residual Risks

--- a/tests/Arch/LoggingConventionsTest.php
+++ b/tests/Arch/LoggingConventionsTest.php
@@ -8,7 +8,7 @@
  * the mechanically checkable rules: debug-free production code, static dotted
  * event names, payload-free info events, stable `reason` codes, `rfa.`-namespaced
  * context keys, the approved `rfa.outcome` vocabulary, banned absolute-path keys,
- * and the privacy ban on raw exception text in payloads.
+ * repository roots in warning payloads, and raw exception text in payloads.
  *
  * Semantic rules — logging ownership, context richness, and deeper privacy
  * judgment — still belong in review because they require call-chain and domain
@@ -354,6 +354,25 @@ test('warning and error logs include a stable reason payload', function () {
         $payload = $arguments[1] ?? '';
 
         if (! preg_match('/[\'"]reason[\'"]\s*=>/', $payload)) {
+            $violations[] = "{$call['path']}:{$call['line']} {$call['source']}";
+        }
+    }
+
+    expect($violations)->toBeEmpty();
+});
+
+test('warning and error logs do not expose repository root paths', function () {
+    $violations = [];
+
+    foreach (loggingConventionCalls() as $call) {
+        if (! in_array($call['level'], ['warning', 'error', 'critical'], true)) {
+            continue;
+        }
+
+        $arguments = loggingConventionArguments($call['source']);
+        $payload = $arguments[1] ?? '';
+
+        if (preg_match('/=>\s*\$repoPath\b/', $payload)) {
             $violations[] = "{$call['path']}:{$call['line']} {$call['source']}";
         }
     }

--- a/tests/Unit/Providers/NativeAppServiceProviderTest.php
+++ b/tests/Unit/Providers/NativeAppServiceProviderTest.php
@@ -4,7 +4,12 @@ use App\Console\Benchmark\BenchmarkIsolation;
 use App\Providers\NativeAppServiceProvider;
 use App\Support\Shortcuts;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Native\Desktop\Events\AutoUpdater\UpdateNotAvailable;
 use Tests\TestCase;
 
 uses(TestCase::class);
@@ -22,6 +27,62 @@ beforeEach(function () {
     ])->each(function (string $property) use ($provider): void {
         $provider->getProperty($property)->setValue(false);
     });
+});
+
+function updateNotAvailableListener(): Closure
+{
+    Event::forget(UpdateNotAvailable::class);
+
+    $provider = new ReflectionClass(NativeAppServiceProvider::class);
+    $registerNativeEventListeners = $provider->getMethod('registerNativeEventListeners');
+    $registerNativeEventListeners->invoke(new NativeAppServiceProvider);
+
+    return collect(Event::getFacadeRoot()->getListeners(UpdateNotAvailable::class))->sole();
+}
+
+function updateNotAvailableEvent(): UpdateNotAvailable
+{
+    return new UpdateNotAvailable(
+        version: '1.2.3',
+        files: [],
+        releaseDate: '2026-08-13',
+    );
+}
+
+test('no-update listener emits a canonical terminal event', function () {
+    Http::fake();
+    Log::spy();
+
+    $listener = updateNotAvailableListener();
+    $event = updateNotAvailableEvent();
+
+    $listener(UpdateNotAvailable::class, [$event]);
+
+    Log::shouldHaveReceived('info')->once()->with('updater.current');
+    expect(Cache::get('native-update-state'))->toMatchArray(['status' => 'up-to-date'])
+        ->and(Context::get('rfa.update_version'))->toBe('1.2.3')
+        ->and(Context::get('rfa.outcome'))->toBe('completed')
+        ->and(Context::get('rfa.duration_ms'))->toBeInt();
+});
+
+test('no-update listener emits an error outcome when handling fails', function () {
+    Log::spy();
+    Cache::shouldReceive('put')
+        ->once()
+        ->andThrow(new RuntimeException('Cache write failed.'));
+
+    $listener = updateNotAvailableListener();
+    $event = updateNotAvailableEvent();
+
+    expect(fn () => $listener(UpdateNotAvailable::class, [$event]))
+        ->toThrow(RuntimeException::class, 'Cache write failed.');
+
+    Log::shouldHaveReceived('info')->once()->with('updater.current');
+    expect(Context::get('rfa.update_version'))->toBe('1.2.3')
+        ->and(Context::get('rfa.outcome'))->toBe('error')
+        ->and(Context::get('rfa.reason'))->toBe('update_not_available_handling_failed')
+        ->and(Context::get('rfa.error_class'))->toBe(RuntimeException::class)
+        ->and(Context::get('rfa.duration_ms'))->toBeInt();
 });
 
 test('dev compiled view cleanup does not clear persisted updater state', function () {


### PR DESCRIPTION
The weekly audit found two real gaps. This PR fixes both and keeps the report as evidence.

- Removes absolute repository roots from 11 warning payloads
- Adds a C10 architecture check to prevent the path leak from returning
- Adds a canonical `updater.current` event for completed and failed no-update handling
- Updates the audit classification and dispositions

## Checks

- `composer test:lint`
- `composer test:types`
- `composer test` (1,738 tests, 4,861 assertions)