### PR TITLE
Fix markdown table layout by budgeting cell padding into tracks

### DIFF
--- a/app/Services/MarkdownTableAlignerService.php
+++ b/app/Services/MarkdownTableAlignerService.php
@@ -24,6 +24,24 @@ class MarkdownTableAlignerService
     private const COLUMN_WEIGHT_MIN = 3;
 
     /**
+     * Horizontal padding a cell adds on top of its text, in characters. Mirrors
+     * the `1ch` per side on `.diff-md-td`. Folded into the track so the `fr`
+     * ratios describe the full cell box: without it the shared max-width is
+     * short by the padding of every column, and the whole table renders squeezed
+     * — short labels like `Estado` wrapping to `Esta`/`do`.
+     */
+    private const COLUMN_PADDING = 2;
+
+    /**
+     * Smallest track a column may shrink to when the table is wider than the
+     * available space, in characters. `fr` alone shrinks every column by the
+     * same ratio, so a narrow label column gets crushed to a few characters to
+     * buy width for a prose column that has plenty. A column narrower than this
+     * is never shrunk at all; wider ones stop here.
+     */
+    private const COLUMN_MIN_TRACK = 14;
+
+    /**
      * Annotate contiguous markdown table rows with the structured cell data and
      * shared column template the diff view needs to lay each row out as a real
      * CSS grid. The source content is left untouched; only `table` metadata is
@@ -117,11 +135,12 @@ class MarkdownTableAlignerService
             return $group;
         }
 
-        $weights = $this->columnWeights($parsed, $maxCols);
-        $template = collect($weights)
-            ->map(fn (int $weight) => "minmax(0,{$weight}fr)")
+        $tracks = collect($this->columnWeights($parsed, $maxCols))
+            ->map(fn (int $weight) => $weight + self::COLUMN_PADDING);
+        $template = $tracks
+            ->map(fn (int $track) => sprintf('minmax(%dch,%dfr)', min($track, self::COLUMN_MIN_TRACK), $track))
             ->implode(' ');
-        $maxWidth = array_sum($weights);
+        $maxWidth = $tracks->sum();
 
         $result = [];
         foreach ($group as $offset => $line) {
@@ -171,7 +190,7 @@ class MarkdownTableAlignerService
 
     /**
      * Column weight is the widest cell in that column, capped so a prose column
-     * can't starve its neighbours. Used as the `fr` ratio for the grid track.
+     * can't starve its neighbours. Padding is added on top to form the track.
      *
      * @param  array<int, array{indent: string, cells: string[], isSeparator: bool}>  $parsed
      * @return int[]

--- a/app/Services/MarkdownTableAlignerService.php
+++ b/app/Services/MarkdownTableAlignerService.php
@@ -28,9 +28,19 @@ class MarkdownTableAlignerService
      * the `1ch` per side on `.diff-md-td`. Folded into the track so the `fr`
      * ratios describe the full cell box: without it the shared max-width is
      * short by the padding of every column, and the whole table renders squeezed
-     * — short labels like `Estado` wrapping to `Esta`/`do`.
+     * — short labels like `Estado` wrapping to `Esta`/`do`. The column rule is
+     * drawn as an inset shadow rather than a border precisely so it costs no
+     * layout width and stays out of this budget.
      */
     private const COLUMN_PADDING = 2;
