### PR TITLE
Resolve wide-events audit findings (2026-08-18)

### DIFF
--- a/app/Actions/OpenProjectFromPathAction.php
+++ b/app/Actions/OpenProjectFromPathAction.php
@@ -45,9 +45,12 @@ final readonly class OpenProjectFromPathAction
             Context::add('rfa.reason', 'project_registration_failed');
             Context::add('rfa.error_class', $e::class);
 
+            // The deep-link owner already carries this hash as rfa.path_hash,
+            // so triage keeps the correlation without a second copy of
+            // an absolute path in the log.
             Log::warning('project.registration.failed', [
                 'reason' => 'project_registration_failed',
-                'path' => $path,
+                'path_hash' => hash('xxh128', $path),
                 'error_class' => $e::class,
             ]);
 

--- a/app/Actions/OpenProjectFromPathAction.php
+++ b/app/Actions/OpenProjectFromPathAction.php
@@ -45,9 +45,8 @@ final readonly class OpenProjectFromPathAction
             Context::add('rfa.reason', 'project_registration_failed');
             Context::add('rfa.error_class', $e::class);
 
-            // The deep-link owner already carries this hash as rfa.path_hash,
-            // so triage keeps the correlation without a second copy of
-            // an absolute path in the log.
+            // The owner already carries this hash as rfa.path_hash, so the
+            // correlation survives without a second copy of the path.
             Log::warning('project.registration.failed', [
                 'reason' => 'project_registration_failed',
                 'path_hash' => hash('xxh128', $path),

--- a/app/Actions/OpenRepositoryDialogAction.php
+++ b/app/Actions/OpenRepositoryDialogAction.php
@@ -7,6 +7,7 @@ namespace App\Actions;
 use App\Exceptions\NotAGitRepositoryException;
 use App\Models\Project;
 use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Log;
 use Native\Desktop\Dialog;
 use Native\Desktop\Facades\Alert;
 use Throwable;
@@ -46,6 +47,13 @@ final readonly class OpenRepositoryDialogAction
             // "not a git repository".
             Context::add('rfa.reason', 'project_registration_failed');
             Context::add('rfa.error_class', $e::class);
+
+            // The picked path stays out of the payload: a dialog result is an
+            // absolute path with no project to relativize it against.
+            Log::warning('project.registration.failed', [
+                'reason' => 'project_registration_failed',
+                'error_class' => $e::class,
+            ]);
 
             Alert::new()
                 ->type('warning')

--- a/app/Actions/OpenRepositoryDialogAction.php
+++ b/app/Actions/OpenRepositoryDialogAction.php
@@ -7,7 +7,6 @@ namespace App\Actions;
 use App\Exceptions\NotAGitRepositoryException;
 use App\Models\Project;
 use Illuminate\Support\Facades\Context;
-use Illuminate\Support\Facades\Log;
 use Native\Desktop\Dialog;
 use Native\Desktop\Facades\Alert;
 use Throwable;
@@ -48,13 +47,6 @@ final readonly class OpenRepositoryDialogAction
             Context::add('rfa.reason', 'project_registration_failed');
             Context::add('rfa.error_class', $e::class);
 
-            // The picked path stays out of the payload: a dialog result is an
-            // absolute path with no project to relativize it against.
-            Log::warning('project.registration.failed', [
-                'reason' => 'project_registration_failed',
-                'error_class' => $e::class,
-            ]);
-
             Alert::new()
                 ->type('warning')
                 ->title('Could Not Open Repository')
@@ -62,5 +54,21 @@ final readonly class OpenRepositoryDialogAction
 
             return null;
         }
+    }
+
+    /**
+     * Map a null return from handle() to a canonical outcome.
+     *
+     * The caller owns the canonical event, so it reads back the reason
+     * this action recorded. A dismissed dialog is the only null
+     * left unmarked.
+     */
+    public static function outcomeForNullProject(): string
+    {
+        return match (Context::get('rfa.reason')) {
+            'project_registration_failed' => 'error',
+            'not_a_git_repository' => 'rejected',
+            default => 'cancelled',
+        };
     }
 }

--- a/app/Actions/OpenTerminalRequestAction.php
+++ b/app/Actions/OpenTerminalRequestAction.php
@@ -66,6 +66,22 @@ final readonly class OpenTerminalRequestAction
     }
 
     /**
+     * Map a null return from handle() to a canonical outcome.
+     *
+     * A request the other transport already claimed stood down rather
+     * than being turned away, so it reads as skipped instead
+     * of rejected.
+     */
+    public static function outcomeForNullProject(): string
+    {
+        return match (Context::get('rfa.reason')) {
+            'request_already_claimed' => 'skipped',
+            'project_registration_failed' => 'error',
+            default => 'rejected',
+        };
+    }
+
+    /**
      * Fail open on junk mode values: anything that isn't `context` lands on
      * the review page rather than failing the whole open.
      */

--- a/app/Listeners/HandleDeepLink.php
+++ b/app/Listeners/HandleDeepLink.php
@@ -64,16 +64,7 @@ final readonly class HandleDeepLink
             $project = app(OpenTerminalRequestAction::class)->handle($path, $mode, $requestId);
 
             if (! $project) {
-                // The action marks why it returned null via Context. A
-                // request the inbox already claimed was handled correctly by
-                // the other transport, so this delivery stood down rather
-                // than being turned away; an unexpected registration failure
-                // is an error; anything else is a rejection.
-                $outcome = match (Context::get('rfa.reason')) {
-                    'request_already_claimed' => 'skipped',
-                    'project_registration_failed' => 'error',
-                    default => 'rejected',
-                };
+                $outcome = OpenTerminalRequestAction::outcomeForNullProject();
 
                 Context::addIf('rfa.reason', 'not_a_project');
 

--- a/app/Listeners/HandleMenuItemClicked.php
+++ b/app/Listeners/HandleMenuItemClicked.php
@@ -108,7 +108,7 @@ final readonly class HandleMenuItemClicked
         $project = app(OpenRepositoryDialogAction::class)->handle();
 
         if (! $project) {
-            return $this->outcomeForNullProject();
+            return OpenRepositoryDialogAction::outcomeForNullProject();
         }
 
         Context::add('rfa.project_id', $project->id);
@@ -141,7 +141,7 @@ final readonly class HandleMenuItemClicked
         }
 
         if (! $project) {
-            return $this->outcomeForNullProject();
+            return OpenRepositoryDialogAction::outcomeForNullProject();
         }
 
         Context::add('rfa.project_id', $project->id);
@@ -157,20 +157,5 @@ final readonly class HandleMenuItemClicked
         Window::get('main')->url(route($routeName, ['slug' => $project->slug]));
 
         return 'completed';
-    }
-
-    /**
-     * Map a null project from OpenRepositoryDialogAction to its outcome.
-     *
-     * The action marks non-dismissal causes via Context (rfa.reason), so
-     * a plain dismissal is the only null left unmarked.
-     */
-    private function outcomeForNullProject(): string
-    {
-        return match (Context::get('rfa.reason')) {
-            'project_registration_failed' => 'error',
-            'not_a_git_repository' => 'rejected',
-            default => 'cancelled',
-        };
     }
 }

