### PR TITLE
Own effective review settings, version the diff cache, unify .rfaignore, and model discards as one operation

### DIFF
--- a/app/Actions/BuildDiffContextAction.php
+++ b/app/Actions/BuildDiffContextAction.php
@@ -60,7 +60,7 @@ final readonly class BuildDiffContextAction
             $key = "{$comment['file']}:{$comment['side']}:{$comment['startLine']}:{$comment['endLine']}";
 
             if ($diffData->outcome === DiffLoadOutcome::TooLarge) {
-                $context[$key] = '[Diff skipped: '.DiffLoadOutcome::TooLarge->value.']';
+                $context[$key] = "[Diff skipped: {$diffData->outcome->value}]";
 
                 continue;
             }

--- a/app/Actions/BuildDiffContextAction.php
+++ b/app/Actions/BuildDiffContextAction.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\DTOs\DiffTarget;
+use App\DTOs\LoadedDiff;
+use App\Enums\DiffLoadOutcome;
 use App\Enums\DiffSide;
 use App\Enums\LineType;
 use App\Services\ReviewConfigService;
@@ -50,29 +52,26 @@ final readonly class BuildDiffContextAction
             $fileId = $file['id'];
 
             if (! array_key_exists($fileId, $loaded)) {
-                $cached = Cache::get(DiffCacheKey::for($repoPath, $fileId, $reviewFingerprint, $contextKey));
-                $loaded[$fileId] = DiffCacheKey::isCurrentShape($cached)
-                    ? $cached
-                    : $this->loadFileDiffAction->handle($repoPath, $file['path'], $file['isUntracked'] ?? false, oldPath: $file['oldPath'] ?? null, target: $target);
+                $loaded[$fileId] = LoadedDiff::fromCache(Cache::get(DiffCacheKey::for($repoPath, $fileId, $reviewFingerprint, $contextKey)))
+                    ?? $this->loadFileDiffAction->handle($repoPath, $file['path'], $file['isUntracked'] ?? false, oldPath: $file['oldPath'] ?? null, target: $target);
             }
 
             $diffData = $loaded[$fileId];
             $key = "{$comment['file']}:{$comment['side']}:{$comment['startLine']}:{$comment['endLine']}";
 
-            if (($diffData['tooLarge'] ?? false)) {
-                $reason = $diffData['skipReason'] ?? 'too-large';
-                $context[$key] = "[Diff skipped: {$reason}]";
+            if ($diffData->outcome === DiffLoadOutcome::TooLarge) {
+                $context[$key] = '[Diff skipped: '.DiffLoadOutcome::TooLarge->value.']';
 
                 continue;
             }
 
-            if (array_key_exists('error', $diffData)) {
+            if ($diffData->outcome === DiffLoadOutcome::TransientError) {
                 continue;
             }
 
             $useOld = $comment['side'] === DiffSide::Left->value;
             $lines = [];
-            foreach ($diffData['hunks'] as $hunk) {
+            foreach ($diffData->hunks() as $hunk) {
                 foreach ($hunk['lines'] as $line) {
                     // Use the line number for the comment's own side only. Falling back
                     // to the other side would pull in lines absent from this side. For example,

--- a/app/Actions/BuildDiffContextAction.php
+++ b/app/Actions/BuildDiffContextAction.php
@@ -7,6 +7,7 @@ namespace App\Actions;
 use App\DTOs\DiffTarget;
 use App\Enums\DiffSide;
 use App\Enums\LineType;
+use App\Services\ReviewConfigService;
 use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
 
@@ -14,6 +15,7 @@ final readonly class BuildDiffContextAction
 {
     public function __construct(
         private LoadFileDiffAction $loadFileDiffAction,
+        private ReviewConfigService $reviewConfigService,
     ) {}
 
     /**
@@ -33,6 +35,7 @@ final readonly class BuildDiffContextAction
         $loaded = [];
         $filesById = collect($files)->keyBy('id');
         $contextKey = ($target ?? DiffTarget::workingDirectory())->contextKey();
+        $reviewFingerprint = $this->reviewConfigService->resolve()->movedLineFingerprint();
 
         foreach ($comments as $comment) {
             if ($comment['startLine'] === null) {
@@ -47,7 +50,7 @@ final readonly class BuildDiffContextAction
             $fileId = $file['id'];
 
             if (! array_key_exists($fileId, $loaded)) {
-                $cached = Cache::get(DiffCacheKey::for($repoPath, $fileId, $contextKey));
+                $cached = Cache::get(DiffCacheKey::for($repoPath, $fileId, $reviewFingerprint, $contextKey));
                 $loaded[$fileId] = DiffCacheKey::isCurrentShape($cached)
                     ? $cached
                     : $this->loadFileDiffAction->handle($repoPath, $file['path'], $file['isUntracked'] ?? false, oldPath: $file['oldPath'] ?? null, target: $target);

--- a/app/Actions/BuildDiffContextAction.php
+++ b/app/Actions/BuildDiffContextAction.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\DTOs\DiffTarget;
-use App\DTOs\LoadedDiff;
 use App\Enums\DiffLoadOutcome;
 use App\Enums\DiffSide;
 use App\Enums\LineType;
 use App\Services\ReviewConfigService;
 use App\Support\DiffCacheKey;
-use Illuminate\Support\Facades\Cache;
 
 final readonly class BuildDiffContextAction
 {
@@ -37,7 +35,7 @@ final readonly class BuildDiffContextAction
         $loaded = [];
         $filesById = collect($files)->keyBy('id');
         $contextKey = ($target ?? DiffTarget::workingDirectory())->contextKey();
-        $reviewFingerprint = $this->reviewConfigService->resolve()->movedLineFingerprint();
+        $reviewFingerprint = $this->reviewConfigService->resolve()->cacheFingerprint();
 
         foreach ($comments as $comment) {
             if ($comment['startLine'] === null) {
@@ -52,15 +50,25 @@ final readonly class BuildDiffContextAction
             $fileId = $file['id'];
 
             if (! array_key_exists($fileId, $loaded)) {
-                $loaded[$fileId] = LoadedDiff::fromCache(Cache::get(DiffCacheKey::for($repoPath, $fileId, $reviewFingerprint, $contextKey)))
-                    ?? $this->loadFileDiffAction->handle($repoPath, $file['path'], $file['isUntracked'] ?? false, oldPath: $file['oldPath'] ?? null, target: $target);
+                // Read and write through the Action's own cache path rather than
+                // reimplementing it: exporting twice used to recompute every miss
+                // (a git spawn plus syntax highlighting per file) and throw the
+                // result away, because nothing wrote it back.
+                $loaded[$fileId] = $this->loadFileDiffAction->handle(
+                    $repoPath,
+                    $file['path'],
+                    $file['isUntracked'] ?? false,
+                    cacheKey: DiffCacheKey::for($repoPath, $fileId, $reviewFingerprint, $contextKey),
+                    oldPath: $file['oldPath'] ?? null,
+                    target: $target,
+                );
             }
 
             $diffData = $loaded[$fileId];
             $key = "{$comment['file']}:{$comment['side']}:{$comment['startLine']}:{$comment['endLine']}";
 
             if ($diffData->outcome === DiffLoadOutcome::TooLarge) {
-                $context[$key] = "[Diff skipped: {$diffData->outcome->value}]";
+                $context[$key] = '[Diff skipped: '.DiffLoadOutcome::TooLarge->value.']';
 
                 continue;
             }

--- a/app/Actions/CLAUDE.md
+++ b/app/Actions/CLAUDE.md
@@ -4,5 +4,6 @@ Business logic. Each Action is a single use-case callable from any interface (Li
 
 ## Caching
 
-- `LoadFileDiffAction` uses self-healing cache: validates cached entries have expected keys (e.g. `syntaxStyles`) before returning. Stale entries are re-computed and overwritten automatically. Prefer adding key checks over bumping `DiffCacheKey` version for format changes.
+- `LoadFileDiffAction` stores a `LoadedDiff` envelope stamped with `LoadedDiff::VERSION`. Entries written under any other version read back as misses and recompute, so a payload shape change means bumping that constant, not `DiffCacheKey`'s prefix. Bump the prefix only when cache *identity* changes (a new input to the key).
+- Every load ends in one `DiffLoadOutcome`. Only `DiffLoadOutcome::TransientError` is uncacheable, so a failed git process retries on the next read instead of serving the failure for the whole TTL.
 - Actions may accept an optional `cacheKey` param for opt-in caching. Use `DiffCacheKey::for()` for diff cache keys.

--- a/app/Actions/DiscardFileChangesAction.php
+++ b/app/Actions/DiscardFileChangesAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Enums\DiscardOperation;
 use App\Models\TrashedFile;
 use App\Services\GitProcessService;
 use App\Support\PathGuard;
@@ -35,13 +36,14 @@ final readonly class DiscardFileChangesAction
             PathGuard::assertRelative($oldPath);
         }
 
+        $operation = DiscardOperation::forChangedFile($status, $isUntracked);
+
         // Save content to trash before running git commands
         $trashRecord = TrashedFile::create([
             'project_id' => $projectId,
             'file_path' => $path,
-            'file_status' => $status,
-            'old_path' => $oldPath,
-            'is_untracked' => $isUntracked,
+            'operation' => $operation,
+            'old_path' => $operation->usesOldPath() ? $oldPath : null,
             'is_symlink' => $isSymlink,
             'comments' => ! empty($comments) ? $comments : null,
             'expires_at' => now()->addMinutes(30),
@@ -62,7 +64,7 @@ final readonly class DiscardFileChangesAction
 
         // Run the discard operation
         try {
-            $this->executeDiscard($repoPath, $path, $status, $oldPath, $isUntracked, $fullPath);
+            $this->executeDiscard($repoPath, $path, $operation, $oldPath, $fullPath);
         } catch (\Throwable $e) {
             // Roll back: deleting the record also purges its blob (TrashedFile::deleting).
             $trashRecord->delete();
@@ -75,16 +77,16 @@ final readonly class DiscardFileChangesAction
     private function executeDiscard(
         string $repoPath,
         string $path,
-        string $status,
+        DiscardOperation $operation,
         ?string $oldPath,
-        bool $isUntracked,
         string $fullPath,
     ): void {
-        match (true) {
-            $status === 'added' && $isUntracked => File::delete($fullPath),
-            $status === 'added' => $this->git->run($repoPath, ['rm', '-f', '--', $path]),
-            $status === 'renamed' => $this->git->run($repoPath, ['restore', '--source=HEAD', '--staged', '--worktree', '--', $oldPath, $path]),
-            default => $this->git->run($repoPath, ['restore', '--source=HEAD', '--staged', '--worktree', '--', $path]),
+        match ($operation) {
+            DiscardOperation::UntrackedFileDeleted => File::delete($fullPath),
+            DiscardOperation::AddedFileRemoved => $this->git->run($repoPath, ['rm', '-f', '--', $path]),
+            DiscardOperation::RenameReverted => $this->git->run($repoPath, ['restore', '--source=HEAD', '--staged', '--worktree', '--', (string) $oldPath, $path]),
+            DiscardOperation::DeletionReverted,
+            DiscardOperation::ModificationReverted => $this->git->run($repoPath, ['restore', '--source=HEAD', '--staged', '--worktree', '--', $path]),
         };
     }
 }

--- a/app/Actions/GetFileListAction.php
+++ b/app/Actions/GetFileListAction.php
@@ -10,6 +10,7 @@ use App\DTOs\ReviewChangeset;
 use App\Models\Project;
 use App\Services\ExternalFilesService;
 use App\Services\GitDiffService;
+use App\Services\ReviewConfigService;
 use App\Support\DiffCacheKey;
 use App\Support\FilePathSorter;
 
@@ -18,6 +19,7 @@ final readonly class GetFileListAction
     public function __construct(
         private GitDiffService $gitDiffService,
         private ExternalFilesService $externalFilesService,
+        private ReviewConfigService $reviewConfigService,
     ) {}
 
     /**
@@ -37,8 +39,10 @@ final readonly class GetFileListAction
 
         if ($clearCache && ! $target->isImmutable()) {
             $projectKey = $projectId ?? $repoPath;
-            collect($files)->each(function (array $file) use ($projectKey, $target): void {
-                DiffCacheKey::forget($projectKey, $file['id'], $target->contextKey());
+            $reviewFingerprint = $this->reviewConfigService->resolve()->movedLineFingerprint();
+
+            collect($files)->each(function (array $file) use ($projectKey, $reviewFingerprint, $target): void {
+                DiffCacheKey::forget($projectKey, $file['id'], $reviewFingerprint, $target->contextKey());
             });
         }
 

--- a/app/Actions/GetFileListAction.php
+++ b/app/Actions/GetFileListAction.php
@@ -39,7 +39,7 @@ final readonly class GetFileListAction
 
         if ($clearCache && ! $target->isImmutable()) {
             $projectKey = $projectId ?? $repoPath;
-            $reviewFingerprint = $this->reviewConfigService->resolve()->movedLineFingerprint();
+            $reviewFingerprint = $this->reviewConfigService->resolve()->cacheFingerprint();
 
             collect($files)->each(function (array $file) use ($projectKey, $reviewFingerprint, $target): void {
                 DiffCacheKey::forget($projectKey, $file['id'], $reviewFingerprint, $target->contextKey());

--- a/app/Actions/LoadFileDiffAction.php
+++ b/app/Actions/LoadFileDiffAction.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\DTOs\DiffTarget;
-use App\DTOs\FileDiff;
+use App\DTOs\LoadedDiff;
 use App\Exceptions\GitCommandException;
 use App\Services\CsvAlignerService;
 use App\Services\DiffParser;
@@ -15,7 +15,6 @@ use App\Services\MarkdownRegionService;
 use App\Services\MarkdownTableAlignerService;
 use App\Services\ReviewConfigService;
 use App\Services\SyntaxHighlightService;
-use App\Support\DiffCacheKey;
 use App\Support\LogSanitizer;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
@@ -37,13 +36,12 @@ final readonly class LoadFileDiffAction
 
     private readonly ReviewConfigService $reviewConfigService;
 
-    /** @return array{path: string, status: string, oldPath: ?string, hunks: array<int, array<string, mixed>>, additions: int, deletions: int, isBinary: bool, tooLarge: bool, skipReason?: ?string, syntaxStyles: string} */
-    public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, ?int $contextLines = null, ?DiffTarget $target = null, ?string $oldPath = null, ?string $externalAbsolutePath = null): array
+    public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, ?int $contextLines = null, ?DiffTarget $target = null, ?string $oldPath = null, ?string $externalAbsolutePath = null): LoadedDiff
     {
         $target ??= DiffTarget::workingDirectory();
         $reviewConfig = $this->reviewConfigService->resolve();
 
-        $compute = function () use ($repoPath, $path, $isUntracked, $contextLines, $target, $oldPath, $externalAbsolutePath, $reviewConfig): array {
+        $compute = function () use ($repoPath, $path, $isUntracked, $contextLines, $target, $oldPath, $externalAbsolutePath, $reviewConfig): LoadedDiff {
             try {
                 $rawDiff = $externalAbsolutePath !== null
                     ? $this->externalFilesService->buildDiff($externalAbsolutePath, $path)
@@ -56,16 +54,15 @@ final readonly class LoadFileDiffAction
                     'stderr_summary' => LogSanitizer::summary($e->stderr),
                 ]);
 
-                return FileDiff::emptyArray($path, 'modified', tooLarge: false)
-                    + ['error' => 'Failed to load diff for this file.', 'syntaxStyles' => '', 'headingsAnnotated' => true];
+                return LoadedDiff::transientError($path);
             }
 
             if ($rawDiff === null) {
-                return FileDiff::emptyArray($path, 'modified', tooLarge: true, skipReason: 'too-large') + ['syntaxStyles' => '', 'headingsAnnotated' => true];
+                return LoadedDiff::tooLarge($path);
             }
 
             if (trim($rawDiff) === '') {
-                return FileDiff::emptyArray($path, 'modified', tooLarge: false) + ['syntaxStyles' => '', 'headingsAnnotated' => true];
+                return LoadedDiff::empty($path);
             }
 
             // Untracked and external diffs are hand-built (never git-colorized),
@@ -77,7 +74,7 @@ final readonly class LoadFileDiffAction
             $fileDiff = $this->diffParser->parseSingle($rawDiff, detectMovedLines: $reviewConfig->movedLineDetection && ! $isHandBuiltDiff);
 
             if (! $fileDiff) {
-                return FileDiff::emptyArray($path, 'modified', tooLarge: false) + ['syntaxStyles' => '', 'headingsAnnotated' => true];
+                return LoadedDiff::unparsable($path);
             }
 
             $fileDiff = $fileDiff->withHunks(
@@ -107,40 +104,32 @@ final readonly class LoadFileDiffAction
                     ? $this->gitDiffService->countLinesInFile($externalAbsolutePath)
                     : $this->gitDiffService->getNewFileLineCount($repoPath, $path, $target));
 
-            return $fileDiff->withHunks($annotatedHunks)->toArray() + [
-                'tooLarge' => false,
-                'skipReason' => null,
-                'syntaxStyles' => $css,
-                'tableAligned' => true,
-                'newFileLineCount' => $newFileLineCount,
-                'headingsAnnotated' => true,
-                'gridLayout' => true,
-                'lineTypesAreEnum' => true,
-                'renameAware' => true,
-                'syntaxHighlighter' => $this->syntaxHighlightService->lastHighlighter(),
-            ];
+            return LoadedDiff::loaded(
+                $fileDiff->withHunks($annotatedHunks),
+                syntaxStyles: $css,
+                newFileLineCount: $newFileLineCount,
+                syntaxHighlighter: $this->syntaxHighlightService->lastHighlighter(),
+            );
         };
 
-        if ($cacheKey) {
-            $cached = Cache::get($cacheKey);
-            if (DiffCacheKey::isCurrentShape($cached)) {
-                return $cached;
-            }
-            $result = $compute();
-
-            // A git failure is transient, so don't persist it — the next read
-            // should retry rather than serve a cached error for the full TTL.
-            // Skip results (too-large/empty/no-parse) are deterministic and do
-            // carry the current cache shape, so they cache and stop re-spawning git.
-            if (! array_key_exists('error', $result)) {
-                $ttlHours = $target->cacheTtlHours($reviewConfig->cacheTtlHours);
-
-                Cache::put($cacheKey, $result, now()->addHours($ttlHours));
-            }
-
-            return $result;
+        if ($cacheKey === null) {
+            return $compute();
         }
 
-        return $compute();
+        $cached = LoadedDiff::fromCache(Cache::get($cacheKey));
+
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        $result = $compute();
+
+        if ($result->outcome->isCacheable()) {
+            $ttlHours = $target->cacheTtlHours($reviewConfig->cacheTtlHours);
+
+            Cache::put($cacheKey, $result->toArray(), now()->addHours($ttlHours));
+        }
+
+        return $result;
     }
 }

--- a/app/Actions/LoadFileDiffAction.php
+++ b/app/Actions/LoadFileDiffAction.php
@@ -116,7 +116,7 @@ final readonly class LoadFileDiffAction
             return $compute();
         }
 
-        $cached = LoadedDiff::fromCache(Cache::get($cacheKey));
+        $cached = LoadedDiff::tryFrom(Cache::get($cacheKey));
 
         if ($cached !== null) {
             return $cached;

--- a/app/Actions/ResolveReviewConfigAction.php
+++ b/app/Actions/ResolveReviewConfigAction.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\DTOs\ReviewConfig;
+use App\Services\ReviewConfigService;
+
+/**
+ * Hand the effective review configuration to interfaces that cannot reach
+ * ReviewConfigService themselves (Livewire components, console tooling), so
+ * every layer bases cache identity and TTLs on the same coerced values.
+ */
+final readonly class ResolveReviewConfigAction
+{
+    public function __construct(
+        private ReviewConfigService $reviewConfigService,
+    ) {}
+
+    public function handle(): ReviewConfig
+    {
+        return $this->reviewConfigService->resolve();
+    }
+}

--- a/app/Actions/RestoreDiscardedFileAction.php
+++ b/app/Actions/RestoreDiscardedFileAction.php
@@ -6,6 +6,7 @@ namespace App\Actions;
 
 use App\DTOs\CommentReply as CommentReplyData;
 use App\DTOs\CommentThreadSnapshot;
+use App\Enums\DiscardOperation;
 use App\Models\Comment;
 use App\Models\TrashedFile;
 use App\Support\PathGuard;
@@ -35,10 +36,12 @@ final readonly class RestoreDiscardedFileAction
             ? Storage::get($trashed->blobPath())
             : null;
 
-        match ($trashed->file_status) {
-            'deleted' => File::delete($fullPath),
-            'renamed' => $this->restoreRenamed($trashed, $repoPath, $fullPath, $content),
-            default => $this->writeContent($trashed, $fullPath, $content),
+        match ($trashed->operation) {
+            DiscardOperation::DeletionReverted => File::delete($fullPath),
+            DiscardOperation::RenameReverted => $this->restoreRenamed($trashed, $repoPath, $fullPath, $content),
+            DiscardOperation::UntrackedFileDeleted,
+            DiscardOperation::AddedFileRemoved,
+            DiscardOperation::ModificationReverted => $this->writeContent($trashed, $fullPath, $content),
         };
 
         $rawComments = $trashed->getAttribute('comments');

--- a/app/Concerns/ReviewPage/ManagesReviewTrash.php
+++ b/app/Concerns/ReviewPage/ManagesReviewTrash.php
@@ -86,7 +86,7 @@ trait ManagesReviewTrash
         DiffCacheKey::forget(
             $projectKey,
             $fileId,
-            app(ResolveReviewConfigAction::class)->handle()->movedLineFingerprint(),
+            app(ResolveReviewConfigAction::class)->handle()->cacheFingerprint(),
             $this->buildDiffTarget()->contextKey(),
         );
 

--- a/app/Concerns/ReviewPage/ManagesReviewTrash.php
+++ b/app/Concerns/ReviewPage/ManagesReviewTrash.php
@@ -8,6 +8,7 @@ use App\Actions\CleanExpiredTrashAction;
 use App\Actions\CreateCommentThreadSnapshotsAction;
 use App\Actions\DeleteTrashedFileAction;
 use App\Actions\DiscardFileChangesAction;
+use App\Actions\ResolveReviewConfigAction;
 use App\Actions\RestoreDiscardedFileAction;
 use App\Exceptions\GitCommandException;
 use App\Support\DiffCacheKey;
@@ -82,7 +83,12 @@ trait ManagesReviewTrash
 
         // Invalidate every diff-cache variant for this file (base + :full-context).
         $projectKey = $this->projectId > 0 ? $this->projectId : $this->repoPath;
-        DiffCacheKey::forget($projectKey, $fileId, $this->buildDiffTarget()->contextKey());
+        DiffCacheKey::forget(
+            $projectKey,
+            $fileId,
+            app(ResolveReviewConfigAction::class)->handle()->movedLineFingerprint(),
+            $this->buildDiffTarget()->contextKey(),
+        );
 
         unset($this->reviewedFiles[$file['path']]);
 

--- a/app/Console/Benchmark/DiffFixtureFactory.php
+++ b/app/Console/Benchmark/DiffFixtureFactory.php
@@ -6,6 +6,8 @@ namespace App\Console\Benchmark;
 
 use App\DTOs\CommentAuthor;
 use App\DTOs\FileListEntry;
+use App\DTOs\LoadedDiff;
+use App\Enums\DiffLoadOutcome;
 use App\Enums\DiffSide;
 use App\Enums\LineType;
 
@@ -45,8 +47,10 @@ use App\Enums\LineType;
  *     additions: int,
  *     deletions: int,
  *     isBinary: bool,
- *     tooLarge: bool,
+ *     cacheVersion: int,
+ *     outcome: string,
  *     syntaxStyles: string,
+ *     newFileLineCount: ?int,
  *     syntaxHighlighter: string
  * }
  * @phpstan-type CommentData array{
@@ -214,10 +218,11 @@ final class DiffFixtureFactory
             'additions' => $totalAdditions,
             'deletions' => $totalDeletions,
             'isBinary' => false,
-            'tooLarge' => false,
+            'cacheVersion' => LoadedDiff::VERSION,
+            'outcome' => DiffLoadOutcome::Loaded->value,
             'syntaxStyles' => '.hl-variable{color:#e36209;}.dark .hl-variable{color:#ffab70;}.hl-comment{color:#6a737d;}.dark .hl-comment{color:#6a737d;}',
+            'newFileLineCount' => null,
             'syntaxHighlighter' => 'fixture',
-            'lineTypesAreEnum' => true,
         ];
     }
 

--- a/app/Console/Benchmark/DiffFixtureFactory.php
+++ b/app/Console/Benchmark/DiffFixtureFactory.php
@@ -10,6 +10,7 @@ use App\DTOs\LoadedDiff;
 use App\Enums\DiffLoadOutcome;
 use App\Enums\DiffSide;
 use App\Enums\LineType;
+use RuntimeException;
 
 /**
  * @phpstan-type FileEntryData array{
@@ -210,20 +211,33 @@ final class DiffFixtureFactory
             $currentNewLine += 20;
         }
 
+        // Both halves of the shape are derived, never re-listed: the file keys
+        // come from FileDiff and the envelope keys from LoadedDiff, so a new key
+        // or a VERSION bump reaches the fixture automatically instead of leaving
+        // it to read back as a silent cache miss.
         return [
-            'path' => $path,
+            ...LoadedDiff::empty($path)->toArray(),
             'status' => 'modified',
-            'oldPath' => null,
             'hunks' => $hunkData,
             'additions' => $totalAdditions,
             'deletions' => $totalDeletions,
-            'isBinary' => false,
-            'cacheVersion' => LoadedDiff::VERSION,
             'outcome' => DiffLoadOutcome::Loaded->value,
             'syntaxStyles' => '.hl-variable{color:#e36209;}.dark .hl-variable{color:#ffab70;}.hl-comment{color:#6a737d;}.dark .hl-comment{color:#6a737d;}',
-            'newFileLineCount' => null,
             'syntaxHighlighter' => 'fixture',
         ];
+    }
+
+    /**
+     * The same fixture as {@see self::diffData()}, already wrapped. Fakes that
+     * stand in for LoadFileDiffAction need the DTO, not the stored array.
+     */
+    public static function loadedDiff(
+        int $hunks = 1,
+        int $linesPerHunk = 10,
+        string $path = 'src/Example.php',
+    ): LoadedDiff {
+        return LoadedDiff::tryFrom(self::diffData($hunks, $linesPerHunk, $path))
+            ?? throw new RuntimeException('The diff fixture no longer matches the LoadedDiff envelope.');
     }
 
     /** @return list<CommentData> */

--- a/app/Console/Benchmark/PerfScenarioRunner.php
+++ b/app/Console/Benchmark/PerfScenarioRunner.php
@@ -12,6 +12,7 @@ use App\Actions\ResolveProjectAction;
 use App\Actions\ResolveReviewConfigAction;
 use App\Actions\SessionStateAction;
 use App\DTOs\DiffTarget;
+use App\DTOs\LoadedDiff;
 use App\Models\Comment;
 use App\Models\CommentReply;
 use App\Models\Project;
@@ -231,7 +232,6 @@ final class PerfScenarioRunner
             /** @param  array<string, mixed>  $diffData */
             public function __construct(private readonly array $diffData) {}
 
-            /** @return array<string, mixed> */
             public function handle(
                 string $repoPath,
                 string $path,
@@ -241,8 +241,8 @@ final class PerfScenarioRunner
                 ?DiffTarget $target = null,
                 ?string $oldPath = null,
                 ?string $externalAbsolutePath = null,
-            ): array {
-                return $this->diffData;
+            ): LoadedDiff {
+                return LoadedDiff::fromCache($this->diffData) ?? LoadedDiff::empty($path);
             }
         });
 

