### PR TITLE
Isolate test fixture repos from the developer's git config, and read git state fresh when releasing

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -19,9 +19,40 @@ If pre-flight fails locally, the tag push will also fail at the server. Don't by
 
 ## Steps
 
+### 0. Sync with the remote first
+
+Never reason about the release from stale local state. The session's opening git
+snapshot and any earlier `git log` output can be out of date. Always fetch before
+you read tags, commits, or status:
+
+```bash
+git branch --show-current
+git fetch --all --tags --prune
+git status --short
+git rev-list --left-right --count main...origin/main
+```
+
+Confirm `main` is the checked-out branch before anything else. Both the
+fast-forward below and the tag in step 4 act on the current `HEAD`, so running
+them from a feature branch releases the wrong commit. Switch first
+(`git switch main`) if you are somewhere else.
+
+Then reconcile with the remote, reading the `left<TAB>right` counts as
+`ahead<TAB>behind`:
+
+- behind only — fast-forward with `git merge --ff-only origin/main`.
+- ahead or diverged — stop and ask the user. Local commits on `main` have not
+  passed the required checks, and the tag ruleset will reject the push.
+- both zero — continue.
+
+Re-read tags and commits only after the fetch. The same rule applies to every
+later step: read CI, release, and PR state with a fresh command, never from
+memory of an earlier answer.
+
 ### 1. Determine version
 