--- a/app/Providers/NativeAppServiceProvider.php
+++ b/app/Providers/NativeAppServiceProvider.php
@@ -291,19 +291,54 @@ class NativeAppServiceProvider implements ProvidesPhpIni
 
     private function processInbox(): void
     {
+        $latest = $this->claimLatestInboxFile();
+
+        if ($latest === null) {
+            return;
+        }
+
+        Context::flush();
+
+        $startedAt = microtime(true);
+        $outcome = 'completed';
+
+        try {
+            $outcome = $this->openFromInboxFile($latest);
+        } catch (Throwable $e) {
+            $outcome = 'error';
+            Context::add('rfa.error_class', $e::class);
+            Context::add('rfa.reason', 'inbox_open_failed');
+
+            throw $e;
+        } finally {
+            Context::add('rfa.outcome', $outcome);
+            Context::add('rfa.duration_ms', (int) round((microtime(true) - $startedAt) * 1000));
+
+            Log::info('inbox.opened');
+        }
+    }
+
+    /**
+     * Take the newest queued request and discard the rest.
+     *
+     * Returns null when the terminal helper left nothing to open, which
+     * is the common case on any boot the user did not start
+     * from `./rfa`.
+     */
+    private function claimLatestInboxFile(): ?string
+    {
         $dir = self::inboxDir();
 
         if (! File::isDirectory($dir)) {
-            return;
+            return null;
         }
 
         $files = File::glob($dir.'/*.path');
 
         if ($files === []) {
-            return;
+            return null;
         }
 
-        // Process the most recent entry, discard the rest
         sort($files);
         $latest = array_pop($files);
 
@@ -311,36 +346,66 @@ class NativeAppServiceProvider implements ProvidesPhpIni
             File::delete($stale);
         }
 
-        $contents = rescue(fn () => File::get($latest));
+        return $latest;
+    }
+
+    /**
+     * Open the repository a claimed inbox file names, and return the outcome
+     * for the canonical event.
+     */
+    private function openFromInboxFile(string $file): string
+    {
+        $contents = rescue(fn () => File::get($file));
         // The filename stem is the request id the terminal helper also put in
         // the deep link, so claiming it here is what stops the URL delivery of
         // the same request from opening the project a second time.
-        $requestId = OpenTerminalRequestAction::inboxRequestId($latest);
-        File::delete($latest);
+        $requestId = OpenTerminalRequestAction::inboxRequestId($file);
+        File::delete($file);
+
+        Context::add('rfa.request_id', $requestId);
 
         if ($contents === null) {
-            return;
+            Context::add('rfa.reason', 'unreadable_inbox_file');
+
+            return 'rejected';
         }
 
         ['path' => $path, 'mode' => $mode] = OpenTerminalRequestAction::parseInboxContents($contents);
 
         if ($path === '') {
-            return;
+            Context::add('rfa.reason', 'missing_path');
+
+            return 'rejected';
         }
+
+        $routeName = OpenTerminalRequestAction::routeName($mode);
+
+        Context::add('rfa.mode', $mode);
+        Context::add('rfa.path_hash', hash('xxh128', $path));
+        Context::add('rfa.route', $routeName);
 
         $project = app(OpenTerminalRequestAction::class)->handle($path, $mode, $requestId);
 
         if (! $project) {
-            return;
+            $outcome = OpenTerminalRequestAction::outcomeForNullProject();
+
+            Context::addIf('rfa.reason', 'not_a_project');
+
+            return $outcome;
         }
 
+        Context::add('rfa.project_id', $project->id);
+        Context::add('rfa.project_slug', $project->slug);
+
         app(RecordRuntimeDiagnosticAction::class)->handle('inbox.opened', [
-            'route' => OpenTerminalRequestAction::routeName($mode),
+            'route' => $routeName,
             'request_id' => $requestId,
             'project_id' => $project->id,
             'project_slug' => $project->slug,
             'path_hash' => hash('xxh128', $path),
         ]);
+
+        return 'completed';
     }
 
     public static function inboxDir(): string

