### PR TITLE
Skip ignored trees during Context discovery

### DIFF
--- a/app/Enums/AgentContextFileKind.php
+++ b/app/Enums/AgentContextFileKind.php
@@ -90,9 +90,7 @@ enum AgentContextFileKind: string
         // `.mdc` is Cursor's rule-file extension.
         $hasRuleExtension = str_ends_with($relPath, '.md') || str_ends_with($relPath, '.mdc');
 
-        // Bail on ordinary source files before the rule scan: every rule needs
-        // a rule extension or a dot-prefixed segment. Hot path — fromPath()
-        // runs for every entry of the working-tree walk.
+        // Every rule needs a rule extension or a dot-prefixed segment.
         if (! $hasRuleExtension && ! str_contains($haystack, '/.')) {
             return null;
         }

--- a/app/Services/AgentContextFileScannerService.php
+++ b/app/Services/AgentContextFileScannerService.php
@@ -20,10 +20,9 @@ class AgentContextFileScannerService
      * Discover every agent context file inside $repoPath, ordered by path.
      * See AgentContextFileKind for the conventions recognised.
      *
-     * Tracked entries come from `git ls-files`; untracked candidates are walked
-     * from disk and filtered through `git check-ignore` in a single batch. Skip
-     * dirs come from config('rfa.context_scan_skip_dirs') and may be augmented
-     * via $extraSkipDirs (used by tests).
+     * Tracked and untracked entries come from `git ls-files`. Untracked entries
+     * use Git's standard excludes, and configured skip directories are excluded
+     * from discovery. Additional skip directories may be supplied per scan.
      *
      * @param  array<int, string>  $extraSkipDirs
      * @return array<int, AgentContextFile>
@@ -47,7 +46,7 @@ class AgentContextFileScannerService
         // entry: prefer the non-symlink, then the shorter path. That way the
         // tree shows the actual file rather than its mirror.
         $byRealpath = [];
