### PR TITLE
Validate AGENTS.md symlinks from the index, not the working tree

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,19 +11,41 @@ pre-commit:
       run: ./vendor/bin/pint --test
     agents-symlinks:
       run: |
-        status=0
-        for claude in $(find . -name CLAUDE.md -not -path './.git/*' -not -path '*/vendor/*' -not -path '*/nativephp/*' -not -path '*/node_modules/*'); do
-          dir=$(dirname "$claude")
-          agents="$dir/AGENTS.md"
-          if [ ! -L "$agents" ]; then
-            echo "Missing AGENTS.md symlink for $claude"
-            status=1
-          elif [ "$(readlink "$agents")" != "CLAUDE.md" ]; then
-            echo "AGENTS.md in $dir is not a symlink to CLAUDE.md"
-            status=1
+        # Validates the index, not the working tree, so the tree being
+        # committed is what gets checked: a partially staged pair fails
+        # here even when the working tree looks complete. Untracked
+        # trees (vendor, nativephp, node_modules) never appear in the
+        # index, so no path exclusions are needed. Iteration splits on
+        # newlines only, so paths with spaces survive.
+        nl=$(printf '\nx'); IFS=${nl%x}
+        failed=0
+
+        # Every CLAUDE.md needs a sibling AGENTS.md symlink pointing exactly to CLAUDE.md.
+        for claude in $(git ls-files -- 'CLAUDE.md' '*/CLAUDE.md'); do
+          agents="${claude%CLAUDE.md}AGENTS.md"
+          if ! git ls-files --error-unmatch -- "$agents" >/dev/null 2>&1; then
+            echo "Missing staged AGENTS.md symlink for $claude"
+            failed=1
           fi
         done
-        exit $status
+
+        # AGENTS.md exists only as that sibling symlink: no orphans or dangling links.
+        for agents in $(git ls-files -- 'AGENTS.md' '*/AGENTS.md'); do
+          if ! git ls-files --error-unmatch -- "${agents%AGENTS.md}CLAUDE.md" >/dev/null 2>&1; then
+            echo "$agents has no sibling CLAUDE.md (AGENTS.md exists only as a symlink to one)"
+            failed=1
+          fi
+          mode=$(git ls-files -s -- "$agents" | cut -d' ' -f1)
+          if [ "$mode" != "120000" ]; then
+            echo "$agents must be a symlink (staged as mode $mode)"
+            failed=1
+          elif [ "$(git show ":$agents")" != "CLAUDE.md" ]; then
+            echo "$agents is not a symlink to CLAUDE.md"
+            failed=1
+          fi
+        done
+
+        exit $failed
 
 pre-push:
   commands:


### PR DESCRIPTION
## Summary
Rework the `agents-symlinks` pre-commit hook to validate the index instead of the working tree, and remove a dangling symlink the stricter check caught.

## Why
Two defects surfaced while porting this hook to farfalla (publicala/farfalla#999, found by Codex review there):
- The `find`-based scan reads the working tree, so a partially staged pair passes: stage a new `CLAUDE.md`, leave its `AGENTS.md` symlink unstaged, and the commit lands without the symlink while the hook sees the working-tree copy and stays green.
- `$(find ...)` output goes through shell word splitting, so a path containing a space produces false "Missing" errors.

## Solution
Read the index: `git ls-files` for pairing, `git ls-files -s` for the 120000 symlink mode, `git show :path` for the target. That checks the tree actually being committed, and untracked trees (vendor, nativephp, node_modules) never appear in the index, so the `find` exclusions go away. Iteration splits on newlines only.

## Changes
- `lefthook.yml`: index-based `agents-symlinks` check, plus a reverse pass the old hook lacked — an AGENTS.md with no sibling CLAUDE.md, staged as a regular file, or pointing anywhere but `CLAUDE.md` now fails
- `agents/AGENTS.md` removed: the new reverse pass immediately flagged it as a dangling symlink to an `agents/CLAUDE.md` that does not exist

## Testing
- Hook ran live on this commit and passed
- Fixture-tested in farfalla with the same script: partial staging fails, regular-file AGENTS.md fails, orphan fails, spaced paths pass

## Deployment
No special steps required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZQMmvD9SgXRCw4inyHfU7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pre-commit validation for staged documentation links.
  - Validation now detects missing companion files, incorrect links, and multiple issues in a single check.
  - Prevents invalid documentation link changes from being committed.

- **Documentation**
  - Removed an outdated documentation reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->