+
+    /**
+     * A spare character per column, in characters. The `fr` division resolves to
+     * fractional pixels, so a track budgeted to the exact width of its text can
+     * come up a fraction short and wrap the last glyph onto its own line. One
+     * character of headroom absorbs that, and reads as air between columns.
+     */
+    private const COLUMN_SLACK = 1;
 
     /**
      * Smallest track a column may shrink to when the table is wider than the
@@ -136,7 +146,7 @@ class MarkdownTableAlignerService
         }
 
         $tracks = collect($this->columnWeights($parsed, $maxCols))
-            ->map(fn (int $weight) => $weight + self::COLUMN_PADDING);
+            ->map(fn (int $weight) => $weight + self::COLUMN_PADDING + self::COLUMN_SLACK);
         $template = $tracks
             ->map(fn (int $track) => sprintf('minmax(%dch,%dfr)', min($track, self::COLUMN_MIN_TRACK), $track))
             ->implode(' ');

--- a/app/Services/MarkdownTableAlignerService.php
+++ b/app/Services/MarkdownTableAlignerService.php
@@ -24,15 +24,24 @@ class MarkdownTableAlignerService
     private const COLUMN_WEIGHT_MIN = 3;
 
     /**
-     * Horizontal padding a cell adds on top of its text, in characters. Mirrors
-     * the `1ch` per side on `.diff-md-td`. Folded into the track so the `fr`
-     * ratios describe the full cell box: without it the shared max-width is
-     * short by the padding of every column, and the whole table renders squeezed
-     * — short labels like `Estado` wrapping to `Esta`/`do`. The column rule is
-     * drawn as an inset shadow rather than a border precisely so it costs no
-     * layout width and stays out of this budget.
+     * Horizontal padding a cell adds per side, in characters. The layout reads
+     * this straight out of the stylesheet — `.diff-md-td` in the app layout is
+     * declared `padding: 0 {CELL_PADDING_CH}ch` — so the CSS and the track
+     * budget below can never drift apart.
      */
-    private const COLUMN_PADDING = 2;
+    public const CELL_PADDING_CH = 1;
+
+    /**
+     * Padding a cell adds on top of its text, in characters. Folded into the
+     * track so the `fr` ratios describe the full cell box: without it the shared
+     * max-width is short by the padding of every column, and the whole table
+     * renders squeezed — short labels like `Estado` wrapping to `Esta`/`do`. The
+     * first column drops its left padding, so its track is budgeted one
+     * character wide; that errs toward air, never toward a mid-word break. The
+     * column rule is drawn as an inset shadow rather than a border precisely so
+     * it costs no layout width and stays out of this budget.
+     */
+    private const COLUMN_PADDING = self::CELL_PADDING_CH * 2;
 
     /**
      * A spare character per column, in characters. The `fr` division resolves to
@@ -47,7 +56,8 @@ class MarkdownTableAlignerService
      * available space, in characters. `fr` alone shrinks every column by the
      * same ratio, so a narrow label column gets crushed to a few characters to
      * buy width for a prose column that has plenty. A column narrower than this
-     * is never shrunk at all; wider ones stop here.
+     * is never shrunk at all; wider ones stop here. Roughly two status words
+     * (`completed`, `Valentina`) — enough that a label column stays readable.
      */
     private const COLUMN_MIN_TRACK = 14;
 

--- a/app/Services/MarkdownTableAlignerService.php
+++ b/app/Services/MarkdownTableAlignerService.php
@@ -158,7 +158,11 @@ class MarkdownTableAlignerService
         $tracks = collect($this->columnWeights($parsed, $maxCols))
             ->map(fn (int $weight) => $weight + self::COLUMN_PADDING + self::COLUMN_SLACK);
         $template = $tracks
-            ->map(fn (int $track) => sprintf('minmax(%dch,%dfr)', min($track, self::COLUMN_MIN_TRACK), $track))
+            ->map(fn (int $track) => sprintf(
+                'minmax(%s,%dfr)',
+                $this->columnFloor($track, $maxCols),
+                $track,
+            ))
             ->implode(' ');
         $maxWidth = $tracks->sum();
 
@@ -206,6 +210,27 @@ class MarkdownTableAlignerService
             'template' => $template,
             'maxWidth' => $maxWidth,
         ];