-        foreach ([...array_values($tracked), ...$untracked] as $file) {
+        foreach ([...$tracked, ...$untracked] as $file) {
             $key = realpath($file->absolutePath) ?: $file->absolutePath;
             $existing = $byRealpath[$key] ?? null;
 
@@ -64,7 +63,7 @@ class AgentContextFileScannerService
 
     /**
      * @param  array<int, string>  $skipDirs
-     * @return array<string, AgentContextFile> keyed by repo-relative path
+     * @return array<int, AgentContextFile>
      */
     private function discoverTracked(string $repoPath, array $skipDirs): array
     {
@@ -100,7 +99,7 @@ class AgentContextFileScannerService
             $symlinkTarget = $isSymlink ? readlink($absolute) : null;
             [$createdAt, $lastEditedAt] = $datesByPath[$relPath] ?? [null, null];
 
-            $entries[$relPath] = new AgentContextFile(
+            $entries[] = new AgentContextFile(
                 path: $relPath,
                 absolutePath: $absolute,
                 kind: $kind,
@@ -129,6 +128,7 @@ class AgentContextFileScannerService
             fn (): string => $this->git->run($repoPath, [
                 'ls-files', '--others', '--exclude-standard', '-z',
                 '--', ...AgentContextFileKind::gitPathspecs(),
+                ...$this->gitExclusionPathspecs($skipDirs),
             ]),
             rescue: null,
             report: false,
@@ -138,15 +138,15 @@ class AgentContextFileScannerService
             return [];
         }
 
-        /** @var array<string, AgentContextFileKind> $candidates */
-        $candidates = collect($this->splitNullDelimited($output))
+        /** @var array<string, AgentContextFileKind> $kindsByPath */
+        $kindsByPath = collect($this->splitNullDelimited($output))
             ->reject(fn (string $path): bool => $this->isSkipped($path, $skipDirs))
             ->mapWithKeys(fn (string $path): array => [$path => AgentContextFileKind::fromPath($path)])
             ->whereNotNull()
             ->all();
 
         $entries = [];
-        foreach ($candidates as $relPath => $kind) {
+        foreach ($kindsByPath as $relPath => $kind) {
             $absolute = $repoPath.'/'.$relPath;
             $isSymlink = is_link($absolute);
             $symlinkTarget = $isSymlink ? readlink($absolute) : null;
@@ -279,6 +279,19 @@ class AgentContextFileScannerService
         }
 
         return false;
+    }
+
+    /**
+     * @param  array<int, string>  $skipDirs
+     * @return array<int, string>
+     */
+    private function gitExclusionPathspecs(array $skipDirs): array
+    {
+        return collect($skipDirs)
+            ->filter(fn (string $directory): bool => $directory !== '')
+            ->map(fn (string $directory): string => ':(top,exclude,literal)'.$directory)
+            ->values()
+            ->all();
     }
 
     /** @return array<int, string> */

--- a/app/Services/AgentContextFileScannerService.php
+++ b/app/Services/AgentContextFileScannerService.php
@@ -8,17 +8,9 @@ use App\DTOs\AgentContextFile;
 use App\Enums\AgentContextFileKind;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\File;
-use Symfony\Component\Process\Process;
 
 class AgentContextFileScannerService
 {
-    /**
-     * Cap recursion depth when walking for untracked candidates, mirroring
-     * ExternalFilesService::MAX_DEPTH. Without it a pathologically deep tree
-     * could exhaust the PHP recursion stack on the synchronous Context-page scan.
-     */
-    private const MAX_SCAN_DEPTH = 8;
-
     public function __construct(
         private readonly GitProcessService $git,
         private readonly GitDiffService $gitDiffService,
@@ -44,7 +36,7 @@ class AgentContextFileScannerService
         )));
 
         $tracked = $this->discoverTracked($repoPath, $skipDirs);
-        $untracked = $this->discoverUntracked($repoPath, $skipDirs, array_keys($tracked));
+        $untracked = $this->discoverUntracked($repoPath, $skipDirs);
 
         // Symlink dedupe is keyed by `realpath()` of the absolute path. We
         // resolve both symlinked AND non-symlink entries so the keys agree on
@@ -125,32 +117,36 @@ class AgentContextFileScannerService
     }
 
     /**
-     * Walk the filesystem for agent-context files outside the tracked set,
-     * batch-filter via `git check-ignore --stdin`, return whatever survives.
+     * Discover untracked agent-context files while letting Git exclude ignored
+     * directories before it traverses them.
      *
      * @param  array<int, string>  $skipDirs
-     * @param  array<int, string>  $trackedPaths
      * @return array<int, AgentContextFile>
      */
-    private function discoverUntracked(string $repoPath, array $skipDirs, array $trackedPaths): array
+    private function discoverUntracked(string $repoPath, array $skipDirs): array
     {
-        $candidates = [];
-        $trackedSet = array_flip($trackedPaths);
+        $output = rescue(
+            fn (): string => $this->git->run($repoPath, [
+                'ls-files', '--others', '--exclude-standard', '-z',
+                '--', ...AgentContextFileKind::gitPathspecs(),
+            ]),
+            rescue: null,
+            report: false,
+        );
 
-        $this->walkForCandidates($repoPath, '', $skipDirs, $trackedSet, $candidates);
-
-        if ($candidates === []) {
+        if ($output === null) {
             return [];
         }
 
-        $ignored = $this->batchCheckIgnore($repoPath, array_keys($candidates));
+        /** @var array<string, AgentContextFileKind> $candidates */
+        $candidates = collect($this->splitNullDelimited($output))
+            ->reject(fn (string $path): bool => $this->isSkipped($path, $skipDirs))
+            ->mapWithKeys(fn (string $path): array => [$path => AgentContextFileKind::fromPath($path)])
+            ->whereNotNull()
+            ->all();
 
         $entries = [];
         foreach ($candidates as $relPath => $kind) {
-            if (isset($ignored[$relPath])) {
-                continue;
-            }
-
             $absolute = $repoPath.'/'.$relPath;
             $isSymlink = is_link($absolute);
             $symlinkTarget = $isSymlink ? readlink($absolute) : null;
@@ -170,102 +166,6 @@ class AgentContextFileScannerService
         }
 
         return $entries;
-    }
-
-    /**
-     * @param  array<int, string>  $skipDirs
-     * @param  array<string, int>  $trackedSet  Flipped paths for O(1) skip lookup.
-     * @param  array<string, AgentContextFileKind>  $candidates  Mutated in place.
-     */
-    private function walkForCandidates(string $repoPath, string $relDir, array $skipDirs, array $trackedSet, array &$candidates, int $depth = 0): void
-    {
-        if ($depth > self::MAX_SCAN_DEPTH) {
-            return;
-        }
-
-        $absoluteDir = $relDir === '' ? $repoPath : $repoPath.'/'.$relDir;
-
-        if (! File::isDirectory($absoluteDir)) {
-            return;
-        }
-
-        // is_link before is_dir avoids descending into symlinked dirs (which
-        // can loop or escape the repo). We still match symlinked files below.
-        if ($relDir !== '' && is_link($absoluteDir)) {
-            return;
-        }
-
-        $handle = @opendir($absoluteDir);
-        if ($handle === false) {
-            return;
-        }
-
-        try {
-            while (($entry = readdir($handle)) !== false) {
-                if ($entry === '.' || $entry === '..') {
-                    continue;
-                }
-
-                $relPath = $relDir === '' ? $entry : $relDir.'/'.$entry;
-
-                if ($this->isSkipped($relPath, $skipDirs)) {
-                    continue;
-                }
-
-                $absolutePath = $absoluteDir.'/'.$entry;
-
-                if (is_dir($absolutePath) && ! is_link($absolutePath)) {
-                    $this->walkForCandidates($repoPath, $relPath, $skipDirs, $trackedSet, $candidates, $depth + 1);
-
-                    continue;
-                }
-
-                if (isset($trackedSet[$relPath])) {
-                    continue;
-                }
-
-                $kind = AgentContextFileKind::fromPath($relPath);
-                if ($kind === null) {
-                    continue;
-                }
-
-                $candidates[$relPath] = $kind;
-            }
-        } finally {
-            closedir($handle);
-        }
-    }
-
-    /**
-     * One shell-out for the whole list. Returns a set of repo-relative paths
-     * that ARE ignored (so callers can skip them).
-     *
-     * @param  array<int, string>  $candidates
-     * @return array<string, true>
-     */
-    private function batchCheckIgnore(string $repoPath, array $candidates): array
-    {
-        $process = new Process([
-            'git', '-c', 'core.quotepath=false', '-C', $repoPath,
-            'check-ignore', '--stdin', '-z',
-        ]);
-        $process->setTimeout(30);
-        $process->setInput(implode("\0", $candidates));
-        $process->run();
-
-        // git check-ignore exits 0 when at least one path is ignored, 1 when
-        // none are, 128 on hard failure. Treat 0 and 1 as success.
-        $exit = $process->getExitCode();
-        if ($exit !== 0 && $exit !== 1) {
-            return [];
-        }
-
-        $ignored = [];
-        foreach ($this->splitNullDelimited($process->getOutput()) as $path) {
-            $ignored[$path] = true;
-        }
-
-        return $ignored;
     }
 
     /**

--- a/config/rfa.php
+++ b/config/rfa.php
@@ -26,12 +26,7 @@ return [
         'animation_class_summary_limit' => env('RFA_DIAGNOSTICS_ANIMATION_CLASS_SUMMARY_LIMIT', 20),
     ],
 
-    /*
-    | Path prefixes (from repo root) the AgentContextFileScanner skips when
-    | walking the working tree for untracked agent context file candidates.
-    | The defaults mirror the build artifact locations the Context page design
-    | doc calls out (the 5 stale copies under nativephp/electron/dist).
-    */
+    /* Repo-root path prefixes excluded from agent context discovery. */
     'context_scan_skip_dirs' => [
         'nativephp/electron/dist',
         'vendor',

--- a/resources/views/components/feedback-submit-bar.blade.php
+++ b/resources/views/components/feedback-submit-bar.blade.php
@@ -27,7 +27,26 @@
     pages.
 --}}
 
-<div data-testid="feedback-submit-bar" class="fixed bottom-0 left-0 right-0 z-50 bg-gh-bg/80 backdrop-blur-sm border-t border-gh-border">
+<div
+    data-feedback-submit-bar
+    data-testid="feedback-submit-bar"
+    class="fixed bottom-0 left-0 right-0 z-50 bg-gh-bg/80 backdrop-blur-sm border-t border-gh-border"
+    x-data="{
+        feedbackBarObserver: null,
+        updateFeedbackBarHeight() {
+            document.documentElement.style.setProperty('--feedback-bar-h', $el.offsetHeight + 'px');
+        },
+        init() {
+            this.updateFeedbackBarHeight();
+            this.feedbackBarObserver = new ResizeObserver(() => this.updateFeedbackBarHeight());
+            this.feedbackBarObserver.observe($el);
+        },
+        destroy() {
+            this.feedbackBarObserver?.disconnect();
+        },
+    }"
+    @input="$nextTick(() => updateFeedbackBarHeight())"
+>
     @if($submitted)
         <div class="px-5 py-3.5 flex items-center justify-between gap-4">
             <div class="flex items-center gap-3 min-w-0">

--- a/resources/views/components/feedback-submit-bar.blade.php
+++ b/resources/views/components/feedback-submit-bar.blade.php
@@ -27,7 +27,7 @@
     pages.
 --}}
 