--- a/app/Console/Benchmark/PerfScenarioRunner.php
+++ b/app/Console/Benchmark/PerfScenarioRunner.php
@@ -242,14 +242,14 @@ final class PerfScenarioRunner
                 ?string $oldPath = null,
                 ?string $externalAbsolutePath = null,
             ): LoadedDiff {
-                return LoadedDiff::fromCache($this->diffData) ?? LoadedDiff::empty($path);
+                return LoadedDiff::tryFrom($this->diffData) ?? LoadedDiff::empty($path);
             }
         });
 
         $cacheKey = DiffCacheKey::for(
             $project->id,
             $file['id'],
-            $this->app->make(ResolveReviewConfigAction::class)->handle()->movedLineFingerprint(),
+            $this->app->make(ResolveReviewConfigAction::class)->handle()->cacheFingerprint(),
         );
         Cache::put($cacheKey, $diffData, 3600);
 

--- a/app/Console/Benchmark/PerfScenarioRunner.php
+++ b/app/Console/Benchmark/PerfScenarioRunner.php
@@ -9,6 +9,7 @@ use App\Actions\GetFileListAction;
 use App\Actions\LoadCommentsDrawerAction;
 use App\Actions\LoadFileDiffAction;
 use App\Actions\ResolveProjectAction;
+use App\Actions\ResolveReviewConfigAction;
 use App\Actions\SessionStateAction;
 use App\DTOs\DiffTarget;
 use App\Models\Comment;
@@ -245,7 +246,11 @@ final class PerfScenarioRunner
             }
         });
 
-        $cacheKey = DiffCacheKey::for($project->id, $file['id']);
+        $cacheKey = DiffCacheKey::for(
+            $project->id,
+            $file['id'],
+            $this->app->make(ResolveReviewConfigAction::class)->handle()->movedLineFingerprint(),
+        );
         Cache::put($cacheKey, $diffData, 3600);
 
         // Mount-only renders the loading skeleton; `loadFileDiff` triggers the actual diff-grid + syntax-highlight work.

--- a/app/DTOs/DiffTarget.php
+++ b/app/DTOs/DiffTarget.php
@@ -90,17 +90,12 @@ final readonly class DiffTarget
     /**
      * Cache lifetime in hours for this target's diffs. An immutable target
      * caches for IMMUTABLE_TTL_HOURS since its diff never changes; a
-     * working-directory target uses the given TTL, falling back to the
-     * configured value when a caller (e.g. an SFC, which may not depend on
-     * ReviewConfigService) cannot supply the coerced one.
+     * working-directory target uses the effective TTL the caller resolved from
+     * ReviewConfig, so the stored entry and the pipeline that built it agree.
      */
-    public function cacheTtlHours(?int $workingDirectoryTtlHours = null): int
+    public function cacheTtlHours(int $workingDirectoryTtlHours): int
     {
-        if ($this->isImmutable()) {
-            return self::IMMUTABLE_TTL_HOURS;
-        }
-
-        return $workingDirectoryTtlHours ?? (int) config('rfa.cache_ttl_hours', 24);
+        return $this->isImmutable() ? self::IMMUTABLE_TTL_HOURS : $workingDirectoryTtlHours;
     }
 
     /** @return array{from: string, to: ?string} */

--- a/app/DTOs/FileDiff.php
+++ b/app/DTOs/FileDiff.php
@@ -35,13 +35,14 @@ class FileDiff
         );
     }
 
-    /** @return array<string, mixed> */
-    public static function emptyArray(
-        string $path,
-        string $status,
-        bool $tooLarge,
-        ?string $skipReason = null,
-    ): array {
+    /**
+     * The payload shape for a file whose diff carries no hunks. LoadedDiff
+     * wraps it for every non-Loaded outcome.
+     *
+     * @return array<string, mixed>
+     */
+    public static function emptyArray(string $path, string $status): array
+    {
         return [
             'path' => $path,
             'status' => $status,
@@ -52,18 +53,6 @@ class FileDiff
             'isBinary' => false,
             'isSymlink' => false,
             'symlinkTarget' => null,
-            'tooLarge' => $tooLarge,
-            'skipReason' => $skipReason,
-            // Cache-shape markers: skip results (too-large/empty/no-parse) must
-            // carry the same keys DiffCacheKey::isCurrentShape() asserts, or they
-            // fail validation on every read and re-spawn git forever. Callers add
-            // syntaxStyles/headingsAnnotated; the rest live here.
-            'tableAligned' => true,
-            'newFileLineCount' => null,
-            'gridLayout' => true,
-            'lineTypesAreEnum' => true,
-            'renameAware' => true,
-            'syntaxHighlighter' => 'none',
         ];
     }
 

--- a/app/DTOs/LoadedDiff.php
+++ b/app/DTOs/LoadedDiff.php
@@ -17,7 +17,7 @@ final readonly class LoadedDiff
 {
     /**
      * Stored format version. Bump it whenever the array {@see self::toArray()}
-     * writes changes shape: {@see self::fromCache()} reads every other version
+     * writes changes shape: {@see self::tryFrom()} reads every other version
      * as a miss, so entries written by an older build are recomputed.
      */
     public const VERSION = 1;
@@ -63,26 +63,26 @@ final readonly class LoadedDiff
     }
 
     /** Rebuild from a cached or in-flight array, or null when the entry is not a current envelope. */
-    public static function fromCache(mixed $cached): ?self
+    public static function tryFrom(mixed $stored): ?self
     {
-        if (! is_array($cached) || ($cached['cacheVersion'] ?? null) !== self::VERSION) {
+        if (! is_array($stored) || ($stored['cacheVersion'] ?? null) !== self::VERSION) {
             return null;
         }
 
-        $outcome = is_string($cached['outcome'] ?? null) ? DiffLoadOutcome::tryFrom($cached['outcome']) : null;
+        $outcome = is_string($stored['outcome'] ?? null) ? DiffLoadOutcome::tryFrom($stored['outcome']) : null;
 
         if ($outcome === null) {
             return null;
         }
 
-        $file = collect($cached)->except(self::ENVELOPE_KEYS)->all();
+        $file = collect($stored)->except(self::ENVELOPE_KEYS)->all();
 
         return new self(
             $outcome,
             $file,
-            is_string($cached['syntaxStyles'] ?? null) ? $cached['syntaxStyles'] : '',
-            is_int($cached['newFileLineCount'] ?? null) ? $cached['newFileLineCount'] : null,
-            is_string($cached['syntaxHighlighter'] ?? null) ? $cached['syntaxHighlighter'] : 'none',
+            is_string($stored['syntaxStyles'] ?? null) ? $stored['syntaxStyles'] : '',
+            is_int($stored['newFileLineCount'] ?? null) ? $stored['newFileLineCount'] : null,
+            is_string($stored['syntaxHighlighter'] ?? null) ? $stored['syntaxHighlighter'] : 'none',
         );
     }
 

--- a/app/DTOs/LoadedDiff.php
+++ b/app/DTOs/LoadedDiff.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs;
+
+use App\Enums\DiffLoadOutcome;
+
+/**
+ * The cache contract for one loaded file diff: an explicit outcome plus the
+ * rendered payload, stamped with the format version that wrote it.
+ *
+ * Livewire and Blade consume {@see self::toArray()}, never the object, so the
+ * component's state stays a plain array.
+ */
+final readonly class LoadedDiff
+{
+    /**
+     * Stored format version. Bump it whenever the array {@see self::toArray()}
+     * writes changes shape: {@see self::fromCache()} reads every other version
+     * as a miss, so entries written by an older build are recomputed.
+     */
+    public const VERSION = 1;
+
+    /** Envelope keys {@see self::toArray()} adds around the file payload. */
+    private const ENVELOPE_KEYS = ['cacheVersion', 'outcome', 'syntaxStyles', 'newFileLineCount', 'syntaxHighlighter'];
+
+    /**
+     * @param  array<string, mixed>  $file  A FileDiff::toArray() payload, or its empty equivalent.
+     */
+    private function __construct(
+        public DiffLoadOutcome $outcome,
+        public array $file,
+        public string $syntaxStyles,
+        public ?int $newFileLineCount,
+        public string $syntaxHighlighter,
+    ) {}
+
+    public static function loaded(FileDiff $fileDiff, string $syntaxStyles, ?int $newFileLineCount, string $syntaxHighlighter): self
+    {
+        return new self(DiffLoadOutcome::Loaded, $fileDiff->toArray(), $syntaxStyles, $newFileLineCount, $syntaxHighlighter);
+    }
+
+    /** Git produced no output for the file. */
+    public static function empty(string $path): self
+    {
+        return self::skipped(DiffLoadOutcome::Empty, $path);
+    }
+
+    public static function tooLarge(string $path): self
+    {
+        return self::skipped(DiffLoadOutcome::TooLarge, $path);
+    }
+
+    public static function unparsable(string $path): self
+    {
+        return self::skipped(DiffLoadOutcome::Unparsable, $path);
+    }
+
+    public static function transientError(string $path): self
+    {
+        return self::skipped(DiffLoadOutcome::TransientError, $path);
+    }
+
+    /** Rebuild from a cached or in-flight array, or null when the entry is not a current envelope. */
+    public static function fromCache(mixed $cached): ?self
+    {
+        if (! is_array($cached) || ($cached['cacheVersion'] ?? null) !== self::VERSION) {
+            return null;
+        }
+
+        $outcome = is_string($cached['outcome'] ?? null) ? DiffLoadOutcome::tryFrom($cached['outcome']) : null;
+
+        if ($outcome === null) {
+            return null;
+        }
+
+        $file = collect($cached)->except(self::ENVELOPE_KEYS)->all();
+
+        return new self(
+            $outcome,
+            $file,
+            is_string($cached['syntaxStyles'] ?? null) ? $cached['syntaxStyles'] : '',
+            is_int($cached['newFileLineCount'] ?? null) ? $cached['newFileLineCount'] : null,
+            is_string($cached['syntaxHighlighter'] ?? null) ? $cached['syntaxHighlighter'] : 'none',
+        );
+    }
+
+    /**
+     * The same diff re-read at full context. Gap expansion replaces the hunks
+     * and appends the styles the wider read introduced.
+     *
+     * @param  array<int, array<string, mixed>>  $hunks
+     */
+    public function withExpandedHunks(array $hunks, string $additionalSyntaxStyles): self
+    {
+        return new self(
+            $this->outcome,
+            [...$this->file, 'hunks' => $hunks],
+            $this->syntaxStyles.$additionalSyntaxStyles,
+            $this->newFileLineCount,
+            $this->syntaxHighlighter,
+        );
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function hunks(): array
+    {
+        $hunks = $this->file['hunks'] ?? [];
+
+        return is_array($hunks) ? $hunks : [];
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            ...$this->file,
+            'cacheVersion' => self::VERSION,
+            'outcome' => $this->outcome->value,
+            'syntaxStyles' => $this->syntaxStyles,
+            'newFileLineCount' => $this->newFileLineCount,
+            'syntaxHighlighter' => $this->syntaxHighlighter,
+        ];
+    }
+
+    private static function skipped(DiffLoadOutcome $outcome, string $path): self
+    {
+        return new self($outcome, FileDiff::emptyArray($path, 'modified'), '', null, 'none');
+    }
+}

--- a/app/DTOs/ReviewConfig.php
+++ b/app/DTOs/ReviewConfig.php
@@ -16,15 +16,27 @@ final readonly class ReviewConfig
     ) {}
 
     /**
-     * Cache-identity fingerprint for the moved-line settings. Git colorizes
-     * moves and the parser bakes those markers into the stored diff, so a
-     * cached diff is only valid for the settings that produced it. The mode
-     * only matters while detection is on, so a disabled run collapses to a
-     * single bucket.
+     * Cache-identity fingerprint for every setting that shapes a stored diff, so
+     * a cached entry is only ever read back by a run that would have produced
+     * it. Each covered setting changes the bytes we store:
+     *
+     * - moved-line detection and mode: git colorizes moves and the parser bakes
+     *   those markers into the hunks. The mode only matters while detection is
+     *   on, so a disabled run collapses to a single bucket.
+     * - `diffMaxBytes`: decides whether a file is diffed at all or stored as a
+     *   `too-large` outcome. Raising the limit must not keep serving the skip.
+     * - `defaultContextLines`: sets the `-U` width of the stored hunks.
+     *
+     * `sourceMaxBytes` and `cacheTtlHours` are deliberately absent: neither
+     * changes the diff content, so keying on them would discard good entries.
      */
-    public function movedLineFingerprint(): string
+    public function cacheFingerprint(): string
     {
-        return $this->movedLineDetection ? 'm1-'.$this->movedLineMode : 'm0';
+        return implode('|', [
+            $this->movedLineDetection ? 'm1-'.$this->movedLineMode : 'm0',
+            'b'.$this->diffMaxBytes,
+            'c'.$this->defaultContextLines,
+        ]);
     }
 
     /**

--- a/app/DTOs/ReviewConfig.php
+++ b/app/DTOs/ReviewConfig.php
@@ -16,6 +16,18 @@ final readonly class ReviewConfig
     ) {}
 
     /**
+     * Cache-identity fingerprint for the moved-line settings. Git colorizes
+     * moves and the parser bakes those markers into the stored diff, so a
+     * cached diff is only valid for the settings that produced it. The mode
+     * only matters while detection is on, so a disabled run collapses to a
+     * single bucket.
+     */
+    public function movedLineFingerprint(): string
+    {
+        return $this->movedLineDetection ? 'm1-'.$this->movedLineMode : 'm0';
+    }
+
+    /**
      * @return array{
      *     diffMaxBytes: int,
      *     sourceMaxBytes: int,

--- a/app/Enums/DiffLoadOutcome.php
+++ b/app/Enums/DiffLoadOutcome.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * How a diff load ended. Exactly one case describes any loaded diff, so cache
+ * readers and the renderer branch on this rather than on a combination of
+ * flags.
+ */
+enum DiffLoadOutcome: string
+{
+    /** Git produced a patch and the parser turned it into hunks. */
+    case Loaded = 'loaded';
+
+    /** Git produced no output: the file has no changes against the target. */
+    case Empty = 'empty';
+
+    /** The patch exceeded the configured byte cap and was never parsed. */
+    case TooLarge = 'too-large';
+
+    /** Git produced output the parser could not turn into a file diff. */
+    case Unparsable = 'unparsable';
+
+    /** The git process failed. The next read retries instead of serving this. */
+    case TransientError = 'transient-error';
+
+    /**
+     * A transient error says nothing about the file, only about one failed
+     * process, so storing it would serve the failure for the whole TTL.
+     */
+    public function isCacheable(): bool
+    {
+        return $this !== self::TransientError;
+    }
+}

--- a/app/Enums/DiscardOperation.php
+++ b/app/Enums/DiscardOperation.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * What a discard actually did to the working tree. One case per operation, so
+ * a trashed file cannot describe a combination that never happened, and each
+ * case maps to exactly one way of undoing it.
+ *
+ * Symlink state stays a separate field: it describes the content that was
+ * saved, not the operation that removed it.
+ */
+enum DiscardOperation: string
+{
+    /** An untracked file was deleted from disk. */
+    case UntrackedFileDeleted = 'untracked-file-deleted';
+
+    /** A staged new file was removed with `git rm`. */
+    case AddedFileRemoved = 'added-file-removed';
+
+    /** A rename was rolled back to HEAD on both paths. */
+    case RenameReverted = 'rename-reverted';
+
+    /** A deletion was rolled back, bringing the file back from HEAD. */
+    case DeletionReverted = 'deletion-reverted';
+
+    /** An edit to a tracked file was rolled back to HEAD. */
+    case ModificationReverted = 'modification-reverted';
+
+    /** The operation a discard of a file in the given list state performs. */
+    public static function forChangedFile(string $status, bool $isUntracked): self
+    {
+        return match (true) {
+            $status === 'added' && $isUntracked => self::UntrackedFileDeleted,
+            $status === 'added' => self::AddedFileRemoved,
+            $status === 'renamed' => self::RenameReverted,
+            $status === 'deleted' => self::DeletionReverted,
+            default => self::ModificationReverted,
+        };
+    }
+
+    /** Only a rename touches a second path, so only a rename may store one. */
+    public function usesOldPath(): bool
+    {
+        return $this === self::RenameReverted;
+    }
+}

--- a/app/Enums/DiscardOperation.php
+++ b/app/Enums/DiscardOperation.php
@@ -37,6 +37,10 @@ enum DiscardOperation: string
             $status === 'added' => self::AddedFileRemoved,
             $status === 'renamed' => self::RenameReverted,
             $status === 'deleted' => self::DeletionReverted,
+            // 'binary' is a display distinction in the file list, not a
+            // different discard: both roll the tracked file back to HEAD. It is
+            // listed so `default` stays a genuine fallback for unknown states.
+            $status === 'modified', $status === 'binary' => self::ModificationReverted,
             default => self::ModificationReverted,
         };
     }