+    }
+
+    /**
+     * The smallest a column may get, as the `minmax()` minimum for its track.
+     *
+     * A `ch` floor alone is unbounded in aggregate: enough columns and the
+     * floors sum past the pane, and the grid — `width: 100%` with no scroll
+     * container — paints over the split view's other half. Pairing it with an
+     * equal share of the pane bounds the sum at exactly 100% no matter how many
+     * columns there are or how narrow the pane gets, and costs nothing while
+     * there is room, where the `ch` value is the smaller of the two. Shrinking
+     * rather than scrolling is what the rest of the diff does — `.diff-cell-content`
+     * wraps, it never scrolls sideways.
+     */
+    private function columnFloor(int $track, int $columns): string
+    {
+        // Truncated, not rounded: rounding up would let the shares total over
+        // 100% and reintroduce the overflow this exists to prevent.
+        $share = floor(100 / $columns * 10000) / 10000;
+
+        return sprintf('min(%dch,%s%%)', min($track, self::COLUMN_MIN_TRACK), rtrim(rtrim(number_format($share, 4, '.', ''), '0'), '.'));
     }
 
     /**

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -168,14 +168,23 @@
            source) so blade whitespace collapses and prose wraps on word bounds. */
         .diff-cell-table { white-space: normal; }
         .diff-md-table { display: grid; align-items: start; width: 100%; }
+        /* Padding is in `ch` because the shared max-width the aligner computes is
+           in `ch` too: it budgets COLUMN_PADDING (2ch) per column, so the two must
+           stay in step or every column renders narrower than its content and even
+           short labels wrap mid-word. */
         .diff-md-td {
             min-width: 0;
-            padding: 0 0.6rem;
+            padding: 0 1ch;
             white-space: normal;
-            overflow-wrap: anywhere;
+            /* break-word, not anywhere: both break an over-long word the same way,
+               but `anywhere` also drops the intrinsic min-content width to a single
+               character, which lets a column collapse to a vertical letter stack. */
+            overflow-wrap: break-word;
             word-break: normal;
             border-left: 1px solid rgb(var(--gh-border) / 0.6);
         }
+        /* The first cell forgoes its left padding so the table starts flush with
+           the rest of the diff; the 1ch that frees pays for the column borders. */
         .diff-md-td:first-child { padding-left: 0; border-left: 0; }
         .diff-md-th { font-weight: 600; color: rgb(var(--gh-text)); }
         .diff-md-sep { height: 0; border-bottom: 1px solid rgb(var(--gh-border)); margin: 0.15rem 0; }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -181,11 +181,13 @@
                character, which lets a column collapse to a vertical letter stack. */
             overflow-wrap: break-word;
             word-break: normal;
-            border-left: 1px solid rgb(var(--gh-border) / 0.6);
+            /* The column rule is an inset shadow, not a border: a border eats a
+               pixel of the track that the aligner's ch budget doesn't know about,
+               which was enough to wrap the last letter of every tight column
+               (`complete`/`d`). A shadow paints in the same place for free. */
+            box-shadow: inset 1px 0 0 rgb(var(--gh-border) / 0.6);
         }
-        /* The first cell forgoes its left padding so the table starts flush with
-           the rest of the diff; the 1ch that frees pays for the column borders. */
-        .diff-md-td:first-child { padding-left: 0; border-left: 0; }
+        .diff-md-td:first-child { padding-left: 0; box-shadow: none; }
         .diff-md-th { font-weight: 600; color: rgb(var(--gh-text)); }
         .diff-md-sep { height: 0; border-bottom: 1px solid rgb(var(--gh-border)); margin: 0.15rem 0; }
         /* A changed separator shows its raw `:---`/`---:` markers, muted so they

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -168,23 +168,19 @@
            source) so blade whitespace collapses and prose wraps on word bounds. */
         .diff-cell-table { white-space: normal; }
         .diff-md-table { display: grid; align-items: start; width: 100%; }