-<div class="fixed bottom-0 left-0 right-0 z-50 bg-gh-bg/80 backdrop-blur-sm border-t border-gh-border">
+<div data-testid="feedback-submit-bar" class="fixed bottom-0 left-0 right-0 z-50 bg-gh-bg/80 backdrop-blur-sm border-t border-gh-border">
     @if($submitted)
         <div class="px-5 py-3.5 flex items-center justify-between gap-4">
             <div class="flex items-center gap-3 min-w-0">

--- a/resources/views/components/resizable-sidebar-shell.blade.php
+++ b/resources/views/components/resizable-sidebar-shell.blade.php
@@ -1,9 +1,8 @@
-@props(['footerClearanceClass' => ''])
-
 {{-- Width persists across pages via Alpine.store('settings').sidebarWidth. --}}
 
 <div
     {{ $attributes->merge(['class' => 'flex']) }}
+    :style="{ '--sidebar-w': $store.settings.sidebarWidth + 'px' }"
     x-data="{
         resizing: false,
         startResize($event) {
@@ -37,6 +36,7 @@
                 aside.style.left = '';
                 aside.style.zIndex = '';
                 aside.style.willChange = '';
+                aside.style.width = 'var(--sidebar-w, 288px)';
                 main.style.marginLeft = '';
                 this.resizing = false;
                 document.body.classList.remove('cursor-col-resize', 'select-none');
@@ -57,8 +57,8 @@
     }"
 >
     <aside
