### PR TITLE
Harden asynchronous review flows and page-search navigation

### DIFF
--- a/app/Actions/LoadBranchExplorerSnapshotAction.php
+++ b/app/Actions/LoadBranchExplorerSnapshotAction.php
@@ -63,7 +63,7 @@ final readonly class LoadBranchExplorerSnapshotAction
     }
 
     /**
-     * @param  array{state: string, baseBranch: ?string, baseSha: ?string, hashesInRange: list<string>, commitCount: int}  $branchBase
+     * @param  array{state: string, baseBranch: ?string, baseSha: ?string, hashesInRange: list<string>, commitCount: int, unavailableReason: ?string}  $branchBase
      */
     private function loadedLimit(string $branch, string $currentBranch, array $branchBase, int $pageSize, int $minimumCommitCount): int
     {

--- a/app/Actions/ResolveBranchBaseAction.php
+++ b/app/Actions/ResolveBranchBaseAction.php
@@ -9,6 +9,8 @@ use App\Enums\BranchBaseUnavailableReason;
 use App\Exceptions\GitCommandException;
 use App\Services\GitProcessService;
 use Illuminate\Support\Facades\Log;
+use Symfony\Component\Process\Exception\ExceptionInterface as ProcessException;
+use Throwable;
 
 final readonly class ResolveBranchBaseAction
 {
@@ -37,7 +39,7 @@ final readonly class ResolveBranchBaseAction
 
         try {
             $baseSha = $this->resolveBaseRef($repoPath, $base);
-        } catch (GitCommandException $exception) {
+        } catch (GitCommandException|ProcessException $exception) {
             return $this->commandUnavailable($base, null, 'resolve_ref', $exception);
         }
 
@@ -47,8 +49,8 @@ final readonly class ResolveBranchBaseAction
 
         try {
             $mergeBase = trim($this->gitProcessService->run($repoPath, ['merge-base', $baseSha, 'HEAD']));
-        } catch (GitCommandException $exception) {
-            if ($exception->exitCode === 1) {
+        } catch (GitCommandException|ProcessException $exception) {
+            if ($exception instanceof GitCommandException && $exception->exitCode === 1) {
                 return BranchBaseResult::unavailable($base, null, BranchBaseUnavailableReason::UnrelatedHistory);
             }
 
@@ -61,7 +63,7 @@ final readonly class ResolveBranchBaseAction
 
         try {
             $hashes = $this->commitsBetween($repoPath, $mergeBase, 'HEAD');
-        } catch (GitCommandException $exception) {
+        } catch (GitCommandException|ProcessException $exception) {
             return $this->commandUnavailable($base, $mergeBase, 'list_commits', $exception);
         }
 
@@ -97,13 +99,13 @@ final readonly class ResolveBranchBaseAction
         string $baseBranch,
         ?string $baseSha,
         string $stage,
-        GitCommandException $exception,
+        Throwable $exception,
     ): BranchBaseResult {
         Log::warning('git.branch_base.resolve_failed', [
             'reason' => 'branch_base_resolve_failed',
             'base_branch' => $baseBranch,
             'stage' => $stage,
-            'exit_code' => $exception->exitCode,
+            'exit_code' => $exception instanceof GitCommandException ? $exception->exitCode : 1,
         ]);
 
         return BranchBaseResult::unavailable(

--- a/app/Actions/ResolveBranchBaseAction.php
+++ b/app/Actions/ResolveBranchBaseAction.php
@@ -10,7 +10,6 @@ use App\Exceptions\GitCommandException;
 use App\Services\GitProcessService;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\Process\Exception\ExceptionInterface as ProcessException;
-use Throwable;
 
 final readonly class ResolveBranchBaseAction
 {
@@ -99,7 +98,7 @@ final readonly class ResolveBranchBaseAction
         string $baseBranch,
         ?string $baseSha,
         string $stage,
-        Throwable $exception,
+        GitCommandException|ProcessException $exception,
     ): BranchBaseResult {
         Log::warning('git.branch_base.resolve_failed', [
             'reason' => 'branch_base_resolve_failed',

--- a/app/Actions/ResolveBranchBaseAction.php
+++ b/app/Actions/ResolveBranchBaseAction.php
@@ -5,27 +5,19 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\DTOs\BranchBaseResult;
+use App\Enums\BranchBaseUnavailableReason;
 use App\Exceptions\GitCommandException;
-use App\Services\GitMetadataService;
 use App\Services\GitProcessService;
 use Illuminate\Support\Facades\Log;
 
 final readonly class ResolveBranchBaseAction
 {
     public function __construct(
-        private GitMetadataService $gitMetadataService,
         private GitProcessService $gitProcessService,
     ) {}
 
     /**
      * Compute the diff range "since base branch" for the current HEAD.
-     *
-     * Returns one of five outcomes encoded as a {@see BranchBaseResult}:
-     *  - Ready          - base resolved, HEAD is ahead, range hashes returned
-     *  - UpToDate       - base resolved but HEAD has no commits ahead of it
-     *  - NotConfigured  - no base branch set on the project
-     *  - MissingRef     - base branch is configured but the ref isn't local
-     *  - OnBaseBranch   - current branch is the configured base
      *
      * `currentBranch` is the working branch (typically the project's branch).
      * Pass `null` (or empty string) for detached HEAD - the action treats it
@@ -43,27 +35,82 @@ final readonly class ResolveBranchBaseAction
             return BranchBaseResult::onBaseBranch($base);
         }
 
-        $baseSha = $this->gitMetadataService->resolveRef($repoPath, $base);
+        try {
+            $baseSha = $this->resolveBaseRef($repoPath, $base);
+        } catch (GitCommandException $exception) {
+            return $this->commandUnavailable($base, null, 'resolve_ref', $exception);
+        }
 
         if ($baseSha === null) {
             return BranchBaseResult::missingRef($base);
         }
 
-        $mergeBase = $this->gitMetadataService->getMergeBase($repoPath, $base, 'HEAD');
+        try {
+            $mergeBase = trim($this->gitProcessService->run($repoPath, ['merge-base', $baseSha, 'HEAD']));
+        } catch (GitCommandException $exception) {
+            if ($exception->exitCode === 1) {
+                return BranchBaseResult::unavailable($base, null, BranchBaseUnavailableReason::UnrelatedHistory);
+            }
 
-        if ($mergeBase === null) {
-            // Unrelated histories - treat like a missing ref so the UI surfaces
-            // an actionable state rather than silently doing nothing.
-            return BranchBaseResult::missingRef($base);
+            return $this->commandUnavailable($base, null, 'merge_base', $exception);
         }
 
-        $hashes = $this->commitsBetween($repoPath, $mergeBase, 'HEAD');
+        if ($mergeBase === '') {
+            return BranchBaseResult::unavailable($base, null, BranchBaseUnavailableReason::UnrelatedHistory);
+        }
+
+        try {
+            $hashes = $this->commitsBetween($repoPath, $mergeBase, 'HEAD');
+        } catch (GitCommandException $exception) {
+            return $this->commandUnavailable($base, $mergeBase, 'list_commits', $exception);
+        }
 
         if ($hashes === []) {
             return BranchBaseResult::upToDate($base, $mergeBase);
         }
 
         return BranchBaseResult::ready($base, $mergeBase, $hashes);
+    }
+
+    private function resolveBaseRef(string $repoPath, string $base): ?string
+    {
+        if (str_starts_with($base, '-')) {
+            return null;
+        }
+
+        try {
+            $resolved = trim($this->gitProcessService->run($repoPath, [
+                'rev-parse', '--verify', '--quiet', '--end-of-options', $base.'^{commit}',
+            ]));
+        } catch (GitCommandException $exception) {
+            if ($exception->exitCode === 1) {
+                return null;
+            }
+
+            throw $exception;
+        }
+
+        return $resolved !== '' ? $resolved : null;
+    }
+
+    private function commandUnavailable(
+        string $baseBranch,
+        ?string $baseSha,
+        string $stage,
+        GitCommandException $exception,
+    ): BranchBaseResult {
+        Log::warning('git.branch_base.resolve_failed', [
+            'reason' => 'branch_base_resolve_failed',
+            'base_branch' => $baseBranch,
+            'stage' => $stage,
+            'exit_code' => $exception->exitCode,
+        ]);
+
+        return BranchBaseResult::unavailable(
+            $baseBranch,
+            $baseSha,
+            BranchBaseUnavailableReason::CommandFailed,
+        );
     }
 
     /**
@@ -74,20 +121,9 @@ final readonly class ResolveBranchBaseAction
      */
     private function commitsBetween(string $repoPath, string $from, string $to): array
     {
-        try {
-            $output = $this->gitProcessService->run($repoPath, [
-                'log', '--format=%H', $from.'..'.$to,
-            ]);
-        } catch (GitCommandException $e) {
-            Log::warning('git.commit_range.list_failed', [
-                'reason' => 'commit_range_list_failed',
-                'from' => $from,
-                'to' => $to,
-                'exit_code' => $e->exitCode,
-            ]);
-
-            return [];
-        }
+        $output = $this->gitProcessService->run($repoPath, [
+            'log', '--format=%H', $from.'..'.$to,
+        ]);
 
         return collect(explode("\n", trim($output)))
             ->filter()

--- a/app/Actions/ResolveBranchExplorerSelectionAction.php
+++ b/app/Actions/ResolveBranchExplorerSelectionAction.php
@@ -119,7 +119,7 @@ final readonly class ResolveBranchExplorerSelectionAction
     }
 
     /**
-     * @param  array{state: string, baseBranch: ?string, baseSha: ?string, hashesInRange: list<string>, commitCount: int}  $branchBase
+     * @param  array{state: string, baseBranch: ?string, baseSha: ?string, hashesInRange: list<string>, commitCount: int, unavailableReason: ?string}  $branchBase
      * @param  list<string>  $selectedHashes
      */
     private function isExactSinceBaseSelection(

--- a/app/DTOs/BranchBaseResult.php
+++ b/app/DTOs/BranchBaseResult.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\DTOs;
 
 use App\Enums\BranchBaseState;
+use App\Enums\BranchBaseUnavailableReason;
 
 final readonly class BranchBaseResult
 {
@@ -16,6 +17,7 @@ final readonly class BranchBaseResult
         public ?string $baseBranch,
         public ?string $baseSha,
         public array $hashesInRange,
+        public ?BranchBaseUnavailableReason $unavailableReason = null,
     ) {}
 
     public static function notConfigured(): self
@@ -44,7 +46,15 @@ final readonly class BranchBaseResult
         return new self(BranchBaseState::Ready, $baseBranch, $baseSha, $hashesInRange);
     }
 
-    /** @return array{state: string, baseBranch: ?string, baseSha: ?string, hashesInRange: list<string>, commitCount: int} */
+    public static function unavailable(
+        string $baseBranch,
+        ?string $baseSha,
+        BranchBaseUnavailableReason $reason,
+    ): self {
+        return new self(BranchBaseState::Unavailable, $baseBranch, $baseSha, [], $reason);
+    }
+
+    /** @return array{state: string, baseBranch: ?string, baseSha: ?string, hashesInRange: list<string>, commitCount: int, unavailableReason: ?string} */
     public function toArray(): array
     {
         return [
@@ -53,6 +63,7 @@ final readonly class BranchBaseResult
             'baseSha' => $this->baseSha,
             'hashesInRange' => $this->hashesInRange,
             'commitCount' => count($this->hashesInRange),
+            'unavailableReason' => $this->unavailableReason?->value,
         ];
     }
 }

--- a/app/DTOs/BranchExplorerSnapshot.php
+++ b/app/DTOs/BranchExplorerSnapshot.php
@@ -8,7 +8,7 @@ final readonly class BranchExplorerSnapshot
 {
     /**
      * @param  array{local: list<array<string, mixed>>, remote: list<array<string, mixed>>, current: string}  $branches
-     * @param  array{state: string, baseBranch: ?string, baseSha: ?string, hashesInRange: list<string>, commitCount: int}  $branchBase
+     * @param  array{state: string, baseBranch: ?string, baseSha: ?string, hashesInRange: list<string>, commitCount: int, unavailableReason: ?string}  $branchBase
      * @param  list<array<string, mixed>>  $commits
      */
     public function __construct(
@@ -24,7 +24,7 @@ final readonly class BranchExplorerSnapshot
     ) {}
 
     /**
-     * @param  array{state: string, baseBranch: ?string, baseSha: ?string, hashesInRange: list<string>, commitCount: int}  $branchBase
+     * @param  array{state: string, baseBranch: ?string, baseSha: ?string, hashesInRange: list<string>, commitCount: int, unavailableReason: ?string}  $branchBase
      */
     public static function keyFor(string $selectedBranch, ?string $selectedBranchTipSha, array $branchBase): string
     {
@@ -35,6 +35,7 @@ final readonly class BranchExplorerSnapshot
             'branchBaseBranch' => $branchBase['baseBranch'],
             'branchBaseSha' => $branchBase['baseSha'],
             'branchBaseHashes' => $branchBase['hashesInRange'],
+            'branchBaseUnavailableReason' => $branchBase['unavailableReason'],
         ], JSON_THROW_ON_ERROR));
     }
 
@@ -43,7 +44,7 @@ final readonly class BranchExplorerSnapshot
      *     branches: array{local: list<array<string, mixed>>, remote: list<array<string, mixed>>, current: string},
      *     selectedBranch: string,
      *     selectedBranchTipSha: ?string,
-     *     branchBase: array{state: string, baseBranch: ?string, baseSha: ?string, hashesInRange: list<string>, commitCount: int},
+     *     branchBase: array{state: string, baseBranch: ?string, baseSha: ?string, hashesInRange: list<string>, commitCount: int, unavailableReason: ?string},
      *     commits: list<array<string, mixed>>,
      *     hasMore: bool,
      *     pageSize: int,

--- a/app/Enums/BranchBaseState.php
+++ b/app/Enums/BranchBaseState.php
@@ -20,4 +20,7 @@ enum BranchBaseState: string
 
     /** HEAD is currently on the configured base branch - comparing to itself is nonsense. */
     case OnBaseBranch = 'on_base_branch';
+
+    /** Git could not produce a safe base comparison. */
+    case Unavailable = 'unavailable';
 }

--- a/app/Enums/BranchBaseUnavailableReason.php
+++ b/app/Enums/BranchBaseUnavailableReason.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum BranchBaseUnavailableReason: string
+{
+    case UnrelatedHistory = 'unrelated_history';
+
+    case CommandFailed = 'command_failed';
+}

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -8,13 +8,19 @@
         api.autoInstall(root);
     }
 })(typeof window !== 'undefined' ? window : null, function () {
-    // Mirrors App\Enums\BranchBaseState. Keep values in sync with the PHP enum.
+    // Mirrors the PHP branch-base enums. Keep values in sync.
     const BranchBaseState = Object.freeze({
         Ready: 'ready',
         NotConfigured: 'not_configured',
         UpToDate: 'up_to_date',
         MissingRef: 'missing_ref',
         OnBaseBranch: 'on_base_branch',
+        Unavailable: 'unavailable',
+    });
+
+    const BranchBaseUnavailableReason = Object.freeze({
+        UnrelatedHistory: 'unrelated_history',
+        CommandFailed: 'command_failed',
     });
 
     /**
@@ -189,6 +195,10 @@
                         return "you're on the base branch";
                     case BranchBaseState.NotConfigured:
                         return 'set a base branch to compare';
+                    case BranchBaseState.Unavailable:
+                        return base.unavailableReason === BranchBaseUnavailableReason.UnrelatedHistory
+                            ? 'base and current branch have unrelated histories'
+                            : 'unable to compare with the base branch';
                     default:
                         return '';
                 }
@@ -854,5 +864,5 @@
         }
     }
 
-    return { BranchBaseState, EMPTY_TREE_HASH, isSinceBaseExactly, violatesTipAnchor, stripRemotePrefix, createBranchExplorer, install, autoInstall };
+    return { BranchBaseState, BranchBaseUnavailableReason, EMPTY_TREE_HASH, isSinceBaseExactly, violatesTipAnchor, stripRemotePrefix, createBranchExplorer, install, autoInstall };
 });

--- a/public/js/branch-explorer.js
+++ b/public/js/branch-explorer.js
@@ -122,6 +122,7 @@
             lastSelectionIndex: -1,
             lastSelectionAnchorIsWT: false,
             _loadId: 0, // Stale-response guard: incremented before each async load, checked after
+            _openGeneration: 0,
 
             get isWorkingTreeActive() {
                 return this.activeCommitHash === null && this.selectedBranch === this.currentBranch;
@@ -278,6 +279,7 @@
             },
 
             async openPanel() {
+                const generation = ++this._openGeneration;
                 this.open = true;
                 this.search = '';
                 this.selectedIndex = 0;
@@ -286,19 +288,29 @@
                 this._clearSelectionError();
                 Alpine.store('overlays').open('branch-explorer');
 
-                await this.refreshSnapshot(this.selectedBranch || this.currentBranch, { force: true });
+                const refreshed = await this.refreshSnapshot(this.selectedBranch || this.currentBranch, { force: true });
+                if (!refreshed || !this._ownsOverlay(generation)) return;
 
                 const currentIdx = this.allFiltered.findIndex(b => b.name === this.selectedBranch);
                 if (currentIdx >= 0) this.selectedIndex = currentIdx;
                 this._rehydrateSelectionFromActiveView();
                 await this.$nextTick();
+                if (!this._ownsOverlay(generation)) return;
+
                 this._scrollActiveCommitIntoView();
                 this.$refs.searchInput?.focus();
             },
 
             closePanel() {
+                this._openGeneration++;
                 this.open = false;
                 if (Alpine.store('overlays').is('branch-explorer')) Alpine.store('overlays').close();
+            },
+
+            _ownsOverlay(generation) {
+                return this._openGeneration === generation
+                    && this.open
+                    && Alpine.store('overlays').is('branch-explorer');
             },
 
             async refreshSnapshot(branchName, { clear = false, force = false, minimumCommitCount = 0 } = {}) {

--- a/public/js/page-search.js
+++ b/public/js/page-search.js
@@ -203,35 +203,51 @@
                     }
                     return;
                 }
+                const previousIndex = this.currentMatch - 1;
                 if (backwards) {
                     this.currentMatch = this.currentMatch <= 1 ? total : this.currentMatch - 1;
                 } else {
                     this.currentMatch = this.currentMatch >= total ? 1 : this.currentMatch + 1;
                 }
-                this.updateCurrent(true);
+                this.updateCurrent(true, previousIndex);
             },
 
-            updateCurrent(scroll) {
+            updateCurrent(scroll, previousIndex = null) {
                 const total = this.matches.length;
                 const badge = `${this.currentMatch} of ${total}`;
-                this.matches.forEach((pieces, i) => {
-                    const isCurrent = (i + 1) === this.currentMatch;
-                    pieces.forEach((piece, j) => {
-                        piece.classList.toggle(CURRENT_CLASS, isCurrent);
-                        if (isCurrent && j === 0) {
-                            piece.setAttribute('data-match-number', badge);
-                        } else {
-                            piece.removeAttribute('data-match-number');
-                            piece.style.removeProperty('--rfa-match-center');
-                        }
+                const currentIndex = this.currentMatch - 1;
+
+                if (previousIndex === null) {
+                    this.matches.forEach((pieces, index) => {
+                        this.updateMatch(pieces, index === currentIndex, badge, scroll);
                     });
-                    if (isCurrent) {
-                        this.centerBadge(pieces);
-                        if (scroll && pieces[0]) {
-                            pieces[0].scrollIntoView({ block: 'center', behavior: 'smooth' });
-                        }
+
+                    return;
+                }
+
+                this.updateMatch(this.matches[previousIndex], false, badge, false);
+                this.updateMatch(this.matches[currentIndex], true, badge, scroll);
+            },
+
+            updateMatch(pieces, isCurrent, badge, scroll) {
+                if (!pieces) return;
+
+                pieces.forEach((piece, index) => {
+                    piece.classList.toggle(CURRENT_CLASS, isCurrent);
+                    if (isCurrent && index === 0) {
+                        piece.setAttribute('data-match-number', badge);
+                    } else {
+                        piece.removeAttribute('data-match-number');
+                        piece.style.removeProperty('--rfa-match-center');
                     }
                 });
+
+                if (!isCurrent) return;
+
+                this.centerBadge(pieces);
+                if (scroll && pieces[0]) {
+                    pieces[0].scrollIntoView({ block: 'center', behavior: 'smooth' });
+                }
             },
 
             // Center the "X of Y" pill on the horizontal midpoint of the whole

--- a/public/js/review-page.js
+++ b/public/js/review-page.js
@@ -288,32 +288,42 @@
 
     function createChangePoller(config = {}) {
         return {
-            hasChanges: false,
-            fingerprint: null,
-            currentCount: 0,
+            baselineFingerprint: null,
+            pendingChangeCount: null,
+            pollGeneration: 0,
             stopPoll: null,
+            get hasChanges() {
+                return this.pendingChangeCount !== null;
+            },
             async check() {
+                const generation = ++this.pollGeneration;
                 try {
                     const res = await fetch('/api/changes/' + config.projectId);
                     const data = await res.json();
-                    if (this.fingerprint === null) {
-                        this.fingerprint = data.fingerprint;
-                    } else if (data.fingerprint !== this.fingerprint) {
-                        const newCount = data.count ?? 0;
-                        if (!this.hasChanges || this.currentCount !== newCount) {
-                            this.hasChanges = true;
-                            this.currentCount = newCount;
-                        }
+
+                    if (generation !== this.pollGeneration) {
+                        return;
+                    }
+
+                    if (this.baselineFingerprint === null) {
+                        this.baselineFingerprint = data.fingerprint;
+
+                        return;
+                    }
+
+                    if (data.fingerprint !== this.baselineFingerprint) {
+                        this.pendingChangeCount = data.count ?? 0;
                     }
                 } catch {}
             },
             // Re-baseline after a refresh applied the pending changes. Bound to the
             // page's fingerprint-reset event.
             reset() {
-                this.fingerprint = null;
-                this.hasChanges = false;
-                this.currentCount = 0;
-                this.check();
+                this.pollGeneration++;
+                this.baselineFingerprint = null;
+                this.pendingChangeCount = null;
+
+                return this.check();
             },
             softRefresh() { this.$wire.softRefresh(); },
             hardReload() { window.location.reload(); },
@@ -321,7 +331,7 @@
                 if (!this.hasChanges) {
                     return `Refresh · ${config.refreshCombo} · ${config.hardReloadCombo} to hard reload`;
                 }
-                const n = this.currentCount;
+                const n = this.pendingChangeCount;
                 const noun = n === 1 ? 'file' : 'files';
                 return `${n} ${noun} changed externally - click to refresh`;
             },
@@ -342,6 +352,7 @@
                 }
             },
             destroy() {
+                this.pollGeneration++;
                 if (this.stopPoll) this.stopPoll();
                 // Drop the shortcut bindings on teardown so a poller that's gone
                 // (e.g. after navigating away) doesn't leave ⌘R pointing at a

--- a/resources/views/livewire/⚡branch-explorer.blade.php
+++ b/resources/views/livewire/⚡branch-explorer.blade.php
@@ -52,7 +52,7 @@ new class extends Component {
      * Surfaced so the picker can render the "Since {base}" row and pre-fill
      * checkboxes when clicked.
      *
-     * @var array{state: string, baseBranch: ?string, baseSha: ?string, hashesInRange: list<string>, commitCount: int}|null
+     * @var array{state: string, baseBranch: ?string, baseSha: ?string, hashesInRange: list<string>, commitCount: int, unavailableReason: ?string}|null
      */
     public ?array $branchBase = null;
 

--- a/tests/Js/branch-explorer.test.js
+++ b/tests/Js/branch-explorer.test.js
@@ -829,11 +829,32 @@ describe('snapshot loading', () => {
         delete window.Alpine;
     });
 
+    function deferred() {
+        let resolve;
+        const promise = new Promise((resolvePromise) => {
+            resolve = resolvePromise;
+        });
+
+        return { promise, resolve };
+    }
+
+    function installOverlayStore() {
+        let owner = null;
+        const overlays = {
+            open: vi.fn((name) => { owner = name; }),
+            is: vi.fn((name) => owner === name),
+            close: vi.fn(() => { owner = null; }),
+        };
+        global.Alpine = window.Alpine = { store: () => overlays };
+
+        return { overlays, setOwner: (name) => { owner = name; } };
+    }
+
     it('openPanel refreshes the snapshot even when commit rows are already loaded', async () => {
         const branches = { local: [{ name: 'main', isCurrent: true }], remote: [] };
         const a = createBranchExplorer({
             currentBranch: 'main',
-            activeCommitHash: null,
+            activeCommitHash: 'fresh',
             activeDiffFrom: 'HEAD',
             projectSlug: 'p',
             branches,
@@ -853,19 +874,135 @@ describe('snapshot loading', () => {
             branchBase: null,
             loadSnapshot,
         };
+        const scrollIntoView = vi.fn();
         a.$refs = {
             searchInput: { focus: vi.fn() },
-            commitList: { querySelector: vi.fn() },
+            commitList: { querySelector: vi.fn(() => ({ scrollIntoView })) },
         };
         a.$nextTick = vi.fn(async () => {});
-        global.Alpine = window.Alpine = {
-            store: () => ({ open: vi.fn(), is: vi.fn(() => true), close: vi.fn() }),
-        };
+        installOverlayStore();
 
         await a.openPanel();
 
         expect(loadSnapshot).toHaveBeenCalledWith('main', 0);
         expect(a.$wire.commits).toEqual([{ hash: 'fresh' }]);
+        expect(a.$nextTick).toHaveBeenCalledOnce();
+        expect(scrollIntoView).toHaveBeenCalledWith({ block: 'center' });
+        expect(a.$refs.searchInput.focus).toHaveBeenCalledOnce();
+    });
+
+    it('keeps a refreshed snapshot but skips focus and scroll after the panel closes', async () => {
+        const branches = { local: [{ name: 'main', isCurrent: true }], remote: [] };
+        const refreshedBranches = { local: [...branches.local, { name: 'feature', isCurrent: false }], remote: [] };
+        const refresh = deferred();
+        const a = createBranchExplorer({
+            currentBranch: 'main',
+            activeCommitHash: 'fresh',
+            activeDiffFrom: 'HEAD',
+            projectSlug: 'p',
+            branches,
+        });
+        const scrollIntoView = vi.fn();
+        a.$wire = {
+            commits: [{ hash: 'stale' }],
+            branches,
+            snapshotBranch: 'main',
+            branchBase: null,
+            loadSnapshot: vi.fn(async () => {
+                await refresh.promise;
+                a.$wire.branches = refreshedBranches;
+                a.$wire.commits = [{ hash: 'fresh' }];
+            }),
+        };
+        a.$refs = {
+            searchInput: { focus: vi.fn() },
+            commitList: { querySelector: vi.fn(() => ({ scrollIntoView })) },
+        };
+        a.$nextTick = vi.fn(async () => {});
+        installOverlayStore();
+
+        const opening = a.openPanel();
+        a.closePanel();
+        refresh.resolve();
+        await opening;
+
+        expect(a.allBranches).toBe(refreshedBranches);
+        expect(a.$nextTick).not.toHaveBeenCalled();
+        expect(scrollIntoView).not.toHaveBeenCalled();
+        expect(a.$refs.searchInput.focus).not.toHaveBeenCalled();
+    });
+
+    it('does not steal focus back after another overlay opens during refresh', async () => {
+        const branches = { local: [{ name: 'main', isCurrent: true }], remote: [] };
+        const refresh = deferred();
+        const a = createBranchExplorer({
+            currentBranch: 'main',
+            activeCommitHash: 'fresh',
+            activeDiffFrom: 'HEAD',
+            projectSlug: 'p',
+            branches,
+        });
+        const scrollIntoView = vi.fn();
+        a.$wire = {
+            commits: [{ hash: 'stale' }],
+            branches,
+            snapshotBranch: 'main',
+            branchBase: null,
+            loadSnapshot: vi.fn(async () => {
+                await refresh.promise;
+                a.$wire.commits = [{ hash: 'fresh' }];
+            }),
+        };
+        a.$refs = {
+            searchInput: { focus: vi.fn() },
+            commitList: { querySelector: vi.fn(() => ({ scrollIntoView })) },
+        };
+        a.$nextTick = vi.fn(async () => {});
+        const { setOwner } = installOverlayStore();
+
+        const opening = a.openPanel();
+        setOwner('comments-drawer');
+        refresh.resolve();
+        await opening;
+
+        expect(a.$nextTick).not.toHaveBeenCalled();
+        expect(scrollIntoView).not.toHaveBeenCalled();
+        expect(a.$refs.searchInput.focus).not.toHaveBeenCalled();
+    });
+
+    it('does not scroll or focus when overlay ownership changes during rendering', async () => {
+        const branches = { local: [{ name: 'main', isCurrent: true }], remote: [] };
+        const rendering = deferred();
+        const a = createBranchExplorer({
+            currentBranch: 'main',
+            activeCommitHash: 'fresh',
+            activeDiffFrom: 'HEAD',
+            projectSlug: 'p',
+            branches,
+        });
+        const scrollIntoView = vi.fn();
+        a.$wire = {
+            commits: [{ hash: 'fresh' }],
+            branches,
+            snapshotBranch: 'main',
+            branchBase: null,
+            loadSnapshot: vi.fn(),
+        };
+        a.$refs = {
+            searchInput: { focus: vi.fn() },
+            commitList: { querySelector: vi.fn(() => ({ scrollIntoView })) },
+        };
+        a.$nextTick = vi.fn(() => rendering.promise);
+        const { setOwner } = installOverlayStore();
+
+        const opening = a.openPanel();
+        await vi.waitFor(() => expect(a.$nextTick).toHaveBeenCalledOnce());
+        setOwner('comments-drawer');
+        rendering.resolve();
+        await opening;
+
+        expect(scrollIntoView).not.toHaveBeenCalled();
+        expect(a.$refs.searchInput.focus).not.toHaveBeenCalled();
     });
 
     it('loadMoreCommits updates branch state from the current load-more response', async () => {

--- a/tests/Js/branch-explorer.test.js
+++ b/tests/Js/branch-explorer.test.js
@@ -630,12 +630,12 @@ describe('since the beginning (entire repo)', () => {
 });
 
 describe('since-base row predictability', () => {
-    function withBase(state, { branch = 'main', baseBranch = 'main', commitCount = 3 } = {}) {
+    function withBase(state, { branch = 'main', baseBranch = 'main', commitCount = 3, unavailableReason = null } = {}) {
         return makeForView({
             branch,
             branchBase: state === null
                 ? null
-                : { state, baseBranch, commitCount, baseSha: 'base', hashesInRange: [] },
+                : { state, baseBranch, commitCount, baseSha: 'base', hashesInRange: [], unavailableReason },
         });
     }
 
@@ -645,6 +645,7 @@ describe('since-base row predictability', () => {
         expect(withBase(BranchBaseState.MissingRef).sinceBaseActionable).toBe(false);
         expect(withBase(BranchBaseState.NotConfigured).sinceBaseActionable).toBe(false);
         expect(withBase(BranchBaseState.OnBaseBranch).sinceBaseActionable).toBe(false);
+        expect(withBase(BranchBaseState.Unavailable).sinceBaseActionable).toBe(false);
     });
 
     it('is not actionable while browsing a different branch even when ready', () => {
@@ -658,6 +659,10 @@ describe('since-base row predictability', () => {
         expect(withBase(BranchBaseState.MissingRef).sinceBaseReason).toBe('base ref not found locally (run git fetch)');
         expect(withBase(BranchBaseState.OnBaseBranch).sinceBaseReason).toBe("you're on the base branch");
         expect(withBase(BranchBaseState.NotConfigured).sinceBaseReason).toBe('set a base branch to compare');
+        expect(withBase(BranchBaseState.Unavailable, { unavailableReason: 'unrelated_history' }).sinceBaseReason)
+            .toBe('base and current branch have unrelated histories');
+        expect(withBase(BranchBaseState.Unavailable, { unavailableReason: 'command_failed' }).sinceBaseReason)
+            .toBe('unable to compare with the base branch');
     });
 
     it('explains the off-branch case with the current branch name', () => {
@@ -707,15 +712,18 @@ describe('since-base auto-apply (row body)', () => {
 
     it('viewSinceBase is a noop when the row is not actionable', async () => {
         const upToDate = makeAutoApply({ branchBase: { ...readyBase, state: BranchBaseState.UpToDate } });
+        const unavailable = makeAutoApply({ branchBase: { ...readyBase, state: BranchBaseState.Unavailable } });
         const offBranch = makeAutoApply({ branch: 'feature/x' });
         const noBase = makeAutoApply({ branchBase: null });
         noBase.$wire.applySelection = vi.fn();
 
         await upToDate.viewSinceBase();
+        await unavailable.viewSinceBase();
         await offBranch.viewSinceBase();
         await noBase.viewSinceBase();
 
         expect(upToDate.$wire.applySelection).not.toHaveBeenCalled();
+        expect(unavailable.$wire.applySelection).not.toHaveBeenCalled();
         expect(offBranch.$wire.applySelection).not.toHaveBeenCalled();
         expect(noBase.$wire.applySelection).not.toHaveBeenCalled();
     });

--- a/tests/Js/page-search.test.js
+++ b/tests/Js/page-search.test.js
@@ -172,6 +172,23 @@ describe('refresh', () => {
         expect(data.currentMatch).toBe(0);
         expect(document.querySelectorAll('.rfa-search-match')).toHaveLength(0);
     });
+
+    it('rebuilds active state after the searchable DOM changes', () => {
+        document.body.innerHTML = '<p>cat one</p><p>cat two</p>';
+        data.query = 'cat';
+        data.refresh();
+        data.find(false);
+
+        document.body.insertAdjacentHTML('beforeend', '<p>cat three</p>');
+        data.refresh();
+
+        expect(data.matches).toHaveLength(3);
+        expect(data.currentMatch).toBe(1);
+        expect(document.querySelectorAll('.rfa-search-match--current')).toHaveLength(1);
+        expect(data.matches[0][0].getAttribute('data-match-number')).toBe('1 of 3');
+        expect(data.matches[1][0].hasAttribute('data-match-number')).toBe(false);
+        expect(data.matches[2][0].hasAttribute('data-match-number')).toBe(false);
+    });
 });
 
 describe('find', () => {
@@ -351,6 +368,31 @@ describe('updateCurrent', () => {
         expect(data.matches[1][0].classList.contains('rfa-search-match--current')).toBe(true);
     });
 
+    it('updates only the previous and next indexed groups during navigation', () => {
+        data.query = 'cat';
+        data.refresh();
+        const toggles = data.matches.map(([piece]) => vi.spyOn(piece.classList, 'toggle'));
+
+        data.find(false);
+
+        expect(toggles[0]).toHaveBeenCalledWith('rfa-search-match--current', false);
+        expect(toggles[1]).toHaveBeenCalledWith('rfa-search-match--current', true);
+        expect(toggles[2]).not.toHaveBeenCalled();
+    });
+
+    it('updates only the wrapped groups when navigation crosses either end', () => {
+        data.query = 'cat';
+        data.refresh();
+        const toggles = data.matches.map(([piece]) => vi.spyOn(piece.classList, 'toggle'));
+
+        data.find(true);
+
+        expect(toggles[0]).toHaveBeenCalledWith('rfa-search-match--current', false);
+        expect(toggles[1]).not.toHaveBeenCalled();
+        expect(toggles[2]).toHaveBeenCalledWith('rfa-search-match--current', true);
+        expect(data.currentMatch).toBe(3);
+    });
+
     it('toggles the current class on every span of a multi-piece match', () => {
         document.body.innerHTML = "<p><span>'</span><span>local</span><span>'</span></p>";
         data.query = "'local'";
@@ -368,6 +410,29 @@ describe('updateCurrent', () => {
         expect(spans[0].getAttribute('data-match-number')).toBe('1 of 1');
         expect(spans[1].hasAttribute('data-match-number')).toBe(false);
         expect(spans[2].hasAttribute('data-match-number')).toBe(false);
+    });
+
+    it('moves active state across every piece without touching other groups', () => {
+        document.body.innerHTML = [
+            "<p><span>'</span><span>local</span><span>'</span></p>",
+            "<p><span>'</span><span>local</span><span>'</span></p>",
+            "<p><span>'</span><span>local</span><span>'</span></p>",
+        ].join('');
+        data.query = "'local'";
+        data.refresh();
+        const untouchedToggles = data.matches[2].map((piece) => vi.spyOn(piece.classList, 'toggle'));
+
+        data.find(false);
+
+        data.matches[0].forEach((piece) => {
+            expect(piece.classList.contains('rfa-search-match--current')).toBe(false);
+        });
+        data.matches[1].forEach((piece) => {
+            expect(piece.classList.contains('rfa-search-match--current')).toBe(true);
+        });
+        untouchedToggles.forEach((toggle) => expect(toggle).not.toHaveBeenCalled());
+        expect(data.matches[0][0].hasAttribute('data-match-number')).toBe(false);
+        expect(data.matches[1][0].getAttribute('data-match-number')).toBe('2 of 3');
     });
 
     it('centers the badge across a multi-piece match via --rfa-match-center', () => {

--- a/tests/Js/review-page.test.js
+++ b/tests/Js/review-page.test.js
@@ -139,14 +139,24 @@ describe('createChangePoller', () => {
         return fn;
     }
 
+    function deferredResponse() {
+        let resolve;
+        const response = new Promise((resolvePromise) => {
+            resolve = (payload) => resolvePromise({ json: async () => payload });
+        });
+
+        return { response, resolve };
+    }
+
     it('baselines the fingerprint on the first check without flagging changes', async () => {
         respondWith({ fingerprint: 'fp-1', count: 0 });
         const poller = createChangePoller({ projectId: 5 });
 
         await poller.check();
 
-        expect(poller.fingerprint).toBe('fp-1');
+        expect(poller.baselineFingerprint).toBe('fp-1');
         expect(poller.hasChanges).toBe(false);
+        expect(poller.pendingChangeCount).toBeNull();
     });
 
     it('flags changes and records the count when the fingerprint moves', async () => {
@@ -158,7 +168,7 @@ describe('createChangePoller', () => {
 
         expect(fetchFn).toHaveBeenCalledWith('/api/changes/5');
         expect(poller.hasChanges).toBe(true);
-        expect(poller.currentCount).toBe(3);
+        expect(poller.pendingChangeCount).toBe(3);
     });
 
     it('swallows fetch failures and leaves state untouched', async () => {
@@ -167,8 +177,24 @@ describe('createChangePoller', () => {
 
         await poller.check();
 
-        expect(poller.fingerprint).toBeNull();
+        expect(poller.baselineFingerprint).toBeNull();
         expect(poller.hasChanges).toBe(false);
+        expect(poller.pendingChangeCount).toBeNull();
+    });
+
+    it.each([
+        new Error('offline'),
+        new DOMException('aborted', 'AbortError'),
+    ])('preserves an established baseline when a request fails', async (error) => {
+        const fetchFn = respondWith({ fingerprint: 'fp-1', count: 0 });
+        fetchFn.mockRejectedValueOnce(error);
+        const poller = createChangePoller({ projectId: 5 });
+
+        await poller.check();
+        await poller.check();
+
+        expect(poller.baselineFingerprint).toBe('fp-1');
+        expect(poller.pendingChangeCount).toBeNull();
     });
 
     it('reset() re-baselines and re-checks', async () => {
@@ -179,24 +205,82 @@ describe('createChangePoller', () => {
         await poller.check();
         expect(poller.hasChanges).toBe(true);
 
-        poller.reset();
-        await Promise.resolve();
-        await Promise.resolve();
+        await poller.reset();
 
         expect(poller.hasChanges).toBe(false);
-        expect(poller.currentCount).toBe(0);
-        expect(poller.fingerprint).toBe('fp-3');
+        expect(poller.pendingChangeCount).toBeNull();
+        expect(poller.baselineFingerprint).toBe('fp-3');
+    });
+
+    it('ignores a response from before reset establishes a new baseline', async () => {
+        const staleResponse = deferredResponse();
+        const currentResponse = deferredResponse();
+        const fetchFn = respondWith({ fingerprint: 'fp-1', count: 0 });
+        fetchFn
+            .mockReturnValueOnce(staleResponse.response)
+            .mockReturnValueOnce(currentResponse.response);
+        const poller = createChangePoller({ projectId: 5 });
+
+        await poller.check();
+        const staleCheck = poller.check();
+        const resetCheck = poller.reset();
+
+        currentResponse.resolve({ fingerprint: 'fp-3', count: 0 });
+        await resetCheck;
+        staleResponse.resolve({ fingerprint: 'fp-2', count: 2 });
+        await staleCheck;
+
+        expect(poller.baselineFingerprint).toBe('fp-3');
+        expect(poller.pendingChangeCount).toBeNull();
+    });
+
+    it('keeps the newest check when responses arrive out of order', async () => {
+        const olderResponse = deferredResponse();
+        const newerResponse = deferredResponse();
+        const fetchFn = respondWith({ fingerprint: 'fp-1', count: 0 });
+        fetchFn
+            .mockReturnValueOnce(olderResponse.response)
+            .mockReturnValueOnce(newerResponse.response);
+        const poller = createChangePoller({ projectId: 5 });
+
+        await poller.check();
+        const olderCheck = poller.check();
+        const newerCheck = poller.check();
+
+        newerResponse.resolve({ fingerprint: 'fp-3', count: 3 });
+        await newerCheck;
+        olderResponse.resolve({ fingerprint: 'fp-2', count: 2 });
+        await olderCheck;
+
+        expect(poller.baselineFingerprint).toBe('fp-1');
+        expect(poller.pendingChangeCount).toBe(3);
+    });
+
+    it('ignores pending work after destruction', async () => {
+        const pendingResponse = deferredResponse();
+        const fetchFn = respondWith({ fingerprint: 'fp-1', count: 0 });
+        fetchFn.mockReturnValueOnce(pendingResponse.response);
+        const poller = createChangePoller({ projectId: 5 });
+
+        await poller.check();
+        const pendingCheck = poller.check();
+        poller.destroy();
+
+        pendingResponse.resolve({ fingerprint: 'fp-2', count: 2 });
+        await pendingCheck;
+
+        expect(poller.baselineFingerprint).toBe('fp-1');
+        expect(poller.pendingChangeCount).toBeNull();
     });
 
     it('renders the changed-file count in the tooltip', () => {
         const poller = createChangePoller({ projectId: 5, refreshCombo: '⌘R', hardReloadCombo: '⌘⇧R' });
         expect(poller.tooltip).toBe('Refresh · ⌘R · ⌘⇧R to hard reload');
 
-        poller.hasChanges = true;
-        poller.currentCount = 1;
+        poller.pendingChangeCount = 1;
         expect(poller.tooltip).toBe('1 file changed externally - click to refresh');
 
-        poller.currentCount = 4;
+        poller.pendingChangeCount = 4;
         expect(poller.tooltip).toBe('4 files changed externally - click to refresh');
     });
 

--- a/tests/Unit/Actions/ResolveBranchBaseActionTest.php
+++ b/tests/Unit/Actions/ResolveBranchBaseActionTest.php
@@ -6,6 +6,9 @@ use App\Enums\BranchBaseUnavailableReason;
 use App\Exceptions\GitCommandException;
 use App\Services\GitProcessService;
 use Illuminate\Support\Facades\File;
+use Symfony\Component\Process\Exception\ProcessStartFailedException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Process;
 use Tests\TestCase;
 
 uses(TestCase::class);
@@ -125,6 +128,34 @@ test('returns Unavailable when listing the resolved range fails', function () {
         ->and($result->unavailableReason)->toBe(BranchBaseUnavailableReason::CommandFailed)
         ->and($result->baseSha)->toBe('merge-base')
         ->and($result->hashesInRange)->toBeEmpty();
+});
+
+test('returns Unavailable when merge-base times out', function () {
+    $process = new Process(['git', 'merge-base']);
+    $process->setTimeout(30);
+    $git = Mockery::mock(GitProcessService::class);
+    $git->shouldReceive('run')->once()->andReturn("base-sha\n");
+    $git->shouldReceive('run')->once()->andThrow(
+        new ProcessTimedOutException($process, ProcessTimedOutException::TYPE_GENERAL),
+    );
+
+    $result = (new ResolveBranchBaseAction($git))->handle('/tmp/repo', 'main', 'feature');
+
+    expect($result->state)->toBe(BranchBaseState::Unavailable)
+        ->and($result->unavailableReason)->toBe(BranchBaseUnavailableReason::CommandFailed);
+});
+
+test('returns Unavailable when merge-base cannot start', function () {
+    $git = Mockery::mock(GitProcessService::class);
+    $git->shouldReceive('run')->once()->andReturn("base-sha\n");
+    $git->shouldReceive('run')->once()->andThrow(
+        new ProcessStartFailedException(new Process(['git', 'merge-base']), 'unable to start'),
+    );
+
+    $result = (new ResolveBranchBaseAction($git))->handle('/tmp/repo', 'main', 'feature');
+
+    expect($result->state)->toBe(BranchBaseState::Unavailable)
+        ->and($result->unavailableReason)->toBe(BranchBaseUnavailableReason::CommandFailed);
 });
 
 test('treats detached HEAD (null currentBranch) as not on base branch', function () {

--- a/tests/Unit/Actions/ResolveBranchBaseActionTest.php
+++ b/tests/Unit/Actions/ResolveBranchBaseActionTest.php
@@ -2,7 +2,8 @@
 
 use App\Actions\ResolveBranchBaseAction;
 use App\Enums\BranchBaseState;
-use App\Services\GitMetadataService;
+use App\Enums\BranchBaseUnavailableReason;
+use App\Exceptions\GitCommandException;
 use App\Services\GitProcessService;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
@@ -17,10 +18,7 @@ beforeEach(function () {
     $this->commitTestRepo($this->tmpDir, 'shared');
     $this->sharedSha = trim($this->runTestRepoCommand($this->tmpDir, 'git rev-parse HEAD'));
 
-    $this->action = new ResolveBranchBaseAction(
-        new GitMetadataService(new GitProcessService),
-        new GitProcessService,
-    );
+    $this->action = new ResolveBranchBaseAction(new GitProcessService);
 });
 
 test('returns Ready with newest-first hashes when feature branch is ahead of base', function () {
@@ -79,7 +77,54 @@ test('returns MissingRef when base branch does not exist locally', function () {
     $result = $this->action->handle($this->tmpDir, 'origin/nonexistent', 'main');
 
     expect($result->state)->toBe(BranchBaseState::MissingRef)
-        ->and($result->baseBranch)->toBe('origin/nonexistent');
+        ->and($result->baseBranch)->toBe('origin/nonexistent')
+        ->and($result->unavailableReason)->toBeNull();
+});
+
+test('returns Unavailable for unrelated histories', function () {
+    $this->runTestRepoCommand($this->tmpDir, 'git checkout --orphan feature');
+    $this->runTestRepoCommand($this->tmpDir, 'git rm -rf .');
+    File::put($this->tmpDir.'/unrelated.txt', "unrelated\n");
+    $this->commitTestRepo($this->tmpDir, 'unrelated root');
+
+    $result = $this->action->handle($this->tmpDir, 'main', 'feature');
+
+    expect($result->state)->toBe(BranchBaseState::Unavailable)
+        ->and($result->unavailableReason)->toBe(BranchBaseUnavailableReason::UnrelatedHistory)
+        ->and($result->baseBranch)->toBe('main')
+        ->and($result->baseSha)->toBeNull();
+});
+
+test('returns Unavailable when ref resolution fails', function () {
+    $result = $this->action->handle('/path/that/does/not/exist', 'main', 'feature');
+
+    expect($result->state)->toBe(BranchBaseState::Unavailable)
+        ->and($result->unavailableReason)->toBe(BranchBaseUnavailableReason::CommandFailed)
+        ->and($result->baseBranch)->toBe('main')
+        ->and($result->baseSha)->toBeNull();
+});
+
+test('returns Unavailable when listing the resolved range fails', function () {
+    $git = Mockery::mock(GitProcessService::class);
+    $git->shouldReceive('run')
+        ->once()
+        ->with('/tmp/repo', ['rev-parse', '--verify', '--quiet', '--end-of-options', 'main^{commit}'])
+        ->andReturn("base-sha\n");
+    $git->shouldReceive('run')
+        ->once()
+        ->with('/tmp/repo', ['merge-base', 'base-sha', 'HEAD'])
+        ->andReturn("merge-base\n");
+    $git->shouldReceive('run')
+        ->once()
+        ->with('/tmp/repo', ['log', '--format=%H', 'merge-base..HEAD'])
+        ->andThrow(new GitCommandException('git log', 'failed', 128));
+
+    $result = (new ResolveBranchBaseAction($git))->handle('/tmp/repo', 'main', 'feature');
+
+    expect($result->state)->toBe(BranchBaseState::Unavailable)
+        ->and($result->unavailableReason)->toBe(BranchBaseUnavailableReason::CommandFailed)
+        ->and($result->baseSha)->toBe('merge-base')
+        ->and($result->hashesInRange)->toBeEmpty();
 });
 
 test('treats detached HEAD (null currentBranch) as not on base branch', function () {

--- a/tests/Unit/JsConstantParityTest.php
+++ b/tests/Unit/JsConstantParityTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\DTOs\DiffTarget;
+use App\Enums\BranchBaseState;
+use App\Enums\BranchBaseUnavailableReason;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
 
@@ -15,4 +17,24 @@ test('branch-explorer.js EMPTY_TREE_HASH matches the PHP constant', function () 
     $js = File::get(base_path('public/js/branch-explorer.js'));
 
     expect($js)->toMatch("/EMPTY_TREE_HASH\s*=\s*'".preg_quote(DiffTarget::EMPTY_TREE_HASH, '/')."'/");
+});
+
+test('branch-explorer.js branch-base enums match the PHP enums', function () {
+    $js = File::get(base_path('public/js/branch-explorer.js'));
+
+    $valuesFor = function (string $name) use ($js): array {
+        preg_match('/const '.preg_quote($name, '/').' = Object\.freeze\(\{(?<body>.*?)\}\);/s', $js, $enum);
+        preg_match_all("/^\\s+\\w+:\\s+'([^']+)',/m", $enum['body'] ?? '', $values);
+
+        return $values[1];
+    };
+
+    expect($valuesFor('BranchBaseState'))->toBe(
+        array_map(fn (BranchBaseState $state): string => $state->value, BranchBaseState::cases()),
+    )->and($valuesFor('BranchBaseUnavailableReason'))->toBe(
+        array_map(
+            fn (BranchBaseUnavailableReason $reason): string => $reason->value,
+            BranchBaseUnavailableReason::cases(),
+        ),
+    );
 });


### PR DESCRIPTION
## Why

Several review flows could apply stale asynchronous work or translate Git failures into valid branch states. Page-search navigation also scanned every rendered match when only two indexed groups needed updates.

## What changed

- Invalidate stale review polling responses after reset and teardown.
- Stop branch explorer focus and scroll work after overlay ownership changes.
- Preserve missing refs, unrelated histories, command failures, and up-to-date branch-base results.
- Update only the previous and next page-search match groups during navigation.

## Validation

- `npm test` (377 tests)
- `composer test:lint`
- `composer test:types`
- `composer test` (1,819 tests, 5,063 assertions)

## Closes

- https://github.com/fgilio/rfa/issues/149
- https://github.com/fgilio/rfa/issues/150
- https://github.com/fgilio/rfa/issues/151
- https://github.com/fgilio/rfa/issues/152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Branch comparisons now report unavailable states with clear reasons, including unrelated histories and command failures.
  - Search navigation updates match highlighting more efficiently.
- **Bug Fixes**
  - Prevented stale asynchronous refreshes from changing reopened or closed panels.
  - Improved review change polling during resets, failures, and out-of-order responses.
  - Preserved focus and scrolling safely after branch snapshot refreshes.
- **Tests**
  - Expanded coverage for unavailable comparisons, search navigation, polling behavior, refresh handling, and enum consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->