-        /* Padding is in `ch` because the shared max-width the aligner computes is
-           in `ch` too: it budgets COLUMN_PADDING (2ch) per column, so the two must
-           stay in step or every column renders narrower than its content and even
-           short labels wrap mid-word. */
         .diff-md-td {
             min-width: 0;
-            padding: 0 1ch;
+            /* In `ch`, and printed from the constant the aligner budgets its
+               tracks with, so the stylesheet and that budget cannot drift. */
+            padding: 0 {{ \App\Services\MarkdownTableAlignerService::CELL_PADDING_CH }}ch;
             white-space: normal;
             /* break-word, not anywhere: both break an over-long word the same way,
                but `anywhere` also drops the intrinsic min-content width to a single
                character, which lets a column collapse to a vertical letter stack. */
             overflow-wrap: break-word;
             word-break: normal;
-            /* The column rule is an inset shadow, not a border: a border eats a
-               pixel of the track that the aligner's ch budget doesn't know about,
-               which was enough to wrap the last letter of every tight column
-               (`complete`/`d`). A shadow paints in the same place for free. */
+            /* Inset shadow, not a border: a border would eat a pixel of the track
+               that the aligner's ch budget does not know about — see CELL_PADDING_CH. */
             box-shadow: inset 1px 0 0 rgb(var(--gh-border) / 0.6);
         }
         .diff-md-td:first-child { padding-left: 0; box-shadow: none; }