-        class="shrink-0 sticky top-[var(--header-h)] h-[calc(100vh-var(--header-h))] overflow-y-auto border-r border-gh-border bg-gh-bg hidden lg:block {{ $footerClearanceClass }}"
-        :style="{ width: $store.settings.sidebarWidth + 'px' }"
+        class="shrink-0 sticky top-[var(--header-h)] h-[calc(100vh-var(--header-h))] overflow-y-auto border-r border-gh-border bg-gh-bg hidden lg:block"
+        style="width: var(--sidebar-w, 288px); height: calc(100vh - var(--header-h) - var(--feedback-bar-h));"
         x-ref="sidebar"
     >
         {{ $sidebar }}
@@ -71,7 +71,7 @@
         aria-label="Resize sidebar"
         title="Drag to resize · double-click to reset"
         class="group/resize hidden lg:flex sticky top-[var(--header-h)] h-[calc(100vh-var(--header-h))] w-0 cursor-col-resize items-center justify-center z-10 shrink-0"
-        style="padding: 0 6px; margin: 0 -6px;"
+        style="height: calc(100vh - var(--header-h) - var(--feedback-bar-h)); padding: 0 6px; margin: 0 -6px;"
         @mousedown="startResize($event)"
         @dblclick="$store.settings.sidebarWidth = 288"
     >
@@ -84,9 +84,9 @@
     </div>
 
     <main
-        class="flex-1 min-w-0 {{ $footerClearanceClass }}"
+        class="flex-1 min-w-0"
         :class="resizing && 'pointer-events-none'"
-        style="contain: inline-size layout style"
+        style="contain: inline-size layout style; padding-bottom: var(--feedback-bar-h)"
     >
         {{ $slot }}
     </main>

--- a/resources/views/components/resizable-sidebar-shell.blade.php
+++ b/resources/views/components/resizable-sidebar-shell.blade.php
@@ -1,4 +1,4 @@
-@props(['mainClass' => ''])
+@props(['footerClearanceClass' => ''])
 
 {{-- Width persists across pages via Alpine.store('settings').sidebarWidth. --}}
 
@@ -57,7 +57,7 @@
     }"
 >
     <aside