--- a/app/Models/TrashedFile.php
+++ b/app/Models/TrashedFile.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Enums\DiscardOperation;
 use Database\Factories\TrashedFileFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
 
+/**
+ * @property DiscardOperation $operation
+ * @property ?string $old_path
+ */
 class TrashedFile extends Model
 {
     /** @use HasFactory<TrashedFileFactory> */
@@ -19,24 +25,39 @@ class TrashedFile extends Model
     protected $fillable = [
         'project_id',
         'file_path',
-        'file_status',
+        'operation',
         'old_path',
-        'is_untracked',
         'is_symlink',
         'comments',
         'expires_at',
     ];
 
-    /**
-     * Delete the on-disk content blob whenever the row is deleted, so a
-     * trashed file's content can never outlive its record. This is the single
-     * source of truth for blob cleanup — every deletion path must go through a
-     * model delete (NOT a query-builder bulk delete or a DB-level cascade,
-     * both of which bypass model events). Project deletion is handled in
-     * ProjectObserver::deleting for exactly that reason.
-     */
     protected static function booted(): void
     {
+        static::saving(function (TrashedFile $trashedFile): void {
+            throw_if(
+                $trashedFile->getAttribute('operation') === null,
+                InvalidArgumentException::class,
+                'The operation field is required to trash a file.',
+            );
+
+            $operation = $trashedFile->operation;
+
+            throw_unless(
+                $operation->usesOldPath() === ($trashedFile->old_path !== null),
+                InvalidArgumentException::class,
+                $operation->usesOldPath()
+                    ? "The old_path field is required for a {$operation->value} discard."
+                    : "The old_path field must be empty for a {$operation->value} discard.",
+            );
+        });
+
+        // Delete the on-disk content blob whenever the row is deleted, so a
+        // trashed file's content can never outlive its record. This is the
+        // single source of truth for blob cleanup: every deletion path must go
+        // through a model delete (NOT a query-builder bulk delete or a DB-level
+        // cascade, both of which bypass model events). Project deletion is
+        // handled in ProjectObserver::deleting for exactly that reason.
         static::deleting(function (TrashedFile $trashedFile): void {
             Storage::delete($trashedFile->blobPath());
         });
@@ -51,7 +72,7 @@ class TrashedFile extends Model
     {
         return [
             'expires_at' => 'datetime',
-            'is_untracked' => 'boolean',
+            'operation' => DiscardOperation::class,
             'is_symlink' => 'boolean',
             'comments' => 'array',
         ];

--- a/app/Services/GitDiffService.php
+++ b/app/Services/GitDiffService.php
@@ -46,10 +46,14 @@ class GitDiffService
             '--', '.',
         ]);
 
-        // Get +/- line counts for tracked changes
+        // Get +/- line counts for tracked changes. Lockfiles are excluded via
+        // pathspec so git never diffs them: `--numstat` computes real line
+        // counts, which is expensive for exactly the huge generated files the
+        // evaluator drops a moment later. Only the non-negatable lockfile set
+        // goes here, so this cannot disagree with isPathExcluded().
         $numstat = $this->git->run($repoPath, [
             ...$this->diffArgs($target, ['--numstat']),
-            '--', '.',
+            '--', '.', ...$this->ignoreService->alwaysExcludePathspecs(),
         ]);
 
         // Parse name-status into [path => [status, oldPath]]
@@ -289,7 +293,12 @@ class GitDiffService
 
     private function withWorkingTreeFileFingerprint(string $repoPath, string $line): string
     {
-        $path = $this->statusLineWorkingTreePath($line);
+        // A deleted file has no on-disk content left to fingerprint.
+        if (str_starts_with($line, "D\t")) {
+            return $line;
+        }
+
+        $path = $this->statusLinePath($line);
 
         if ($path === null) {
             return $line;
@@ -313,12 +322,6 @@ class GitDiffService
         return str_starts_with($status, 'R') || str_starts_with($status, 'C')
             ? ($parts[2] ?? null)
             : ($parts[1] ?? null);
-    }
-
-    /** The path whose on-disk content fingerprints the line, or null when nothing is left on disk. */
-    private function statusLineWorkingTreePath(string $line): ?string
-    {
-        return str_starts_with($line, "D\t") ? null : $this->statusLinePath($line);
     }
 
     public function getFileDiff(string $repoPath, string $path, bool $isUntracked = false, ?int $maxBytes = null, ?int $contextLines = null, ?DiffTarget $target = null, ?string $oldPath = null, bool $detectMovedLines = true): ?string

--- a/app/Services/GitDiffService.php
+++ b/app/Services/GitDiffService.php
@@ -38,19 +38,18 @@ class GitDiffService
     public function getFileList(string $repoPath, ?string $globalGitignorePath = null, ?DiffTarget $target = null): array
     {
         $target ??= DiffTarget::workingDirectory();
-        $excludes = $this->ignoreService->getExcludePathspecs($repoPath);
         $ignoreRules = $this->ignoreService->rules($repoPath);
 
         // Get status (M/A/D/R) for tracked changes
         $nameStatus = $this->git->run($repoPath, [
             ...$this->diffArgs($target, ['--name-status']),
-            '--', '.', ...$excludes,
+            '--', '.',
         ]);
 
         // Get +/- line counts for tracked changes
         $numstat = $this->git->run($repoPath, [
             ...$this->diffArgs($target, ['--numstat']),
-            '--', '.', ...$excludes,
+            '--', '.',
         ]);
 
         // Parse name-status into [path => [status, oldPath]]
@@ -104,6 +103,7 @@ class GitDiffService
         }
 
         $entries = collect($statusMap)
+            ->reject(fn (array $entry, string $path): bool => $this->ignoreService->isPathExcluded($path, $ignoreRules))
             ->map(function (array $entry, string $path) use ($statMap, $target, $repoPath): FileListEntry {
                 [$status, $oldPath] = $entry;
 
@@ -231,12 +231,11 @@ class GitDiffService
      */
     public function getWorkingDirectoryStatus(string $repoPath, ?string $globalGitignorePath = null): array
     {
-        $excludes = $this->ignoreService->getExcludePathspecs($repoPath);
         $ignoreRules = $this->ignoreService->rules($repoPath);
 
         $nameStatus = $this->git->run($repoPath, [
             ...$this->diffArgs(DiffTarget::workingDirectory(), ['--name-status']),
-            '--', '.', ...$excludes,
+            '--', '.',
         ]);
 
         $lsFilesArgs = ['ls-files', '--others', '--exclude-standard'];
@@ -253,18 +252,13 @@ class GitDiffService
             ),
         ]);
 
-        $lines = array_filter($lines, function (string $line) use ($ignoreRules) {
-            if (! str_starts_with($line, "?\t")) {
-                return true;
-            }
-
-            return ! $this->ignoreService->isPathExcluded(substr($line, 2), $ignoreRules);
-        });
-
-        $lines = array_map(
-            fn (string $line): string => $this->withWorkingTreeFileFingerprint($repoPath, $line),
-            $lines,
-        );
+        // The fingerprint must cover exactly the files getFileList() shows, so
+        // tracked and untracked lines run through the same evaluator here.
+        $lines = collect($lines)
+            ->reject(fn (string $line): bool => $this->ignoreService->isPathExcluded($this->statusLinePath($line) ?? '', $ignoreRules))
+            ->map(fn (string $line): string => $this->withWorkingTreeFileFingerprint($repoPath, $line))
+            ->values()
+            ->all();
 
         sort($lines);
 
@@ -306,20 +300,25 @@ class GitDiffService
         return $fingerprint === '' ? $line : "{$line}\t{$fingerprint}";
     }
 
-    private function statusLineWorkingTreePath(string $line): ?string
+    /** The path a status line is about: the destination for a rename or copy, the file itself otherwise. */
+    private function statusLinePath(string $line): ?string
     {
         $parts = preg_split('/\t/', $line);
         $status = $parts[0] ?? '';
 
-        if ($status === '' || $status === 'D') {
+        if ($status === '') {
             return null;
         }
 
-        if (str_starts_with($status, 'R') || str_starts_with($status, 'C')) {
-            return $parts[2] ?? null;
-        }
+        return str_starts_with($status, 'R') || str_starts_with($status, 'C')
+            ? ($parts[2] ?? null)
+            : ($parts[1] ?? null);
+    }
 
-        return $parts[1] ?? null;
+    /** The path whose on-disk content fingerprints the line, or null when nothing is left on disk. */
+    private function statusLineWorkingTreePath(string $line): ?string
+    {
+        return str_starts_with($line, "D\t") ? null : $this->statusLinePath($line);
     }
 
     public function getFileDiff(string $repoPath, string $path, bool $isUntracked = false, ?int $maxBytes = null, ?int $contextLines = null, ?DiffTarget $target = null, ?string $oldPath = null, bool $detectMovedLines = true): ?string
@@ -341,11 +340,13 @@ class GitDiffService
             return '';
         }
 
+        if ($this->ignoreService->isPathExcluded($path, $this->ignoreService->rules($repoPath))) {
+            return '';
+        }
+
         if ($isUntracked && $target->isWorkingDirectory()) {
             return $this->buildUntrackedDiff($repoPath, $path, $maxBytes);
         }
-
-        $excludes = $this->ignoreService->getExcludePathspecs($repoPath);
 
         // Rename-detection only fires when both sides of the rename are within
         // the pathspec; pass the old path alongside so git can pair them.
@@ -353,7 +354,7 @@ class GitDiffService
 
         $raw = $this->git->run($repoPath, [
             ...$this->diffArgs($target, ["--unified={$contextLines}", '--text'], detectMovedLines: $detectMovedLines, reviewConfig: $reviewConfig),
-            '--', $path, ...$renamePaths, ...$excludes,
+            '--', $path, ...$renamePaths,
         ]);
 
         // The size cap protects the parser and renderer from oversized diffs,

--- a/app/Services/IgnoreService.php
+++ b/app/Services/IgnoreService.php
@@ -7,11 +7,15 @@ namespace App\Services;
 use Illuminate\Support\Facades\File;
 
 /**
- * Filters files out of the changed-files list using `.rfaignore` — a
- * gitignore-flavoured file RFA reads itself (git's own ignore handling never
- * sees it). Tracked changes are pre-filtered by git via {@see self::getExcludePathspecs()};
- * untracked files are filtered in PHP via {@see self::isPathExcluded()}, which
- * is where the gitignore semantics below live.
+ * Filters files out of the changed-files list using `.rfaignore` (a
+ * gitignore-flavoured file RFA reads itself, since git's own ignore handling
+ * never sees it).
+ *
+ * {@see self::isPathExcluded()} is the only evaluator. Tracked and untracked
+ * files run through it alike, so a file's visibility never turns on whether git
+ * happens to track it. Git pathspecs are deliberately not used for this: a
+ * pathspec can express an exclude but not a `!` re-include, which is exactly
+ * where the two would disagree.
  *
  * Supported `.rfaignore` syntax (a practical subset of gitignore):
  * - `# comment` and blank lines are skipped.
@@ -21,13 +25,13 @@ use Illuminate\Support\Facades\File;
  * - a bare `name` matches at any depth (basename match).
  * - `*` matches within a path segment, `?` a single char, `**` across segments.
  *
- * Note: `!` re-inclusion is honoured for untracked files (the PHP path). Tracked
- * files are filtered by git pathspecs, which can express the exclude but not the
- * re-include, so a `!` rule does not resurrect a tracked file an exclude hid.
+ * A rename is judged on the path the user sees (the new one), so moving a file
+ * out of an ignored directory reveals it and moving one in hides it.
  */
 class IgnoreService
 {
-    private const ALWAYS_EXCLUDE = [
+    /** Lockfiles RFA hides from every review, ahead of and immune to `.rfaignore`. */
+    public const ALWAYS_EXCLUDE = [
         'package-lock.json',
         'pnpm-lock.yaml',
         'yarn.lock',
@@ -35,14 +39,25 @@ class IgnoreService
         'composer.lock',
     ];
 
+    /** @var array<int, array{regex: string, negated: bool}>|null */
+    private ?array $lockfileRules = null;
+
     /**
      * Whether a repo-relative path is excluded, applying the rules in order with
      * last-match-wins so `!` negations can re-include.
+     *
+     * Lockfiles are checked first and are not re-includable: they carry no
+     * review value at any size, and leaving them negatable would make the one
+     * rule set RFA guarantees depend on user input.
      *
      * @param  array<int, array{regex: string, negated: bool}>  $rules  Output of {@see self::rules()}.
      */
     public function isPathExcluded(string $path, array $rules): bool
     {
+        if ($this->matchesAny($path, $this->lockfileRules())) {
+            return true;
+        }
+
         $excluded = false;
 
         foreach ($rules as $rule) {
@@ -55,8 +70,9 @@ class IgnoreService
     }
 
     /**
-     * Parse the effective ignore rules for a repo (always-excluded lockfiles plus
-     * `.rfaignore`), in order, each precompiled to a matcher regex.
+     * The repo's `.rfaignore` rules in order, each precompiled to a matcher
+     * regex. Lockfiles are not included: {@see self::isPathExcluded()} applies
+     * them ahead of these.
      *
      * @return array<int, array{regex: string, negated: bool}>
      */
@@ -81,50 +97,35 @@ class IgnoreService
     }
 
     /**
-     * Git pathspecs that exclude the same files for tracked-change commands.
-     * Negation (`!`) lines are skipped — a pathspec can exclude but not re-include,
-     * and emitting one would wrongly exclude a file literally named like the rule.
-     *
-     * @return array<int, string>
-     */
-    public function getExcludePathspecs(string $repoPath): array
-    {
-        return collect($this->rawPatterns($repoPath))
-            ->reject(fn (string $pattern): bool => str_starts_with($pattern, '!'))
-            ->map(function (string $pattern): string {
-                $needsGlob = ! str_contains($pattern, '/') && ! str_contains($pattern, '*');
-
-                return $needsGlob
-                    ? ":(glob,exclude)**/{$pattern}"
-                    : ":(exclude){$pattern}";
-            })
-            ->values()
-            ->all();
-    }
-
-    /**
-     * Raw ignore lines: the always-excluded lockfiles followed by the user's
-     * `.rfaignore`, with comments and blanks stripped.
+     * The user's `.rfaignore` lines, with comments and blanks stripped.
      *
      * @return array<int, string>
      */
     private function rawPatterns(string $repoPath): array
     {
-        $patterns = self::ALWAYS_EXCLUDE;
-
         $ignoreFile = $repoPath.'/.rfaignore';
-        if (File::exists($ignoreFile)) {
-            $patterns = array_merge(
-                $patterns,
-                collect(explode("\n", File::get($ignoreFile)))
-                    ->map(fn (string $line): string => trim($line))
-                    ->reject(fn (string $line): bool => $line === '' || str_starts_with($line, '#'))
-                    ->values()
-                    ->all()
-            );
+
+        if (! File::exists($ignoreFile)) {
+            return [];
         }
 
-        return $patterns;
+        return collect(explode("\n", File::get($ignoreFile)))
+            ->map(fn (string $line): string => trim($line))
+            ->reject(fn (string $line): bool => $line === '' || str_starts_with($line, '#'))
+            ->values()
+            ->all();
+    }
+
+    /** @return array<int, array{regex: string, negated: bool}> */
+    private function lockfileRules(): array
+    {
+        return $this->lockfileRules ??= $this->compile(self::ALWAYS_EXCLUDE);
+    }
+
+    /** @param array<int, array{regex: string, negated: bool}> $rules */
+    private function matchesAny(string $path, array $rules): bool
+    {
+        return collect($rules)->contains(fn (array $rule): bool => preg_match($rule['regex'], $path) === 1);
     }
 
     /**

--- a/app/Services/IgnoreService.php
+++ b/app/Services/IgnoreService.php
@@ -13,9 +13,14 @@ use Illuminate\Support\Facades\File;
  *
  * {@see self::isPathExcluded()} is the only evaluator. Tracked and untracked
  * files run through it alike, so a file's visibility never turns on whether git
- * happens to track it. Git pathspecs are deliberately not used for this: a
- * pathspec can express an exclude but not a `!` re-include, which is exactly
+ * happens to track it. Git pathspecs are deliberately not used for `.rfaignore`:
+ * a pathspec can express an exclude but not a `!` re-include, which is exactly
  * where the two would disagree.
+ *
+ * The one exception is {@see self::alwaysExcludePathspecs()}, which covers only
+ * the lockfiles no `.rfaignore` rule can re-include. Because that set is fixed
+ * and non-negatable, the pathspec and the evaluator cannot reach different
+ * answers, so git is allowed to skip those paths before it diffs them.
  *
  * Supported `.rfaignore` syntax (a practical subset of gitignore):
  * - `# comment` and blank lines are skipped.
@@ -42,6 +47,9 @@ class IgnoreService
     /** @var array<int, array{regex: string, negated: bool}>|null */
     private ?array $lockfileRules = null;
 
+    /** @var array<string, array<int, array{regex: string, negated: bool}>> */
+    private array $rulesByRepo = [];
+
     /**
      * Whether a repo-relative path is excluded, applying the rules in order with
      * last-match-wins so `!` negations can re-include.
@@ -54,7 +62,7 @@ class IgnoreService
      */
     public function isPathExcluded(string $path, array $rules): bool
     {
-        if ($this->matchesAny($path, $this->lockfileRules())) {
+        if ($this->isLockfile($path)) {
             return true;
         }
 
@@ -78,7 +86,27 @@ class IgnoreService
      */
     public function rules(string $repoPath): array
     {
-        return $this->compile($this->rawPatterns($repoPath));
+        // Memoized per repo: getFileDiff() consults the rules once per file, so
+        // without this a review of N files re-reads and recompiles `.rfaignore`
+        // N times. A service instance never outlives a single request.
+        return $this->rulesByRepo[$repoPath] ??= $this->compile($this->rawPatterns($repoPath));
+    }
+
+    /**
+     * Pathspecs for the always-excluded lockfiles, for git commands whose cost
+     * scales with the paths they touch (`--numstat` diffs every file it lists).
+     *
+     * Safe precisely because this set is fixed and non-negatable: unlike
+     * `.rfaignore` rules, no `!` line can re-include a lockfile, so git skipping
+     * these paths can never disagree with {@see self::isPathExcluded()}.
+     *
+     * @return array<int, string>
+     */
+    public function alwaysExcludePathspecs(): array
+    {
+        return collect(self::ALWAYS_EXCLUDE)
+            ->map(fn (string $pattern): string => ":(glob,exclude)**/{$pattern}")
+            ->all();
     }
 
     /**
@@ -116,16 +144,12 @@ class IgnoreService
             ->all();
     }
 
-    /** @return array<int, array{regex: string, negated: bool}> */
-    private function lockfileRules(): array
+    private function isLockfile(string $path): bool
     {
-        return $this->lockfileRules ??= $this->compile(self::ALWAYS_EXCLUDE);
-    }
+        $this->lockfileRules ??= $this->compile(self::ALWAYS_EXCLUDE);
 
-    /** @param array<int, array{regex: string, negated: bool}> $rules */
-    private function matchesAny(string $path, array $rules): bool
-    {
-        return collect($rules)->contains(fn (array $rule): bool => preg_match($rule['regex'], $path) === 1);
+        return collect($this->lockfileRules)
+            ->contains(fn (array $rule): bool => preg_match($rule['regex'], $path) === 1);
     }
 
     /**

--- a/app/Support/DiffCacheKey.php
+++ b/app/Support/DiffCacheKey.php
@@ -44,24 +44,4 @@ final class DiffCacheKey
             Cache::forget(self::for($projectIdOrRepoPath, $fileId, $reviewFingerprint, $contextKey.$variant));
         }
     }
-
-    /**
-     * Each historical shape change adds a marker key; missing any means the
-     * entry predates a format change and must be recomputed.
-     *
-     * @phpstan-assert-if-true array<string, mixed> $cached
-     */
-    public static function isCurrentShape(mixed $cached): bool
-    {
-        return is_array($cached)
-            && array_key_exists('syntaxStyles', $cached)
-            && array_key_exists('isSymlink', $cached)
-            && array_key_exists('tableAligned', $cached)
-            && array_key_exists('newFileLineCount', $cached)
-            && array_key_exists('headingsAnnotated', $cached)
-            && array_key_exists('gridLayout', $cached)
-            && array_key_exists('lineTypesAreEnum', $cached)
-            && array_key_exists('renameAware', $cached)
-            && array_key_exists('syntaxHighlighter', $cached);
-    }
 }

--- a/app/Support/DiffCacheKey.php
+++ b/app/Support/DiffCacheKey.php
@@ -24,7 +24,7 @@ final class DiffCacheKey
 
     /**
      * @param  string  $reviewFingerprint  Effective review settings that shape the cached
-     *                                     content, from ReviewConfig::movedLineFingerprint().
+     *                                     content, from ReviewConfig::cacheFingerprint().
      *                                     Passing a raw config value here would let two runs
      *                                     with identical behavior land on different keys.
      */

--- a/app/Support/DiffCacheKey.php
+++ b/app/Support/DiffCacheKey.php
@@ -22,35 +22,15 @@ final class DiffCacheKey
      */
     public const VARIANTS = ['', ':full-context'];
 
-    public static function for(int|string $projectIdOrRepoPath, string $fileId, string $contextKey = self::WORKING_TREE_CONTEXT): string
-    {
-        return 'rfa_diff_v12_'.hash('xxh128', $projectIdOrRepoPath.':'.$contextKey.':'.self::movedLineFingerprint().':'.$fileId);
-    }
-
     /**
-     * Moved-line settings shape the cached hunk content: git colorizes moves
-     * and the parser bakes those markers into the stored diff. They must vary
-     * the key so flipping the setting cannot serve content computed under the
-     * old one. The mode only matters while detection is on, so a disabled run
-     * collapses to a single bucket.
+     * @param  string  $reviewFingerprint  Effective review settings that shape the cached
+     *                                     content, from ReviewConfig::movedLineFingerprint().
+     *                                     Passing a raw config value here would let two runs
+     *                                     with identical behavior land on different keys.
      */
-    private static function movedLineFingerprint(): string
+    public static function for(int|string $projectIdOrRepoPath, string $fileId, string $reviewFingerprint, string $contextKey = self::WORKING_TREE_CONTEXT): string
     {
-        // Keys are only built within a booted app in production. Pure-unit
-        // callers (no config bound) get a stable bucket, which still preserves
-        // every key relationship since the fingerprint is constant for them.
-        if (! app()->bound('config')) {
-            return 'm0';
-        }
-
-        // Read config directly rather than through ReviewConfigService: the
-        // Support layer must not depend on Services, and a raw value is enough
-        // to bucket the cache (the mode only matters while detection is on).
-        if (! config('rfa.moved_lines.enabled', false)) {
-            return 'm0';
-        }
-
-        return 'm1-'.(string) config('rfa.moved_lines.mode', 'zebra');
+        return 'rfa_diff_v13_'.hash('xxh128', $projectIdOrRepoPath.':'.$contextKey.':'.$reviewFingerprint.':'.$fileId);
     }
 
     /**
@@ -58,10 +38,10 @@ final class DiffCacheKey
      * this instead of forgetting a single {@see self::for()} key so new
      * variants (e.g. `:full-context`) can never be left stale.
      */
-    public static function forget(int|string $projectIdOrRepoPath, string $fileId, string $contextKey = self::WORKING_TREE_CONTEXT): void
+    public static function forget(int|string $projectIdOrRepoPath, string $fileId, string $reviewFingerprint, string $contextKey = self::WORKING_TREE_CONTEXT): void
     {
         foreach (self::VARIANTS as $variant) {
-            Cache::forget(self::for($projectIdOrRepoPath, $fileId, $contextKey.$variant));
+            Cache::forget(self::for($projectIdOrRepoPath, $fileId, $reviewFingerprint, $contextKey.$variant));
         }
     }
 

--- a/database/factories/TrashedFileFactory.php
+++ b/database/factories/TrashedFileFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Database\Factories;
 
+use App\Enums\DiscardOperation;
 use App\Models\Project;
 use App\Models\TrashedFile;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -23,13 +24,20 @@ class TrashedFileFactory extends Factory
         return [
             'project_id' => Project::factory(),
             'file_path' => 'src/'.fake()->unique()->slug(2).'.php',
-            'file_status' => 'modified',
+            'operation' => DiscardOperation::ModificationReverted,
             'old_path' => null,
-            'is_untracked' => false,
             'is_symlink' => false,
             'comments' => null,
             'expires_at' => now()->addMinutes(30),
         ];
+    }
+
+    public function renamed(string $oldPath = 'src/OldName.php'): static
+    {
+        return $this->state(fn () => [
+            'operation' => DiscardOperation::RenameReverted,
+            'old_path' => $oldPath,
+        ]);
     }
 
     public function expired(): static

--- a/database/migrations/2026_08_23_120000_replace_trashed_file_status_with_operation.php
+++ b/database/migrations/2026_08_23_120000_replace_trashed_file_status_with_operation.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Enums\DiscardOperation;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('trashed_files', function (Blueprint $table) {
+            $table->string('operation')->nullable()->after('file_path');
+        });
+
+        DB::table('trashed_files')->orderBy('id')->lazyById()->each(function (object $row): void {
+            DB::table('trashed_files')->where('id', $row->id)->update([
+                'operation' => DiscardOperation::forChangedFile(
+                    (string) $row->file_status,
+                    (bool) $row->is_untracked,
+                )->value,
+            ]);
+        });
+
+        Schema::table('trashed_files', function (Blueprint $table) {
+            $table->string('operation')->nullable(false)->change();
+            $table->dropColumn(['file_status', 'is_untracked']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('trashed_files', function (Blueprint $table) {
+            $table->string('file_status')->default('modified');
+            $table->boolean('is_untracked')->default(false);
+        });
+
+        DB::table('trashed_files')->orderBy('id')->lazyById()->each(function (object $row): void {
+            $operation = DiscardOperation::tryFrom((string) $row->operation) ?? DiscardOperation::ModificationReverted;
+
+            DB::table('trashed_files')->where('id', $row->id)->update([
+                'file_status' => match ($operation) {
+                    DiscardOperation::UntrackedFileDeleted, DiscardOperation::AddedFileRemoved => 'added',
+                    DiscardOperation::RenameReverted => 'renamed',
+                    DiscardOperation::DeletionReverted => 'deleted',
+                    DiscardOperation::ModificationReverted => 'modified',
+                },
+                'is_untracked' => $operation === DiscardOperation::UntrackedFileDeleted,
+            ]);
+        });
+
+        Schema::table('trashed_files', function (Blueprint $table) {
+            $table->dropColumn('operation');
+        });
+    }
+};

--- a/database/migrations/2026_08_23_120000_replace_trashed_file_status_with_operation.php
+++ b/database/migrations/2026_08_23_120000_replace_trashed_file_status_with_operation.php
@@ -14,12 +14,20 @@ return new class extends Migration
             $table->string('operation')->nullable()->after('file_path');
         });
 
+        // `old_path` is normalized alongside the operation, not just carried
+        // over: the legacy writer stored whatever it was handed, so a non-rename
+        // row can hold one. Left in place it would satisfy the schema but
+        // violate the operation/old_path pairing TrashedFile now enforces,
+        // making the row unsaveable the next time anything touched it.
         DB::table('trashed_files')->orderBy('id')->lazyById()->each(function (object $row): void {
+            $operation = DiscardOperation::forChangedFile(
+                (string) $row->file_status,
+                (bool) $row->is_untracked,
+            );
+
             DB::table('trashed_files')->where('id', $row->id)->update([
-                'operation' => DiscardOperation::forChangedFile(
-                    (string) $row->file_status,
-                    (bool) $row->is_untracked,
-                )->value,
+                'operation' => $operation->value,
+                'old_path' => $operation->usesOldPath() ? $row->old_path : null,
             ]);
         });
 

--- a/resources/views/components/diff/file-header.blade.php
+++ b/resources/views/components/diff/file-header.blade.php
@@ -3,7 +3,7 @@
      $wire.copyContent(), $dispatch('open-remote-menu' | 'discard-file' | 'copy-to-clipboard') --}}
 @props([
     'file',
-    'diffData' => null,
+    'outcome' => null,
     'hasRemote' => false,
     'diffTo' => null,
     'repoPath' => '',
@@ -13,7 +13,7 @@
 @php
     $showContentCopy = ! ($file['isBinary'] ?? false)
         && ! ($file['isSymlink'] ?? false)
-        && ($diffData['outcome'] ?? null) !== \App\Enums\DiffLoadOutcome::TooLarge->value;
+        && $outcome !== \App\Enums\DiffLoadOutcome::TooLarge;
     $isAdded = ($file['status'] ?? '') === 'added' || ($file['isUntracked'] ?? false);
     $isDeleted = ($file['status'] ?? '') === 'deleted';
 @endphp

--- a/resources/views/components/diff/file-header.blade.php
+++ b/resources/views/components/diff/file-header.blade.php
@@ -13,7 +13,7 @@
 @php
     $showContentCopy = ! ($file['isBinary'] ?? false)
         && ! ($file['isSymlink'] ?? false)
-        && ! ($diffData['tooLarge'] ?? false);
+        && ($diffData['outcome'] ?? null) !== \App\Enums\DiffLoadOutcome::TooLarge->value;
     $isAdded = ($file['status'] ?? '') === 'added' || ($file['isUntracked'] ?? false);
     $isDeleted = ($file['status'] ?? '') === 'deleted';
 @endphp

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -58,8 +58,6 @@ new class extends Component {
 
     private ?DiffTarget $cachedTarget = null;
 
-    private ?ReviewConfig $cachedReviewConfig = null;
-
     public function placeholder(): string
     {
         return <<<'HTML'
@@ -76,7 +74,7 @@ HTML;
 
     public function hydrate(): void
     {
-        $this->diffData = LoadedDiff::fromCache(Cache::get($this->diffCacheKey()))?->toArray();
+        $this->diffData = LoadedDiff::tryFrom(Cache::get($this->diffCacheKey()))?->toArray();
     }
 
     /** @param array<int, array<string, mixed>> $comments */
@@ -204,7 +202,7 @@ HTML;
 
     public function expandGap(int $hunkIndex, ?int $lineCount = null): void
     {
-        $loaded = LoadedDiff::fromCache($this->diffData);
+        $loaded = LoadedDiff::tryFrom($this->diffData);
 
         if ($loaded === null || $loaded->hunks() === []) {
             // Diff fell out of cache between render and click: nothing to expand.
@@ -295,7 +293,7 @@ HTML;
             'extension' => isset($this->file['path']) ? pathinfo((string) $this->file['path'], PATHINFO_EXTENSION) : '',
             'status' => ($this->file['isUntracked'] ?? false) ? 'added' : ($this->file['status'] ?? 'modified'),
             'target' => $this->buildDiffTarget()->contextKey(),
-            'too_large' => ($diffData['outcome'] ?? null) === DiffLoadOutcome::TooLarge->value,
+            'too_large' => $this->outcome($diffData) === DiffLoadOutcome::TooLarge,
             'binary' => (bool) ($diffData['isBinary'] ?? false),
             'hunk_count' => count($diffData['hunks'] ?? []),
             'diff_line_count' => $lineCount,
@@ -396,7 +394,21 @@ HTML;
 
     private function reviewConfig(): ReviewConfig
     {
-        return $this->cachedReviewConfig ??= app(ResolveReviewConfigAction::class)->handle();
+        // ReviewConfigService is a container singleton that memoizes resolve(),
+        // so this is already cheap enough not to need a local copy.
+        return app(ResolveReviewConfigAction::class)->handle();
+    }
+
+    /**
+     * The load outcome of the currently-held diff, as an enum. The stored
+     * envelope carries the backing string, so this is the single place that
+     * converts it — the view compares cases, never strings.
+     */
+    private function outcome(?array $diffData): ?DiffLoadOutcome
+    {
+        $outcome = $diffData['outcome'] ?? null;
+
+        return is_string($outcome) ? DiffLoadOutcome::tryFrom($outcome) : null;
     }
 
     private function diffCacheKey(string $variant = ''): string
@@ -406,14 +418,17 @@ HTML;
         return DiffCacheKey::for(
             $projectKey,
             $this->file['id'],
-            $this->reviewConfig()->movedLineFingerprint(),
+            $this->reviewConfig()->cacheFingerprint(),
             $this->buildDiffTarget()->contextKey().$variant,
         );
     }
 
     public function render(): \Illuminate\Contracts\View\View
     {
-        return $this->view(['diffData' => $this->diffData]);
+        return $this->view([
+            'diffData' => $this->diffData,
+            'outcome' => $this->outcome($this->diffData),
+        ]);
     }
 };
 ?>
@@ -459,7 +474,7 @@ HTML;
 >
     <x-diff.file-header
         :file="$file"
-        :diff-data="$diffData"
+        :outcome="$outcome"
         :has-remote="$hasRemote"
         :diff-to="$diffTo"
         :repo-path="$repoPath"
@@ -576,12 +591,12 @@ HTML;
             <div x-intersect.once="setTimeout(() => { markDiffActionStart('loadFileDiff'); $wire.loadFileDiff(); }, {{ $loadDelay }})">
                 <x-diff-skeleton />
             </div>
-        @elseif(($diffData['outcome'] ?? null) === DiffLoadOutcome::TooLarge->value)
+        @elseif($outcome === DiffLoadOutcome::TooLarge)
             <div class="px-4 py-8 text-center">
                 <flux:icon icon="exclamation-triangle" variant="outline" class="!size-4 inline-block text-gh-muted mr-1" />
                 <flux:text variant="subtle" size="sm" inline>File diff too large to display</flux:text>
             </div>
-        @elseif(($diffData['outcome'] ?? null) === DiffLoadOutcome::TransientError->value)
+        @elseif($outcome === DiffLoadOutcome::TransientError)
             <div class="px-4 py-8 text-center">
                 <flux:icon icon="exclamation-triangle" variant="outline" class="!size-4 inline-block text-gh-red mr-1" />
                 <flux:text variant="subtle" size="sm" inline>Git error: failed to load the diff for this file.</flux:text>

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -4,7 +4,9 @@ use App\Actions\ExpandDiffGapAction;
 use App\Actions\GetFileCopyContentAction;
 use App\Actions\LoadFileDiffAction;
 use App\Actions\RecordRuntimeDiagnosticAction;
+use App\Actions\ResolveReviewConfigAction;
 use App\DTOs\DiffTarget;
+use App\DTOs\ReviewConfig;
 use App\Enums\DiffSide;
 use App\Enums\GitRef;
 use App\Support\DiffCacheKey;
@@ -53,6 +55,8 @@ new class extends Component {
     private bool $contextExpanded = false;
 
     private ?DiffTarget $cachedTarget = null;
+
+    private ?ReviewConfig $cachedReviewConfig = null;
 
     public function placeholder(): string
     {
@@ -242,7 +246,11 @@ HTML;
             $this->diffData['syntaxStyles'] = ($this->diffData['syntaxStyles'] ?? '').$fullDiff['syntaxStyles'];
         }
 
-        Cache::put($this->diffCacheKey(), $this->diffData, now()->addHours($this->buildDiffTarget()->cacheTtlHours()));
+        Cache::put(
+            $this->diffCacheKey(),
+            $this->diffData,
+            now()->addHours($this->buildDiffTarget()->cacheTtlHours($this->reviewConfig()->cacheTtlHours)),
+        );
 
         $durationMs = $this->durationSince($startedAt);
 
@@ -382,11 +390,21 @@ HTML;
         return $this->cachedTarget ??= DiffTarget::fromRefs($this->diffFrom, $this->diffTo);
     }
 
+    private function reviewConfig(): ReviewConfig
+    {
+        return $this->cachedReviewConfig ??= app(ResolveReviewConfigAction::class)->handle();
+    }
+
     private function diffCacheKey(string $variant = ''): string
     {
         $projectKey = $this->projectId > 0 ? $this->projectId : $this->repoPath;
 
-        return DiffCacheKey::for($projectKey, $this->file['id'], $this->buildDiffTarget()->contextKey().$variant);
+        return DiffCacheKey::for(
+            $projectKey,
+            $this->file['id'],
+            $this->reviewConfig()->movedLineFingerprint(),
+            $this->buildDiffTarget()->contextKey().$variant,
+        );
     }
 
     public function render(): \Illuminate\Contracts\View\View

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -6,7 +6,9 @@ use App\Actions\LoadFileDiffAction;
 use App\Actions\RecordRuntimeDiagnosticAction;
 use App\Actions\ResolveReviewConfigAction;
 use App\DTOs\DiffTarget;
+use App\DTOs\LoadedDiff;
 use App\DTOs\ReviewConfig;
+use App\Enums\DiffLoadOutcome;
 use App\Enums\DiffSide;
 use App\Enums\GitRef;
 use App\Support\DiffCacheKey;
@@ -74,8 +76,7 @@ HTML;
 
     public function hydrate(): void
     {
-        $cached = Cache::get($this->diffCacheKey());
-        $this->diffData = DiffCacheKey::isCurrentShape($cached) ? $cached : null;
+        $this->diffData = LoadedDiff::fromCache(Cache::get($this->diffCacheKey()))?->toArray();
     }
 
     /** @param array<int, array<string, mixed>> $comments */
@@ -117,7 +118,7 @@ HTML;
             target: $this->buildDiffTarget(),
             oldPath: $this->file['oldPath'] ?? null,
             externalAbsolutePath: $this->file['externalAbsolutePath'] ?? null,
-        );
+        )->toArray();
 
         $durationMs = $this->durationSince($startedAt);
 
@@ -190,7 +191,7 @@ HTML;
             target: $this->buildDiffTarget(),
             oldPath: $this->file['oldPath'] ?? null,
             externalAbsolutePath: $this->file['externalAbsolutePath'] ?? null,
-        );
+        )->toArray();
 
         $durationMs = $this->durationSince($startedAt);
 
@@ -203,7 +204,9 @@ HTML;
 
     public function expandGap(int $hunkIndex, ?int $lineCount = null): void
     {
-        if ($this->diffData === null || empty($this->diffData['hunks'])) {
+        $loaded = LoadedDiff::fromCache($this->diffData);
+
+        if ($loaded === null || $loaded->hunks() === []) {
             // Diff fell out of cache between render and click: nothing to expand.
             // Still settle the action so the client clears the optimistic loading
             // spinner and the paired runtime-diagnostics start mark isn't orphaned.
@@ -225,8 +228,8 @@ HTML;
             externalAbsolutePath: $this->file['externalAbsolutePath'] ?? null,
         );
 
-        if (empty($fullDiff['hunks'])) {
-            // The full-context reload found no diff — the file changed underneath
+        if ($fullDiff->hunks() === []) {
+            // The full-context reload found no diff: the file changed underneath
             // the cached hunks. Same settle contract as the guard above so the
             // expander's spinner can't get stuck on a no-op that morphs nothing.
             $this->dispatchDiffActionCompleted('expandGap', $this->durationSince($startedAt));
@@ -234,17 +237,18 @@ HTML;
             return;
         }
 
-        $this->diffData['hunks'] = app(ExpandDiffGapAction::class)->handle(
-            hunks: $this->diffData['hunks'],
-            hunkIndex: $hunkIndex,
-            fullDiffLines: $fullDiff['hunks'][0]['lines'],
-            lineCount: $lineCount,
-            newFileLineCount: $this->diffData['newFileLineCount'] ?? null,
+        $expanded = $loaded->withExpandedHunks(
+            app(ExpandDiffGapAction::class)->handle(
+                hunks: $loaded->hunks(),
+                hunkIndex: $hunkIndex,
+                fullDiffLines: $fullDiff->hunks()[0]['lines'],
+                lineCount: $lineCount,
+                newFileLineCount: $loaded->newFileLineCount,
+            ),
+            $fullDiff->syntaxStyles,
         );
 
-        if (! empty($fullDiff['syntaxStyles'])) {
-            $this->diffData['syntaxStyles'] = ($this->diffData['syntaxStyles'] ?? '').$fullDiff['syntaxStyles'];
-        }
+        $this->diffData = $expanded->toArray();
 
         Cache::put(
             $this->diffCacheKey(),
@@ -291,7 +295,7 @@ HTML;
             'extension' => isset($this->file['path']) ? pathinfo((string) $this->file['path'], PATHINFO_EXTENSION) : '',
             'status' => ($this->file['isUntracked'] ?? false) ? 'added' : ($this->file['status'] ?? 'modified'),
             'target' => $this->buildDiffTarget()->contextKey(),
-            'too_large' => (bool) ($diffData['tooLarge'] ?? false),
+            'too_large' => ($diffData['outcome'] ?? null) === DiffLoadOutcome::TooLarge->value,
             'binary' => (bool) ($diffData['isBinary'] ?? false),
             'hunk_count' => count($diffData['hunks'] ?? []),
             'diff_line_count' => $lineCount,
@@ -572,15 +576,15 @@ HTML;
             <div x-intersect.once="setTimeout(() => { markDiffActionStart('loadFileDiff'); $wire.loadFileDiff(); }, {{ $loadDelay }})">
                 <x-diff-skeleton />
             </div>
-        @elseif($diffData['tooLarge'] ?? false)
+        @elseif(($diffData['outcome'] ?? null) === DiffLoadOutcome::TooLarge->value)
             <div class="px-4 py-8 text-center">
                 <flux:icon icon="exclamation-triangle" variant="outline" class="!size-4 inline-block text-gh-muted mr-1" />
                 <flux:text variant="subtle" size="sm" inline>File diff too large to display</flux:text>
             </div>
-        @elseif($diffData['error'] ?? false)
+        @elseif(($diffData['outcome'] ?? null) === DiffLoadOutcome::TransientError->value)
             <div class="px-4 py-8 text-center">
                 <flux:icon icon="exclamation-triangle" variant="outline" class="!size-4 inline-block text-gh-red mr-1" />
-                <flux:text variant="subtle" size="sm" inline>Git error: {{ $diffData['error'] }}</flux:text>
+                <flux:text variant="subtle" size="sm" inline>Git error: failed to load the diff for this file.</flux:text>
             </div>
         @elseif(empty($diffData['hunks']))
             <div class="px-4 py-8 text-center">

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Actions\ResolveReviewConfigAction;
 use App\DTOs\FileSourceSpec;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Mockery\Matcher\Closure;
@@ -28,6 +29,12 @@ function absoluteSourceSpec(string $absolutePath): Closure
     return Mockery::on(fn ($source): bool => $source instanceof FileSourceSpec
         && $source->type === FileSourceSpec::TYPE_ABSOLUTE
         && $source->absolutePath === $absolutePath);
+}
+
+/** The effective moved-line fingerprint every diff cache key is built from. */
+function reviewFingerprint(): string
+{
+    return app(ResolveReviewConfigAction::class)->handle()->movedLineFingerprint();
 }
 
 uses(TestCase::class, LazilyRefreshDatabase::class, Browsable::class, CreatesTestRepo::class)

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,7 +1,7 @@
 <?php
 
-use App\Actions\ResolveReviewConfigAction;
 use App\DTOs\FileSourceSpec;
+use App\Services\ReviewConfigService;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Mockery\Matcher\Closure;
 use Pest\Browser\Browsable;
@@ -31,10 +31,14 @@ function absoluteSourceSpec(string $absolutePath): Closure
         && $source->absolutePath === $absolutePath);
 }
 
-/** The effective moved-line fingerprint every diff cache key is built from. */
+/**
+ * The effective review fingerprint every diff cache key is built from. Resolved
+ * from a fresh service so a test's config changes are never masked by the
+ * memoization on the container's singleton.
+ */
 function reviewFingerprint(): string
 {
-    return app(ResolveReviewConfigAction::class)->handle()->movedLineFingerprint();
+    return (new ReviewConfigService)->resolve()->cacheFingerprint();
 }
 
 uses(TestCase::class, LazilyRefreshDatabase::class, Browsable::class, CreatesTestRepo::class)

--- a/tests/Unit/Actions/CleanExpiredTrashActionTest.php
+++ b/tests/Unit/Actions/CleanExpiredTrashActionTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Actions\CleanExpiredTrashAction;
+use App\Enums\DiscardOperation;
 use App\Models\Project;
 use App\Models\TrashedFile;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
@@ -26,7 +27,7 @@ test('removes expired entries and their storage files', function () {
     $expired = TrashedFile::create([
         'project_id' => $this->project->id,
         'file_path' => 'old.txt',
-        'file_status' => 'modified',
+        'operation' => DiscardOperation::ModificationReverted,
         'expires_at' => now()->subMinutes(5),
     ]);
     Storage::put("trash/{$expired->id}", 'old content');
@@ -41,14 +42,14 @@ test('returns active entries only', function () {
     TrashedFile::create([
         'project_id' => $this->project->id,
         'file_path' => 'active.txt',
-        'file_status' => 'modified',
+        'operation' => DiscardOperation::ModificationReverted,
         'expires_at' => now()->addMinutes(10),
     ]);
 
     TrashedFile::create([
         'project_id' => $this->project->id,
         'file_path' => 'expired.txt',
-        'file_status' => 'added',
+        'operation' => DiscardOperation::AddedFileRemoved,
         'expires_at' => now()->subMinute(),
     ]);
 
@@ -69,7 +70,7 @@ test('does not touch entries from other projects', function () {
     $otherExpired = TrashedFile::create([
         'project_id' => $otherProject->id,
         'file_path' => 'other.txt',
-        'file_status' => 'modified',
+        'operation' => DiscardOperation::ModificationReverted,
         'expires_at' => now()->subMinutes(5),
     ]);
 
@@ -83,7 +84,7 @@ test('returns empty array when no active entries', function () {
     TrashedFile::create([
         'project_id' => $this->project->id,
         'file_path' => 'expired.txt',
-        'file_status' => 'modified',
+        'operation' => DiscardOperation::ModificationReverted,
         'expires_at' => now()->subMinute(),
     ]);
 

--- a/tests/Unit/Actions/DeleteTrashedFileActionTest.php
+++ b/tests/Unit/Actions/DeleteTrashedFileActionTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Actions\DeleteTrashedFileAction;
+use App\Enums\DiscardOperation;
 use App\Models\Project;
 use App\Models\TrashedFile;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
@@ -26,7 +27,7 @@ test('deletes trash entry and storage file', function () {
     $trashed = TrashedFile::create([
         'project_id' => $this->project->id,
         'file_path' => 'file.txt',
-        'file_status' => 'modified',
+        'operation' => DiscardOperation::ModificationReverted,
         'expires_at' => now()->addMinutes(30),
     ]);
     Storage::put("trash/{$trashed->id}", 'content');
@@ -55,7 +56,7 @@ test('rejects entry from another project', function () {
     $trashed = TrashedFile::create([
         'project_id' => $otherProject->id,
         'file_path' => 'file.txt',
-        'file_status' => 'modified',
+        'operation' => DiscardOperation::ModificationReverted,
         'expires_at' => now()->addMinutes(30),
     ]);
     Storage::put("trash/{$trashed->id}", 'content');
@@ -72,7 +73,7 @@ test('handles entry without storage file', function () {
     $trashed = TrashedFile::create([
         'project_id' => $this->project->id,
         'file_path' => 'deleted-file.txt',
-        'file_status' => 'deleted',
+        'operation' => DiscardOperation::DeletionReverted,
         'expires_at' => now()->addMinutes(30),
     ]);
 

--- a/tests/Unit/Actions/DiscardFileChangesActionTest.php
+++ b/tests/Unit/Actions/DiscardFileChangesActionTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Actions\DiscardFileChangesAction;
+use App\Enums\DiscardOperation;
 use App\Models\Project;
 use App\Models\TrashedFile;
 use Carbon\Carbon;
@@ -39,7 +40,7 @@ test('discards modified file and creates trash record', function () {
 
     expect($trashed)->toBeInstanceOf(TrashedFile::class)
         ->and($trashed->file_path)->toBe('file.txt')
-        ->and($trashed->file_status)->toBe('modified')
+        ->and($trashed->operation)->toBe(DiscardOperation::ModificationReverted)
         ->and($trashed->project_id)->toBe($this->project->id)
         ->and($trashed->expires_at)->toBeInstanceOf(Carbon::class);
 
@@ -58,7 +59,7 @@ test('discards deleted file', function () {
 
     $trashed = $this->action->handle($this->tmpDir, 'file.txt', 'deleted', $this->project->id);
 
-    expect($trashed->file_status)->toBe('deleted');
+    expect($trashed->operation)->toBe(DiscardOperation::DeletionReverted);
 
     // File should be restored from HEAD
     expect(File::exists($this->tmpDir.'/file.txt'))->toBeTrue();
@@ -77,8 +78,7 @@ test('discards untracked added file', function () {
         $this->tmpDir, 'new.txt', 'added', $this->project->id, isUntracked: true
     );
 
-    expect($trashed->file_status)->toBe('added')
-        ->and($trashed->is_untracked)->toBeTrue();
+    expect($trashed->operation)->toBe(DiscardOperation::UntrackedFileDeleted);
 
     // File should be removed
     expect(File::exists($this->tmpDir.'/new.txt'))->toBeFalse();
@@ -97,7 +97,7 @@ test('discards tracked added file', function () {
         $this->tmpDir, 'staged.txt', 'added', $this->project->id, isUntracked: false
     );
 
-    expect($trashed->file_status)->toBe('added');
+    expect($trashed->operation)->toBe(DiscardOperation::AddedFileRemoved);
     expect(File::exists($this->tmpDir.'/staged.txt'))->toBeFalse();
     expect(Storage::get("trash/{$trashed->id}"))->toBe("staged content\n");
 });
@@ -111,7 +111,7 @@ test('discards renamed file', function () {
         $this->tmpDir, 'renamed.txt', 'renamed', $this->project->id, oldPath: 'file.txt'
     );
 
-    expect($trashed->file_status)->toBe('renamed')
+    expect($trashed->operation)->toBe(DiscardOperation::RenameReverted)
         ->and($trashed->old_path)->toBe('file.txt');
 
     // Old path restored, new path gone
@@ -127,7 +127,7 @@ test('discards binary file', function () {
 
     $trashed = $this->action->handle($this->tmpDir, 'file.txt', 'binary', $this->project->id);
 
-    expect($trashed->file_status)->toBe('binary');
+    expect($trashed->operation)->toBe(DiscardOperation::ModificationReverted);
     expect(File::get($this->tmpDir.'/file.txt'))->toBe("original\n");
     expect(Storage::get("trash/{$trashed->id}"))->toBe($binaryContent);
 });

--- a/tests/Unit/Actions/GetFileListActionTest.php
+++ b/tests/Unit/Actions/GetFileListActionTest.php
@@ -7,6 +7,7 @@ use App\Services\ExternalFilesService;
 use App\Services\GitDiffService;
 use App\Services\GitProcessService;
 use App\Services\IgnoreService;
+use App\Services\ReviewConfigService;
 use App\Support\DiffCacheKey;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Cache;
@@ -27,7 +28,7 @@ beforeEach(function () {
 test('returns files as arrays with id field', function () {
     File::put($this->tmpDir.'/file.txt', "changed\n");
 
-    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class));
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class), app(ReviewConfigService::class));
     $files = $action->handle($this->tmpDir);
 
     expect($files)->toHaveCount(1);
@@ -39,7 +40,7 @@ test('returns files as arrays with id field', function () {
 test('loads typed changeset using existing file entries', function () {
     File::put($this->tmpDir.'/file.txt', "changed\n");
 
-    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class));
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class), app(ReviewConfigService::class));
     $changeset = $action->changeset($this->tmpDir);
 
     expect($changeset->repoPath)->toBe($this->tmpDir)
@@ -59,7 +60,7 @@ test('returns the changeset files folders-first', function () {
     File::put($this->tmpDir.'/z/b.txt', "b\n");
     File::put($this->tmpDir.'/z/c/d.txt', "d\n");
 
-    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class));
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class), app(ReviewConfigService::class));
     $paths = collect($action->changeset($this->tmpDir)->files)->map(fn ($file) => $file->path)->all();
 
     expect($paths)->toBe([
@@ -72,10 +73,10 @@ test('returns the changeset files folders-first', function () {
 test('clears cache by default', function () {
     File::put($this->tmpDir.'/file.txt', "changed\n");
 
-    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class));
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class), app(ReviewConfigService::class));
     $files = $action->handle($this->tmpDir);
 
-    $cacheKey = DiffCacheKey::for($this->tmpDir, $files[0]['id']);
+    $cacheKey = DiffCacheKey::for($this->tmpDir, $files[0]['id'], reviewFingerprint());
     Cache::put($cacheKey, 'stale', 60);
 
     $action->handle($this->tmpDir);
@@ -86,11 +87,11 @@ test('clears cache by default', function () {
 test('clears the full-context cache variant too', function () {
     File::put($this->tmpDir.'/file.txt', "changed\n");
 
-    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class));
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class), app(ReviewConfigService::class));
     $files = $action->handle($this->tmpDir);
 
-    $baseKey = DiffCacheKey::for($this->tmpDir, $files[0]['id']);
-    $fullContextKey = DiffCacheKey::for($this->tmpDir, $files[0]['id'], DiffTarget::workingDirectory()->contextKey().':full-context');
+    $baseKey = DiffCacheKey::for($this->tmpDir, $files[0]['id'], reviewFingerprint());
+    $fullContextKey = DiffCacheKey::for($this->tmpDir, $files[0]['id'], reviewFingerprint(), DiffTarget::workingDirectory()->contextKey().':full-context');
     Cache::put($baseKey, 'stale-base', 60);
     Cache::put($fullContextKey, 'stale-full', 60);
 
@@ -103,10 +104,10 @@ test('clears the full-context cache variant too', function () {
 test('preserves cache when clearCache is false', function () {
     File::put($this->tmpDir.'/file.txt', "changed\n");
 
-    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class));
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class), app(ReviewConfigService::class));
     $files = $action->handle($this->tmpDir, clearCache: false);
 
-    $cacheKey = DiffCacheKey::for($this->tmpDir, $files[0]['id']);
+    $cacheKey = DiffCacheKey::for($this->tmpDir, $files[0]['id'], reviewFingerprint());
     Cache::put($cacheKey, 'kept', 60);
 
     $action->handle($this->tmpDir, clearCache: false);
@@ -126,7 +127,7 @@ test('appends entries from configured external paths in working-tree mode', func
         'external_paths' => [['label' => 'notes', 'path' => $extDir]],
     ]);
 
-    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class));
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class), app(ReviewConfigService::class));
     $files = $action->handle($this->tmpDir, projectId: $project->id);
 
     $paths = collect($files)->pluck('path')->all();
@@ -150,7 +151,7 @@ test('typed changeset includes external entries in working-tree mode', function 
         'external_paths' => [['label' => 'notes', 'path' => $extDir]],
     ]);
 
-    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class));
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class), app(ReviewConfigService::class));
     $changeset = $action->changeset($this->tmpDir, projectId: $project->id);
 
     $paths = collect($changeset->files)->pluck('path')->all();
@@ -168,7 +169,7 @@ test('hides external entries when the diff target is an immutable commit range',
         'external_paths' => [['label' => 'notes', 'path' => $extDir]],
     ]);
 
-    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class));
+    $action = new GetFileListAction(new GitDiffService(new GitProcessService, new IgnoreService), app(ExternalFilesService::class), app(ReviewConfigService::class));
 
     $files = $action->handle(
         $this->tmpDir,

--- a/tests/Unit/Actions/LoadFileDiffActionTest.php
+++ b/tests/Unit/Actions/LoadFileDiffActionTest.php
@@ -448,7 +448,7 @@ test('a too-large skip result is stored as a readable envelope (no git re-spawn 
     $result = $action->handle($this->tmpDir, 'hello.txt', cacheKey: $cacheKey)->toArray();
 
     expect($result['outcome'])->toBe(DiffLoadOutcome::TooLarge->value)
-        ->and(LoadedDiff::fromCache(Cache::get($cacheKey))?->outcome)->toBe(DiffLoadOutcome::TooLarge);
+        ->and(LoadedDiff::tryFrom(Cache::get($cacheKey))?->outcome)->toBe(DiffLoadOutcome::TooLarge);
 });
 
 test('a transient git error is not cached so the next read can retry', function () {

--- a/tests/Unit/Actions/LoadFileDiffActionTest.php
+++ b/tests/Unit/Actions/LoadFileDiffActionTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Actions\LoadFileDiffAction;
+use App\DTOs\LoadedDiff;
+use App\Enums\DiffLoadOutcome;
 use App\Exceptions\GitCommandException;
 use App\Services\CsvAlignerService;
 use App\Services\DiffParser;
@@ -11,7 +13,6 @@ use App\Services\IgnoreService;
 use App\Services\MarkdownRegionService;
 use App\Services\MarkdownTableAlignerService;
 use App\Services\SyntaxHighlightService;
-use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
@@ -31,28 +32,27 @@ test('returns full DTO array for modified file', function () {
     File::put($this->tmpDir.'/hello.txt', "line1\nline2\n");
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'hello.txt');
+    $result = $action->handle($this->tmpDir, 'hello.txt')->toArray();
 
-    expect($result)->toHaveKeys(['path', 'status', 'hunks', 'additions', 'deletions', 'isBinary', 'tooLarge'])
-        ->and($result['tooLarge'])->toBeFalse()
+    expect($result)->toHaveKeys(['path', 'status', 'hunks', 'additions', 'deletions', 'isBinary', 'outcome'])
+        ->and($result['outcome'])->toBe(DiffLoadOutcome::Loaded->value)
         ->and($result['path'])->toBe('hello.txt')
         ->and($result['hunks'])->toHaveCount(1)
         ->and($result['hunks'][0])->toHaveKeys(['header', 'oldStart', 'newStart', 'lines'])
         ->and($result)->not->toHaveKeys(['oldSource', 'newSource']);
 });
 
-test('returns tooLarge true when diff exceeds limit', function () {
+test('reports the too-large outcome when the diff exceeds the limit', function () {
     File::put($this->tmpDir.'/hello.txt', str_repeat("long line\n", 500));
 
     // Use a very low maxBytes config
     config(['rfa.diff_max_bytes' => 100]);
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'hello.txt');
+    $result = $action->handle($this->tmpDir, 'hello.txt')->toArray();
 
-    expect($result)->toHaveKeys(['path', 'status', 'oldPath', 'hunks', 'additions', 'deletions', 'isBinary', 'tooLarge'])
-        ->and($result['tooLarge'])->toBeTrue()
-        ->and($result['skipReason'])->toBe('too-large')
+    expect($result)->toHaveKeys(['path', 'status', 'oldPath', 'hunks', 'additions', 'deletions', 'isBinary', 'outcome'])
+        ->and($result['outcome'])->toBe(DiffLoadOutcome::TooLarge->value)
         ->and($result['hunks'])->toBe([])
         ->and($result['path'])->toBe('hello.txt')
         ->and($result)->not->toHaveKeys(['oldSource', 'newSource'])
@@ -61,24 +61,23 @@ test('returns tooLarge true when diff exceeds limit', function () {
         ->and($result['isBinary'])->toBeFalse();
 });
 
-test('returns empty array for empty diff', function () {
+test('reports the empty outcome for an empty diff', function () {
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'nonexistent.txt', isUntracked: true);
+    $result = $action->handle($this->tmpDir, 'nonexistent.txt', isUntracked: true)->toArray();
 
     expect($result['hunks'])->toBe([])
-        ->and($result['tooLarge'])->toBeFalse()
-        ->and($result['skipReason'])->toBeNull();
+        ->and($result['outcome'])->toBe(DiffLoadOutcome::Empty->value);
 });
 
 test('handles untracked file', function () {
     File::put($this->tmpDir.'/newfile.txt', "hello\nworld\n");
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'newfile.txt', isUntracked: true);
+    $result = $action->handle($this->tmpDir, 'newfile.txt', isUntracked: true)->toArray();
 
     expect($result)->not->toBeNull()
         ->and($result['hunks'])->toHaveCount(1)
-        ->and($result['tooLarge'])->toBeFalse()
+        ->and($result['outcome'])->toBe(DiffLoadOutcome::Loaded->value)
         ->and($result['path'])->toBe('newfile.txt')
         ->and($result)->not->toHaveKeys(['oldSource', 'newSource']);
 });
@@ -97,7 +96,7 @@ test('renamed file passes oldPath so rename detection finds the source', functio
     File::put($this->tmpDir.'/new.txt', $modified);
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'new.txt', oldPath: 'old.txt');
+    $result = $action->handle($this->tmpDir, 'new.txt', oldPath: 'old.txt')->toArray();
 
     expect($result['status'])->toBe('renamed')
         ->and($result['oldPath'])->toBe('old.txt')
@@ -112,7 +111,7 @@ test('external file diffs expose absolute source metadata', function () {
     File::put($absolutePath, "# Notes\n");
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'external/specs/notes.md', externalAbsolutePath: $absolutePath);
+    $result = $action->handle($this->tmpDir, 'external/specs/notes.md', externalAbsolutePath: $absolutePath)->toArray();
 
     expect($result['status'])->toBe('added')
         ->and($result)->not->toHaveKeys(['oldSource', 'newSource']);
@@ -130,7 +129,7 @@ test('without oldPath the rename diff degrades to all additions', function () {
     File::put($this->tmpDir.'/new.txt', $modified);
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'new.txt');
+    $result = $action->handle($this->tmpDir, 'new.txt')->toArray();
 
     expect($result['status'])->toBe('added')
         ->and($result['oldPath'])->toBeNull()
@@ -146,7 +145,7 @@ test('adds highlightedContent for known file types', function () {
     File::put($this->tmpDir.'/hello.php', "<?php\necho 'hello';\n");
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'hello.php');
+    $result = $action->handle($this->tmpDir, 'hello.php')->toArray();
 
     expect($result)->not->toBeNull()
         ->and($result['hunks'])->toHaveCount(1);
@@ -163,7 +162,7 @@ test('result contains syntaxStyles CSS for known file types', function () {
     File::put($this->tmpDir.'/hello.php', "<?php\necho 'hello';\n");
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'hello.php');
+    $result = $action->handle($this->tmpDir, 'hello.php')->toArray();
 
     expect($result)->toHaveKey('syntaxStyles')
         ->and($result['syntaxStyles'])->toBeString()
@@ -177,7 +176,7 @@ test('keeps syntax highlighting for large known file diffs', function () {
     File::put($this->tmpDir.'/large.php', "<?php\n".implode("\n", array_map(fn ($i) => "\$value{$i} = ".($i + 1).';', range(1, 20)))."\n");
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'large.php', contextLines: 99999);
+    $result = $action->handle($this->tmpDir, 'large.php', contextLines: 99999)->toArray();
 
     $hasHighlighted = collect($result['hunks'])
         ->flatMap(fn ($hunk) => $hunk['lines'])
@@ -194,7 +193,7 @@ test('no highlightedContent for unknown file types', function () {
     File::put($this->tmpDir.'/data.xyz', "updated content\n");
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'data.xyz');
+    $result = $action->handle($this->tmpDir, 'data.xyz')->toArray();
 
     expect($result)->not->toBeNull();
 
@@ -224,24 +223,24 @@ test('contextLines parameter produces single hunk for full context', function ()
         app(ExternalFilesService::class),
     );
 
-    $default = $action->handle($this->tmpDir, 'many.txt');
-    $full = $action->handle($this->tmpDir, 'many.txt', contextLines: 99999);
+    $default = $action->handle($this->tmpDir, 'many.txt')->toArray();
+    $full = $action->handle($this->tmpDir, 'many.txt', contextLines: 99999)->toArray();
 
     expect($default['hunks'])->toHaveCount(2);
     expect($full['hunks'])->toHaveCount(1);
     expect($full['hunks'][0]['newStart'])->toBe(1);
 });
 
-// -- self-healing cache --
+// -- cache envelope versioning --
 
-test('stale cache without syntaxStyles triggers re-computation', function () {
+test('a cache entry written before the envelope existed is a miss', function () {
     File::put($this->tmpDir.'/hello.php', "<?php\necho 'hi';\n");
     $this->commitTestRepo($this->tmpDir, 'add php cache');
     File::put($this->tmpDir.'/hello.php', "<?php\necho 'hello';\n");
 
-    $cacheKey = 'test-stale-cache-key';
+    $cacheKey = 'test-unversioned-cache-key';
 
-    // Seed cache with stale data missing syntaxStyles
+    // The pre-envelope shape: file payload only, no version and no outcome.
     Cache::put($cacheKey, [
         'path' => 'hello.php',
         'status' => 'modified',
@@ -251,14 +250,44 @@ test('stale cache without syntaxStyles triggers re-computation', function () {
         'deletions' => 0,
         'isBinary' => false,
         'tooLarge' => false,
+        'syntaxStyles' => '',
     ], 3600);
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'hello.php', cacheKey: $cacheKey);
+    $result = $action->handle($this->tmpDir, 'hello.php', cacheKey: $cacheKey)->toArray();
 
-    expect($result)->toHaveKey('syntaxStyles')
+    expect($result['outcome'])->toBe(DiffLoadOutcome::Loaded->value)
         ->and($result['syntaxStyles'])->toBeString()
         ->and($result['hunks'])->not->toBeEmpty();
+});
+
+test('a cache entry stamped with another format version is a miss', function () {
+    File::put($this->tmpDir.'/hello.txt', "line1\nline2\n");
+
+    $cacheKey = 'test-future-version-cache-key';
+
+    Cache::put($cacheKey, [
+        'cacheVersion' => LoadedDiff::VERSION + 1,
+        'outcome' => DiffLoadOutcome::Loaded->value,
+        'path' => 'hello.txt',
+        'status' => 'modified',
+        'oldPath' => null,
+        'hunks' => [],
+        'additions' => 0,
+        'deletions' => 0,
+        'isBinary' => false,
+        'isSymlink' => false,
+        'symlinkTarget' => null,
+        'syntaxStyles' => '',
+        'newFileLineCount' => null,
+        'syntaxHighlighter' => 'none',
+    ], 3600);
+
+    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
+    $result = $action->handle($this->tmpDir, 'hello.txt', cacheKey: $cacheKey)->toArray();
+
+    expect($result['hunks'])->not->toBeEmpty()
+        ->and($result['newFileLineCount'])->toBe(2);
 });
 
 test('class names in highlightedContent have matching selectors in syntaxStyles', function () {
@@ -267,7 +296,7 @@ test('class names in highlightedContent have matching selectors in syntaxStyles'
     File::put($this->tmpDir.'/hello.php', "<?php\necho 'hello';\n");
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'hello.php');
+    $result = $action->handle($this->tmpDir, 'hello.php')->toArray();
 
     $classNames = [];
     foreach ($result['hunks'] as $hunk) {
@@ -296,7 +325,7 @@ test('result includes newFileLineCount for modified file', function () {
     File::put($this->tmpDir.'/hello.txt', "line1\nline2\nline3\n");
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'hello.txt');
+    $result = $action->handle($this->tmpDir, 'hello.txt')->toArray();
 
     expect($result)->toHaveKey('newFileLineCount')
         ->and($result['newFileLineCount'])->toBe(3);
@@ -312,7 +341,7 @@ test('newFileLineCount reflects actual file length beyond last hunk', function (
     File::put($this->tmpDir.'/many.txt', implode("\n", $lines)."\n");
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'many.txt');
+    $result = $action->handle($this->tmpDir, 'many.txt')->toArray();
 
     expect($result['newFileLineCount'])->toBe(20);
 
@@ -320,32 +349,6 @@ test('newFileLineCount reflects actual file length beyond last hunk', function (
     $lastHunk = end($result['hunks']);
     $lastHunkEnd = $lastHunk['newStart'] + $lastHunk['newCount'] - 1;
     expect($lastHunkEnd)->toBeLessThan(20);
-});
-
-test('stale cache without newFileLineCount triggers re-computation', function () {
-    File::put($this->tmpDir.'/hello.txt', "line1\nline2\n");
-
-    $cacheKey = 'test-stale-no-linecount';
-
-    Cache::put($cacheKey, [
-        'path' => 'hello.txt',
-        'status' => 'modified',
-        'oldPath' => null,
-        'hunks' => [],
-        'additions' => 0,
-        'deletions' => 0,
-        'isBinary' => false,
-        'isSymlink' => false,
-        'tooLarge' => false,
-        'syntaxStyles' => '',
-        'tableAligned' => true,
-    ], 3600);
-
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'hello.txt', cacheKey: $cacheKey);
-
-    expect($result)->toHaveKey('newFileLineCount')
-        ->and($result['newFileLineCount'])->toBe(2);
 });
 
 // -- markdown heading annotation --
@@ -356,13 +359,13 @@ test('markdown files get heading metadata on hunk lines', function () {
     File::put($this->tmpDir.'/doc.md', "# Title\n\nbody updated\n");
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'doc.md');
+    $result = $action->handle($this->tmpDir, 'doc.md')->toArray();
 
     $hasHeading = collect($result['hunks'][0]['lines'])
         ->contains(fn ($line) => ($line['headingLevel'] ?? null) === 1);
 
     expect($hasHeading)->toBeTrue()
-        ->and($result)->toHaveKey('headingsAnnotated');
+        ->and($result['outcome'])->toBe(DiffLoadOutcome::Loaded->value);
 });
 
 test('non-markdown files do not get heading metadata', function () {
@@ -371,41 +374,12 @@ test('non-markdown files do not get heading metadata', function () {
     File::put($this->tmpDir.'/hello.php', "<?php\n# updated comment\n");
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'hello.php');
+    $result = $action->handle($this->tmpDir, 'hello.php')->toArray();
 
     $hasHeading = collect($result['hunks'][0]['lines'])
         ->contains(fn ($line) => isset($line['headingLevel']));
 
     expect($hasHeading)->toBeFalse();
-});
-
-test('stale cache without headingsAnnotated triggers re-computation', function () {
-    File::put($this->tmpDir.'/doc.md', "# New\n");
-    $this->commitTestRepo($this->tmpDir, 'add md cache');
-    File::put($this->tmpDir.'/doc.md', "# Changed\n");
-
-    $cacheKey = 'test-stale-headings-key';
-
-    Cache::put($cacheKey, [
-        'path' => 'doc.md',
-        'status' => 'modified',
-        'oldPath' => null,
-        'hunks' => [],
-        'additions' => 0,
-        'deletions' => 0,
-        'isBinary' => false,
-        'isSymlink' => false,
-        'tooLarge' => false,
-        'syntaxStyles' => '',
-        'tableAligned' => true,
-        'newFileLineCount' => 1,
-    ], 3600);
-
-    $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'doc.md', cacheKey: $cacheKey);
-
-    expect($result)->toHaveKey('headingsAnnotated')
-        ->and($result['hunks'])->not->toBeEmpty();
 });
 
 // -- external files --
@@ -421,10 +395,10 @@ test('builds a synthetic whole-file diff for an external file via its absolute p
         $this->tmpDir,
         'external/notes/note.md',
         externalAbsolutePath: $absolute,
-    );
+    )->toArray();
 
     expect($result['hunks'])->not->toBeEmpty();
-    expect($result['tooLarge'])->toBeFalse();
+    expect($result['outcome'])->toBe(DiffLoadOutcome::Loaded->value);
     expect($result['additions'])->toBeGreaterThan(0);
 });
 
@@ -450,33 +424,31 @@ test('does not shell out to git when an external file is requested', function ()
 
 // -- git error propagation --
 
-test('returns error field when git command fails', function () {
+test('reports the transient-error outcome when the git command fails', function () {
     $gitService = Mockery::mock(GitDiffService::class);
     $gitService->shouldReceive('getFileDiff')
         ->andThrow(new GitCommandException('git diff', 'fatal: bad revision', 128));
 
     $action = new LoadFileDiffAction($gitService, new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'hello.txt');
+    $result = $action->handle($this->tmpDir, 'hello.txt')->toArray();
 
-    expect($result['error'])->toBe('Failed to load diff for this file.')
-        ->and($result['hunks'])->toBe([])
-        ->and($result['tooLarge'])->toBeFalse();
+    expect($result['outcome'])->toBe(DiffLoadOutcome::TransientError->value)
+        ->and($result['hunks'])->toBe([]);
 });
 
 // -- skip-result caching --
 
-test('a too-large skip result carries the current cache shape and is cached (no git re-spawn on re-read)', function () {
+test('a too-large skip result is stored as a readable envelope (no git re-spawn on re-read)', function () {
     File::put($this->tmpDir.'/hello.txt', str_repeat("long line\n", 500));
     config(['rfa.diff_max_bytes' => 100]);
 
     $cacheKey = 'test-too-large-cacheable';
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'hello.txt', cacheKey: $cacheKey);
+    $result = $action->handle($this->tmpDir, 'hello.txt', cacheKey: $cacheKey)->toArray();
 
-    expect($result['tooLarge'])->toBeTrue()
-        ->and(DiffCacheKey::isCurrentShape($result))->toBeTrue()
-        ->and(DiffCacheKey::isCurrentShape(Cache::get($cacheKey)))->toBeTrue();
+    expect($result['outcome'])->toBe(DiffLoadOutcome::TooLarge->value)
+        ->and(LoadedDiff::fromCache(Cache::get($cacheKey))?->outcome)->toBe(DiffLoadOutcome::TooLarge);
 });
 
 test('a transient git error is not cached so the next read can retry', function () {
@@ -487,9 +459,9 @@ test('a transient git error is not cached so the next read can retry', function 
     $cacheKey = 'test-error-not-cached';
 
     $action = new LoadFileDiffAction($gitService, new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'hello.txt', cacheKey: $cacheKey);
+    $result = $action->handle($this->tmpDir, 'hello.txt', cacheKey: $cacheKey)->toArray();
 
-    expect($result)->toHaveKey('error')
+    expect($result['outcome'])->toBe(DiffLoadOutcome::TransientError->value)
         ->and(Cache::get($cacheKey))->toBeNull();
 });
 
@@ -504,7 +476,7 @@ test('literal ANSI in an untracked file survives moved-line detection', function
     File::put($this->tmpDir.'/log.txt', "\e[31mred\e[0m\n");
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'log.txt', isUntracked: true);
+    $result = $action->handle($this->tmpDir, 'log.txt', isUntracked: true)->toArray();
 
     $content = $result['hunks'][0]['lines'][0]['content'];
 
@@ -528,7 +500,7 @@ test('default context lines come from review config when the caller omits them',
     config(['rfa.default_context_lines' => 99999]);
 
     $action = new LoadFileDiffAction(new GitDiffService(new GitProcessService, new IgnoreService), new DiffParser, new SyntaxHighlightService, new MarkdownTableAlignerService, new CsvAlignerService, new MarkdownRegionService, app(ExternalFilesService::class));
-    $result = $action->handle($this->tmpDir, 'many.txt');
+    $result = $action->handle($this->tmpDir, 'many.txt')->toArray();
 
     expect($result['hunks'])->toHaveCount(1);
 });

--- a/tests/Unit/Actions/RestoreDiscardedFileActionTest.php
+++ b/tests/Unit/Actions/RestoreDiscardedFileActionTest.php
@@ -87,6 +87,21 @@ test('restores untracked added file', function () {
     expect(File::get($this->tmpDir.'/new.txt'))->toBe("brand new\n");
 });
 
+test('restores tracked added file', function () {
+    File::put($this->tmpDir.'/staged.txt', "staged content\n");
+    $this->runTestRepoCommand($this->tmpDir, 'git add staged.txt');
+
+    $trashed = $this->discardAction->handle(
+        $this->tmpDir, 'staged.txt', 'added', $this->project->id, isUntracked: false
+    );
+
+    expect(File::exists($this->tmpDir.'/staged.txt'))->toBeFalse();
+
+    $this->restoreAction->handle($trashed->id, $this->tmpDir, $this->project->id);
+
+    expect(File::get($this->tmpDir.'/staged.txt'))->toBe("staged content\n");
+});
+
 // -- renamed files --
 
 test('restores renamed file', function () {

--- a/tests/Unit/DTOs/DiffTargetTest.php
+++ b/tests/Unit/DTOs/DiffTargetTest.php
@@ -61,11 +61,9 @@ test('toDiffArgs emits single-arg diff for range-to-working', function () {
         ->and(DiffTarget::range('from', 'to')->toDiffArgs())->toBe(['diff', 'from', 'to']);
 });
 
-test('cacheTtlHours caps immutable targets and passes the configured TTL through for working-tree targets', function () {
+test('cacheTtlHours caps immutable targets and passes the effective TTL through for working-tree targets', function () {
     expect(DiffTarget::range('from', 'to')->cacheTtlHours(24))->toBe(720)
-        // Immutable targets short-circuit, so the arg is optional for callers
-        // (e.g. SFCs) that can't supply the coerced TTL.
-        ->and(DiffTarget::range('from', 'to')->cacheTtlHours())->toBe(720)
+        ->and(DiffTarget::range('from', 'to')->cacheTtlHours(12))->toBe(720)
         ->and(DiffTarget::workingDirectory()->cacheTtlHours(24))->toBe(24)
         ->and(DiffTarget::rangeToWorking('abc123')->cacheTtlHours(12))->toBe(12);
 });
@@ -80,15 +78,15 @@ test('contextKey disambiguates working-tree targets by their from ref', function
 });
 
 test('DiffCacheKey produces distinct keys for HEAD→WT vs commit→WT', function () {
-    $keyHead = DiffCacheKey::for('repo', 'file-1', DiffTarget::workingDirectory()->contextKey());
-    $keyCommit = DiffCacheKey::for('repo', 'file-1', DiffTarget::rangeToWorking('abc123')->contextKey());
+    $keyHead = DiffCacheKey::for('repo', 'file-1', 'm0', DiffTarget::workingDirectory()->contextKey());
+    $keyCommit = DiffCacheKey::for('repo', 'file-1', 'm0', DiffTarget::rangeToWorking('abc123')->contextKey());
 
     expect($keyHead)->not->toBe($keyCommit);
 });
 
 test('DiffCacheKey default matches workingDirectory contextKey', function () {
-    $defaultKey = DiffCacheKey::for('repo', 'file-1');
-    $explicitKey = DiffCacheKey::for('repo', 'file-1', DiffTarget::workingDirectory()->contextKey());
+    $defaultKey = DiffCacheKey::for('repo', 'file-1', 'm0');
+    $explicitKey = DiffCacheKey::for('repo', 'file-1', 'm0', DiffTarget::workingDirectory()->contextKey());
 
     expect($defaultKey)->toBe($explicitKey);
 });

--- a/tests/Unit/DTOs/LoadedDiffTest.php
+++ b/tests/Unit/DTOs/LoadedDiffTest.php
@@ -13,7 +13,7 @@ test('a loaded diff round-trips through the cache array', function () {
     ], 1, 0);
 
     $loaded = LoadedDiff::loaded($fileDiff, syntaxStyles: '.hl{color:red}', newFileLineCount: 12, syntaxHighlighter: 'phiki');
-    $restored = LoadedDiff::fromCache($loaded->toArray());
+    $restored = LoadedDiff::tryFrom($loaded->toArray());
 
     expect($restored?->outcome)->toBe(DiffLoadOutcome::Loaded)
         ->and($restored?->syntaxStyles)->toBe('.hl{color:red}')
@@ -23,7 +23,7 @@ test('a loaded diff round-trips through the cache array', function () {
 });
 
 test('every skip outcome round-trips with no hunks', function (LoadedDiff $skipped, DiffLoadOutcome $outcome) {
-    $restored = LoadedDiff::fromCache($skipped->toArray());
+    $restored = LoadedDiff::tryFrom($skipped->toArray());
 
     expect($restored?->outcome)->toBe($outcome)
         ->and($restored?->hunks())->toBe([]);
@@ -43,7 +43,7 @@ test('only a transient error is uncacheable', function () {
 });
 
 test('unsupported cache entries read as a miss', function (mixed $entry) {
-    expect(LoadedDiff::fromCache($entry))->toBeNull();
+    expect(LoadedDiff::tryFrom($entry))->toBeNull();
 })->with([
     'not an array' => 'stale',
     'null' => null,
@@ -62,7 +62,7 @@ test('an expanded rewrite stays a readable envelope', function () {
     );
 
     $expanded = $loaded->withExpandedHunks([['header' => '@@', 'lines' => []]], '.b{}');
-    $restored = LoadedDiff::fromCache($expanded->toArray());
+    $restored = LoadedDiff::tryFrom($expanded->toArray());
 
     expect($restored?->outcome)->toBe(DiffLoadOutcome::Loaded)
         ->and($restored?->hunks())->toHaveCount(1)

--- a/tests/Unit/DTOs/LoadedDiffTest.php
+++ b/tests/Unit/DTOs/LoadedDiffTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\DTOs\DiffLine;
+use App\DTOs\FileDiff;
+use App\DTOs\Hunk;
+use App\DTOs\LoadedDiff;
+use App\Enums\DiffLoadOutcome;
+use App\Enums\LineType;
+
+test('a loaded diff round-trips through the cache array', function () {
+    $fileDiff = new FileDiff('src/App.php', 'modified', null, [
+        new Hunk('@@ -1 +1 @@', 1, 1, 1, 1, [new DiffLine(LineType::Add, 'new', null, 1)]),
+    ], 1, 0);
+
+    $loaded = LoadedDiff::loaded($fileDiff, syntaxStyles: '.hl{color:red}', newFileLineCount: 12, syntaxHighlighter: 'phiki');
+    $restored = LoadedDiff::fromCache($loaded->toArray());
+
+    expect($restored?->outcome)->toBe(DiffLoadOutcome::Loaded)
+        ->and($restored?->syntaxStyles)->toBe('.hl{color:red}')
+        ->and($restored?->newFileLineCount)->toBe(12)
+        ->and($restored?->syntaxHighlighter)->toBe('phiki')
+        ->and($restored?->toArray())->toBe($loaded->toArray());
+});
+
+test('every skip outcome round-trips with no hunks', function (LoadedDiff $skipped, DiffLoadOutcome $outcome) {
+    $restored = LoadedDiff::fromCache($skipped->toArray());
+
+    expect($restored?->outcome)->toBe($outcome)
+        ->and($restored?->hunks())->toBe([]);
+})->with([
+    'empty' => fn () => [LoadedDiff::empty('a.php'), DiffLoadOutcome::Empty],
+    'too large' => fn () => [LoadedDiff::tooLarge('a.php'), DiffLoadOutcome::TooLarge],
+    'unparsable' => fn () => [LoadedDiff::unparsable('a.php'), DiffLoadOutcome::Unparsable],
+    'transient error' => fn () => [LoadedDiff::transientError('a.php'), DiffLoadOutcome::TransientError],
+]);
+
+test('only a transient error is uncacheable', function () {
+    expect(DiffLoadOutcome::TransientError->isCacheable())->toBeFalse()
+        ->and(DiffLoadOutcome::Loaded->isCacheable())->toBeTrue()
+        ->and(DiffLoadOutcome::Empty->isCacheable())->toBeTrue()
+        ->and(DiffLoadOutcome::TooLarge->isCacheable())->toBeTrue()
+        ->and(DiffLoadOutcome::Unparsable->isCacheable())->toBeTrue();
+});
+
+test('unsupported cache entries read as a miss', function (mixed $entry) {
+    expect(LoadedDiff::fromCache($entry))->toBeNull();
+})->with([
+    'not an array' => 'stale',
+    'null' => null,
+    'no version' => [['outcome' => 'loaded', 'hunks' => []]],
+    'another version' => [['cacheVersion' => LoadedDiff::VERSION + 1, 'outcome' => 'loaded', 'hunks' => []]],
+    'unknown outcome' => [['cacheVersion' => LoadedDiff::VERSION, 'outcome' => 'partially-loaded', 'hunks' => []]],
+    'missing outcome' => [['cacheVersion' => LoadedDiff::VERSION, 'hunks' => []]],
+]);
+
+test('an expanded rewrite stays a readable envelope', function () {
+    $loaded = LoadedDiff::loaded(
+        new FileDiff('src/App.php', 'modified', null, [], 0, 0),
+        syntaxStyles: '.a{}',
+        newFileLineCount: 40,
+        syntaxHighlighter: 'phiki',
+    );
+
+    $expanded = $loaded->withExpandedHunks([['header' => '@@', 'lines' => []]], '.b{}');
+    $restored = LoadedDiff::fromCache($expanded->toArray());
+
+    expect($restored?->outcome)->toBe(DiffLoadOutcome::Loaded)
+        ->and($restored?->hunks())->toHaveCount(1)
+        ->and($restored?->syntaxStyles)->toBe('.a{}.b{}')
+        ->and($restored?->newFileLineCount)->toBe(40);
+});

--- a/tests/Unit/Enums/DiscardOperationTest.php
+++ b/tests/Unit/Enums/DiscardOperationTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Enums\DiscardOperation;
+
+test('maps a changed file to the operation a discard performs', function (string $status, bool $isUntracked, DiscardOperation $expected) {
+    expect(DiscardOperation::forChangedFile($status, $isUntracked))->toBe($expected);
+})->with([
+    'untracked new file' => ['added', true, DiscardOperation::UntrackedFileDeleted],
+    'staged new file' => ['added', false, DiscardOperation::AddedFileRemoved],
+    'rename' => ['renamed', false, DiscardOperation::RenameReverted],
+    'deletion' => ['deleted', false, DiscardOperation::DeletionReverted],
+    'edit' => ['modified', false, DiscardOperation::ModificationReverted],
+    'binary edit' => ['binary', false, DiscardOperation::ModificationReverted],
+]);
+
+test('only a rename stores a second path', function () {
+    $usingOldPath = collect(DiscardOperation::cases())->filter(fn (DiscardOperation $case): bool => $case->usesOldPath())->values();
+
+    expect($usingOldPath->all())->toBe([DiscardOperation::RenameReverted]);
+});

--- a/tests/Unit/FileDiffTest.php
+++ b/tests/Unit/FileDiffTest.php
@@ -4,7 +4,6 @@ use App\DTOs\DiffLine;
 use App\DTOs\FileDiff;
 use App\DTOs\Hunk;
 use App\Enums\LineType;
-use App\Support\DiffCacheKey;
 use Faker\Factory as Faker;
 
 beforeEach(function () {
@@ -67,10 +66,8 @@ test('withHunks returns new instance with replaced hunks', function () {
         ->and($updated->additions)->toBe(1);
 });
 
-test('emptyArray returns tooLarge array structure', function () {
-    $result = FileDiff::emptyArray('big.php', 'modified', tooLarge: true);
-
-    expect($result)->toBe([
+test('emptyArray returns the no-hunks payload shape', function () {
+    expect(FileDiff::emptyArray('big.php', 'modified'))->toBe([
         'path' => 'big.php',
         'status' => 'modified',
         'oldPath' => null,
@@ -80,38 +77,9 @@ test('emptyArray returns tooLarge array structure', function () {
         'isBinary' => false,
         'isSymlink' => false,
         'symlinkTarget' => null,
-        'tooLarge' => true,
-        'skipReason' => null,
-        'tableAligned' => true,
-        'newFileLineCount' => null,
-        'gridLayout' => true,
-        'lineTypesAreEnum' => true,
-        'renameAware' => true,
-        'syntaxHighlighter' => 'none',
     ]);
 });
 
-test('emptyArray skip result carries the current cache shape so it is cacheable', function () {
-    // Skip results (too-large / empty / no-parse) get merged with the two keys
-    // their caller adds; the combined array must satisfy isCurrentShape() or it
-    // fails validation on every read and re-spawns git forever.
-    $skipResult = FileDiff::emptyArray('big.php', 'modified', tooLarge: true, skipReason: 'too-large')
-        + ['syntaxStyles' => '', 'headingsAnnotated' => true];
-
-    expect(DiffCacheKey::isCurrentShape($skipResult))->toBeTrue();
-});
-
-test('emptyArray returns non-tooLarge array structure', function () {
-    $result = FileDiff::emptyArray('empty.php', 'added', tooLarge: false);
-
-    expect($result['tooLarge'])->toBeFalse()
-        ->and($result['skipReason'])->toBeNull()
-        ->and($result['status'])->toBe('added');
-});
-
-test('emptyArray preserves skipped reason', function () {
-    $result = FileDiff::emptyArray('big.php', 'modified', tooLarge: true, skipReason: 'too-large');
-
-    expect($result['tooLarge'])->toBeTrue()
-        ->and($result['skipReason'])->toBe('too-large');
+test('emptyArray carries the given status', function () {
+    expect(FileDiff::emptyArray('empty.php', 'added')['status'])->toBe('added');
 });

--- a/tests/Unit/GitDiffServiceTest.php
+++ b/tests/Unit/GitDiffServiceTest.php
@@ -178,6 +178,69 @@ test('getFileList excludes rfaignore patterns', function () {
     expect($paths)->not->toContain('debug.log');
 });
 
+test('a negation re-includes a tracked file the same way it does an untracked one', function () {
+    $this->initTestRepo($this->tmpDir);
+    File::makeDirectory($this->tmpDir.'/logs');
+    File::put($this->tmpDir.'/logs/tracked.log', "before\n");
+    $this->commitTestRepo($this->tmpDir, 'initial');
+
+    File::put($this->tmpDir.'/.rfaignore', "*.log\n!logs/tracked.log\n!logs/untracked.log\n");
+    File::put($this->tmpDir.'/logs/tracked.log', "after\n");
+    File::put($this->tmpDir.'/logs/untracked.log', "new\n");
+    File::put($this->tmpDir.'/logs/hidden.log', "hidden\n");
+
+    $paths = collect($this->service->getFileList($this->tmpDir))->pluck('path')->all();
+
+    expect($paths)->toContain('logs/tracked.log')
+        ->and($paths)->toContain('logs/untracked.log')
+        ->and($paths)->not->toContain('logs/hidden.log');
+});
+
+test('a tracked lock file stays excluded even when rfaignore re-includes it', function () {
+    $this->initTestRepo($this->tmpDir);
+    File::put($this->tmpDir.'/composer.lock', "{}\n");
+    $this->commitTestRepo($this->tmpDir, 'initial');
+
+    File::put($this->tmpDir.'/.rfaignore', "!composer.lock\n");
+    File::put($this->tmpDir.'/composer.lock', "{\"changed\": true}\n");
+
+    $paths = collect($this->service->getFileList($this->tmpDir))->pluck('path')->all();
+
+    expect($paths)->not->toContain('composer.lock');
+});
+
+test('a rename out of an ignored directory stays visible as a rename', function () {
+    $this->initTestRepo($this->tmpDir);
+    File::makeDirectory($this->tmpDir.'/vendored');
+    File::put($this->tmpDir.'/vendored/lib.js', str_repeat("const answer = 42;\n", 20));
+    $this->commitTestRepo($this->tmpDir, 'initial');
+
+    File::put($this->tmpDir.'/.rfaignore', "vendored/\n");
+    $this->runTestRepoCommand($this->tmpDir, 'git mv vendored/lib.js lib.js');
+
+    $entry = collect($this->service->getFileList($this->tmpDir))->firstWhere('path', 'lib.js');
+
+    expect($entry)->not->toBeNull()
+        ->and($entry->status)->toBe('renamed')
+        ->and($entry->oldPath)->toBe('vendored/lib.js');
+});
+
+test('the working-directory fingerprint covers exactly the files getFileList shows', function () {
+    $this->initTestRepo($this->tmpDir);
+    File::put($this->tmpDir.'/keep.txt', "before\n");
+    File::put($this->tmpDir.'/build.log', "before\n");
+    $this->commitTestRepo($this->tmpDir, 'initial');
+
+    File::put($this->tmpDir.'/.rfaignore', "*.log\n");
+    File::put($this->tmpDir.'/keep.txt', "after\n");
+    File::put($this->tmpDir.'/build.log', "after\n");
+
+    $status = $this->service->getWorkingDirectoryStatus($this->tmpDir);
+    $listed = $this->service->getFileList($this->tmpDir);
+
+    expect($status['count'])->toBe(count($listed));
+});
+
 test('getFileList excludes untracked files matching globalGitignorePath', function () {
     $this->initTestRepo($this->tmpDir);
     File::put($this->tmpDir.'/tracked.txt', "ok\n");

--- a/tests/Unit/IgnoreServiceTest.php
+++ b/tests/Unit/IgnoreServiceTest.php
@@ -14,24 +14,21 @@ beforeEach(function () {
     $this->tmpDir = $this->createTempDirectory('rfa_ignore_test_');
 });
 
-test('always excludes lock files without rfaignore', function () {
-    $pathspecs = $this->service->getExcludePathspecs($this->tmpDir);
+test('always excludes lock files, with or without an rfaignore', function () {
+    $rules = $this->service->rules($this->tmpDir);
 
-    expect($pathspecs)->toContain(':(glob,exclude)**/package-lock.json');
-    expect($pathspecs)->toContain(':(glob,exclude)**/pnpm-lock.yaml');
-    expect($pathspecs)->toContain(':(glob,exclude)**/yarn.lock');
-    expect($pathspecs)->toContain(':(glob,exclude)**/bun.lock');
-    expect($pathspecs)->toContain(':(glob,exclude)**/composer.lock');
-    expect($pathspecs)->toHaveCount(5);
+    foreach (IgnoreService::ALWAYS_EXCLUDE as $lockfile) {
+        expect($this->service->isPathExcluded($lockfile, $rules))->toBeTrue();
+        expect($this->service->isPathExcluded("packages/app/{$lockfile}", $rules))->toBeTrue();
+    }
 });
 
-test('returns only defaults when no rfaignore exists', function () {
-    $pathspecs = $this->service->getExcludePathspecs($this->tmpDir);
+test('a negation cannot re-include a lock file', function () {
+    File::put($this->tmpDir.'/.rfaignore', "!composer.lock\n");
 
-    expect($pathspecs)->toHaveCount(5);
-    foreach ($pathspecs as $ps) {
-        expect($ps)->toStartWith(':(glob,exclude)**/');
-    }
+    $rules = $this->service->rules($this->tmpDir);
+
+    expect($this->service->isPathExcluded('composer.lock', $rules))->toBeTrue();
 });
 
 test('reads custom patterns from rfaignore', function () {
@@ -43,46 +40,44 @@ test('reads custom patterns from rfaignore', function () {
 
     File::put($this->tmpDir.'/.rfaignore', implode("\n", $patterns));
 
-    $pathspecs = $this->service->getExcludePathspecs($this->tmpDir);
+    $rules = $this->service->rules($this->tmpDir);
 
-    expect($pathspecs)->toHaveCount(5 + $count);
+    expect($rules)->toHaveCount($count);
     foreach ($patterns as $pattern) {
-        expect($pathspecs)->toContain(":(glob,exclude)**/{$pattern}");
+        expect($this->service->isPathExcluded($pattern, $rules))->toBeTrue();
+        expect($this->service->isPathExcluded("src/{$pattern}", $rules))->toBeTrue();
     }
 });
 
 test('ignores comments and blank lines in rfaignore', function () {
     $validPattern = $this->faker->word().'.log';
-    $content = "# This is a comment\n\n{$validPattern}\n   \n# Another comment\n";
 
-    File::put($this->tmpDir.'/.rfaignore', $content);
+    File::put($this->tmpDir.'/.rfaignore', "# This is a comment\n\n{$validPattern}\n   \n# Another comment\n");
 
-    $pathspecs = $this->service->getExcludePathspecs($this->tmpDir);
+    $rules = $this->service->rules($this->tmpDir);
 
-    expect($pathspecs)->toHaveCount(6); // 5 defaults + 1 valid
-    expect($pathspecs)->toContain(":(glob,exclude)**/{$validPattern}");
+    expect($rules)->toHaveCount(1);
+    expect($this->service->isPathExcluded($validPattern, $rules))->toBeTrue();
 });
 
 test('handles glob patterns in rfaignore', function () {
     $ext = $this->faker->fileExtension();
-    $globPattern = "*.{$ext}";
 
-    File::put($this->tmpDir.'/.rfaignore', $globPattern);
+    File::put($this->tmpDir.'/.rfaignore', "*.{$ext}");
 
-    $pathspecs = $this->service->getExcludePathspecs($this->tmpDir);
+    $rules = $this->service->rules($this->tmpDir);
 
-    expect($pathspecs)->toContain(":(exclude){$globPattern}");
+    expect($this->service->isPathExcluded("report.{$ext}", $rules))->toBeTrue();
 });
 
-test('getExcludePathspecs skips negation lines', function () {
-    File::put($this->tmpDir.'/.rfaignore', "*.log\n!keep.log\n");
+test('a negation line re-includes rather than excluding the literal name', function () {
+    File::put($this->tmpDir.'/.rfaignore', "build/\n!notes.txt\n");
 
-    $pathspecs = $this->service->getExcludePathspecs($this->tmpDir);
+    $rules = $this->service->rules($this->tmpDir);
 
-    expect($pathspecs)->toContain(':(exclude)*.log');
-    // The negation must NOT become a literal exclude for a file named "!keep.log".
-    expect($pathspecs)->not->toContain(':(glob,exclude)**/!keep.log');
-    expect($pathspecs)->not->toContain(':(exclude)!keep.log');
+    expect($this->service->isPathExcluded('build/out.js', $rules))->toBeTrue()
+        ->and($this->service->isPathExcluded('notes.txt', $rules))->toBeFalse()
+        ->and($this->service->isPathExcluded('!notes.txt', $rules))->toBeFalse();
 });
 
 // -- isPathExcluded tests (operate on compiled rules) --

--- a/tests/Unit/Livewire/DiffFileTest.php
+++ b/tests/Unit/Livewire/DiffFileTest.php
@@ -29,7 +29,7 @@ beforeEach(function () {
     {
         public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, int $contextLines = 3, ?DiffTarget $target = null, ?string $oldPath = null, ?string $externalAbsolutePath = null): LoadedDiff
         {
-            return LoadedDiff::fromCache(DiffFixtureFactory::diffData(path: $path)) ?? LoadedDiff::empty($path);
+            return DiffFixtureFactory::loadedDiff(path: $path);
         }
     });
 });
@@ -313,7 +313,7 @@ function mountMultiHunkDiffFile(array $diffData, array $file): Testable
 
         public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, int $contextLines = 3, ?DiffTarget $target = null, ?string $oldPath = null, ?string $externalAbsolutePath = null): LoadedDiff
         {
-            return LoadedDiff::fromCache($this->diffData) ?? LoadedDiff::empty($path);
+            return LoadedDiff::tryFrom($this->diffData) ?? LoadedDiff::empty($path);
         }
     });
 
@@ -461,7 +461,7 @@ test('expandGap writes a readable envelope back to the cache', function () {
         'fileComments' => [],
     ])->call('expandGap', 0);
 
-    expect(LoadedDiff::fromCache(Cache::get($cacheKey))?->outcome)->toBe(DiffLoadOutcome::Loaded);
+    expect(LoadedDiff::tryFrom(Cache::get($cacheKey))?->outcome)->toBe(DiffLoadOutcome::Loaded);
 });
 
 test('expandContext replaces the diff with a readable envelope', function () {
@@ -474,7 +474,7 @@ test('expandContext replaces the diff with a readable envelope', function () {
 
     $component->assertDispatched('rfa:diff-action-completed', action: 'expandContext');
 
-    expect(LoadedDiff::fromCache(Cache::get(DiffCacheKey::for(0, $this->file['id'], reviewFingerprint()))))->not->toBeNull();
+    expect(LoadedDiff::tryFrom(Cache::get(DiffCacheKey::for(0, $this->file['id'], reviewFingerprint()))))->not->toBeNull();
 });
 
 test('expandGap settles the action when the diff is no longer cached', function () {
@@ -504,7 +504,7 @@ test('expandGap settles the action when the full-context reload finds no diff', 
         {
             return $contextLines >= 99999
                 ? LoadedDiff::empty($path)
-                : (LoadedDiff::fromCache(DiffFixtureFactory::diffData(path: $path)) ?? LoadedDiff::empty($path));
+                : (DiffFixtureFactory::loadedDiff(path: $path));
         }
     });
 
@@ -528,7 +528,7 @@ test('expandGap settles a tiered-chip expand when the reload finds no diff', fun
         {
             return $contextLines >= 99999
                 ? LoadedDiff::empty($path)
-                : (LoadedDiff::fromCache(DiffFixtureFactory::diffData(path: $path)) ?? LoadedDiff::empty($path));
+                : (DiffFixtureFactory::loadedDiff(path: $path));
         }
     });
 

--- a/tests/Unit/Livewire/DiffFileTest.php
+++ b/tests/Unit/Livewire/DiffFileTest.php
@@ -5,6 +5,8 @@ use App\Actions\LoadFileDiffAction;
 use App\Console\Benchmark\DiffFixtureFactory;
 use App\DTOs\CopyContentResult;
 use App\DTOs\DiffTarget;
+use App\DTOs\LoadedDiff;
+use App\Enums\DiffLoadOutcome;
 use App\Enums\LineType;
 use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
@@ -25,9 +27,9 @@ beforeEach(function () {
     // Mock LoadFileDiffAction so it never touches git
     app()->bind(LoadFileDiffAction::class, fn () => new class
     {
-        public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, int $contextLines = 3, ?DiffTarget $target = null, ?string $oldPath = null, ?string $externalAbsolutePath = null): array
+        public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, int $contextLines = 3, ?DiffTarget $target = null, ?string $oldPath = null, ?string $externalAbsolutePath = null): LoadedDiff
         {
-            return DiffFixtureFactory::diffData(path: $path);
+            return LoadedDiff::fromCache(DiffFixtureFactory::diffData(path: $path)) ?? LoadedDiff::empty($path);
         }
     });
 });
@@ -309,9 +311,9 @@ function mountMultiHunkDiffFile(array $diffData, array $file): Testable
     {
         public function __construct(private array $diffData) {}
 
-        public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, int $contextLines = 3, ?DiffTarget $target = null, ?string $oldPath = null, ?string $externalAbsolutePath = null): array
+        public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, int $contextLines = 3, ?DiffTarget $target = null, ?string $oldPath = null, ?string $externalAbsolutePath = null): LoadedDiff
         {
-            return $this->diffData;
+            return LoadedDiff::fromCache($this->diffData) ?? LoadedDiff::empty($path);
         }
     });
 
@@ -449,6 +451,32 @@ test('1-line gap shows single expand button', function () {
 
 // -- Expand loading spinner settles on no-op early returns --
 
+test('expandGap writes a readable envelope back to the cache', function () {
+    $cacheKey = DiffCacheKey::for(0, $this->file['id'], reviewFingerprint());
+
+    Livewire::test('diff-file', [
+        'file' => $this->file,
+        'repoPath' => '/tmp/test',
+        'projectId' => 0,
+        'fileComments' => [],
+    ])->call('expandGap', 0);
+
+    expect(LoadedDiff::fromCache(Cache::get($cacheKey))?->outcome)->toBe(DiffLoadOutcome::Loaded);
+});
+
+test('expandContext replaces the diff with a readable envelope', function () {
+    $component = Livewire::test('diff-file', [
+        'file' => $this->file,
+        'repoPath' => '/tmp/test',
+        'projectId' => 0,
+        'fileComments' => [],
+    ])->call('expandContext');
+
+    $component->assertDispatched('rfa:diff-action-completed', action: 'expandContext');
+
+    expect(LoadedDiff::fromCache(Cache::get(DiffCacheKey::for(0, $this->file['id'], reviewFingerprint()))))->not->toBeNull();
+});
+
 test('expandGap settles the action when the diff is no longer cached', function () {
     // Force diffData to hydrate null: the cached diff was evicted between the
     // render that showed the expander and this click. expandGap hits its first
@@ -472,9 +500,11 @@ test('expandGap settles the action when the full-context reload finds no diff', 
     // the completion event itself or the spinner stays stuck until a refresh.
     app()->bind(LoadFileDiffAction::class, fn () => new class
     {
-        public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, int $contextLines = 3, ?DiffTarget $target = null, ?string $oldPath = null, ?string $externalAbsolutePath = null): array
+        public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, int $contextLines = 3, ?DiffTarget $target = null, ?string $oldPath = null, ?string $externalAbsolutePath = null): LoadedDiff
         {
-            return $contextLines >= 99999 ? ['hunks' => []] : DiffFixtureFactory::diffData(path: $path);
+            return $contextLines >= 99999
+                ? LoadedDiff::empty($path)
+                : (LoadedDiff::fromCache(DiffFixtureFactory::diffData(path: $path)) ?? LoadedDiff::empty($path));
         }
     });
 
@@ -494,9 +524,11 @@ test('expandGap settles a tiered-chip expand when the reload finds no diff', fun
     // stuck. Guards a regression that only settles when $lineCount is null.
     app()->bind(LoadFileDiffAction::class, fn () => new class
     {
-        public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, int $contextLines = 3, ?DiffTarget $target = null, ?string $oldPath = null, ?string $externalAbsolutePath = null): array
+        public function handle(string $repoPath, string $path, bool $isUntracked = false, ?string $cacheKey = null, int $contextLines = 3, ?DiffTarget $target = null, ?string $oldPath = null, ?string $externalAbsolutePath = null): LoadedDiff
         {
-            return $contextLines >= 99999 ? ['hunks' => []] : DiffFixtureFactory::diffData(path: $path);
+            return $contextLines >= 99999
+                ? LoadedDiff::empty($path)
+                : (LoadedDiff::fromCache(DiffFixtureFactory::diffData(path: $path)) ?? LoadedDiff::empty($path));
         }
     });
 

--- a/tests/Unit/Livewire/DiffFileTest.php
+++ b/tests/Unit/Livewire/DiffFileTest.php
@@ -19,7 +19,7 @@ beforeEach(function () {
     $this->diffData = DiffFixtureFactory::diffData(path: 'src/Test.php');
 
     // Prime cache so component doesn't try to load from git
-    $cacheKey = DiffCacheKey::for(0, $this->file['id']);
+    $cacheKey = DiffCacheKey::for(0, $this->file['id'], reviewFingerprint());
     Cache::put($cacheKey, $this->diffData, 3600);
 
     // Mock LoadFileDiffAction so it never touches git
@@ -454,7 +454,7 @@ test('expandGap settles the action when the diff is no longer cached', function 
     // render that showed the expander and this click. expandGap hits its first
     // guard, but must still dispatch so the client clears the optimistic spinner
     // (and the paired runtime-diagnostics start mark isn't left orphaned).
-    Cache::forget(DiffCacheKey::for(0, $this->file['id']));
+    Cache::forget(DiffCacheKey::for(0, $this->file['id'], reviewFingerprint()));
 
     Livewire::test('diff-file', [
         'file' => $this->file,

--- a/tests/Unit/Livewire/ReviewPageTest.php
+++ b/tests/Unit/Livewire/ReviewPageTest.php
@@ -11,6 +11,7 @@ use App\Actions\ResolveRangeToWorkingAction;
 use App\Actions\ScanReviewFilesAction;
 use App\Actions\SessionStateAction;
 use App\DTOs\DiffTarget;
+use App\Enums\DiscardOperation;
 use App\Models\Comment;
 use App\Models\CommentReply;
 use App\Models\Project;
@@ -700,7 +701,7 @@ test('discardFileChanges dispatches undo-available with file name', function () 
     $trashRecord = TrashedFile::create([
         'project_id' => $this->project->id,
         'file_path' => 'src/Foo.php',
-        'file_status' => 'modified',
+        'operation' => DiscardOperation::ModificationReverted,
         'expires_at' => now()->addMinutes(30),
     ]);
 
@@ -735,7 +736,7 @@ test('discardFileChanges includes comment count in undo message', function () {
     $trashRecord = TrashedFile::create([
         'project_id' => $this->project->id,
         'file_path' => 'src/Foo.php',
-        'file_status' => 'modified',
+        'operation' => DiscardOperation::ModificationReverted,
         'expires_at' => now()->addMinutes(30),
     ]);
 

--- a/tests/Unit/Migrations/ReplaceTrashedFileStatusWithOperationTest.php
+++ b/tests/Unit/Migrations/ReplaceTrashedFileStatusWithOperationTest.php
@@ -2,7 +2,7 @@
 
 use App\Enums\DiscardOperation;
 use App\Models\Project;
-use Illuminate\Database\Schema\Blueprint;
+use App\Models\TrashedFile;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -10,30 +10,42 @@ use Tests\TestCase;
 
 uses(TestCase::class, LazilyRefreshDatabase::class);
 
-test('every legacy field combination backfills to one operation', function () {
-    $project = Project::factory()->create();
-
-    recreateLegacyTrashedFilesTable();
-
-    $legacyRows = [
+/**
+ * @return array<int, array<string, mixed>>
+ */
+function legacyTrashedFileRows(): array
+{
+    return [
         ['file_path' => 'a.txt', 'file_status' => 'added', 'is_untracked' => true, 'old_path' => null],
         ['file_path' => 'b.txt', 'file_status' => 'added', 'is_untracked' => false, 'old_path' => null],
         ['file_path' => 'c.txt', 'file_status' => 'renamed', 'is_untracked' => false, 'old_path' => 'was-c.txt'],
         ['file_path' => 'd.txt', 'file_status' => 'deleted', 'is_untracked' => false, 'old_path' => null],
         ['file_path' => 'e.txt', 'file_status' => 'modified', 'is_untracked' => false, 'old_path' => null],
         ['file_path' => 'f.txt', 'file_status' => 'binary', 'is_untracked' => false, 'old_path' => null],
+        // The legacy writer stored whatever old_path it was handed, so a
+        // non-rename row can carry one. The backfill has to clear it.
+        ['file_path' => 'g.txt', 'file_status' => 'modified', 'is_untracked' => false, 'old_path' => 'stale-g.txt'],
     ];
+}
 
-    foreach ($legacyRows as $row) {
-        DB::table('trashed_files')->insert([
-            ...$row,
-            'project_id' => $project->id,
-            'is_symlink' => false,
-            'expires_at' => now()->addMinutes(30),
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
-    }
+function seedLegacyTrashedFiles(): void
+{
+    $project = Project::factory()->create();
+
+    recreateLegacyTrashedFilesTable();
+
+    collect(legacyTrashedFileRows())->each(fn (array $row) => DB::table('trashed_files')->insert([
+        ...$row,
+        'project_id' => $project->id,
+        'is_symlink' => false,
+        'expires_at' => now()->addMinutes(30),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]));
+}
+
+test('every legacy field combination backfills to one operation', function () {
+    seedLegacyTrashedFiles();
 
     trashedFileOperationMigration()->up();
 
@@ -44,10 +56,69 @@ test('every legacy field combination backfills to one operation', function () {
         'd.txt' => DiscardOperation::DeletionReverted->value,
         'e.txt' => DiscardOperation::ModificationReverted->value,
         'f.txt' => DiscardOperation::ModificationReverted->value,
+        'g.txt' => DiscardOperation::ModificationReverted->value,
     ]);
 
     expect(Schema::hasColumn('trashed_files', 'file_status'))->toBeFalse()
         ->and(Schema::hasColumn('trashed_files', 'is_untracked'))->toBeFalse();
+});
+
+test('the backfill clears an old_path the migrated operation cannot carry', function () {
+    seedLegacyTrashedFiles();
+
+    trashedFileOperationMigration()->up();
+
+    expect(DB::table('trashed_files')->pluck('old_path', 'file_path')->all())
+        ->toBe([
+            'a.txt' => null,
+            'b.txt' => null,
+            'c.txt' => 'was-c.txt',
+            'd.txt' => null,
+            'e.txt' => null,
+            'f.txt' => null,
+            'g.txt' => null,
+        ]);
+});
+
+test('every migrated row satisfies the model contract it will be saved under', function () {
+    seedLegacyTrashedFiles();
+
+    trashedFileOperationMigration()->up();
+
+    // A row that migrates into a combination TrashedFile rejects would be
+    // permanently unsaveable, so re-saving each one is the real assertion.
+    TrashedFile::query()->get()->each(fn (TrashedFile $trashed) => $trashed->touch());
+})->throwsNoExceptions();
+
+test('down restores the legacy columns and values', function () {
+    seedLegacyTrashedFiles();
+
+    $migration = trashedFileOperationMigration();
+    $migration->up();
+    $migration->down();
+
+    expect(Schema::hasColumn('trashed_files', 'operation'))->toBeFalse()
+        ->and(Schema::hasColumn('trashed_files', 'file_status'))->toBeTrue()
+        ->and(Schema::hasColumn('trashed_files', 'is_untracked'))->toBeTrue();
+
+    $restored = DB::table('trashed_files')
+        ->get()
+        ->mapWithKeys(fn (object $row): array => [
+            $row->file_path => [(string) $row->file_status, (bool) $row->is_untracked],
+        ])
+        ->all();
+
+    expect($restored)->toBe([
+        'a.txt' => ['added', true],
+        'b.txt' => ['added', false],
+        'c.txt' => ['renamed', false],
+        'd.txt' => ['deleted', false],
+        'e.txt' => ['modified', false],
+        // 'binary' is not a discard operation of its own, so it round-trips as
+        // the 'modified' it always mapped to.
+        'f.txt' => ['modified', false],
+        'g.txt' => ['modified', false],
+    ]);
 });
 
 function trashedFileOperationMigration(): object
@@ -55,21 +126,15 @@ function trashedFileOperationMigration(): object
     return require database_path('migrations/2026_08_23_120000_replace_trashed_file_status_with_operation.php');
 }
 
-/** The pre-migration schema, so the backfill runs against rows it would actually find. */
+/**
+ * Rebuild the pre-migration schema by replaying the create migration, so the
+ * backfill runs against the real legacy shape rather than a copy of it that can
+ * silently drift.
+ */
 function recreateLegacyTrashedFilesTable(): void
 {
-    Schema::dropIfExists('trashed_files');
+    $create = require database_path('migrations/2026_03_15_000000_create_trashed_files_table.php');
 
-    Schema::create('trashed_files', function (Blueprint $table) {
-        $table->id();
-        $table->foreignId('project_id')->constrained()->cascadeOnDelete();
-        $table->string('file_path');
-        $table->string('file_status');
-        $table->string('old_path')->nullable();
-        $table->boolean('is_untracked')->default(false);
-        $table->boolean('is_symlink')->default(false);
-        $table->json('comments')->nullable();
-        $table->timestamp('expires_at');
-        $table->timestamps();
-    });
+    $create->down();
+    $create->up();
 }

--- a/tests/Unit/Migrations/ReplaceTrashedFileStatusWithOperationTest.php
+++ b/tests/Unit/Migrations/ReplaceTrashedFileStatusWithOperationTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Enums\DiscardOperation;
+use App\Models\Project;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+test('every legacy field combination backfills to one operation', function () {
+    $project = Project::factory()->create();
+
+    recreateLegacyTrashedFilesTable();
+
+    $legacyRows = [
+        ['file_path' => 'a.txt', 'file_status' => 'added', 'is_untracked' => true, 'old_path' => null],
+        ['file_path' => 'b.txt', 'file_status' => 'added', 'is_untracked' => false, 'old_path' => null],
+        ['file_path' => 'c.txt', 'file_status' => 'renamed', 'is_untracked' => false, 'old_path' => 'was-c.txt'],
+        ['file_path' => 'd.txt', 'file_status' => 'deleted', 'is_untracked' => false, 'old_path' => null],
+        ['file_path' => 'e.txt', 'file_status' => 'modified', 'is_untracked' => false, 'old_path' => null],
+        ['file_path' => 'f.txt', 'file_status' => 'binary', 'is_untracked' => false, 'old_path' => null],
+    ];
+
+    foreach ($legacyRows as $row) {
+        DB::table('trashed_files')->insert([
+            ...$row,
+            'project_id' => $project->id,
+            'is_symlink' => false,
+            'expires_at' => now()->addMinutes(30),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    trashedFileOperationMigration()->up();
+
+    expect(DB::table('trashed_files')->pluck('operation', 'file_path')->all())->toBe([
+        'a.txt' => DiscardOperation::UntrackedFileDeleted->value,
+        'b.txt' => DiscardOperation::AddedFileRemoved->value,
+        'c.txt' => DiscardOperation::RenameReverted->value,
+        'd.txt' => DiscardOperation::DeletionReverted->value,
+        'e.txt' => DiscardOperation::ModificationReverted->value,
+        'f.txt' => DiscardOperation::ModificationReverted->value,
+    ]);
+
+    expect(Schema::hasColumn('trashed_files', 'file_status'))->toBeFalse()
+        ->and(Schema::hasColumn('trashed_files', 'is_untracked'))->toBeFalse();
+});
+
+function trashedFileOperationMigration(): object
+{
+    return require database_path('migrations/2026_08_23_120000_replace_trashed_file_status_with_operation.php');
+}
+
+/** The pre-migration schema, so the backfill runs against rows it would actually find. */
+function recreateLegacyTrashedFilesTable(): void
+{
+    Schema::dropIfExists('trashed_files');
+
+    Schema::create('trashed_files', function (Blueprint $table) {
+        $table->id();
+        $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+        $table->string('file_path');
+        $table->string('file_status');
+        $table->string('old_path')->nullable();
+        $table->boolean('is_untracked')->default(false);
+        $table->boolean('is_symlink')->default(false);
+        $table->json('comments')->nullable();
+        $table->timestamp('expires_at');
+        $table->timestamps();
+    });
+}

--- a/tests/Unit/Models/TrashedFileTest.php
+++ b/tests/Unit/Models/TrashedFileTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Enums\DiscardOperation;
+use App\Models\Project;
+use App\Models\TrashedFile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+uses(TestCase::class, LazilyRefreshDatabase::class);
+
+test('a trashed file needs an operation', function () {
+    expect(fn () => TrashedFile::create([
+        'project_id' => Project::factory()->create()->id,
+        'file_path' => 'src/App.php',
+        'expires_at' => now()->addMinutes(30),
+    ]))->toThrow(InvalidArgumentException::class, 'The operation field is required to trash a file.');
+});
+
+test('only a rename may store an old path', function () {
+    expect(fn () => TrashedFile::factory()->create([
+        'operation' => DiscardOperation::ModificationReverted,
+        'old_path' => 'src/Old.php',
+    ]))->toThrow(InvalidArgumentException::class, 'The old_path field must be empty for a modification-reverted discard.');
+});
+
+test('a rename must store an old path', function () {
+    expect(fn () => TrashedFile::factory()->create([
+        'operation' => DiscardOperation::RenameReverted,
+        'old_path' => null,
+    ]))->toThrow(InvalidArgumentException::class, 'The old_path field is required for a rename-reverted discard.');
+});
+
+test('a rename with its old path saves', function () {
+    $trashed = TrashedFile::factory()->renamed('src/Old.php')->create();
+
+    expect($trashed->operation)->toBe(DiscardOperation::RenameReverted)
+        ->and($trashed->old_path)->toBe('src/Old.php');
+});

--- a/tests/Unit/Observers/ProjectObserverTest.php
+++ b/tests/Unit/Observers/ProjectObserverTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Actions\ResolveStartupRouteAction;
+use App\Enums\DiscardOperation;
 use App\Models\Project;
 use App\Models\TrashedFile;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
@@ -39,7 +40,7 @@ test('deleting a project purges its trashed-file content blobs', function () {
     $trashed = TrashedFile::create([
         'project_id' => $project->id,
         'file_path' => 'a.txt',
-        'file_status' => 'modified',
+        'operation' => DiscardOperation::ModificationReverted,
         'expires_at' => now()->addMinutes(30),
     ]);
     Storage::put($trashed->blobPath(), 'discarded content');

--- a/tests/Unit/Support/DiffCacheKeyTest.php
+++ b/tests/Unit/Support/DiffCacheKeyTest.php
@@ -1,33 +1,43 @@
 <?php
 
+use App\DTOs\ReviewConfig;
+use App\Services\ReviewConfigService;
 use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
 use Tests\TestCase;
 
 uses(TestCase::class);
 
-test('for is deterministic and varies by project, file, and context', function () {
-    $a = DiffCacheKey::for(1, 'file-a');
-    $b = DiffCacheKey::for(1, 'file-a');
-    $c = DiffCacheKey::for(2, 'file-a');
-    $d = DiffCacheKey::for(1, 'file-b');
-    $e = DiffCacheKey::for(1, 'file-a', 'HEAD..abc');
+/** Resolve from a fresh service so a test's config changes are not masked by memoization. */
+function fingerprint(): string
+{
+    return (new ReviewConfigService)->resolve()->movedLineFingerprint();
+}
+
+test('for is deterministic and varies by project, file, context, and review settings', function () {
+    $a = DiffCacheKey::for(1, 'file-a', 'm0');
+    $b = DiffCacheKey::for(1, 'file-a', 'm0');
+    $c = DiffCacheKey::for(2, 'file-a', 'm0');
+    $d = DiffCacheKey::for(1, 'file-b', 'm0');
+    $e = DiffCacheKey::for(1, 'file-a', 'm0', 'HEAD..abc');
+    $f = DiffCacheKey::for(1, 'file-a', 'm1-zebra');
 
     expect($a)->toBe($b)
         ->and($a)->not->toBe($c)
         ->and($a)->not->toBe($d)
-        ->and($a)->not->toBe($e);
+        ->and($a)->not->toBe($e)
+        ->and($a)->not->toBe($f);
 });
 
 test('forget clears every variant of a file diff', function () {
     foreach (DiffCacheKey::VARIANTS as $variant) {
-        Cache::put(DiffCacheKey::for(7, 'file-x', 'HEAD..working'.$variant), 'stale', 60);
+        Cache::put(DiffCacheKey::for(7, 'file-x', 'm0', 'HEAD..working'.$variant), 'stale', 60);
     }
 
-    DiffCacheKey::forget(7, 'file-x', 'HEAD..working');
+    DiffCacheKey::forget(7, 'file-x', 'm0', 'HEAD..working');
 
     foreach (DiffCacheKey::VARIANTS as $variant) {
-        expect(Cache::has(DiffCacheKey::for(7, 'file-x', 'HEAD..working'.$variant)))->toBeFalse();
+        expect(Cache::has(DiffCacheKey::for(7, 'file-x', 'm0', 'HEAD..working'.$variant)))->toBeFalse();
     }
 });
 
@@ -35,26 +45,53 @@ test('VARIANTS includes the base and full-context shapes', function () {
     expect(DiffCacheKey::VARIANTS)->toContain('')->toContain(':full-context');
 });
 
-test('for varies by the moved-line detection settings', function () {
+test('the fingerprint varies by the moved-line detection settings', function () {
     config(['rfa.moved_lines.enabled' => false]);
-    $off = DiffCacheKey::for(1, 'file-a');
+    $off = fingerprint();
 
     config(['rfa.moved_lines.enabled' => true, 'rfa.moved_lines.mode' => 'zebra']);
-    $onZebra = DiffCacheKey::for(1, 'file-a');
+    $onZebra = fingerprint();
 
     config(['rfa.moved_lines.mode' => 'blocks']);
-    $onBlocks = DiffCacheKey::for(1, 'file-a');
+    $onBlocks = fingerprint();
 
     expect($off)->not->toBe($onZebra)
         ->and($onZebra)->not->toBe($onBlocks);
 });
 
-test('for ignores the moved-line mode while detection is off', function () {
+test('the fingerprint ignores the moved-line mode while detection is off', function () {
     config(['rfa.moved_lines.enabled' => false, 'rfa.moved_lines.mode' => 'zebra']);
-    $zebra = DiffCacheKey::for(1, 'file-a');
+    $zebra = fingerprint();
 
     config(['rfa.moved_lines.mode' => 'blocks']);
-    $blocks = DiffCacheKey::for(1, 'file-a');
+    $blocks = fingerprint();
 
     expect($zebra)->toBe($blocks);
+});
+
+test('malformed moved-line settings land on the same fingerprint as their normalized form', function () {
+    config(['rfa.moved_lines.enabled' => 'off', 'rfa.moved_lines.mode' => 'zebra']);
+    $malformedOff = fingerprint();
+
+    config(['rfa.moved_lines.enabled' => false]);
+    expect($malformedOff)->toBe(fingerprint());
+
+    config(['rfa.moved_lines.enabled' => true, 'rfa.moved_lines.mode' => 'not-a-mode']);
+    $malformedMode = fingerprint();
+
+    config(['rfa.moved_lines.mode' => 'zebra']);
+    expect($malformedMode)->toBe(fingerprint());
+});
+
+test('the fingerprint reads only the effective values', function () {
+    $config = new ReviewConfig(
+        diffMaxBytes: 1,
+        sourceMaxBytes: 1,
+        cacheTtlHours: 1,
+        defaultContextLines: 0,
+        movedLineDetection: false,
+        movedLineMode: 'blocks',
+    );
+
+    expect($config->movedLineFingerprint())->toBe('m0');
 });

--- a/tests/Unit/Support/DiffCacheKeyTest.php
+++ b/tests/Unit/Support/DiffCacheKeyTest.php
@@ -1,18 +1,11 @@
 <?php
 
 use App\DTOs\ReviewConfig;
-use App\Services\ReviewConfigService;
 use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
 use Tests\TestCase;
 
 uses(TestCase::class);
-
-/** Resolve from a fresh service so a test's config changes are not masked by memoization. */
-function fingerprint(): string
-{
-    return (new ReviewConfigService)->resolve()->movedLineFingerprint();
-}
 
 test('for is deterministic and varies by project, file, context, and review settings', function () {
     $a = DiffCacheKey::for(1, 'file-a', 'm0');
@@ -47,13 +40,13 @@ test('VARIANTS includes the base and full-context shapes', function () {
 
 test('the fingerprint varies by the moved-line detection settings', function () {
     config(['rfa.moved_lines.enabled' => false]);
-    $off = fingerprint();
+    $off = reviewFingerprint();
 
     config(['rfa.moved_lines.enabled' => true, 'rfa.moved_lines.mode' => 'zebra']);
-    $onZebra = fingerprint();
+    $onZebra = reviewFingerprint();
 
     config(['rfa.moved_lines.mode' => 'blocks']);
-    $onBlocks = fingerprint();
+    $onBlocks = reviewFingerprint();
 
     expect($off)->not->toBe($onZebra)
         ->and($onZebra)->not->toBe($onBlocks);
@@ -61,26 +54,53 @@ test('the fingerprint varies by the moved-line detection settings', function () 
 
 test('the fingerprint ignores the moved-line mode while detection is off', function () {
     config(['rfa.moved_lines.enabled' => false, 'rfa.moved_lines.mode' => 'zebra']);
-    $zebra = fingerprint();
+    $zebra = reviewFingerprint();
 
     config(['rfa.moved_lines.mode' => 'blocks']);
-    $blocks = fingerprint();
+    $blocks = reviewFingerprint();
 
     expect($zebra)->toBe($blocks);
 });
 
 test('malformed moved-line settings land on the same fingerprint as their normalized form', function () {
     config(['rfa.moved_lines.enabled' => 'off', 'rfa.moved_lines.mode' => 'zebra']);
-    $malformedOff = fingerprint();
+    $malformedOff = reviewFingerprint();
 
     config(['rfa.moved_lines.enabled' => false]);
-    expect($malformedOff)->toBe(fingerprint());
+    expect($malformedOff)->toBe(reviewFingerprint());
 
     config(['rfa.moved_lines.enabled' => true, 'rfa.moved_lines.mode' => 'not-a-mode']);
-    $malformedMode = fingerprint();
+    $malformedMode = reviewFingerprint();
 
     config(['rfa.moved_lines.mode' => 'zebra']);
-    expect($malformedMode)->toBe(fingerprint());
+    expect($malformedMode)->toBe(reviewFingerprint());
+});
+
+test('the fingerprint varies by the diff size limit', function () {
+    config(['rfa.diff_max_bytes' => 512_000]);
+    $small = reviewFingerprint();
+
+    config(['rfa.diff_max_bytes' => 2_048_000]);
+
+    expect(reviewFingerprint())->not->toBe($small);
+});
+
+test('the fingerprint varies by the default context lines', function () {
+    config(['rfa.default_context_lines' => 3]);
+    $narrow = reviewFingerprint();
+
+    config(['rfa.default_context_lines' => 8]);
+
+    expect(reviewFingerprint())->not->toBe($narrow);
+});
+
+test('the fingerprint ignores settings that do not shape the stored diff', function () {
+    config(['rfa.source_max_bytes' => 1_048_576, 'rfa.cache_ttl_hours' => 24]);
+    $before = reviewFingerprint();
+
+    config(['rfa.source_max_bytes' => 4_000_000, 'rfa.cache_ttl_hours' => 1]);
+
+    expect(reviewFingerprint())->toBe($before);
 });
 
 test('the fingerprint reads only the effective values', function () {
@@ -93,5 +113,5 @@ test('the fingerprint reads only the effective values', function () {
         movedLineMode: 'blocks',
     );
 
-    expect($config->movedLineFingerprint())->toBe('m0');
+    expect($config->cacheFingerprint())->toBe('m0|b1|c0');
 });


### PR DESCRIPTION
Closes #157
Closes #158
Closes #159
Closes #160

## Summary

Four related issues across the diff-loading and discard paths. Each is a representation fix: replace a combination of loosely-coupled fields with a single value that cannot express an invalid state.

## #157 — the normalized `ReviewConfig` owns effective review settings

`DiffCacheKey` no longer reads config itself. It takes a `reviewFingerprint` string derived from the normalized `ReviewConfig`, so cache identity describes *effective* behavior rather than raw input — two runs that would behave identically now land on the same key even if their raw config differs.

`ReviewConfig::cacheFingerprint()` covers every setting that shapes a stored diff:

- moved-line detection and mode — git colorizes moves and the parser bakes those markers into the hunks;
- `diffMaxBytes` — decides whether a file is diffed at all or stored as a `too-large` outcome;
- `defaultContextLines` — sets the `-U` width of the stored hunks.

`sourceMaxBytes` and `cacheTtlHours` are deliberately excluded: neither changes diff content, so keying on them would discard good entries. `DiffTarget::cacheTtlHours()` now takes the effective TTL as a parameter instead of falling back to config.

**Expected cache churn:** the key prefix moves `rfa_diff_v12_` → `rfa_diff_v13_`. Cache identity genuinely changed (the fingerprint is normalized, and covers two more inputs), so every pre-existing entry recomputes once. Entries carry a TTL and age out.

`ResolveReviewConfigAction` exists because the arch tests forbid Livewire SFCs from importing Services; it is the sanctioned SFC → Action → Service seam.

## #158 — one versioned cache envelope with an explicit outcome

`DiffLoadOutcome` (`Loaded`, `Empty`, `TooLarge`, `Unparsable`, `TransientError`) replaces the previous `tooLarge` / `skipReason` / `array_key_exists('error')` combination. `LoadedDiff` wraps the parser's `FileDiff` (kept as-is) and stamps `LoadedDiff::VERSION`.

- Entries written under any other version read back as safe misses — this replaces the accreted list of marker keys (`tableAligned`, `gridLayout`, `renameAware`, …) that `DiffCacheKey::isCurrentShape()` had to check.
- Only `TransientError` is uncacheable, so a failed git process retries on the next read instead of serving the failure for a whole TTL.
- Arrays remain the public Livewire boundary; the DTO is never component state. The component derives the outcome once and templates compare enum cases.

Payload-shape changes bump `LoadedDiff::VERSION`; identity changes bump `DiffCacheKey`'s prefix. That split is documented in `app/Actions/CLAUDE.md`.

## #159 — one `.rfaignore` evaluator for tracked and untracked files

`IgnoreService::isPathExcluded()` is now authoritative for both. Previously tracked files were filtered by git pathspecs and untracked files in PHP, and a pathspec can express an exclude but not a `!` re-include — so the two disagreed exactly where negation was used. `getExcludePathspecs()` is gone.

Git-side filtering remains only where it *cannot* change semantics: the fixed lockfile set is excluded via pathspec on the `--numstat` call, because that command computes real line counts for every path it lists, and those lockfiles are non-negatable by construction. `.rfaignore` itself is PHP-only.

Lockfiles are checked ahead of user rules and are not re-includable — the one guarantee RFA makes shouldn't depend on user input. Rename and directory behavior is preserved (a rename is judged on the path the user sees), and the working-tree fingerprint is built from the same visible file set the list shows. `rules()` is memoized per repo, since the evaluator is now consulted once per file diff.

## #160 — a discard is one `DiscardOperation`

`file_status` + `is_untracked` become a single `operation` column. Each case maps to exactly one restore path, so an invalid combination is unrepresentable. Symlink state stays a separate field: it describes the saved content, not the operation.

`TrashedFile` enforces the operation/`old_path` pairing at the model boundary. The migration backfills every legacy combination and **normalizes `old_path`** — the previous writer stored whatever it was handed, so a legacy non-rename row could carry one and would otherwise migrate into a state the model rejects. `down()` restores the legacy columns and is covered by tests.

## Verification

`lint`, `types`, core (Pest), JS (Vitest) and browser suites all pass locally against the current base.