--- a/tests/Unit/MarkdownTableAlignerServiceTest.php
+++ b/tests/Unit/MarkdownTableAlignerServiceTest.php
@@ -123,7 +123,7 @@ test('a changed separator does not inflate its column widths', function () {
 
     // The long dash runs in the separator must not set the column weights —
     // those still come from the (short) body/header cells.
-    expect($lines[0]->table['template'])->toBe('minmax(6ch,6fr) minmax(6ch,6fr)');
+    expect($lines[0]->table['template'])->toBe('minmax(min(6ch,50%),6fr) minmax(min(6ch,50%),6fr)');
 });
 
 test('leaves source content untouched', function () {
@@ -208,7 +208,7 @@ test('caps a prose column so it does not starve its neighbours', function () {
     // and both floors stop at the 14ch shrink limit — so when the table is wider
     // than the space it has, the prose column gives way instead of every column
     // shrinking in step and crushing the narrow one.
-    expect($lines[0]->table['template'])->toBe('minmax(14ch,16fr) minmax(14ch,63fr)');
+    expect($lines[0]->table['template'])->toBe('minmax(min(14ch,50%),16fr) minmax(min(14ch,50%),63fr)');
 });
 
 test('marks every header row before the separator', function () {
@@ -321,6 +321,28 @@ test('budgets cell padding into the track and the shared max width', function ()
     // Text widths are 20 and 9; each track adds the 2ch of cell padding plus 1ch
     // of slack, and the max width is the sum — so the table is never squeezed
     // below its content.
-    expect($lines[0]->table['template'])->toBe('minmax(14ch,23fr) minmax(12ch,12fr)')
+    expect($lines[0]->table['template'])->toBe('minmax(min(14ch,50%),23fr) minmax(min(12ch,50%),12fr)')
         ->and($lines[0]->table['maxWidth'])->toBe(35);
+});
+
+test('bounds the column floors so a wide table cannot overflow its pane', function () {
+    $row = '|'.str_repeat(' a |', 7);
+    $hunks = [
+        new Hunk('', 1, 3, 1, 3, [
+            new DiffLine(LineType::Context, $row, 1, 1),
+            new DiffLine(LineType::Context, '|'.str_repeat(' --- |', 7), 2, 2),
+            new DiffLine(LineType::Context, $row, 3, 3),
+        ]),
+    ];
+
+    $lines = $this->aligner->alignTables($hunks, 'readme.md')[0]->lines;
+
+    // Seven 6ch floors would demand 42ch of a pane that may not have it, and the
+    // grid has no scroll container to absorb the excess. Each floor is also held
+    // to a seventh of the pane, so the shares total 100% at worst.
+    $floors = [];
+    preg_match_all('/min\((\d+)ch,([\d.]+)%\)/', $lines[0]->table['template'], $floors);
+
+    expect($floors[1])->toBe(array_fill(0, 7, '6'))
+        ->and(array_sum(array_map('floatval', $floors[2])))->toBeLessThanOrEqual(100.0);
 });

--- a/tests/Unit/MarkdownTableAlignerServiceTest.php
+++ b/tests/Unit/MarkdownTableAlignerServiceTest.php
@@ -205,7 +205,9 @@ test('caps a prose column so it does not starve its neighbours', function () {
 
     // 'composer.lock' (13) keeps its width; the long prose column is capped at 60.
     // Both tracks carry the cell padding and slack on top of their text width,
-    // and both floors stop at the 14ch shrink limit.
+    // and both floors stop at the 14ch shrink limit — so when the table is wider
+    // than the space it has, the prose column gives way instead of every column
+    // shrinking in step and crushing the narrow one.
     expect($lines[0]->table['template'])->toBe('minmax(14ch,16fr) minmax(14ch,63fr)');
 });
 
@@ -321,21 +323,4 @@ test('budgets cell padding into the track and the shared max width', function ()
     // below its content.
     expect($lines[0]->table['template'])->toBe('minmax(14ch,23fr) minmax(12ch,12fr)')
         ->and($lines[0]->table['maxWidth'])->toBe(35);
-});
-
-test('floors a narrow column so it cannot be crushed by a prose neighbour', function () {
-    $prose = str_repeat('word ', 60);
-    $hunks = [
-        new Hunk('', 1, 3, 1, 3, [
-            new DiffLine(LineType::Context, '| Estado | Notes |', 1, 1),
-            new DiffLine(LineType::Context, '| --- | --- |', 2, 2),
-            new DiffLine(LineType::Context, "| completed | {$prose} |", 3, 3),
-        ]),
-    ];
-
-    $lines = $this->aligner->alignTables($hunks, 'readme.md')[0]->lines;
-
-    // 'completed' (9) + padding is under the floor, so its track never shrinks:
-    // when space runs short the prose column gives way, not the label column.
-    expect($lines[0]->table['template'])->toBe('minmax(12ch,12fr) minmax(14ch,63fr)');
 });

--- a/tests/Unit/MarkdownTableAlignerServiceTest.php
+++ b/tests/Unit/MarkdownTableAlignerServiceTest.php
@@ -123,7 +123,7 @@ test('a changed separator does not inflate its column widths', function () {
 
     // The long dash runs in the separator must not set the column weights —
     // those still come from the (short) body/header cells.
-    expect($lines[0]->table['template'])->toBe('minmax(5ch,5fr) minmax(5ch,5fr)');
+    expect($lines[0]->table['template'])->toBe('minmax(6ch,6fr) minmax(6ch,6fr)');
 });
 
 test('leaves source content untouched', function () {
@@ -204,9 +204,9 @@ test('caps a prose column so it does not starve its neighbours', function () {
     $lines = $this->aligner->alignTables($hunks, 'readme.md')[0]->lines;
 
     // 'composer.lock' (13) keeps its width; the long prose column is capped at 60.
-    // Both tracks carry the 2ch cell padding on top of their text width, and
-    // both floors stop at the 14ch shrink limit.
-    expect($lines[0]->table['template'])->toBe('minmax(14ch,15fr) minmax(14ch,62fr)');
+    // Both tracks carry the cell padding and slack on top of their text width,
+    // and both floors stop at the 14ch shrink limit.
+    expect($lines[0]->table['template'])->toBe('minmax(14ch,16fr) minmax(14ch,63fr)');
 });
 
 test('marks every header row before the separator', function () {
@@ -316,10 +316,11 @@ test('budgets cell padding into the track and the shared max width', function ()
 
     $lines = $this->aligner->alignTables($hunks, 'readme.md')[0]->lines;
 
-    // Text widths are 20 and 9; each track adds the 2ch of cell padding, and the
-    // max width is the sum — so the table is never squeezed below its content.
-    expect($lines[0]->table['template'])->toBe('minmax(14ch,22fr) minmax(11ch,11fr)')
-        ->and($lines[0]->table['maxWidth'])->toBe(33);
+    // Text widths are 20 and 9; each track adds the 2ch of cell padding plus 1ch
+    // of slack, and the max width is the sum — so the table is never squeezed
+    // below its content.
+    expect($lines[0]->table['template'])->toBe('minmax(14ch,23fr) minmax(12ch,12fr)')
+        ->and($lines[0]->table['maxWidth'])->toBe(35);
 });
 
 test('floors a narrow column so it cannot be crushed by a prose neighbour', function () {
@@ -336,5 +337,5 @@ test('floors a narrow column so it cannot be crushed by a prose neighbour', func
 
     // 'completed' (9) + padding is under the floor, so its track never shrinks:
     // when space runs short the prose column gives way, not the label column.
-    expect($lines[0]->table['template'])->toBe('minmax(11ch,11fr) minmax(14ch,62fr)');
+    expect($lines[0]->table['template'])->toBe('minmax(12ch,12fr) minmax(14ch,63fr)');
 });

--- a/tests/Unit/MarkdownTableAlignerServiceTest.php
+++ b/tests/Unit/MarkdownTableAlignerServiceTest.php
@@ -51,7 +51,7 @@ test('attaches grid cell metadata to each table row', function () {
     ]);
     // Every row in the group shares the same column template, so they align.
     expect($lines[0]->table['template'])->toBe($lines[2]->table['template'])
-        ->and($lines[0]->table['template'])->toContain('minmax(0,')
+        ->and($lines[0]->table['template'])->toContain('minmax(')
         ->and($lines[0]->table['maxWidth'])->toBeInt();
 
     // The separator row collapses to a header rule, not cells.
@@ -123,7 +123,7 @@ test('a changed separator does not inflate its column widths', function () {
 
     // The long dash runs in the separator must not set the column weights —
     // those still come from the (short) body/header cells.
-    expect($lines[0]->table['template'])->toBe('minmax(0,3fr) minmax(0,3fr)');
+    expect($lines[0]->table['template'])->toBe('minmax(5ch,5fr) minmax(5ch,5fr)');
 });
 
 test('leaves source content untouched', function () {
@@ -204,7 +204,9 @@ test('caps a prose column so it does not starve its neighbours', function () {
     $lines = $this->aligner->alignTables($hunks, 'readme.md')[0]->lines;
 
     // 'composer.lock' (13) keeps its width; the long prose column is capped at 60.
-    expect($lines[0]->table['template'])->toBe('minmax(0,13fr) minmax(0,60fr)');
+    // Both tracks carry the 2ch cell padding on top of their text width, and
+    // both floors stop at the 14ch shrink limit.
+    expect($lines[0]->table['template'])->toBe('minmax(14ch,15fr) minmax(14ch,62fr)');
 });
 
 test('marks every header row before the separator', function () {
@@ -301,4 +303,38 @@ test('preserves highlighting and heading metadata already on the line', function
     expect($line->highlightedContent)->toBe('<span>| a | b |</span>')
         ->and($line->headingAncestors)->toBe([5])
         ->and($line->table['cells'])->toBe(['a', 'b']);
+});
+
+test('budgets cell padding into the track and the shared max width', function () {
+    $hunks = [
+        new Hunk('', 1, 3, 1, 3, [
+            new DiffLine(LineType::Context, '| Evaluador | Estado |', 1, 1),
+            new DiffLine(LineType::Context, '| --- | --- |', 2, 2),
+            new DiffLine(LineType::Context, '| Juan Pablo Locatelli | completed |', 3, 3),
+        ]),
+    ];
+
+    $lines = $this->aligner->alignTables($hunks, 'readme.md')[0]->lines;
+
+    // Text widths are 20 and 9; each track adds the 2ch of cell padding, and the
+    // max width is the sum — so the table is never squeezed below its content.
+    expect($lines[0]->table['template'])->toBe('minmax(14ch,22fr) minmax(11ch,11fr)')
+        ->and($lines[0]->table['maxWidth'])->toBe(33);
+});
+
+test('floors a narrow column so it cannot be crushed by a prose neighbour', function () {
+    $prose = str_repeat('word ', 60);
+    $hunks = [
+        new Hunk('', 1, 3, 1, 3, [
+            new DiffLine(LineType::Context, '| Estado | Notes |', 1, 1),
+            new DiffLine(LineType::Context, '| --- | --- |', 2, 2),
+            new DiffLine(LineType::Context, "| completed | {$prose} |", 3, 3),
+        ]),
+    ];
+
+    $lines = $this->aligner->alignTables($hunks, 'readme.md')[0]->lines;
+
+    // 'completed' (9) + padding is under the floor, so its track never shrinks:
+    // when space runs short the prose column gives way, not the label column.
+    expect($lines[0]->table['template'])->toBe('minmax(11ch,11fr) minmax(14ch,62fr)');
 });


### PR DESCRIPTION
## Summary

Fixes markdown table rendering that was being squeezed narrower than its content, causing premature word wrapping. The aligner now budgets cell padding and slack into the CSS Grid track widths, and the stylesheet switches from borders to inset shadows to avoid consuming layout width.

## Changes

- **MarkdownTableAlignerService**: Added three new constants to budget layout precisely:
  - `CELL_PADDING_CH`: Horizontal padding per cell (1ch), read directly from the stylesheet to prevent drift
  - `COLUMN_PADDING`: Total padding per column (2ch)
  - `COLUMN_SLACK`: Headroom per column to absorb fractional pixel rounding (1ch)
  - `COLUMN_MIN_TRACK`: Minimum shrink floor for columns (14ch) to prevent narrow label columns from being crushed when the table exceeds available space

- **Track calculation**: Changed from `minmax(0, {weight}fr)` to `minmax({floor}ch, {track}fr)` where track = weight + padding + slack, and floor = min(track, 14ch). This ensures:
  - The table never renders narrower than its content
  - When the table exceeds available space, narrow columns stop shrinking at 14ch while wider columns give way
  - The `fr` ratio still describes the full cell box, not just text

- **Stylesheet** (`app.blade.php`):
  - Changed cell padding from `0.6rem` to `{{ CELL_PADDING_CH }}ch` (1ch), sourced from the constant to keep CSS and aligner in sync
  - Replaced `border-left` with `box-shadow: inset` so the column rule doesn't consume layout width
  - Changed `overflow-wrap: anywhere` to `break-word` to prevent columns from collapsing to single-character stacks

- **Tests**: Updated expectations to reflect new track format and verified padding/slack are correctly budgeted into both the template and maxWidth calculations.

## Implementation Details

The core issue was that the aligner calculated column widths based on text content alone, but CSS Grid's `fr` unit divides the available space after padding is applied. This meant a table budgeted to exact content width would come up short by the padding of every column, causing the grid to squeeze narrower and wrap text prematurely.

By folding padding and slack into the track width calculation, the `fr` ratios now describe the full cell box. The `COLUMN_MIN_TRACK` floor prevents narrow columns from being crushed when the table is wider than available space—instead, wider columns shrink while narrow ones stay readable.

https://claude.ai/code/session_01KMdmmfTznphxrjkRbBeeYw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved Markdown table alignment with configurable cell padding, column spacing, and minimum widths.
  - Updated table sizing to better accommodate padded content.
  - Improved text wrapping within table cells.
  - Replaced cell borders with subtle inset separators for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->