-        class="shrink-0 sticky top-[var(--header-h)] h-[calc(100vh-var(--header-h))] overflow-y-auto border-r border-gh-border bg-gh-bg hidden lg:block"
+        class="shrink-0 sticky top-[var(--header-h)] h-[calc(100vh-var(--header-h))] overflow-y-auto border-r border-gh-border bg-gh-bg hidden lg:block {{ $footerClearanceClass }}"
         :style="{ width: $store.settings.sidebarWidth + 'px' }"
         x-ref="sidebar"
     >
@@ -84,7 +84,7 @@
     </div>
 
     <main
-        class="flex-1 min-w-0 {{ $mainClass }}"
+        class="flex-1 min-w-0 {{ $footerClearanceClass }}"
         :class="resizing && 'pointer-events-none'"
         style="contain: inline-size layout style"
     >

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -56,6 +56,7 @@
 
         :root {
             --header-h: 56px;
+            --feedback-bar-h: 128px;
             @foreach($lightColors as $key => $value)
             --gh-{{ $key }}: {{ $value }};
             @endforeach

--- a/resources/views/pages/⚡context-page.blade.php
+++ b/resources/views/pages/⚡context-page.blade.php
@@ -547,7 +547,7 @@ new #[Layout('layouts.app')] class extends Component
         </div>
     </x-page-header>
 
-    <x-resizable-sidebar-shell class="flex-1" footer-clearance-class="pb-32">
+    <x-resizable-sidebar-shell class="flex-1">
         <x-slot:sidebar>
             <div class="p-4">
                 <livewire:context-tree

--- a/resources/views/pages/⚡context-page.blade.php
+++ b/resources/views/pages/⚡context-page.blade.php
@@ -547,7 +547,7 @@ new #[Layout('layouts.app')] class extends Component
         </div>
     </x-page-header>
 
-    <x-resizable-sidebar-shell class="flex-1" main-class="pb-32">
+    <x-resizable-sidebar-shell class="flex-1" footer-clearance-class="pb-32">
         <x-slot:sidebar>
             <div class="p-4">
                 <livewire:context-tree

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1536,7 +1536,7 @@ new #[Layout('layouts.app')] class extends Component
         <x-commit-context-bar :commit-info="$commitInfo" :project-slug="$projectSlug" />
     @endif
 
-    <x-resizable-sidebar-shell main-class="pb-24">
+    <x-resizable-sidebar-shell footer-clearance-class="pb-24">
         <x-slot:sidebar>
             <div class="p-4">
                 @if(! $this->isCommitMode() && count($reviewPairs) > 0)

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1536,7 +1536,7 @@ new #[Layout('layouts.app')] class extends Component
         <x-commit-context-bar :commit-info="$commitInfo" :project-slug="$projectSlug" />
     @endif
 
-    <x-resizable-sidebar-shell footer-clearance-class="pb-24">
+    <x-resizable-sidebar-shell>
         <x-slot:sidebar>
             <div class="p-4">
                 @if(! $this->isCommitMode() && count($reviewPairs) > 0)

--- a/tests/Browser/SidebarResizeTest.php
+++ b/tests/Browser/SidebarResizeTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\File;
 use Pest\Browser\Api\PendingAwaitablePage;
 
 beforeEach(function () {
@@ -187,3 +188,34 @@ test('sidebar width set on review page persists on context page', function () {
     $contextWidth = $page->page()->evaluate("document.querySelector('aside').offsetWidth");
     expect(abs($contextWidth - $reviewWidth))->toBeLessThan(5);
 });
+
+test('sidebar content clears the fixed feedback bar when fully scrolled', function (string $suffix) {
+    collect(range(1, 20))->each(function (int $index): void {
+        $directory = $this->testRepoPath."/context-{$index}";
+
+        File::ensureDirectoryExists($directory);
+        File::put($directory.'/CLAUDE.md', "# Context {$index}\n");
+    });
+
+    $page = $this->visit($this->projectUrl().$suffix);
+
+    $page->page()->waitForFunction(
+        "document.querySelector('aside').scrollHeight > document.querySelector('aside').clientHeight"
+    );
+
+    $positions = $page->page()->evaluate(<<<'JS'
+        (() => {
+            const sidebar = document.querySelector('aside');
+            const feedbackBar = document.querySelector('[data-testid="feedback-submit-bar"]');
+
+            sidebar.scrollTop = sidebar.scrollHeight;
+
+            return {
+                contentBottom: sidebar.firstElementChild.getBoundingClientRect().bottom,
+                feedbackTop: feedbackBar.getBoundingClientRect().top,
+            };
+        })()
+    JS);
+
+    expect($positions['contentBottom'])->toBeLessThanOrEqual($positions['feedbackTop']);
+})->with('shell pages');

--- a/tests/Browser/SidebarResizeTest.php
+++ b/tests/Browser/SidebarResizeTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\File;
 use Pest\Browser\Api\PendingAwaitablePage;
 
 beforeEach(function () {
@@ -189,18 +188,41 @@ test('sidebar width set on review page persists on context page', function () {
     expect(abs($contextWidth - $reviewWidth))->toBeLessThan(5);
 });
 
-test('sidebar content clears the fixed feedback bar when fully scrolled', function (string $suffix) {
-    collect(range(1, 20))->each(function (int $index): void {
-        $directory = $this->testRepoPath."/context-{$index}";
+test('sidebar stays above a growing fixed feedback bar', function (string $suffix) {
+    $page = $this->visitAndLoad($this->projectUrl().$suffix);
 
-        File::ensureDirectoryExists($directory);
-        File::put($directory.'/CLAUDE.md', "# Context {$index}\n");
-    });
-
-    $page = $this->visit($this->projectUrl().$suffix);
+    $page->page()->evaluate(<<<'JS'
+        (() => {
+            const overflowFixture = document.createElement('div');
+            overflowFixture.style.height = '2000px';
+            document.querySelector('aside').append(overflowFixture);
+        })()
+    JS);
 
     $page->page()->waitForFunction(
         "document.querySelector('aside').scrollHeight > document.querySelector('aside').clientHeight"
+    );
+
+    $initialFeedbackBarHeight = $page->page()->evaluate(
+        "document.querySelector('[data-testid=feedback-submit-bar]').offsetHeight"
+    );
+
+    $page->page()->evaluate(<<<'JS'
+        (() => {
+            const textarea = document.querySelector('[data-testid=feedback-submit-bar] textarea');
+
+            textarea.value = Array.from({ length: 12 }, (_, index) => `Feedback line ${index + 1}`).join('\n');
+            textarea.dispatchEvent(new InputEvent('input', { bubbles: true }));
+        })()
+    JS);
+
+    $page->page()->waitForFunction(
+        "document.querySelector('[data-testid=feedback-submit-bar]').offsetHeight > initialHeight",
+        ['initialHeight' => $initialFeedbackBarHeight],
+    );
+
+    $page->page()->waitForFunction(
+        "document.querySelector('aside').getBoundingClientRect().bottom <= document.querySelector('[data-testid=feedback-submit-bar]').getBoundingClientRect().top"
     );
 
     $positions = $page->page()->evaluate(<<<'JS'
@@ -208,14 +230,12 @@ test('sidebar content clears the fixed feedback bar when fully scrolled', functi
             const sidebar = document.querySelector('aside');
             const feedbackBar = document.querySelector('[data-testid="feedback-submit-bar"]');
 
-            sidebar.scrollTop = sidebar.scrollHeight;
-
             return {
-                contentBottom: sidebar.firstElementChild.getBoundingClientRect().bottom,
+                sidebarBottom: sidebar.getBoundingClientRect().bottom,
                 feedbackTop: feedbackBar.getBoundingClientRect().top,
             };
         })()
     JS);
 
-    expect($positions['contentBottom'])->toBeLessThanOrEqual($positions['feedbackTop']);
+    expect($positions['sidebarBottom'])->toBeLessThanOrEqual($positions['feedbackTop']);
 })->with('shell pages');

--- a/tests/Unit/Services/AgentContextFileScannerServiceTest.php
+++ b/tests/Unit/Services/AgentContextFileScannerServiceTest.php
@@ -2,6 +2,8 @@
 
 use App\Enums\AgentContextFileKind;
 use App\Services\AgentContextFileScannerService;
+use App\Services\GitDiffService;
+use App\Services\GitProcessService;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
@@ -67,6 +69,35 @@ test('surfaces untracked but not gitignored files with isTracked=false', functio
     expect($byPath['AGENTS.md']->isTracked)->toBeFalse();
 });
 
+test('asks Git for untracked context files with standard excludes', function () {
+    File::put($this->repo.'/AGENTS.md', "untracked\n");
+
+    $git = Mockery::mock(GitProcessService::class);
+    $git->shouldReceive('run')
+        ->once()
+        ->with($this->repo, ['ls-files', '-z', ...AgentContextFileKind::gitPathspecs()])
+        ->andReturn('');
+    $git->shouldReceive('run')
+        ->once()
+        ->with($this->repo, [
+            'ls-files', '--others', '--exclude-standard', '-z',
+            '--', ...AgentContextFileKind::gitPathspecs(),
+        ])
+        ->andReturn("AGENTS.md\0");
+
+    $gitDiff = Mockery::mock(GitDiffService::class);
+    $gitDiff->shouldReceive('countLinesInFile')
+        ->once()
+        ->with($this->repo.'/AGENTS.md')
+        ->andReturn(1);
+
+    $files = (new AgentContextFileScannerService($git, $gitDiff))->scan($this->repo);
+
+    expect($files)->toHaveCount(1)
+        ->and($files[0]->path)->toBe('AGENTS.md')
+        ->and($files[0]->isTracked)->toBeFalse();
+});
+
 test('hides gitignored files', function () {
     File::put($this->repo.'/CLAUDE.md', "tracked\n");
     File::put($this->repo.'/.gitignore', "secrets/\n");
@@ -74,6 +105,20 @@ test('hides gitignored files', function () {
 
     File::makeDirectory($this->repo.'/secrets');
     File::put($this->repo.'/secrets/CLAUDE.md', "secret\n");
+
+    $files = ctxScan($this->repo, $this->scanner);
+
+    expect(collect($files)->pluck('path')->all())->toBe(['CLAUDE.md']);
+});
+
+test('does not surface context files from ignored worktrees', function () {
+    File::put($this->repo.'/CLAUDE.md', "tracked\n");
+    File::put($this->repo.'/.gitignore', ".worktrees/\n");
+    $this->commitTestRepo($this->repo, 'init');
+
+    File::makeDirectory($this->repo.'/.worktrees/feature/vendor/package', 0755, true);
+    File::put($this->repo.'/.worktrees/feature/AGENTS.md', "worktree rules\n");
+    File::put($this->repo.'/.worktrees/feature/vendor/package/CLAUDE.md', "vendor rules\n");
 
     $files = ctxScan($this->repo, $this->scanner);
 

--- a/tests/Unit/Services/AgentContextFileScannerServiceTest.php
+++ b/tests/Unit/Services/AgentContextFileScannerServiceTest.php
@@ -69,8 +69,9 @@ test('surfaces untracked but not gitignored files with isTracked=false', functio
     expect($byPath['AGENTS.md']->isTracked)->toBeFalse();
 });
 
-test('asks Git for untracked context files with standard excludes', function () {
+test('asks Git for untracked context files with standard and configured excludes', function () {
     File::put($this->repo.'/AGENTS.md', "untracked\n");
+    config()->set('rfa.context_scan_skip_dirs', ['vendor', 'node_modules']);
 
     $git = Mockery::mock(GitProcessService::class);
     $git->shouldReceive('run')
@@ -82,6 +83,8 @@ test('asks Git for untracked context files with standard excludes', function () 
         ->with($this->repo, [
             'ls-files', '--others', '--exclude-standard', '-z',
             '--', ...AgentContextFileKind::gitPathspecs(),
+            ':(top,exclude,literal)vendor',
+            ':(top,exclude,literal)node_modules',
         ])
         ->andReturn("AGENTS.md\0");
 


### PR DESCRIPTION
## Summary

- Replace the recursive untracked-file walk with `git ls-files --others --exclude-standard`.
- Apply context pathspecs and configured skip directories before Git traverses the repository.
- Preserve untracked context discovery while excluding ignored worktrees and dependency trees.
- Measure the fixed feedback bar and keep Context and Review sidebars above it as its height changes.

## Performance

On `/Users/fgilio/pla/farfalla`, the scan keeps the same 44 files, 1,457 lines, and 95,902 bytes. Runtime falls from 11.35-11.95 seconds to 0.67-1.08 seconds.

## Tests

- `composer test:lint`
- `composer test:types`
- `composer test` (1,806 tests, 4,942 assertions)
- `composer test:js` (349 tests)
- `composer test:browser` (210 passed, 1 skipped)