-Ask the user what version to release. Suggest the next version based on the latest tag:
+Ask the user what version to release. Suggest the next version based on the latest tag
+(read after the fetch above):
 
 ```bash
 git tag --sort=-v:refname | head -5

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -47,6 +47,11 @@
         <env name="PULSE_ENABLED" value="false"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
         <env name="NIGHTWATCH_ENABLED" value="false"/>
+        <!-- Fixture repos must never inherit the developer's git config: a global
+             core.excludesFile with "*.log" makes `git add -A` stage nothing, so
+             tests pass on CI (no global config) and fail only locally. -->
+        <env name="GIT_CONFIG_GLOBAL" value="/dev/null" force="true"/>
+        <env name="GIT_CONFIG_SYSTEM" value="/dev/null" force="true"/>
         <env name="GIT_AUTHOR_NAME" value="RFA Test" force="true"/>
         <env name="GIT_AUTHOR_EMAIL" value="test@rfa.test" force="true"/>
         <env name="GIT_COMMITTER_NAME" value="RFA Test" force="true"/>

--- a/tests/Helpers/InteractsWithTestRepositories.php
+++ b/tests/Helpers/InteractsWithTestRepositories.php
@@ -8,6 +8,19 @@ use Illuminate\Support\Facades\File;
 trait InteractsWithTestRepositories
 {
     /**
+     * Neutralize the developer's global and system git config for every command
+     * the harness runs. Without it a fixture repo inherits whatever the machine
+     * configures — a global `core.excludesFile` containing `*.log` makes
+     * `git add -A` stage nothing and the initial commit fails outright. CI has
+     * no global config, so such a test passes there and fails only locally.
+     *
+     * `phpunit.xml` sets the same two variables process-wide, which also covers
+     * the git calls application code makes. This prefix keeps fixture setup
+     * deterministic even when a test changes the ambient environment.
+     */
+    private const GIT_CONFIG_ISOLATION = 'export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null;';
+
+    /**
      * @param  array<string, mixed>  $overrides
      */
     protected function createTestProject(array $overrides = []): Project
@@ -113,7 +126,7 @@ trait InteractsWithTestRepositories
     {
         $output = [];
         exec(
-            '(cd '.escapeshellarg($directory).' && git count-objects -v && git fsck --no-progress) 2>&1',
+            self::GIT_CONFIG_ISOLATION.' (cd '.escapeshellarg($directory).' && git count-objects -v && git fsck --no-progress) 2>&1',
             $output,
         );
 
@@ -124,7 +137,7 @@ trait InteractsWithTestRepositories
     {
         $output = [];
         $exitCode = 0;
-        exec($command.' 2>&1', $output, $exitCode);
+        exec(self::GIT_CONFIG_ISOLATION.' '.$command.' 2>&1', $output, $exitCode);
 
         if ($exitCode === 0) {
             return implode("\n", $output);

--- a/tests/Unit/Helpers/InteractsWithTestRepositoriesTest.php
+++ b/tests/Unit/Helpers/InteractsWithTestRepositoriesTest.php
@@ -32,3 +32,29 @@ test('failed repo commands append object store forensics to the exception', func
             ->toContain('count:');
     }
 });
+
+test('fixture repos ignore a hostile global git config', function () {
+    // The harness must beat the developer's machine, not just an empty CI box:
+    // a global core.excludesFile with "*.log" would otherwise leave `git add -A`
+    // with nothing to stage and fail the initial commit.
+    $configDir = $this->createTempDirectory('rfa_test_git_global_');
+    $excludesFile = $configDir.'/excludes';
+    $globalConfig = $configDir.'/config';
+
+    File::put($excludesFile, "*.log\n");
+    File::put($globalConfig, "[core]\n\texcludesFile = {$excludesFile}\n");
+
+    $previous = getenv('GIT_CONFIG_GLOBAL');
+    putenv('GIT_CONFIG_GLOBAL='.$globalConfig);
+
+    try {
+        File::put($this->repoDir.'/debug.log', "entry\n");
+        $this->commitTestRepo($this->repoDir, 'initial');
+
+        expect(trim($this->runTestRepoCommand($this->repoDir, 'git ls-files')))->toBe('debug.log');
+    } finally {
+        $previous === false
+            ? putenv('GIT_CONFIG_GLOBAL')
+            : putenv('GIT_CONFIG_GLOBAL='.$previous);
+    }
+});


### PR DESCRIPTION
## Summary

Two pieces of release-and-test hygiene, found while shipping v0.25.0.

## `test(harness)` — fixture repos no longer inherit the developer's git config

A fixture repo inherited whatever git the machine configures. With a global
`core.excludesFile` containing `*.log`, `git add -A` stages nothing and
`commitTestRepo()` fails on the empty commit. That is exactly what happened
locally to:

```
Tests\Unit\GitDiffServiceTest
"a negation re-includes a tracked file the same way it does an untracked one"
→ git add -A && git commit -q -m 'initial'  ("nothing to commit")
```

CI has no global git config, so the same test was green on `c17b6d7` while
failing on the machine cutting the release.

`GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` now point at `/dev/null` in two
places, because they cover different callers:

- `phpunit.xml` sets them process-wide, which reaches the git commands
  application code spawns during a test.
- `InteractsWithTestRepositories::execOrThrow()` exports them per command, so
  fixture setup stays deterministic even when a test changes the ambient
  environment.

Nothing the suite depends on is lost: `git init` passes `-b main` explicitly,
identity comes from the `GIT_AUTHOR_*` / `GIT_COMMITTER_*` env already in
`phpunit.xml`, and the per-command `GIT_CONFIG_COUNT` entries are command-scope
config that still applies.

The new harness test proves the second mechanism rather than the first: it
points `GIT_CONFIG_GLOBAL` at a config that ignores `*.log` and asserts a
fixture repo still tracks `debug.log`. The guard therefore fails on CI too, not
only on a machine that happens to ignore log files.

## `docs(release)` — the release skill reads git state fresh

The v0.25.0 run started from the session's opening git snapshot, which was five
commits stale. `main` was behind `origin/main`, so the scope looked like one PR
instead of six and the suggested version was a patch rather than a minor.

Step 0 now:

- confirms `main` is the checked-out branch, because the fast-forward and the
  tag both act on the current `HEAD`;
- fetches, then reads status and divergence;
- fast-forwards when behind, and stops for the user when ahead or diverged,
  since local commits on `main` have not passed the required checks and the tag
  ruleset would reject the push.

The same "read it fresh" rule is stated for the CI, release and PR state the
later steps read.

## Review

Reviewed by Codex (read-only, no execution). It confirmed the shell `export`
prefix, the `/dev/null` mechanism, the PHPUnit `force="true"` env propagation to
`exec()` children, and the soundness of the regression test's `putenv()` and its
`finally` cleanup. Its one finding — step 0 not verifying the checked-out branch
— is fixed in this branch.

One caveat it raised, recorded here rather than coded around: Symfony Process
gives `$_ENV` priority over a later `putenv()`. The new test is unaffected
because the helper uses `exec()`, but a future Process-based test wanting a
custom global git config must set both, or pass an explicit Process env.

## Testing

Pint passes. The test suite was deliberately **not** run locally (CPU reserved);
CI is the verification for this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pqhh3rXCwZgBhcr37RU2F


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release checks to ensure the latest repository state is evaluated before version recommendations are made.
  * Prevented local Git settings from affecting repository operations, improving consistency when tracking files and creating commits.

* **Tests**
  * Added coverage confirming repository operations remain reliable even when conflicting global Git settings are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->