--- a/reports/wide-events/2026-08-18.md
+++ b/reports/wide-events/2026-08-18.md
@@ -1,0 +1,58 @@
+# Wide Events Audit: 2026-08-18
+
+## Summary
+
+- Deterministic checks: fail
+- Findings: 1 critical, 0 warning, 2 info
+- Files reviewed: 15
+
+## Deterministic Checks
+
+| Command | Result | Notes |
+|---|---|---|
+| `php artisan test --compact tests/Arch/LoggingConventionsTest.php` | fail | [CRITICAL] Could not run. `vendor/autoload.php` was absent and `composer install` was blocked by the session proxy on GitHub API authentication (see Findings). |
+
+## Findings
+
+### [CRITICAL] Deterministic arch test could not run in this session
+
+- **File:** `tests/Arch/LoggingConventionsTest.php:1`
+- **Rule:** Wide Events Audit routine → "Run deterministic checks".
+- **Evidence:** `/home/user/rfa/vendor/autoload.php` was absent and `composer install --no-interaction --prefer-dist` returned "Could not authenticate against github.com" from `AuthHelper.php:132`. The stored composer auth token in `/root/.config/composer/auth.json` was the sentinel string `proxy-injected`, which composer treats as a literal token; removing it did not help because the underlying downloads still hit `api.github.com` for dist archives. Package sync via git URLs completed for most requirements but the install step aborted before `vendor/autoload.php` and the Pest binary were written.
+- **Impact:** C1–C7 and C9–C10 were not re-verified this run. All checkable rules still passed under the same source of truth in the previous audit `reports/wide-events/2026-08-11.md`, and no logging file changed between then and this run outside the report artifacts. The routine still produced findings, but the mechanical safety net was skipped.
+- **Suggested fix:** Provide the session with a working composer auth path (either a real GitHub token in `~/.config/composer/auth.json` or a routine setup step that primes `vendor/` before the audit script runs). No production code change is required.
+
+### [INFO] Warning on `project.registration.failed` embeds the raw deep-link path
+
+- **File:** `app/Actions/OpenProjectFromPathAction.php:48`
+- **Rule:** Agent Review Checklist A9, Privacy → "Prefer project slugs, relative file paths, hashes, counts, booleans, and stable reason codes."
+- **Evidence:** The warning payload passes the incoming `$path` verbatim to `Log::warning('project.registration.failed', ['reason' => 'project_registration_failed', 'path' => $path, 'error_class' => $e::class])`. The action is called by `HandleDeepLink` and by `NativeAppServiceProvider::processInbox`, both of which supply an absolute filesystem path. The Standard permits absolute paths in warning payloads when the path itself is the failed input, which is the case here, so this is not a rule violation.
+- **Impact:** Low. `HandleDeepLink` already writes `rfa.path_hash = hash('xxh128', $path)` into the owner's `Context` before invoking the action, so triage can already correlate the warning to the owner event without keeping the raw path in the warning body. Using the same hash or `LogSanitizer::summary($path)` in the warning would trim one more absolute path from the local log without losing debug value.
+- **Suggested fix:** Replace `'path' => $path` with `'path_hash' => hash('xxh128', $path)` (or `LogSanitizer::summary($path)` if the raw shape needs to remain readable for the inbox path). The inbox path from `NativeAppServiceProvider::processInbox` is not currently hashed on any owner event, so if hashing is preferred, hashing consistently in both callers keeps the correlation key stable.
+
+### [INFO] Unexpected registration failure in `OpenRepositoryDialogAction` never emits a diagnostic warning
+
+- **File:** `app/Actions/OpenRepositoryDialogAction.php:44`
+- **Rule:** Agent Review Checklist A11, Errors And Criticals → "Use `Log::error()` only when the exception is handled or converted into a non-throwing path" and A12 (diagnostic detail).
+- **Evidence:** The `Throwable` branch adds `rfa.reason = project_registration_failed` and `rfa.error_class = $e::class` to Context, then returns null after showing a UI alert. The owner (`HandleMenuItemClicked::outcomeForNullProject`) maps that reason to `rfa.outcome = error` on `menu.item.clicked`, so the failure is queryable through the owner event. The sibling action `OpenProjectFromPathAction` also emits a diagnostic `Log::warning('project.registration.failed', ...)` on the same class of failure. This action does not.
+- **Impact:** Low. The owner canonical event carries `rfa.outcome`, `rfa.reason`, and `rfa.error_class`, which meets the SKILL's minimum for a swallowed unexpected failure. Adding a matching diagnostic warning here would only give parity with `OpenProjectFromPathAction` and slightly richer triage detail; skipping it stays inside the standard.
+- **Suggested fix:** Optional. If parity with `OpenProjectFromPathAction` is preferred, emit a `Log::warning('project.registration.failed', ['reason' => 'project_registration_failed', 'error_class' => $e::class])` inside the `Throwable` branch. Do not include the picked path — the dialog result is a private local filesystem path with no project context to relativize.
+
+## Clean Areas
+
+- Every canonical `Log::info()` has one clear owner and lives in the correct layer: `HandleMenuItemClicked` for `menu.item.clicked`, `HandleDeepLink` for `deeplink.opened`, four terminal updater closures in `NativeAppServiceProvider` for `updater.available` / `updater.current` / `updater.downloaded` / `updater.failed`, and Livewire pages for `context.comment.written` and `review.refreshed`. No child action or service duplicates a parent canonical info event.
+- `Context::flush()` runs first in every owner. Child services and actions (`OpenProjectFromPathAction`, `OpenRepositoryDialogAction`, `GitMetadataService`, `SyntaxHighlightService`, `EnsureRfaGitExcludeAction`) add `rfa.reason` / `rfa.error_class` without flushing, preserving owner correlation.
+- Every canonical event carries `rfa.outcome` and `rfa.duration_ms`. Context is rich enough to reconstruct each operation without reading code: `rfa.repos_found` / `rfa.repos_registered` / `rfa.repos_already_tracked` / `rfa.repos_failed` on scan, `rfa.file_count_before` / `_after` and `rfa.changed_count` / `rfa.changed_file_ids` on review refresh, `rfa.project_slug` / `rfa.file_id` / `rfa.is_draft` on comment writes.
+- `rfa.outcome` values follow the vocabulary and the decision tree. `deeplink.opened` uses `rejected` for `unsupported_url` and `missing_path`, `error` only for a swallowed `project_registration_failed`, and `completed` on the success path. `handleScanDirectory` correctly distinguishes `cancelled` (dialog dismissed), `partial` (some repos failed), and `completed`.
+- `updater.failed` correctly emits a sanitized diagnostic `Log::error` followed by the canonical `Log::info` from `finally`, matching the listener-owned unit-of-work pattern. `updater.current` covers the no-update success path and its own error path.
+- Warning payloads consistently pair `reason` with safe diagnostic fields (`exit_code`, `error_class`, `LogSanitizer::summary($e->stderr)`, relative `path`). No payload passes `$e->getMessage()`, `$e->getTraceAsString()`, or raw `$e->stderr`.
+- No banned absolute-path key appears in any static `Context::add()` call. Warning-payload path values are relative (`LoadFileDiffAction`, `GitMetadataService::getFileContent`) or the failed raw input (`OpenProjectFromPathAction`, allowed by the standard).
+- Storage stays local. `config/logging.php` resolves `default` to `daily` with `LOG_DAILY_DAYS` retention and `info` level. The `slack`, `papertrail`, `syslog`, `errorlog`, and Monolog `stderr` channel definitions remain inert unless env overrides pull them in. `tests/Feature/LogChannelPostureTest.php` guards this by walking the resolved default channel and any stack members.
+
+## Residual Risks
+
+- Deterministic checks were not executable this run. The rules protected by C1–C10 rely on the same file inputs the semantic review just walked, and no logging file changed since the 2026-08-11 audit's green run, but the CI safety net was not re-exercised in this session.
+- Agentic review reads static source, not runtime traffic. Dynamic `Context::add()` values (e.g. `rfa.reason` from an exception's `reason->value` enum) are only spot-checked against the vocabulary. A future reason enum entry could drift from the approved outcome set without arch tests catching it.
+- The routine does not run the app or replay JSONL diagnostics, so runtime-only regressions (e.g. a listener that never reaches `finally` because Electron kills the PHP process mid-callback) are outside its detection surface.
+- `OpenRepositoryDialogAction::handle` still passes `$e->getMessage()` into `Alert::show()` for the user-facing error dialog. This is a UI surface, not a `Log::` or `Context::` payload, so it is outside the SKILL's raw-exception ban, but the exception text still leaves the app boundary through the dialog.
+- `LoadFileDiffAction` runs per-file on lazy render and does not emit a canonical info event. Prior audits classified this as a scope judgment (per-file diff render is not an externally meaningful user operation). Left unchanged, consistent with the 2026-08-11 disposition.

--- a/reports/wide-events/2026-08-18.md
+++ b/reports/wide-events/2026-08-18.md
@@ -2,8 +2,8 @@
 
 ## Summary
 
-- Deterministic checks: fail
-- Findings: 1 critical, 0 warning, 2 info
+- Deterministic checks: fail in session, pass on re-run (2026-08-23)
+- Findings: 1 critical, 0 warning, 2 info (all resolved)
 - Files reviewed: 15
 
 ## Deterministic Checks
@@ -11,32 +11,37 @@
 | Command | Result | Notes |
 |---|---|---|
 | `php artisan test --compact tests/Arch/LoggingConventionsTest.php` | fail | [CRITICAL] Could not run. `vendor/autoload.php` was absent and `composer install` was blocked by the session proxy on GitHub API authentication (see Findings). |
+| `php artisan test --compact tests/Arch/LoggingConventionsTest.php` (re-run 2026-08-23) | pass | 9/9. C1-C7 and C9-C10 hold on `main` at `7e841bc`. |
+| `php artisan test --compact tests/Feature/LogChannelPostureTest.php` (re-run 2026-08-23) | pass | 5/5. The resolved default channel and stack stay local (C8). |
 
 ## Findings
 
-### [CRITICAL] Deterministic arch test could not run in this session
+### [CRITICAL] [RESOLVED] Deterministic arch test could not run in this session
 
 - **File:** `tests/Arch/LoggingConventionsTest.php:1`
 - **Rule:** Wide Events Audit routine → "Run deterministic checks".
 - **Evidence:** `/home/user/rfa/vendor/autoload.php` was absent and `composer install --no-interaction --prefer-dist` returned "Could not authenticate against github.com" from `AuthHelper.php:132`. The stored composer auth token in `/root/.config/composer/auth.json` was the sentinel string `proxy-injected`, which composer treats as a literal token; removing it did not help because the underlying downloads still hit `api.github.com` for dist archives. Package sync via git URLs completed for most requirements but the install step aborted before `vendor/autoload.php` and the Pest binary were written.
 - **Impact:** C1–C7 and C9–C10 were not re-verified this run. All checkable rules still passed under the same source of truth in the previous audit `reports/wide-events/2026-08-11.md`, and no logging file changed between then and this run outside the report artifacts. The routine still produced findings, but the mechanical safety net was skipped.
 - **Suggested fix:** Provide the session with a working composer auth path (either a real GitHub token in `~/.config/composer/auth.json` or a routine setup step that primes `vendor/` before the audit script runs). No production code change is required.
+- **Resolution:** Both checks were re-run on `main` at `7e841bc` and passed (see the table above), so the gap was the audit session's dependency install rather than a rule violation. `.claude/hooks/session-start.sh` already primes dependencies through `scripts/cloud-setup.sh` and deliberately treats a failed install as non-fatal, so a session under restricted egress can still reach the audit with no `vendor/`. No production code change was required.
 
-### [INFO] Warning on `project.registration.failed` embeds the raw deep-link path
+### [INFO] [RESOLVED] Warning on `project.registration.failed` embeds the raw deep-link path
 
 - **File:** `app/Actions/OpenProjectFromPathAction.php:48`
 - **Rule:** Agent Review Checklist A9, Privacy → "Prefer project slugs, relative file paths, hashes, counts, booleans, and stable reason codes."
 - **Evidence:** The warning payload passes the incoming `$path` verbatim to `Log::warning('project.registration.failed', ['reason' => 'project_registration_failed', 'path' => $path, 'error_class' => $e::class])`. The action is called by `HandleDeepLink` and by `NativeAppServiceProvider::processInbox`, both of which supply an absolute filesystem path. The Standard permits absolute paths in warning payloads when the path itself is the failed input, which is the case here, so this is not a rule violation.
 - **Impact:** Low. `HandleDeepLink` already writes `rfa.path_hash = hash('xxh128', $path)` into the owner's `Context` before invoking the action, so triage can already correlate the warning to the owner event without keeping the raw path in the warning body. Using the same hash or `LogSanitizer::summary($path)` in the warning would trim one more absolute path from the local log without losing debug value.
 - **Suggested fix:** Replace `'path' => $path` with `'path_hash' => hash('xxh128', $path)` (or `LogSanitizer::summary($path)` if the raw shape needs to remain readable for the inbox path). The inbox path from `NativeAppServiceProvider::processInbox` is not currently hashed on any owner event, so if hashing is preferred, hashing consistently in both callers keeps the correlation key stable.
+- **Resolution:** The payload now carries `path_hash` instead of `path`, using the same `hash('xxh128', $path)` the deep-link owner already writes to `rfa.path_hash`, so the correlation key is unchanged and one absolute path leaves the log. Covered by `tests/Unit/Actions/OpenProjectFromPathActionTest.php`.
 
-### [INFO] Unexpected registration failure in `OpenRepositoryDialogAction` never emits a diagnostic warning
+### [INFO] [RESOLVED] Unexpected registration failure in `OpenRepositoryDialogAction` never emits a diagnostic warning
 
 - **File:** `app/Actions/OpenRepositoryDialogAction.php:44`
 - **Rule:** Agent Review Checklist A11, Errors And Criticals → "Use `Log::error()` only when the exception is handled or converted into a non-throwing path" and A12 (diagnostic detail).
 - **Evidence:** The `Throwable` branch adds `rfa.reason = project_registration_failed` and `rfa.error_class = $e::class` to Context, then returns null after showing a UI alert. The owner (`HandleMenuItemClicked::outcomeForNullProject`) maps that reason to `rfa.outcome = error` on `menu.item.clicked`, so the failure is queryable through the owner event. The sibling action `OpenProjectFromPathAction` also emits a diagnostic `Log::warning('project.registration.failed', ...)` on the same class of failure. This action does not.
 - **Impact:** Low. The owner canonical event carries `rfa.outcome`, `rfa.reason`, and `rfa.error_class`, which meets the SKILL's minimum for a swallowed unexpected failure. Adding a matching diagnostic warning here would only give parity with `OpenProjectFromPathAction` and slightly richer triage detail; skipping it stays inside the standard.
-- **Suggested fix:** Optional. If parity with `OpenProjectFromPathAction` is preferred, emit a `Log::warning('project.registration.failed', ['reason' => 'project_registration_failed', 'error_class' => $e::class])` inside the `Throwable` branch. Do not include the picked path — the dialog result is a private local filesystem path with no project context to relativize.
+- **Suggested fix:** Optional. If parity with `OpenProjectFromPathAction` is preferred, emit a `Log::warning('project.registration.failed', ['reason' => 'project_registration_failed', 'error_class' => $e::class])` inside the `Throwable` branch. Do not include the picked path (the dialog result is a private local filesystem path with no project context to relativize).
+- **Resolution:** Took the parity option. The `Throwable` branch now emits `project.registration.failed` with `reason` and `error_class` and no path, so triage reads the same for a menu pick as for a deep link. `tests/Unit/Actions/OpenRepositoryDialogActionTest.php` covers the dismissed, rejected, and unexpected-failure paths, which previously had no direct coverage.
 
 ## Clean Areas
 
@@ -51,7 +56,7 @@
 
 ## Residual Risks
 
-- Deterministic checks were not executable this run. The rules protected by C1–C10 rely on the same file inputs the semantic review just walked, and no logging file changed since the 2026-08-11 audit's green run, but the CI safety net was not re-exercised in this session.
+- Deterministic checks were not executable during the audit session itself. They were re-run afterwards on `main` at `7e841bc` and passed, so C1-C10 are re-exercised, but against a `main` that had moved past the tree the semantic review walked.
 - Agentic review reads static source, not runtime traffic. Dynamic `Context::add()` values (e.g. `rfa.reason` from an exception's `reason->value` enum) are only spot-checked against the vocabulary. A future reason enum entry could drift from the approved outcome set without arch tests catching it.
 - The routine does not run the app or replay JSONL diagnostics, so runtime-only regressions (e.g. a listener that never reaches `finally` because Electron kills the PHP process mid-callback) are outside its detection surface.
 - `OpenRepositoryDialogAction::handle` still passes `$e->getMessage()` into `Alert::show()` for the user-facing error dialog. This is a UI surface, not a `Log::` or `Context::` payload, so it is outside the SKILL's raw-exception ban, but the exception text still leaves the app boundary through the dialog.

--- a/reports/wide-events/2026-08-18.md
+++ b/reports/wide-events/2026-08-18.md
@@ -2,15 +2,15 @@
 
 ## Summary
 
-- Deterministic checks: fail in session, pass on re-run (2026-08-23)
-- Findings: 1 critical, 0 warning, 2 info (all resolved)
+- Deterministic checks: blocked in session, pass on re-run (2026-08-23)
+- Findings: 1 critical, 1 warning, 2 info (all resolved)
 - Files reviewed: 15
 
 ## Deterministic Checks
 
 | Command | Result | Notes |
 |---|---|---|
-| `php artisan test --compact tests/Arch/LoggingConventionsTest.php` | fail | [CRITICAL] Could not run. `vendor/autoload.php` was absent and `composer install` was blocked by the session proxy on GitHub API authentication (see Findings). |
+| `php artisan test --compact tests/Arch/LoggingConventionsTest.php` | blocked | [CRITICAL] Could not run. `vendor/autoload.php` was absent and `composer install` was blocked by the session proxy on GitHub API authentication (see Findings). |
 | `php artisan test --compact tests/Arch/LoggingConventionsTest.php` (re-run 2026-08-23) | pass | 9/9. C1-C7 and C9-C10 hold on `main` at `7e841bc`. |
 | `php artisan test --compact tests/Feature/LogChannelPostureTest.php` (re-run 2026-08-23) | pass | 5/5. The resolved default channel and stack stay local (C8). |
 
@@ -20,10 +20,19 @@
 
 - **File:** `tests/Arch/LoggingConventionsTest.php:1`
 - **Rule:** Wide Events Audit routine → "Run deterministic checks".
-- **Evidence:** `/home/user/rfa/vendor/autoload.php` was absent and `composer install --no-interaction --prefer-dist` returned "Could not authenticate against github.com" from `AuthHelper.php:132`. The stored composer auth token in `/root/.config/composer/auth.json` was the sentinel string `proxy-injected`, which composer treats as a literal token; removing it did not help because the underlying downloads still hit `api.github.com` for dist archives. Package sync via git URLs completed for most requirements but the install step aborted before `vendor/autoload.php` and the Pest binary were written.
+- **Evidence:** The run never reached an assertion. `/home/user/rfa/vendor/autoload.php` was absent and `composer install --no-interaction --prefer-dist` returned "Could not authenticate against github.com" from `AuthHelper.php:132`. The stored composer auth token in `/root/.config/composer/auth.json` was the sentinel string `proxy-injected`, which composer treats as a literal token; removing it did not help because the underlying downloads still hit `api.github.com` for dist archives. Package sync via git URLs completed for most requirements but the install step aborted before `vendor/autoload.php` and the Pest binary were written.
 - **Impact:** C1–C7 and C9–C10 were not re-verified this run. All checkable rules still passed under the same source of truth in the previous audit `reports/wide-events/2026-08-11.md`, and no logging file changed between then and this run outside the report artifacts. The routine still produced findings, but the mechanical safety net was skipped.
 - **Suggested fix:** Provide the session with a working composer auth path (either a real GitHub token in `~/.config/composer/auth.json` or a routine setup step that primes `vendor/` before the audit script runs). No production code change is required.
 - **Resolution:** Both checks were re-run on `main` at `7e841bc` and passed (see the table above), so the gap was the audit session's dependency install rather than a rule violation. `.claude/hooks/session-start.sh` already primes dependencies through `scripts/cloud-setup.sh` and deliberately treats a failed install as non-fatal, so a session under restricted egress can still reach the audit with no `vendor/`. No production code change was required.
+
+### [WARNING] [RESOLVED] Two entry points open repositories with no logging owner
+
+- **File:** `resources/views/livewire/add-project-menu.blade.php:11`, `app/Providers/NativeAppServiceProvider.php:292`
+- **Rule:** Logging Ownership, "Pick one logging owner per user or system operation", and A1.
+- **Evidence:** `openRepository()` and `scanDirectory()` on the add-project menu delegate to `OpenRepositoryDialogAction` and `ScanDirectoryDialogAction`, neither of which is a logging owner. `processInbox()` drains the `./rfa` inbox through `OpenTerminalRequestAction`, whose canonical event belongs to `HandleDeepLink` on the other transport. None of the three flushed `Context` or emitted a canonical `Log::info()`, so the child `rfa.reason` and `rfa.error_class` they set had no event to land on.
+- **Impact:** The primary in-app way to add a repository, the directory scan behind it, and every cold-start `./rfa` open produced no canonical event at all. Their outcome distributions were unqueryable, and the same operation was observable through the native menu (`menu.item.clicked`) but invisible from the button next to it.
+- **Suggested fix:** Make each of the three an owner: flush, time the call, map the child reason to an outcome, and emit one canonical event from `finally`.
+- **Resolution:** `openRepository()` now owns `project.opened` and `scanDirectory()` owns `directory.scanned`, both carrying `rfa.outcome` and `rfa.duration_ms` plus the project or scan-count fields. `processInbox()` owns `inbox.opened` from the point it claims a queued file, and stays silent on the boots where the inbox is empty (no work, no event). The null-to-outcome mapping the menu listener used privately now lives on the actions that write the reasons (`OpenRepositoryDialogAction::outcomeForNullProject()`, `OpenTerminalRequestAction::outcomeForNullProject()`), so both transports and both entry points read it the same way. Covered by `tests/Unit/Livewire/AddProjectMenuTest.php` and `tests/Feature/TerminalOpenRequestDeliveryTest.php`.
 
 ### [INFO] [RESOLVED] Warning on `project.registration.failed` embeds the raw deep-link path
 
@@ -41,12 +50,12 @@
 - **Evidence:** The `Throwable` branch adds `rfa.reason = project_registration_failed` and `rfa.error_class = $e::class` to Context, then returns null after showing a UI alert. The owner (`HandleMenuItemClicked::outcomeForNullProject`) maps that reason to `rfa.outcome = error` on `menu.item.clicked`, so the failure is queryable through the owner event. The sibling action `OpenProjectFromPathAction` also emits a diagnostic `Log::warning('project.registration.failed', ...)` on the same class of failure. This action does not.
 - **Impact:** Low. The owner canonical event carries `rfa.outcome`, `rfa.reason`, and `rfa.error_class`, which meets the SKILL's minimum for a swallowed unexpected failure. Adding a matching diagnostic warning here would only give parity with `OpenProjectFromPathAction` and slightly richer triage detail; skipping it stays inside the standard.
 - **Suggested fix:** Optional. If parity with `OpenProjectFromPathAction` is preferred, emit a `Log::warning('project.registration.failed', ['reason' => 'project_registration_failed', 'error_class' => $e::class])` inside the `Throwable` branch. Do not include the picked path (the dialog result is a private local filesystem path with no project context to relativize).
-- **Resolution:** Took the parity option. The `Throwable` branch now emits `project.registration.failed` with `reason` and `error_class` and no path, so triage reads the same for a menu pick as for a deep link. `tests/Unit/Actions/OpenRepositoryDialogActionTest.php` covers the dismissed, rejected, and unexpected-failure paths, which previously had no direct coverage.
+- **Resolution:** Did not take the parity option. A warning carrying only `reason` and `error_class` repeats what the owner canonical event already holds, so it fails A12's requirement that diagnostic detail actually aid triage. The real gap was that one of this action's callers had no canonical event to correlate against, which the WARNING finding above closes. `tests/Unit/Actions/OpenRepositoryDialogActionTest.php` now covers the dismissed, rejected, and unexpected-failure paths, which previously had no direct coverage.
 
 ## Clean Areas
 
-- Every canonical `Log::info()` has one clear owner and lives in the correct layer: `HandleMenuItemClicked` for `menu.item.clicked`, `HandleDeepLink` for `deeplink.opened`, four terminal updater closures in `NativeAppServiceProvider` for `updater.available` / `updater.current` / `updater.downloaded` / `updater.failed`, and Livewire pages for `context.comment.written` and `review.refreshed`. No child action or service duplicates a parent canonical info event.
-- `Context::flush()` runs first in every owner. Child services and actions (`OpenProjectFromPathAction`, `OpenRepositoryDialogAction`, `GitMetadataService`, `SyntaxHighlightService`, `EnsureRfaGitExcludeAction`) add `rfa.reason` / `rfa.error_class` without flushing, preserving owner correlation.
+- Every canonical `Log::info()` has one clear owner and lives in the correct layer: `HandleMenuItemClicked` for `menu.item.clicked`, `HandleDeepLink` for `deeplink.opened`, four terminal updater closures in `NativeAppServiceProvider` for `updater.available` / `updater.current` / `updater.downloaded` / `updater.failed`, and Livewire pages for `context.comment.written` and `review.refreshed`. No child action or service duplicates a parent canonical info event. This held for the events that existed, but it is not the same as every operation having an owner (see the WARNING finding).
+- `Context::flush()` runs first in every owner that emits an event. Child services and actions (`OpenProjectFromPathAction`, `OpenRepositoryDialogAction`, `GitMetadataService`, `SyntaxHighlightService`, `EnsureRfaGitExcludeAction`) add `rfa.reason` / `rfa.error_class` without flushing, preserving owner correlation.
 - Every canonical event carries `rfa.outcome` and `rfa.duration_ms`. Context is rich enough to reconstruct each operation without reading code: `rfa.repos_found` / `rfa.repos_registered` / `rfa.repos_already_tracked` / `rfa.repos_failed` on scan, `rfa.file_count_before` / `_after` and `rfa.changed_count` / `rfa.changed_file_ids` on review refresh, `rfa.project_slug` / `rfa.file_id` / `rfa.is_draft` on comment writes.
 - `rfa.outcome` values follow the vocabulary and the decision tree. `deeplink.opened` uses `rejected` for `unsupported_url` and `missing_path`, `error` only for a swallowed `project_registration_failed`, and `completed` on the success path. `handleScanDirectory` correctly distinguishes `cancelled` (dialog dismissed), `partial` (some repos failed), and `completed`.
 - `updater.failed` correctly emits a sanitized diagnostic `Log::error` followed by the canonical `Log::info` from `finally`, matching the listener-owned unit-of-work pattern. `updater.current` covers the no-update success path and its own error path.
@@ -57,6 +66,7 @@
 ## Residual Risks
 
 - Deterministic checks were not executable during the audit session itself. They were re-run afterwards on `main` at `7e841bc` and passed, so C1-C10 are re-exercised, but against a `main` that had moved past the tree the semantic review walked.
+- The `project.registration.failed` warning in `OpenProjectFromPathAction` is now fully redundant on both of its callers: the deep-link owner and the inbox owner each carry `rfa.reason`, `rfa.error_class`, and `rfa.path_hash` on their canonical events. It is kept because removing a production warning is a wider change than this audit called for, and it is the only record if a future caller arrives without an owner. A later audit should decide whether it earns its place.
 - Agentic review reads static source, not runtime traffic. Dynamic `Context::add()` values (e.g. `rfa.reason` from an exception's `reason->value` enum) are only spot-checked against the vocabulary. A future reason enum entry could drift from the approved outcome set without arch tests catching it.
 - The routine does not run the app or replay JSONL diagnostics, so runtime-only regressions (e.g. a listener that never reaches `finally` because Electron kills the PHP process mid-callback) are outside its detection surface.
 - `OpenRepositoryDialogAction::handle` still passes `$e->getMessage()` into `Alert::show()` for the user-facing error dialog. This is a UI surface, not a `Log::` or `Context::` payload, so it is outside the SKILL's raw-exception ban, but the exception text still leaves the app boundary through the dialog.

--- a/resources/views/livewire/add-project-menu.blade.php
+++ b/resources/views/livewire/add-project-menu.blade.php
@@ -3,6 +3,8 @@
 use App\Actions\OpenRepositoryDialogAction;
 use App\Actions\ScanDirectoryDialogAction;
 use Flux\Flux;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Log;
 use Livewire\Component;
 
 new class extends Component {
@@ -10,33 +12,90 @@ new class extends Component {
 
     public function openRepository(): void
     {
-        $project = app(OpenRepositoryDialogAction::class)->handle();
+        Context::flush();
 
-        if (! $project) {
-            return;
+        $startedAt = microtime(true);
+        $outcome = 'completed';
+
+        try {
+            $project = app(OpenRepositoryDialogAction::class)->handle();
+
+            if (! $project) {
+                $outcome = OpenRepositoryDialogAction::outcomeForNullProject();
+
+                return;
+            }
+
+            Context::add('rfa.project_id', $project->id);
+            Context::add('rfa.project_slug', $project->slug);
+
+            $this->redirect(route('review-page', ['slug' => $project->slug]), navigate: true);
+        } catch (\Throwable $e) {
+            $outcome = 'error';
+            Context::add('rfa.error_class', $e::class);
+            Context::add('rfa.reason', 'open_repository_failed');
+
+            throw $e;
+        } finally {
+            Context::add('rfa.outcome', $outcome);
+            Context::add('rfa.duration_ms', (int) round((microtime(true) - $startedAt) * 1000));
+
+            Log::info('project.opened');
         }
-
-        $this->redirect(route('review-page', ['slug' => $project->slug]), navigate: true);
     }
 
     public function scanDirectory(): void
     {
+        Context::flush();
+
+        $startedAt = microtime(true);
+        $outcome = 'completed';
+
+        try {
+            $outcome = $this->scanAndReport();
+        } catch (\Throwable $e) {
+            $outcome = 'error';
+            Context::add('rfa.error_class', $e::class);
+            Context::add('rfa.reason', 'directory_scan_failed');
+
+            throw $e;
+        } finally {
+            Context::add('rfa.outcome', $outcome);
+            Context::add('rfa.duration_ms', (int) round((microtime(true) - $startedAt) * 1000));
+
+            Log::info('directory.scanned');
+        }
+    }
+
+    /**
+     * Run the scan, toast its result, and return the outcome for the
+     * canonical event the caller owns.
+     */
+    private function scanAndReport(): string
+    {
         try {
             $result = app(ScanDirectoryDialogAction::class)->handle();
         } catch (\InvalidArgumentException $e) {
+            Context::add('rfa.reason', 'unscannable_directory');
+
             Flux::toast(variant: 'danger', text: $e->getMessage());
 
-            return;
+            return 'rejected';
         }
 
         if (! $result) {
-            return;
+            return 'cancelled';
         }
+
+        Context::add('rfa.repos_found', $result->found);
+        Context::add('rfa.repos_registered', $result->registered);
+        Context::add('rfa.repos_already_tracked', $result->alreadyTracked);
+        Context::add('rfa.repos_failed', $result->failed);
 
         if ($result->found === 0) {
             Flux::toast(text: 'No git repositories found in that folder');
 
-            return;
+            return 'completed';
         }
 
         $parts = [];
@@ -56,6 +115,8 @@ new class extends Component {
         if ($result->registered > 0) {
             $this->dispatch('projects-changed');
         }
+
+        return $result->failed > 0 ? 'partial' : 'completed';
     }
 };
 ?>

--- a/tests/Feature/TerminalOpenRequestDeliveryTest.php
+++ b/tests/Feature/TerminalOpenRequestDeliveryTest.php
@@ -3,7 +3,9 @@
 use App\Listeners\HandleDeepLink;
 use App\Providers\NativeAppServiceProvider;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
 use Native\Desktop\Events\App\OpenedFromURL;
 use Tests\Helpers\InteractsWithTestRepositories;
 use Tests\Helpers\MainWindowNavigations;
@@ -119,4 +121,58 @@ test('a legacy inbox file and a path-only deep link both still open', function (
     ));
 
     expect($this->navigations->all())->toHaveCount(2);
+});
+
+// -- canonical events --
+
+test('draining a queued request emits a canonical inbox.opened event', function () {
+    writeInboxRequest($this->inboxDir, '1755975000-4242', $this->repoPath, 'context');
+
+    Log::spy();
+
+    drainInbox();
+
+    Log::shouldHaveReceived('info')->once()->with('inbox.opened');
+    expect(Context::get('rfa.outcome'))->toBe('completed')
+        ->and(Context::get('rfa.request_id'))->toBe('1755975000-4242')
+        ->and(Context::get('rfa.route'))->toBe('context-page')
+        ->and(Context::get('rfa.path_hash'))->toBe(hash('xxh128', $this->repoPath))
+        ->and(Context::get('rfa.project_slug'))->not->toBeNull()
+        ->and(Context::get('rfa.duration_ms'))->toBeInt();
+});
+
+test('a request the deep link already claimed drains as skipped', function () {
+    writeInboxRequest($this->inboxDir, '1755975000-4242', $this->repoPath);
+
+    app(HandleDeepLink::class)->handle(new OpenedFromURL(
+        'rfa://open?path='.rawurlencode($this->repoPath).'&id=1755975000-4242'
+    ));
+
+    Log::spy();
+
+    drainInbox();
+
+    Log::shouldHaveReceived('info')->once()->with('inbox.opened');
+    expect(Context::get('rfa.outcome'))->toBe('skipped')
+        ->and(Context::get('rfa.reason'))->toBe('request_already_claimed');
+});
+
+test('an inbox request for a non-repository drains as rejected', function () {
+    writeInboxRequest($this->inboxDir, '1755975000-4242', '/does/not/exist');
+
+    Log::spy();
+
+    drainInbox();
+
+    Log::shouldHaveReceived('info')->once()->with('inbox.opened');
+    expect(Context::get('rfa.outcome'))->toBe('rejected')
+        ->and(Context::get('rfa.reason'))->toBe('path_not_found');
+});
+
+test('an empty inbox stays silent', function () {
+    Log::spy();
+
+    drainInbox();
+
+    Log::shouldNotHaveReceived('info');
 });

--- a/tests/Unit/Actions/OpenProjectFromPathActionTest.php
+++ b/tests/Unit/Actions/OpenProjectFromPathActionTest.php
@@ -5,6 +5,8 @@ use App\Models\Project;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
 uses(TestCase::class, LazilyRefreshDatabase::class);
@@ -43,4 +45,19 @@ test('returns null and swallows the exception when registration fails', function
         ->and(Context::get('rfa.reason'))->toBe('not_a_git_repository');
 
     expect(Project::count())->toBe(0);
+});
+
+test('warns with a hashed path when registration fails unexpectedly', function () {
+    Schema::drop('projects');
+    Log::spy();
+
+    expect(app(OpenProjectFromPathAction::class)->handle($this->repoPath))->toBeNull()
+        ->and(Context::get('rfa.reason'))->toBe('project_registration_failed');
+
+    Log::shouldHaveReceived('warning')->once()->withArgs(
+        fn (string $event, array $payload): bool => $event === 'project.registration.failed'
+            && $payload['reason'] === 'project_registration_failed'
+            && $payload['path_hash'] === hash('xxh128', $this->repoPath)
+            && ! array_key_exists('path', $payload),
+    );
 });

--- a/tests/Unit/Actions/OpenRepositoryDialogActionTest.php
+++ b/tests/Unit/Actions/OpenRepositoryDialogActionTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use App\Actions\OpenRepositoryDialogAction;
+use App\Models\Project;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Native\Desktop\Dialog;
+use Native\Desktop\Facades\Alert;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+/** Stand in for the folder picker so the action runs without a native dialog. */
+function fakeFolderPick(?string $path): void
+{
+    $dialog = Mockery::mock(Dialog::class);
+    $dialog->shouldReceive('title', 'folders')->andReturnSelf();
+    $dialog->shouldReceive('open')->andReturn($path);
+
+    app()->instance(Dialog::class, $dialog);
+}
+
+beforeEach(function () {
+    $this->repoPath = $this->createTempDirectory('rfa_open_dialog_');
+    $this->initTestRepo($this->repoPath);
+    File::put($this->repoPath.'/file.txt', "ok\n");
+    $this->commitTestRepo($this->repoPath, 'init');
+
+    Alert::shouldReceive('new', 'type', 'title')->andReturnSelf();
+    Alert::shouldReceive('show')->andReturn(0);
+});
+
+test('returns the registered project for the picked directory', function () {
+    fakeFolderPick($this->repoPath);
+
+    expect(app(OpenRepositoryDialogAction::class)->handle())
+        ->toBeInstanceOf(Project::class);
+});
+
+test('returns null when the dialog is dismissed', function () {
+    fakeFolderPick(null);
+
+    expect(app(OpenRepositoryDialogAction::class)->handle())->toBeNull()
+        ->and(Context::get('rfa.reason'))->toBeNull();
+});
+
+test('marks a picked non-repository as rejected without warning', function () {
+    fakeFolderPick($this->createTempDirectory('rfa_open_dialog_nongit_'));
+    Log::spy();
+
+    expect(app(OpenRepositoryDialogAction::class)->handle())->toBeNull()
+        ->and(Context::get('rfa.reason'))->toBe('not_a_git_repository');
+
+    Log::shouldNotHaveReceived('warning');
+});
+
+test('warns without the picked path when registration fails unexpectedly', function () {
+    fakeFolderPick($this->repoPath);
+    Schema::drop('projects');
+    Log::spy();
+
+    expect(app(OpenRepositoryDialogAction::class)->handle())->toBeNull()
+        ->and(Context::get('rfa.reason'))->toBe('project_registration_failed');
+
+    Log::shouldHaveReceived('warning')->once()->withArgs(
+        fn (string $event, array $payload): bool => $event === 'project.registration.failed'
+            && $payload['reason'] === 'project_registration_failed'
+            && $payload['error_class'] !== ''
+            && ! array_key_exists('path', $payload),
+    );
+});

--- a/tests/Unit/Actions/OpenRepositoryDialogActionTest.php
+++ b/tests/Unit/Actions/OpenRepositoryDialogActionTest.php
@@ -44,31 +44,27 @@ test('returns null when the dialog is dismissed', function () {
     fakeFolderPick(null);
 
     expect(app(OpenRepositoryDialogAction::class)->handle())->toBeNull()
-        ->and(Context::get('rfa.reason'))->toBeNull();
+        ->and(Context::get('rfa.reason'))->toBeNull()
+        ->and(OpenRepositoryDialogAction::outcomeForNullProject())->toBe('cancelled');
 });
 
-test('marks a picked non-repository as rejected without warning', function () {
+test('marks a picked non-repository as rejected', function () {
     fakeFolderPick($this->createTempDirectory('rfa_open_dialog_nongit_'));
-    Log::spy();
 
     expect(app(OpenRepositoryDialogAction::class)->handle())->toBeNull()
-        ->and(Context::get('rfa.reason'))->toBe('not_a_git_repository');
-
-    Log::shouldNotHaveReceived('warning');
+        ->and(Context::get('rfa.reason'))->toBe('not_a_git_repository')
+        ->and(OpenRepositoryDialogAction::outcomeForNullProject())->toBe('rejected');
 });
 
-test('warns without the picked path when registration fails unexpectedly', function () {
+test('marks an unexpected registration failure as an error for the owner', function () {
     fakeFolderPick($this->repoPath);
     Schema::drop('projects');
     Log::spy();
 
     expect(app(OpenRepositoryDialogAction::class)->handle())->toBeNull()
-        ->and(Context::get('rfa.reason'))->toBe('project_registration_failed');
+        ->and(Context::get('rfa.reason'))->toBe('project_registration_failed')
+        ->and(Context::get('rfa.error_class'))->not->toBeNull()
+        ->and(OpenRepositoryDialogAction::outcomeForNullProject())->toBe('error');
 
-    Log::shouldHaveReceived('warning')->once()->withArgs(
-        fn (string $event, array $payload): bool => $event === 'project.registration.failed'
-            && $payload['reason'] === 'project_registration_failed'
-            && $payload['error_class'] !== ''
-            && ! array_key_exists('path', $payload),
-    );
+    Log::shouldNotHaveReceived('warning');
 });

--- a/tests/Unit/Livewire/AddProjectMenuTest.php
+++ b/tests/Unit/Livewire/AddProjectMenuTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+use Livewire\Livewire;
+use Native\Desktop\Dialog;
+use Native\Desktop\Facades\Alert;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+/** Stand in for the folder picker both menu actions open. */
+function fakePickedFolder(?string $path): void
+{
+    $dialog = Mockery::mock(Dialog::class);
+    $dialog->shouldReceive('title', 'folders')->andReturnSelf();
+    $dialog->shouldReceive('open')->andReturn($path);
+
+    app()->instance(Dialog::class, $dialog);
+}
+
+beforeEach(function () {
+    $this->repoPath = $this->createTempDirectory('rfa_add_menu_');
+    $this->initTestRepo($this->repoPath);
+    File::put($this->repoPath.'/file.txt', "ok\n");
+    $this->commitTestRepo($this->repoPath, 'init');
+
+    Alert::shouldReceive('new', 'type', 'title')->andReturnSelf();
+    Alert::shouldReceive('show')->andReturn(0);
+
+    Livewire::withoutLazyLoading();
+});
+
+// -- project.opened --
+
+test('emits a canonical project.opened event for a picked repository', function () {
+    fakePickedFolder($this->repoPath);
+    Log::spy();
+
+    Livewire::test('add-project-menu')->call('openRepository');
+
+    Log::shouldHaveReceived('info')->once()->with('project.opened');
+    expect(Context::get('rfa.outcome'))->toBe('completed')
+        ->and(Context::get('rfa.project_slug'))->not->toBeNull()
+        ->and(Context::get('rfa.project_id'))->toBeInt()
+        ->and(Context::get('rfa.duration_ms'))->toBeInt();
+});
+
+test('emits a cancelled outcome when the picker is dismissed', function () {
+    fakePickedFolder(null);
+    Log::spy();
+
+    Livewire::test('add-project-menu')->call('openRepository');
+
+    Log::shouldHaveReceived('info')->once()->with('project.opened');
+    expect(Context::get('rfa.outcome'))->toBe('cancelled');
+});
+
+test('emits a rejected outcome when the picked folder is not a repository', function () {
+    fakePickedFolder($this->createTempDirectory('rfa_add_menu_nongit_'));
+    Log::spy();
+
+    Livewire::test('add-project-menu')->call('openRepository');
+
+    Log::shouldHaveReceived('info')->once()->with('project.opened');
+    expect(Context::get('rfa.outcome'))->toBe('rejected')
+        ->and(Context::get('rfa.reason'))->toBe('not_a_git_repository');
+});
+
+// -- directory.scanned --
+
+test('emits a canonical directory.scanned event with the scan counts', function () {
+    $parent = $this->createTempDirectory('rfa_add_menu_scan_');
+    $nested = $parent.'/repo';
+    File::makeDirectory($nested);
+    $this->initTestRepo($nested);
+    File::put($nested.'/file.txt', "ok\n");
+    $this->commitTestRepo($nested, 'init');
+
+    fakePickedFolder($parent);
+    Log::spy();
+
+    Livewire::test('add-project-menu')->call('scanDirectory');
+
+    Log::shouldHaveReceived('info')->once()->with('directory.scanned');
+    expect(Context::get('rfa.outcome'))->toBe('completed')
+        ->and(Context::get('rfa.repos_found'))->toBe(1)
+        ->and(Context::get('rfa.repos_registered'))->toBe(1)
+        ->and(Context::get('rfa.duration_ms'))->toBeInt();
+});
+
+test('emits a cancelled outcome when the scan picker is dismissed', function () {
+    fakePickedFolder(null);
+    Log::spy();
+
+    Livewire::test('add-project-menu')->call('scanDirectory');
+
+    Log::shouldHaveReceived('info')->once()->with('directory.scanned');
+    expect(Context::get('rfa.outcome'))->toBe('cancelled');
+});


### PR DESCRIPTION
The weekly wide-events audit for 2026-08-18 (`reports/wide-events/2026-08-18.md`) plus the resolutions for every finding it raised, including one the bot reviewers surfaced during review.

**Three entry points opened repositories with no logging owner.** `openRepository()` and `scanDirectory()` on the add-project menu, and `processInbox()` draining the `./rfa` inbox, all delegated to actions that are not owners, so none of them flushed `Context` or emitted a canonical event. The primary in-app way to add a repository was invisible while the native menu path next to it was fully logged. Each is now an owner:

| Owner | Event | Outcomes |
|---|---|---|
| `add-project-menu::openRepository()` | `project.opened` | completed, cancelled, rejected, error |
| `add-project-menu::scanDirectory()` | `directory.scanned` | completed, partial, cancelled, rejected, error |
| `NativeAppServiceProvider::processInbox()` | `inbox.opened` | completed, skipped, rejected, error |

`processInbox()` owns its event from the point it claims a queued file, so the boots where the inbox is empty stay silent: no work, no event.

Mapping a null return to an outcome was a private method on `HandleMenuItemClicked` and an inline `match` in `HandleDeepLink`. Both move onto the actions that write the reasons (`OpenRepositoryDialogAction::outcomeForNullProject()`, `OpenTerminalRequestAction::outcomeForNullProject()`), so all four callers read the vocabulary from one place.

**`OpenProjectFromPathAction` logs `path_hash` instead of the raw deep-link path** on `project.registration.failed`, reusing the `hash('xxh128', $path)` the deep-link owner already writes to `rfa.path_hash`, so the correlation key is unchanged and one absolute path leaves the log.

**The report's `[CRITICAL]` was an environment blocker, not a rule violation.** The audit session had no `vendor/` because `composer install` was refused by the proxy, so the check was blocked rather than failing an assertion. Both deterministic checks were re-run against `main` and pass (`LoggingConventionsTest` 9/9 for C1-C7 and C9-C10, `LogChannelPostureTest` 5/5 for C8).

The report carries `[RESOLVED]` markers and resolution lines throughout, matching the shape of `reports/wide-events/2026-08-11.md`.

Two things are deliberately left as documented rather than fixed. `OpenRepositoryDialogAction::handle` still passes `$e->getMessage()` into `Alert::show()`, which is a UI surface rather than a log payload and so sits outside the standard's raw-exception ban. And the `project.registration.failed` warning is now redundant on both of its callers, but removing a production warning is wider than this audit called for, so a later audit should decide whether it earns its place.