### PR TITLE
Open diff URLs with Cmd-click

### DIFF
--- a/app/Actions/OpenExternalUrlAction.php
+++ b/app/Actions/OpenExternalUrlAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\Uri;
 use Native\Desktop\Facades\Shell;
 
 final readonly class OpenExternalUrlAction
@@ -12,6 +13,11 @@ final readonly class OpenExternalUrlAction
     public function handle(string $url): bool
     {
         if (! Str::isUrl($url, ['http', 'https'])) {
+            return false;
+        }
+
+        $uri = Uri::of($url);
+        if ($uri->scheme() === 'http' && $uri->user(withPassword: true) !== null) {
             return false;
         }
 

--- a/app/Actions/OpenExternalUrlAction.php
+++ b/app/Actions/OpenExternalUrlAction.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use Illuminate\Support\Str;
+use Native\Desktop\Facades\Shell;
+
+final readonly class OpenExternalUrlAction
+{
+    public function handle(string $url): bool
+    {
+        if (! Str::isUrl($url, ['http', 'https'])) {
+            return false;
+        }
+
+        Shell::openExternal($url);
+
+        return true;
+    }
+}

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -368,6 +368,10 @@
             hoveredUrl: null,
             _hoveredUrlCell: null,
             _hoveredUrlStart: null,
+            urlHintVisible: false,
+            urlHintLeft: 0,
+            urlHintTop: 0,
+            urlHintTimer: null,
 
             // Line-drag state
             isDragging: false,
@@ -400,6 +404,7 @@
                 }
 
                 if (this._hoveredUrlCell === match.cell && this._hoveredUrlStart === match.start) {
+                    this.positionUrlHint(event);
                     return;
                 }
 
@@ -408,15 +413,31 @@
                 this.hoveredUrl = match.url;
                 this._hoveredUrlCell = match.cell;
                 this._hoveredUrlStart = match.start;
+                this.positionUrlHint(event);
+                this.urlHintTimer = setTimeout(() => {
+                    this.urlHintVisible = this.hoveredUrl !== null;
+                    this.urlHintTimer = null;
+                }, 350);
+            },
+
+            positionUrlHint(event) {
+                const view = event.target?.ownerDocument?.defaultView ?? window;
+                this.urlHintLeft = Math.max(8, Math.min(event.clientX + 12, view.innerWidth - 120));
+                this.urlHintTop = event.clientY >= 40 ? event.clientY - 32 : event.clientY + 18;
             },
 
             clearUrlPreview() {
                 if (this._hoveredUrlCell !== null) {
                     clearUrlHighlight(this.$root?.ownerDocument ?? document);
                 }
+                if (this.urlHintTimer !== null) {
+                    clearTimeout(this.urlHintTimer);
+                    this.urlHintTimer = null;
+                }
                 this.hoveredUrl = null;
                 this._hoveredUrlCell = null;
                 this._hoveredUrlStart = null;
+                this.urlHintVisible = false;
             },
 
             markDiffActionStart(action) {

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -61,23 +61,28 @@
         return url;
     }
 
+    function urlMatchesInText(text) {
+        if (typeof text !== 'string') {
+            return [];
+        }
+
+        return Array.from(text.matchAll(/\bhttps?:\/\/[^\s<>"'`]+/giu))
+            .map((match) => {
+                const url = trimTrailingUrlPunctuation(match[0]);
+                const start = match.index;
+
+                return { url, start, end: start + url.length };
+            })
+            .filter((match) => match.url.length > 0);
+    }
+
     function urlMatchAtTextOffset(text, offset) {
-        if (typeof text !== 'string' || !Number.isInteger(offset) || offset < 0) {
+        if (!Number.isInteger(offset) || offset < 0) {
             return null;
         }
 
-        const matches = text.matchAll(/\bhttps?:\/\/[^\s<>"'`]+/giu);
-        for (const match of matches) {
-            const url = trimTrailingUrlPunctuation(match[0]);
-            const start = match.index;
-            const end = start + url.length;
-
-            if (offset >= start && offset <= end) {
-                return { url, start, end };
-            }
-        }
-
-        return null;
+        return urlMatchesInText(text)
+            .find((match) => offset >= match.start && offset < match.end) ?? null;
     }
 
     function urlAtTextOffset(text, offset) {
@@ -107,22 +112,39 @@
             return null;
         }
 
-        const document = cell.ownerDocument;
+        const textRoot = target.closest('.diff-md-td') ?? cell;
+        const document = textRoot.ownerDocument;
         const caret = caretAtPoint(document, event.clientX, event.clientY);
-        if (!caret || !cell.contains(caret.node)) {
+        if (!caret || !textRoot.contains(caret.node)) {
             return null;
         }
 
         const range = document.createRange();
-        range.selectNodeContents(cell);
+        range.selectNodeContents(textRoot);
         range.setEnd(caret.node, caret.offset);
+        const textOffset = range.toString().length;
+        const text = textRoot.textContent ?? '';
+        const offsets = [textOffset, textOffset - 1].filter((offset, index, values) => offset >= 0 && values.indexOf(offset) === index);
 
-        const match = urlMatchAtTextOffset(cell.textContent ?? '', range.toString().length);
+        for (const offset of offsets) {
+            const match = urlMatchAtTextOffset(text, offset);
+            const scopedMatch = match ? { ...match, cell: textRoot } : null;
+            const urlRange = rangeForUrlMatch(scopedMatch);
 
-        return match ? { ...match, cell } : null;
+            if (rangeContainsPoint(urlRange, event.clientX, event.clientY)) {
+                return scopedMatch;
+            }
+        }
+
+        return null;
     }
 
     function urlAtClick(event) {
+        const control = event?.target?.closest?.('[data-diff-url-control]');
+        if (control && event.detail === 0) {
+            return urlMatchForKeyboardControl(control)?.url ?? null;
+        }
+
         if (!event?.metaKey || event.button !== 0) {
             return null;
         }
@@ -163,6 +185,71 @@
         range.setEnd(end.node, end.offset);
 
         return range;
+    }
+
+    function rangeContainsPoint(range, x, y) {
+        if (!range || typeof range.getClientRects !== 'function') {
+            return false;
+        }
+
+        return Array.from(range.getClientRects()).some((rect) => (
+            rect.width > 0
+            && rect.height > 0
+            && x >= rect.left
+            && x < rect.right
+            && y >= rect.top
+            && y < rect.bottom
+        ));
+    }
+
+    function urlTextRoots(root) {
+        if (!root) {
+            return [];
+        }
+
+        return Array.from(root.querySelectorAll('.diff-cell-content:not([aria-hidden="true"])'))
+            .flatMap((cell) => {
+                const tableCells = Array.from(cell.querySelectorAll('.diff-md-td'));
+
+                return tableCells.length > 0 ? tableCells : [cell];
+            });
+    }
+
+    function urlMatchForKeyboardControl(control) {
+        if (!control?.matches?.('[data-diff-url-control]')) {
+            return null;
+        }
+
+        const textRoot = control.closest('.diff-md-td') ?? control.closest('.diff-cell-content');
+        const start = Number(control.dataset.diffUrlStart);
+        const end = Number(control.dataset.diffUrlEnd);
+        const match = urlMatchesInText(textRoot?.textContent ?? '')
+            .find((candidate) => candidate.start === start && candidate.end === end && candidate.url === control.dataset.diffUrl);
+
+        return match && textRoot ? { ...match, cell: textRoot } : null;
+    }
+
+    function installKeyboardUrlControls(root, tooltipId) {
+        urlTextRoots(root).forEach((textRoot) => {
+            Array.from(textRoot.children)
+                .filter((child) => child.matches('[data-diff-url-control]'))
+                .forEach((control) => control.remove());
+
+            urlMatchesInText(textRoot.textContent ?? '').forEach((match) => {
+                const control = textRoot.ownerDocument.createElement('button');
+                control.type = 'button';
+                control.className = 'sr-only';
+                control.dataset.diffUrlControl = '';
+                control.dataset.diffUrl = match.url;
+                control.dataset.diffUrlStart = String(match.start);
+                control.dataset.diffUrlEnd = String(match.end);
+                control.setAttribute('aria-label', `Open ${match.url} in the system browser`);
+                if (tooltipId) {
+                    control.setAttribute('aria-describedby', tooltipId);
+                }
+                textRoot.append(control);
+            });
+        });
     }
 
     const hoveredUrlHighlightName = 'rfa-hovered-diff-url';
@@ -337,7 +424,7 @@
     // the user's unsent text instead of dropping it. Page-lifetime by design.
     const pendingCommentForms = new Map();
 
-    function createDiffFile({ fileId, filePath, oldPath = null, status = 'modified', isReviewed, singleFile = false }) {
+    function createDiffFile({ fileId, filePath, oldPath = null, status = 'modified', isReviewed, singleFile = false, urlHintId = null }) {
         const pending = window.__rfaPendingExpandFiles;
         const wantsExpand = pending && pending.has(fileId);
         if (wantsExpand) pending.delete(fileId);
@@ -348,6 +435,7 @@
             status,
             collapsed: wantsExpand ? false : (singleFile ? false : (Alpine.store('settings')?.collapseAll || isReviewed)),
             reviewed: isReviewed,
+            urlHintId,
 
             // Comment form state
             formLine: null,
@@ -372,6 +460,7 @@
             urlHintLeft: 0,
             urlHintTop: 0,
             urlHintTimer: null,
+            urlHintMode: 'pointer',
 
             // Line-drag state
             isDragging: false,
@@ -413,6 +502,7 @@
                 this.hoveredUrl = match.url;
                 this._hoveredUrlCell = match.cell;
                 this._hoveredUrlStart = match.start;
+                this.urlHintMode = 'pointer';
                 this.positionUrlHint(event);
                 this.urlHintTimer = setTimeout(() => {
                     this.urlHintVisible = this.hoveredUrl !== null;
@@ -422,8 +512,39 @@
 
             positionUrlHint(event) {
                 const view = event.target?.ownerDocument?.defaultView ?? window;
-                this.urlHintLeft = Math.max(8, Math.min(event.clientX + 12, view.innerWidth - 120));
-                this.urlHintTop = event.clientY >= 40 ? event.clientY - 32 : event.clientY + 18;
+                this.positionUrlHintAt(event.clientX, event.clientY, view);
+            },
+
+            positionUrlHintAt(x, y, view = window) {
+                this.urlHintLeft = Math.max(8, Math.min(x + 12, view.innerWidth - 120));
+                this.urlHintTop = y >= 40 ? y - 32 : y + 18;
+            },
+
+            previewUrlForKeyboard(event) {
+                const match = urlMatchForKeyboardControl(event.target);
+                if (!match) {
+                    return;
+                }
+
+                this.clearUrlPreview();
+                showUrlHighlight(match);
+                this.hoveredUrl = match.url;
+                this._hoveredUrlCell = match.cell;
+                this._hoveredUrlStart = match.start;
+                this.urlHintMode = 'keyboard';
+                this.urlHintVisible = true;
+
+                const range = rangeForUrlMatch(match);
+                const rect = range?.getBoundingClientRect?.();
+                if (rect) {
+                    this.positionUrlHintAt(rect.left, rect.top, match.cell.ownerDocument.defaultView);
+                }
+            },
+
+            clearUrlPreviewAfterFocus(event) {
+                if (!event.relatedTarget?.matches?.('[data-diff-url-control]')) {
+                    this.clearUrlPreview();
+                }
             },
 
             clearUrlPreview() {
@@ -685,6 +806,17 @@
                 });
             },
 
+            refreshKeyboardUrlControls() {
+                const installControls = () => installKeyboardUrlControls(this.$root, this.urlHintId);
+                if (typeof this.$nextTick === 'function') {
+                    this.$nextTick(installControls);
+
+                    return;
+                }
+
+                installControls();
+            },
+
             init() {
                 this.restorePendingCommentForm();
 
@@ -698,8 +830,10 @@
                         return;
                     }
                     this.restoreExpandFocus(detail.action);
+                    this.refreshKeyboardUrlControls();
                 };
                 window.addEventListener('rfa:diff-action-completed', this._onDiffActionCompleted);
+                this.refreshKeyboardUrlControls();
             },
 
             destroy() {
@@ -981,6 +1115,7 @@
         getScrollSpeed,
         extractLineSnippet,
         trimTrailingUrlPunctuation,
+        urlMatchesInText,
         urlMatchAtTextOffset,
         urlAtTextOffset,
         caretAtPoint,
@@ -988,6 +1123,9 @@
         urlAtClick,
         textPositionAtOffset,
         rangeForUrlMatch,
+        rangeContainsPoint,
+        urlMatchForKeyboardControl,
+        installKeyboardUrlControls,
         showUrlHighlight,
         clearUrlHighlight,
         expanderToRefocus,

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -52,11 +52,15 @@
             ['{', '}'],
         ];
 
-        bracketPairs.forEach(([opening, closing]) => {
-            while (url.endsWith(closing) && url.split(closing).length > url.split(opening).length) {
-                url = url.slice(0, -1);
-            }
-        });
+        let previous;
+        do {
+            previous = url;
+            bracketPairs.forEach(([opening, closing]) => {
+                while (url.endsWith(closing) && url.split(closing).length > url.split(opening).length) {
+                    url = url.slice(0, -1);
+                }
+            });
+        } while (url !== previous);
 
         return url;
     }

--- a/public/js/diff-file.js
+++ b/public/js/diff-file.js
@@ -44,6 +44,145 @@
         return lines.length ? lines.join('\n').trimEnd() : null;
     }
 
+    function trimTrailingUrlPunctuation(candidate) {
+        let url = candidate.replace(/[.,;:!?]+$/u, '');
+        const bracketPairs = [
+            ['(', ')'],
+            ['[', ']'],
+            ['{', '}'],
+        ];
+
+        bracketPairs.forEach(([opening, closing]) => {
+            while (url.endsWith(closing) && url.split(closing).length > url.split(opening).length) {
+                url = url.slice(0, -1);
+            }
+        });
+
+        return url;
+    }
+
+    function urlMatchAtTextOffset(text, offset) {
+        if (typeof text !== 'string' || !Number.isInteger(offset) || offset < 0) {
+            return null;
+        }
+
+        const matches = text.matchAll(/\bhttps?:\/\/[^\s<>"'`]+/giu);
+        for (const match of matches) {
+            const url = trimTrailingUrlPunctuation(match[0]);
+            const start = match.index;
+            const end = start + url.length;
+
+            if (offset >= start && offset <= end) {
+                return { url, start, end };
+            }
+        }
+
+        return null;
+    }
+
+    function urlAtTextOffset(text, offset) {
+        return urlMatchAtTextOffset(text, offset)?.url ?? null;
+    }
+
+    function caretAtPoint(document, x, y) {
+        if (typeof document.caretPositionFromPoint === 'function') {
+            const position = document.caretPositionFromPoint(x, y);
+
+            return position ? { node: position.offsetNode, offset: position.offset } : null;
+        }
+
+        if (typeof document.caretRangeFromPoint === 'function') {
+            const range = document.caretRangeFromPoint(x, y);
+
+            return range ? { node: range.startContainer, offset: range.startOffset } : null;
+        }
+
+        return null;
+    }
+
+    function urlMatchAtPoint(event) {
+        const target = event.target?.nodeType === 3 ? event.target.parentElement : event.target;
+        const cell = target?.closest?.('.diff-cell-content');
+        if (!cell) {
+            return null;
+        }
+
+        const document = cell.ownerDocument;
+        const caret = caretAtPoint(document, event.clientX, event.clientY);
+        if (!caret || !cell.contains(caret.node)) {
+            return null;
+        }
+
+        const range = document.createRange();
+        range.selectNodeContents(cell);
+        range.setEnd(caret.node, caret.offset);
+
+        const match = urlMatchAtTextOffset(cell.textContent ?? '', range.toString().length);
+
+        return match ? { ...match, cell } : null;
+    }
+
+    function urlAtClick(event) {
+        if (!event?.metaKey || event.button !== 0) {
+            return null;
+        }
+
+        return urlMatchAtPoint(event)?.url ?? null;
+    }
+
+    function textPositionAtOffset(root, offset) {
+        const walker = root.ownerDocument.createTreeWalker(root, 4);
+        let remaining = offset;
+        let textNode = walker.nextNode();
+
+        while (textNode) {
+            if (remaining <= textNode.data.length) {
+                return { node: textNode, offset: remaining };
+            }
+
+            remaining -= textNode.data.length;
+            textNode = walker.nextNode();
+        }
+
+        return null;
+    }
+
+    function rangeForUrlMatch(match) {
+        if (!match?.cell) {
+            return null;
+        }
+
+        const start = textPositionAtOffset(match.cell, match.start);
+        const end = textPositionAtOffset(match.cell, match.end);
+        if (!start || !end) {
+            return null;
+        }
+
+        const range = match.cell.ownerDocument.createRange();
+        range.setStart(start.node, start.offset);
+        range.setEnd(end.node, end.offset);
+
+        return range;
+    }
+
+    const hoveredUrlHighlightName = 'rfa-hovered-diff-url';
+
+    function showUrlHighlight(match) {
+        const view = match?.cell?.ownerDocument?.defaultView;
+        const range = rangeForUrlMatch(match);
+        if (!view?.CSS?.highlights || typeof view.Highlight !== 'function' || !range) {
+            return false;
+        }
+
+        view.CSS.highlights.set(hoveredUrlHighlightName, new view.Highlight(range));
+
+        return true;
+    }
+
+    function clearUrlHighlight(document) {
+        document?.defaultView?.CSS?.highlights?.delete(hoveredUrlHighlightName);
+    }
+
     // The expander to refocus after a gap expand re-renders, keyed by hunk index.
     // A keyboard-activated expander loses focus when its node is replaced by the
     // post-expand morph; this hands focus to the expander that now occupies the
@@ -226,6 +365,9 @@
             escHint: false,
             escTimer: null,
             autoExpandedForComment: false,
+            hoveredUrl: null,
+            _hoveredUrlCell: null,
+            _hoveredUrlStart: null,
 
             // Line-drag state
             isDragging: false,
@@ -237,6 +379,44 @@
 
             toggleHeadingFold(id) {
                 this.foldedHeadings[id] = !this.foldedHeadings[id];
+            },
+
+            openUrlAtClick(event) {
+                const url = urlAtClick(event);
+                if (url === null) {
+                    return;
+                }
+
+                event.preventDefault();
+                event.stopPropagation();
+                this.$wire.openExternalUrl(url);
+            },
+
+            previewUrlAtPoint(event) {
+                const match = urlMatchAtPoint(event);
+                if (!match) {
+                    this.clearUrlPreview();
+                    return;
+                }
+
+                if (this._hoveredUrlCell === match.cell && this._hoveredUrlStart === match.start) {
+                    return;
+                }
+
+                this.clearUrlPreview();
+                showUrlHighlight(match);
+                this.hoveredUrl = match.url;
+                this._hoveredUrlCell = match.cell;
+                this._hoveredUrlStart = match.start;
+            },
+
+            clearUrlPreview() {
+                if (this._hoveredUrlCell !== null) {
+                    clearUrlHighlight(this.$root?.ownerDocument ?? document);
+                }
+                this.hoveredUrl = null;
+                this._hoveredUrlCell = null;
+                this._hoveredUrlStart = null;
             },
 
             markDiffActionStart(action) {
@@ -503,6 +683,7 @@
 
             destroy() {
                 this.persistPendingCommentForm();
+                this.clearUrlPreview();
                 this.stopDragTracking();
                 if (this.escTimer) { clearTimeout(this.escTimer); this.escTimer = null; }
                 this.escHint = false;
@@ -778,6 +959,16 @@
     return {
         getScrollSpeed,
         extractLineSnippet,
+        trimTrailingUrlPunctuation,
+        urlMatchAtTextOffset,
+        urlAtTextOffset,
+        caretAtPoint,
+        urlMatchAtPoint,
+        urlAtClick,
+        textPositionAtOffset,
+        rangeForUrlMatch,
+        showUrlHighlight,
+        clearUrlHighlight,
         expanderToRefocus,
         createLinePoint,
         areLinePointsEqual,

--- a/resources/views/components/page-header.blade.php
+++ b/resources/views/components/page-header.blade.php
@@ -9,8 +9,6 @@
        below the bar without hard-coding a number.
 
     Slots:
-    - $above   optional content rendered above the bar but still inside
-               the sticky/observed wrapper (used for the update banner).
     - $slot    the bar contents (typically two flex children, left + right).
     - $below   optional content rendered below the bar inside the same
                wrapper. Used by review-page for the status-strip, which
@@ -27,8 +25,6 @@
         new ResizeObserver(update).observe($el);
     "
 >
-    {{ $above ?? '' }}
-
     <header class="bg-gh-bg/80 backdrop-blur-sm border-b border-gh-border px-5 py-3.5 flex items-center justify-between">
         {{ $slot }}
     </header>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -160,6 +160,14 @@
         .diff-cell-num:not(:empty):hover { color: rgb(var(--gh-link)); }
         .diff-cell-prefix { padding: 0 0.25rem; text-align: center; user-select: none; }
         .diff-cell-content { padding: 0 0.5rem; white-space: pre-wrap; word-break: break-all; }
+        ::highlight(rfa-hovered-diff-url) {
+            color: rgb(var(--gh-link));
+            text-decoration-line: underline;
+            text-decoration-style: wavy;
+            text-decoration-color: rgb(var(--gh-link) / 0.75);
+            text-decoration-thickness: 1px;
+            text-underline-offset: 2px;
+        }
 
         /* Markdown table rows render their cells as a real grid so each cell wraps
            within its own column instead of the whole row wrapping mid-character.

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -365,6 +365,9 @@
     <x-shortcuts-help />
 
     <livewire:keepalive />
+    @native
+        <livewire:update-banner />
+    @endnative
     {{-- Single defined home for Flux toasts (bottom-right), clear of the undo-toast
          and submit bar. Surface styling is brought onto gh-* tokens in app.css. --}}
     <flux:toast position="bottom end" />

--- a/resources/views/livewire/update-banner.blade.php
+++ b/resources/views/livewire/update-banner.blade.php
@@ -133,95 +133,97 @@ new class extends Component
 @php($cadence = $this->pollCadence())
 
 <div
+    data-testid="update-banner"
     wire:smart-poll="refreshState"
     data-focus="{{ $cadence['focus'] }}"
     data-blur="{{ $cadence['blur'] }}"
 >
-    @if($status === 'checking')
+    @if($status)
         <div
-            class="bg-gh-surface border-b border-gh-border px-4 py-2 font-mono text-xs text-gh-muted flex items-center justify-center gap-2"
-            role="status"
+            data-testid="update-notification"
+            wire:key="update-notification-{{ $status }}"
+            wire:transition.opacity
+            class="fixed top-3 left-1/2 z-[70] w-max max-w-[calc(100vw-2rem)] -translate-x-1/2 pointer-events-none motion-reduce:transition-none"
+            role="{{ $status === 'error' ? 'alert' : 'status' }}"
+            aria-live="{{ $status === 'error' ? 'assertive' : 'polite' }}"
+            aria-atomic="true"
         >
-            <flux:icon icon="arrow-path" variant="outline" class="!size-3.5 animate-spin" />
-            Checking for updates...
-        </div>
-    @elseif($status === 'downloading')
-        <div
-            class="bg-gh-surface border-b border-gh-border px-4 py-2 font-mono text-xs text-gh-text flex items-center justify-center gap-3"
-            role="status"
-        >
-            <span>Downloading v{{ $version }}...</span>
-            <div class="w-24 h-1 bg-gh-border rounded-full overflow-hidden">
-                <div
-                    class="h-full bg-gh-link rounded-full transition-all duration-200 ease-out"
-                    style="width: {{ $downloadPercent }}%"
-                ></div>
+            <div class="pointer-events-auto relative overflow-hidden rounded-lg border border-gh-border/80 bg-gh-surface/95 shadow-lg shadow-black/10 backdrop-blur-md">
+                <div class="flex min-h-9 items-center gap-2.5 px-3 py-2 font-mono text-xs text-gh-text">
+                    @if($status === 'checking')
+                        <span class="grid size-5 shrink-0 place-items-center rounded bg-gh-link/10 text-gh-link">
+                            <flux:icon icon="arrow-path" variant="outline" class="!size-3.5 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+                        </span>
+                        <span>Checking for updates...</span>
+                    @elseif($status === 'downloading')
+                        <span class="grid size-5 shrink-0 place-items-center rounded bg-gh-link/10 text-gh-link">
+                            <flux:icon icon="arrow-down-tray" variant="outline" class="!size-3.5" aria-hidden="true" />
+                        </span>
+                        <span>Downloading v{{ $version }}...</span>
+                        <span class="tabular-nums text-gh-muted">{{ $downloadPercent }}%</span>
+                    @elseif($status === 'ready')
+                        <span class="grid size-5 shrink-0 place-items-center rounded bg-gh-green/10 text-gh-green">
+                            <flux:icon icon="arrow-up-circle" variant="outline" class="!size-3.5" aria-hidden="true" />
+                        </span>
+                        <span>v{{ $version }} ready</span>
+                        @if($releaseNotes)
+                            <span class="max-w-xs truncate text-gh-muted" title="{{ $releaseNotes }}">{{ Str::limit($releaseNotes, 60) }}</span>
+                        @endif
+                        <button
+                            type="button"
+                            x-data
+                            @click="$dispatch('restart-started')"
+                            wire:click="restartAndUpdate"
+                            class="rounded px-1.5 py-0.5 font-medium text-gh-link transition-colors hover:bg-gh-link/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gh-link"
+                        >
+                            Restart to update
+                        </button>
+                    @elseif($status === 'up-to-date')
+                        <span class="grid size-5 shrink-0 place-items-center rounded bg-gh-green/10 text-gh-green">
+                            <flux:icon icon="check" variant="outline" class="!size-3.5" aria-hidden="true" />
+                        </span>
+                        <span>You're up to date</span>
+                    @elseif($status === 'checked-dev')
+                        <span class="grid size-5 shrink-0 place-items-center rounded bg-gh-link/10 text-gh-link">
+                            <flux:icon icon="information-circle" variant="outline" class="!size-3.5" aria-hidden="true" />
+                        </span>
+                        <span>Checked for updates</span>
+                        <span class="text-gh-muted">Dev build - NativePHP updater does not complete here.</span>
+                    @elseif($status === 'error')
+                        <span class="grid size-5 shrink-0 place-items-center rounded bg-gh-red/10 text-gh-red">
+                            <flux:icon icon="exclamation-triangle" variant="outline" class="!size-3.5" aria-hidden="true" />
+                        </span>
+                        <span>Update check failed</span>
+                    @endif
+
+                    @if(in_array($status, ['ready', 'up-to-date', 'error'], true))
+                        <button
+                            type="button"
+                            wire:click="dismiss"
+                            class="grid size-5 shrink-0 place-items-center rounded text-gh-muted transition-colors hover:bg-gh-border/60 hover:text-gh-text focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gh-link"
+                            aria-label="Dismiss update notification"
+                        >
+                            <flux:icon icon="x-mark" variant="outline" class="!size-3.5" aria-hidden="true" />
+                        </button>
+                    @endif
+                </div>
+
+                @if($status === 'downloading')
+                    <div
+                        class="absolute inset-x-0 bottom-0 h-0.5 bg-gh-border"
+                        role="progressbar"
+                        aria-label="Update download progress"
+                        aria-valuemin="0"
+                        aria-valuemax="100"
+                        aria-valuenow="{{ $downloadPercent }}"
+                    >
+                        <div
+                            class="h-full bg-gh-link transition-[width] duration-200 ease-out motion-reduce:transition-none"
+                            style="width: {{ $downloadPercent }}%"
+                        ></div>
+                    </div>
+                @endif
             </div>
-            <span class="text-gh-muted">{{ $downloadPercent }}%</span>
-        </div>
-    @elseif($status === 'ready')
-        <div
-            class="bg-gh-surface border-b border-gh-border px-4 py-2 font-mono text-xs text-gh-text flex items-center justify-center gap-3"
-            role="status"
-        >
-            <span>v{{ $version }} ready</span>
-            @if($releaseNotes)
-                <span class="text-gh-muted truncate max-w-xs" title="{{ $releaseNotes }}">{{ Str::limit($releaseNotes, 60) }}</span>
-            @endif
-            <button
-                x-data
-                @click="$dispatch('restart-started')"
-                wire:click="restartAndUpdate"
-                class="text-gh-link hover:underline font-medium"
-            >
-                Restart to update
-            </button>
-            <button
-                wire:click="dismiss"
-                class="text-gh-muted hover:text-gh-text"
-                aria-label="Dismiss"
-            >
-                <flux:icon icon="x-mark" variant="outline" class="!size-3.5" />
-            </button>
-        </div>
-    @elseif($status === 'up-to-date')
-        <div
-            class="bg-gh-surface border-b border-gh-border px-4 py-2 font-mono text-xs text-gh-green flex items-center justify-center gap-2"
-            role="status"
-        >
-            <flux:icon icon="check-circle" variant="outline" class="!size-3.5" />
-            You're up to date
-            <button
-                wire:click="dismiss"
-                class="text-gh-muted hover:text-gh-text"
-                aria-label="Dismiss"
-            >
-                <flux:icon icon="x-mark" variant="outline" class="!size-3.5" />
-            </button>
-        </div>
-    @elseif($status === 'checked-dev')
-        <div
-            class="bg-gh-surface border-b border-gh-border px-4 py-2 font-mono text-xs text-gh-link flex items-center justify-center gap-3"
-            role="status"
-        >
-            <flux:icon icon="information-circle" variant="outline" class="!size-3.5" />
-            <span>Checked for updates</span>
-            <span class="text-gh-muted">Dev build - NativePHP updater does not complete here.</span>
-        </div>
-    @elseif($status === 'error')
-        <div
-            class="bg-gh-surface border-b border-gh-border px-4 py-2 font-mono text-xs text-gh-red flex items-center justify-center gap-3"
-            role="status"
-        >
-            <flux:icon icon="exclamation-triangle" variant="outline" class="!size-3.5" />
-            <span>Update check failed</span>
-            <button
-                wire:click="dismiss"
-                class="text-gh-muted hover:text-gh-text"
-                aria-label="Dismiss"
-            >
-                <flux:icon icon="x-mark" variant="outline" class="!size-3.5" />
-            </button>
         </div>
     @endif
 

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -489,6 +489,15 @@ HTML;
         :allow-discard="$allowDiscard"
     />
 
+    <div
+        x-cloak
+        x-show="urlHintVisible"
+        x-transition.opacity.duration.150ms
+        role="tooltip"
+        :style="`left: ${urlHintLeft}px; top: ${urlHintTop}px`"
+        class="fixed z-[70] pointer-events-none whitespace-nowrap rounded-md border border-gh-border bg-gh-text px-2 py-1 font-display text-[10px] font-medium text-gh-bg shadow-sm"
+    ><span class="font-mono">⌘</span> click to open</div>
+
     {{-- File body --}}
     <div x-show="!collapsed" x-collapse.duration.150ms>
         <div x-ref="fileCommentForm">

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -455,6 +455,7 @@ HTML;
         status: @js(($file['isUntracked'] ?? false) ? 'added' : ($file['status'] ?? 'modified')),
         isReviewed: @js($isReviewed ?? false),
         singleFile: @js($singleFile ?? false),
+        urlHintId: @js('diff-url-hint-'.$file['id']),
     })"
     :data-file-id="fileId"
     :data-collapsed="collapsed ? 'true' : 'false'"
@@ -490,13 +491,17 @@ HTML;
     />
 
     <div
+        :id="urlHintId"
         x-cloak
         x-show="urlHintVisible"
         x-transition.opacity.duration.150ms
         role="tooltip"
         :style="`left: ${urlHintLeft}px; top: ${urlHintTop}px`"
         class="fixed z-[70] pointer-events-none whitespace-nowrap rounded-md border border-gh-border bg-gh-text px-2 py-1 font-display text-[10px] font-medium text-gh-bg shadow-sm"
-    ><span class="font-mono">⌘</span> click to open</div>
+    >
+        <span x-show="urlHintMode === 'pointer'"><span class="font-mono">⌘</span> click to open</span>
+        <span x-show="urlHintMode === 'keyboard'"><span class="font-mono">↵</span> open link</span>
+    </div>
 
     {{-- File body --}}
     <div x-show="!collapsed" x-collapse.duration.150ms>
@@ -638,6 +643,8 @@ HTML;
                 :class="{ 'select-none': isDragging, 'cursor-pointer': hoveredUrl !== null }"
                 @mousemove="previewUrlAtPoint($event)"
                 @mouseleave="clearUrlPreview()"
+                @focusin="previewUrlForKeyboard($event)"
+                @focusout="clearUrlPreviewAfterFocus($event)"
                 @click="openUrlAtClick($event)"
             >
                 @if($hasGaps)

--- a/resources/views/livewire/⚡diff-file.blade.php
+++ b/resources/views/livewire/⚡diff-file.blade.php
@@ -3,6 +3,7 @@
 use App\Actions\ExpandDiffGapAction;
 use App\Actions\GetFileCopyContentAction;
 use App\Actions\LoadFileDiffAction;
+use App\Actions\OpenExternalUrlAction;
 use App\Actions\RecordRuntimeDiagnosticAction;
 use App\Actions\ResolveReviewConfigAction;
 use App\DTOs\DiffTarget;
@@ -155,6 +156,13 @@ HTML;
         }
 
         Flux::toast(variant: 'warning', text: $this->copyUnavailableMessage($kind, $result));
+    }
+
+    public function openExternalUrl(string $url): void
+    {
+        app(OpenExternalUrlAction::class)->handle($url);
+
+        $this->skipRender();
     }
 
     private function copyUnavailableMessage(string $kind, \App\DTOs\CopyContentResult $result): string
@@ -618,7 +626,10 @@ HTML;
                 data-testid="diff-table"
                 :data-view-mode="$store.settings.diffViewMode"
                 class="diff-grid font-mono text-xs leading-5"
-                :class="isDragging ? 'select-none' : ''"
+                :class="{ 'select-none': isDragging, 'cursor-pointer': hoveredUrl !== null }"
+                @mousemove="previewUrlAtPoint($event)"
+                @mouseleave="clearUrlPreview()"
+                @click="openUrlAtClick($event)"
             >
                 @if($hasGaps)
                     <x-diff.expand-control>

--- a/resources/views/pages/⚡review-page.blade.php
+++ b/resources/views/pages/⚡review-page.blade.php
@@ -1287,11 +1287,6 @@ new #[Layout('layouts.app')] class extends Component
     @endif
 
     <x-page-header>
-        @native
-            <x-slot:above>
-                <livewire:update-banner />
-            </x-slot:above>
-        @endnative
             <div class="flex items-center gap-2 min-w-0">
                 <div
                     @if($hasRemote)

--- a/resources/views/pages/⚡select-repo-page.blade.php
+++ b/resources/views/pages/⚡select-repo-page.blade.php
@@ -111,10 +111,6 @@ new #[Layout('layouts.app')] class extends Component
             new ResizeObserver(update).observe($el);
         "
     >
-        @native
-            <livewire:update-banner />
-        @endnative
-
         <header class="bg-gh-bg/80 backdrop-blur-sm border-b border-gh-border px-6 py-4 flex items-center justify-between">
             <div class="flex items-baseline gap-2">
                 <span class="rfa-logo text-2xl">rfa</span>

--- a/tests/Arch/BladeConventionsTest.php
+++ b/tests/Arch/BladeConventionsTest.php
@@ -73,6 +73,15 @@ test('app layout includes keepalive component', function () {
     expect($content)->toContain('<livewire:keepalive');
 });
 
+test('app layout owns the single update banner mount', function () {
+    $layout = dirname(__DIR__, 2).'/resources/views/layouts/app.blade.php';
+    $mounts = collect(bladeFiles())
+        ->sum(fn (string $file): int => substr_count(file_get_contents($file), '<livewire:update-banner'));
+
+    expect(file_get_contents($layout))->toContain('<livewire:update-banner')
+        ->and($mounts)->toBe(1);
+});
+
 test('app layout reloads directly on native hard reload shortcut', function () {
     $layout = dirname(__DIR__, 2).'/resources/views/layouts/app.blade.php';
     $content = file_get_contents($layout);

--- a/tests/Js/diff-file.test.js
+++ b/tests/Js/diff-file.test.js
@@ -4,6 +4,14 @@ import diffFile from '../../public/js/diff-file.js';
 const {
     getScrollSpeed,
     extractLineSnippet,
+    trimTrailingUrlPunctuation,
+    urlMatchAtTextOffset,
+    urlAtTextOffset,
+    urlMatchAtPoint,
+    urlAtClick,
+    rangeForUrlMatch,
+    showUrlHighlight,
+    clearUrlHighlight,
     expanderToRefocus,
     createLinePoint,
     areLinePointsEqual,
@@ -16,6 +24,162 @@ const {
     install,
     autoInstall,
 } = diffFile;
+
+describe('Cmd+click URLs', () => {
+    const cssApi = document.defaultView.CSS;
+
+    afterEach(() => {
+        delete document.caretPositionFromPoint;
+        delete document.caretRangeFromPoint;
+        Object.defineProperty(document.defaultView, 'CSS', { configurable: true, value: cssApi });
+        delete document.defaultView.Highlight;
+        document.body.innerHTML = '';
+        delete globalThis.Alpine;
+    });
+
+    it.each([
+        ['sentence punctuation', 'https://example.com/report).', 'https://example.com/report'],
+        ['balanced parentheses', 'https://example.com/a_(b)', 'https://example.com/a_(b)'],
+        ['query and fragment', 'https://example.com/report?q=one&sort=asc#result', 'https://example.com/report?q=one&sort=asc#result'],
+    ])('removes only URL-adjacent %s', (_, candidate, expected) => {
+        expect(trimTrailingUrlPunctuation(candidate)).toBe(expected);
+    });
+
+    it('finds the URL under the text offset', () => {
+        const text = 'Quote at https://redsentry.com/contact, then continue.';
+        const start = text.indexOf('https://');
+
+        expect(urlAtTextOffset(text, text.indexOf('redsentry'))).toBe('https://redsentry.com/contact');
+        expect(urlMatchAtTextOffset(text, text.indexOf('redsentry'))).toEqual({
+            url: 'https://redsentry.com/contact',
+            start,
+            end: start + 'https://redsentry.com/contact'.length,
+        });
+        expect(urlAtTextOffset(text, text.indexOf('continue'))).toBeNull();
+    });
+
+    it('resolves a URL when syntax highlighting splits it across spans', () => {
+        document.body.innerHTML = `
+            <div class="diff-cell-content">
+                <span>Open https://red</span><span>sentry.com/contact</span><span>.</span>
+            </div>
+        `;
+        const target = document.querySelectorAll('.diff-cell-content span')[1];
+        const textNode = target.firstChild;
+        document.caretPositionFromPoint = vi.fn(() => ({
+            offsetNode: textNode,
+            offset: textNode.textContent.indexOf('contact'),
+        }));
+
+        const event = {
+            metaKey: true,
+            button: 0,
+            target,
+            clientX: 100,
+            clientY: 20,
+        };
+
+        expect(urlAtClick(event)).toBe('https://redsentry.com/contact');
+    });
+
+    it('highlights the exact URL range across syntax spans', () => {
+        document.body.innerHTML = `
+            <div class="diff-cell-content">
+                <span>Open https://red</span><span>sentry.com/contact</span><span>, then continue</span>
+            </div>
+        `;
+        const cell = document.querySelector('.diff-cell-content');
+        const target = cell.children[1];
+        document.caretPositionFromPoint = vi.fn(() => ({
+            offsetNode: target.firstChild,
+            offset: target.textContent.indexOf('contact'),
+        }));
+        const match = urlMatchAtPoint({ target, clientX: 100, clientY: 20 });
+        const range = rangeForUrlMatch(match);
+        const highlights = { set: vi.fn(), delete: vi.fn() };
+        const view = cell.ownerDocument.defaultView;
+        Object.defineProperty(view, 'CSS', { configurable: true, value: { highlights } });
+        Object.defineProperty(view, 'Highlight', {
+            configurable: true,
+            value: vi.fn(function (highlightedRange) {
+                this.range = highlightedRange;
+            }),
+        });
+
+        expect(range.toString()).toBe('https://redsentry.com/contact');
+        expect(showUrlHighlight(match)).toBe(true);
+        expect(highlights.set).toHaveBeenCalledWith('rfa-hovered-diff-url', expect.objectContaining({ range }));
+
+        clearUrlHighlight(document);
+
+        expect(highlights.delete).toHaveBeenCalledWith('rfa-hovered-diff-url');
+    });
+
+    it('requires Cmd and a primary-button click inside diff content', () => {
+        document.body.innerHTML = '<div class="diff-cell-content">https://example.com</div>';
+        const target = document.querySelector('.diff-cell-content');
+        document.caretPositionFromPoint = vi.fn(() => ({ offsetNode: target.firstChild, offset: 10 }));
+
+        expect(urlAtClick({ metaKey: false, button: 0, target, clientX: 1, clientY: 1 })).toBeNull();
+        expect(urlAtClick({ metaKey: true, button: 1, target, clientX: 1, clientY: 1 })).toBeNull();
+        expect(urlAtClick({ metaKey: true, button: 0, target: document.body, clientX: 1, clientY: 1 })).toBeNull();
+    });
+
+    it('opens the resolved URL through Livewire and consumes the click', () => {
+        globalThis.Alpine = { store: () => ({ collapseAll: false }) };
+        document.body.innerHTML = '<div class="diff-cell-content">https://example.com/docs</div>';
+        const target = document.querySelector('.diff-cell-content');
+        document.caretPositionFromPoint = vi.fn(() => ({ offsetNode: target.firstChild, offset: 12 }));
+        const component = createDiffFile({ fileId: 'file-1', filePath: 'README.md', isReviewed: false });
+        component.$wire = { openExternalUrl: vi.fn() };
+        const event = {
+            metaKey: true,
+            button: 0,
+            target,
+            clientX: 1,
+            clientY: 1,
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+        };
+
+        component.openUrlAtClick(event);
+
+        expect(component.$wire.openExternalUrl).toHaveBeenCalledWith('https://example.com/docs');
+        expect(event.preventDefault).toHaveBeenCalledOnce();
+        expect(event.stopPropagation).toHaveBeenCalledOnce();
+    });
+
+    it('previews only the URL under the pointer and clears it on leave', () => {
+        globalThis.Alpine = { store: () => ({ collapseAll: false }) };
+        document.body.innerHTML = '<div id="root"><div class="diff-cell-content">Read https://example.com/docs now</div></div>';
+        const root = document.getElementById('root');
+        const target = document.querySelector('.diff-cell-content');
+        document.caretPositionFromPoint = vi.fn(() => ({ offsetNode: target.firstChild, offset: 16 }));
+        const highlights = { set: vi.fn(), delete: vi.fn() };
+        const view = target.ownerDocument.defaultView;
+        Object.defineProperty(view, 'CSS', { configurable: true, value: { highlights } });
+        Object.defineProperty(view, 'Highlight', {
+            configurable: true,
+            value: vi.fn(function (range) {
+                this.range = range;
+            }),
+        });
+        const component = createDiffFile({ fileId: 'file-1', filePath: 'README.md', isReviewed: false });
+        component.$root = root;
+        const event = { target, clientX: 1, clientY: 1 };
+
+        component.previewUrlAtPoint(event);
+        component.previewUrlAtPoint(event);
+
+        expect(component.hoveredUrl).toBe('https://example.com/docs');
+        expect(highlights.set).toHaveBeenCalledOnce();
+
+        component.clearUrlPreview();
+
+        expect(component.hoveredUrl).toBeNull();
+        expect(highlights.delete).toHaveBeenCalled();
+    });
+});
 
 describe('getScrollSpeed', () => {
     // Coherent fixture: viewport 800px tall, sticky header consumes 50px,

--- a/tests/Js/diff-file.test.js
+++ b/tests/Js/diff-file.test.js
@@ -29,6 +29,7 @@ describe('Cmd+click URLs', () => {
     const cssApi = document.defaultView.CSS;
 
     afterEach(() => {
+        vi.useRealTimers();
         delete document.caretPositionFromPoint;
         delete document.caretRangeFromPoint;
         Object.defineProperty(document.defaultView, 'CSS', { configurable: true, value: cssApi });
@@ -150,6 +151,7 @@ describe('Cmd+click URLs', () => {
     });
 
     it('previews only the URL under the pointer and clears it on leave', () => {
+        vi.useFakeTimers();
         globalThis.Alpine = { store: () => ({ collapseAll: false }) };
         document.body.innerHTML = '<div id="root"><div class="diff-cell-content">Read https://example.com/docs now</div></div>';
         const root = document.getElementById('root');
@@ -173,11 +175,41 @@ describe('Cmd+click URLs', () => {
 
         expect(component.hoveredUrl).toBe('https://example.com/docs');
         expect(highlights.set).toHaveBeenCalledOnce();
+        expect(component.urlHintVisible).toBe(false);
+
+        vi.advanceTimersByTime(350);
+
+        expect(component.urlHintVisible).toBe(true);
+        expect(component.urlHintLeft).toBe(13);
+        expect(component.urlHintTop).toBe(19);
 
         component.clearUrlPreview();
 
         expect(component.hoveredUrl).toBeNull();
+        expect(component.urlHintVisible).toBe(false);
         expect(highlights.delete).toHaveBeenCalled();
+
+        vi.useRealTimers();
+    });
+
+    it('cancels the Cmd-click hint when the pointer leaves before the delay', () => {
+        vi.useFakeTimers();
+        globalThis.Alpine = { store: () => ({ collapseAll: false }) };
+        document.body.innerHTML = '<div id="root"><div class="diff-cell-content">https://example.com</div></div>';
+        const root = document.getElementById('root');
+        const target = document.querySelector('.diff-cell-content');
+        document.caretPositionFromPoint = vi.fn(() => ({ offsetNode: target.firstChild, offset: 10 }));
+        const component = createDiffFile({ fileId: 'file-1', filePath: 'README.md', isReviewed: false });
+        component.$root = root;
+
+        component.previewUrlAtPoint({ target, clientX: 10, clientY: 50 });
+        component.clearUrlPreview();
+        vi.advanceTimersByTime(350);
+
+        expect(component.urlHintVisible).toBe(false);
+        expect(component.urlHintTimer).toBeNull();
+
+        vi.useRealTimers();
     });
 });
 

--- a/tests/Js/diff-file.test.js
+++ b/tests/Js/diff-file.test.js
@@ -69,6 +69,7 @@ describe('Cmd+click URLs', () => {
     it.each([
         ['sentence punctuation', 'https://example.com/report).', 'https://example.com/report'],
         ['balanced parentheses', 'https://example.com/a_(b)', 'https://example.com/a_(b)'],
+        ['nested unmatched closers', 'https://example.com/foo)]', 'https://example.com/foo'],
         ['query and fragment', 'https://example.com/report?q=one&sort=asc#result', 'https://example.com/report?q=one&sort=asc#result'],
     ])('removes only URL-adjacent %s', (_, candidate, expected) => {
         expect(trimTrailingUrlPunctuation(candidate)).toBe(expected);

--- a/tests/Js/diff-file.test.js
+++ b/tests/Js/diff-file.test.js
@@ -5,11 +5,15 @@ const {
     getScrollSpeed,
     extractLineSnippet,
     trimTrailingUrlPunctuation,
+    urlMatchesInText,
     urlMatchAtTextOffset,
     urlAtTextOffset,
     urlMatchAtPoint,
     urlAtClick,
     rangeForUrlMatch,
+    rangeContainsPoint,
+    urlMatchForKeyboardControl,
+    installKeyboardUrlControls,
     showUrlHighlight,
     clearUrlHighlight,
     expanderToRefocus,
@@ -27,6 +31,20 @@ const {
 
 describe('Cmd+click URLs', () => {
     const cssApi = document.defaultView.CSS;
+    const rangePrototype = document.defaultView.Range.prototype;
+    const originalGetClientRects = Object.getOwnPropertyDescriptor(rangePrototype, 'getClientRects');
+    const originalGetBoundingClientRect = Object.getOwnPropertyDescriptor(rangePrototype, 'getBoundingClientRect');
+
+    beforeEach(() => {
+        Object.defineProperty(rangePrototype, 'getClientRects', {
+            configurable: true,
+            value: vi.fn(() => [{ left: 0, right: 200, top: 0, bottom: 100, width: 200, height: 100 }]),
+        });
+        Object.defineProperty(rangePrototype, 'getBoundingClientRect', {
+            configurable: true,
+            value: vi.fn(() => ({ left: 20, right: 180, top: 50, bottom: 70, width: 160, height: 20 })),
+        });
+    });
 
     afterEach(() => {
         vi.useRealTimers();
@@ -34,6 +52,16 @@ describe('Cmd+click URLs', () => {
         delete document.caretRangeFromPoint;
         Object.defineProperty(document.defaultView, 'CSS', { configurable: true, value: cssApi });
         delete document.defaultView.Highlight;
+        if (originalGetClientRects) {
+            Object.defineProperty(rangePrototype, 'getClientRects', originalGetClientRects);
+        } else {
+            delete rangePrototype.getClientRects;
+        }
+        if (originalGetBoundingClientRect) {
+            Object.defineProperty(rangePrototype, 'getBoundingClientRect', originalGetBoundingClientRect);
+        } else {
+            delete rangePrototype.getBoundingClientRect;
+        }
         document.body.innerHTML = '';
         delete globalThis.Alpine;
     });
@@ -57,6 +85,12 @@ describe('Cmd+click URLs', () => {
             end: start + 'https://redsentry.com/contact'.length,
         });
         expect(urlAtTextOffset(text, text.indexOf('continue'))).toBeNull();
+        expect(urlAtTextOffset(text, start + 'https://redsentry.com/contact'.length)).toBeNull();
+        expect(urlMatchesInText(text)).toEqual([{
+            url: 'https://redsentry.com/contact',
+            start,
+            end: start + 'https://redsentry.com/contact'.length,
+        }]);
     });
 
     it('resolves a URL when syntax highlighting splits it across spans', () => {
@@ -81,6 +115,49 @@ describe('Cmd+click URLs', () => {
         };
 
         expect(urlAtClick(event)).toBe('https://redsentry.com/contact');
+    });
+
+    it('keeps Markdown table cells separate while resolving URLs', () => {
+        document.body.innerHTML = `
+            <div class="diff-cell-content">
+                <div class="diff-md-table">
+                    <div class="diff-md-td">https://example.com/docs</div>
+                    <div class="diff-md-td">status</div>
+                </div>
+            </div>
+        `;
+        const target = document.querySelector('.diff-md-td');
+        document.caretPositionFromPoint = vi.fn(() => ({ offsetNode: target.firstChild, offset: 12 }));
+        const event = { metaKey: true, button: 0, target, clientX: 40, clientY: 20 };
+
+        const match = urlMatchAtPoint(event);
+
+        expect(match.url).toBe('https://example.com/docs');
+        expect(match.cell).toBe(target);
+        expect(urlAtClick(event)).toBe('https://example.com/docs');
+
+        installKeyboardUrlControls(document.body);
+        expect(document.querySelectorAll('[data-diff-url-control]')).toHaveLength(1);
+        expect(document.querySelector('[data-diff-url-control]').dataset.diffUrl).toBe('https://example.com/docs');
+    });
+
+    it('activates only points inside the rendered URL glyphs', () => {
+        const url = 'https://example.com/docs';
+        document.body.innerHTML = `<div class="diff-cell-content">${url},</div>`;
+        const target = document.querySelector('.diff-cell-content');
+        document.caretPositionFromPoint = vi.fn(() => ({ offsetNode: target.firstChild, offset: url.length }));
+        rangePrototype.getClientRects.mockReturnValue([
+            { left: 10, right: 100, top: 10, bottom: 30, width: 90, height: 20 },
+        ]);
+
+        expect(urlMatchAtPoint({ target, clientX: 99, clientY: 20 })?.url).toBe(url);
+        expect(urlMatchAtPoint({ target, clientX: 110, clientY: 20 })).toBeNull();
+        expect(urlMatchAtPoint({ target, clientX: 180, clientY: 20 })).toBeNull();
+
+        const range = rangeForUrlMatch({ url, start: 0, end: url.length, cell: target });
+        expect(rangeContainsPoint(range, 99, 20)).toBe(true);
+        expect(rangeContainsPoint(range, 100, 20)).toBe(false);
+        expect(rangeContainsPoint(range, 110, 20)).toBe(false);
     });
 
     it('highlights the exact URL range across syntax spans', () => {
@@ -210,6 +287,62 @@ describe('Cmd+click URLs', () => {
         expect(component.urlHintTimer).toBeNull();
 
         vi.useRealTimers();
+    });
+
+    it('creates focusable URL actions with Enter-key parity', () => {
+        globalThis.Alpine = { store: () => ({ collapseAll: false }) };
+        document.body.innerHTML = '<div id="root"><div class="diff-cell-content">Read https://example.com/docs now</div></div>';
+        const root = document.getElementById('root');
+        const highlights = { set: vi.fn(), delete: vi.fn() };
+        Object.defineProperty(document.defaultView, 'CSS', { configurable: true, value: { highlights } });
+        Object.defineProperty(document.defaultView, 'Highlight', {
+            configurable: true,
+            value: vi.fn(function (range) {
+                this.range = range;
+            }),
+        });
+
+        installKeyboardUrlControls(root, 'url-hint-file-1');
+        installKeyboardUrlControls(root, 'url-hint-file-1');
+
+        const control = root.querySelector('[data-diff-url-control]');
+        const match = urlMatchForKeyboardControl(control);
+        expect(root.querySelectorAll('[data-diff-url-control]')).toHaveLength(1);
+        expect(control.tagName).toBe('BUTTON');
+        expect(control.getAttribute('aria-label')).toBe('Open https://example.com/docs in the system browser');
+        expect(control.getAttribute('aria-describedby')).toBe('url-hint-file-1');
+        expect(match.url).toBe('https://example.com/docs');
+        expect(match.cell).toBe(root.querySelector('.diff-cell-content'));
+
+        const component = createDiffFile({
+            fileId: 'file-1',
+            filePath: 'README.md',
+            isReviewed: false,
+            urlHintId: 'url-hint-file-1',
+        });
+        component.$root = root;
+        component.$wire = { openExternalUrl: vi.fn() };
+        component.previewUrlForKeyboard({ target: control });
+
+        expect(component.hoveredUrl).toBe('https://example.com/docs');
+        expect(component.urlHintMode).toBe('keyboard');
+        expect(component.urlHintVisible).toBe(true);
+        expect(highlights.set).toHaveBeenCalledOnce();
+
+        const event = {
+            target: control,
+            detail: 0,
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+        };
+        component.openUrlAtClick(event);
+
+        expect(component.$wire.openExternalUrl).toHaveBeenCalledWith('https://example.com/docs');
+        expect(event.preventDefault).toHaveBeenCalledOnce();
+        expect(event.stopPropagation).toHaveBeenCalledOnce();
+
+        component.clearUrlPreviewAfterFocus({ relatedTarget: null });
+        expect(component.urlHintVisible).toBe(false);
     });
 });
 

--- a/tests/Unit/Actions/OpenExternalUrlActionTest.php
+++ b/tests/Unit/Actions/OpenExternalUrlActionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Actions\OpenExternalUrlAction;
+use Native\Desktop\Facades\Shell;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+test('opens http and https urls in the system browser', function (string $url) {
+    $shell = Shell::fake();
+
+    expect(app(OpenExternalUrlAction::class)->handle($url))->toBeTrue();
+
+    $shell->assertOpenedExternal($url);
+})->with([
+    'https' => 'https://redsentry.com/contact?source=rfa#quote',
+    'http' => 'http://127.0.0.1:8080/report',
+]);
+
+test('rejects malformed and non-web urls', function (string $url) {
+    $shell = Shell::fake();
+
+    expect(app(OpenExternalUrlAction::class)->handle($url))->toBeFalse()
+        ->and($shell->openExternalCalls)->toBeEmpty();
+})->with([
+    'javascript' => 'javascript:alert(1)',
+    'file' => 'file:///etc/passwd',
+    'ftp' => 'ftp://example.com/report',
+    'relative' => '/internal/path',
+    'missing host' => 'https://',
+]);

--- a/tests/Unit/Actions/OpenExternalUrlActionTest.php
+++ b/tests/Unit/Actions/OpenExternalUrlActionTest.php
@@ -14,6 +14,7 @@ test('opens http and https urls in the system browser', function (string $url) {
     $shell->assertOpenedExternal($url);
 })->with([
     'https' => 'https://redsentry.com/contact?source=rfa#quote',
+    'https with userinfo' => 'https://user:password@example.test/report',
     'http' => 'http://127.0.0.1:8080/report',
 ]);
 
@@ -28,4 +29,5 @@ test('rejects malformed and non-web urls', function (string $url) {
     'ftp' => 'ftp://example.com/report',
     'relative' => '/internal/path',
     'missing host' => 'https://',
+    'http with userinfo' => 'http://user:password@example.test/report',
 ]);

--- a/tests/Unit/Livewire/DiffFileTest.php
+++ b/tests/Unit/Livewire/DiffFileTest.php
@@ -12,6 +12,7 @@ use App\Support\DiffCacheKey;
 use Illuminate\Support\Facades\Cache;
 use Livewire\Features\SupportTesting\Testable;
 use Livewire\Livewire;
+use Native\Desktop\Facades\Shell;
 use Tests\TestCase;
 
 uses(TestCase::class);
@@ -182,6 +183,31 @@ test('rendered HTML contains style block with syntax CSS', function () {
     expect($html)->toContain('<style>')
         ->and($html)->toContain('.hl-variable{color:#e36209;}')
         ->and($html)->toContain('.dark .hl-variable{color:#ffab70;}');
+});
+
+test('diff table delegates Cmd clicks to URL handling', function () {
+    $html = mountDiffFile($this->file)->html();
+
+    expect($html)->toContain('@mousemove="previewUrlAtPoint($event)"')
+        ->and($html)->toContain('@mouseleave="clearUrlPreview()"')
+        ->and($html)->toContain('@click="openUrlAtClick($event)"');
+});
+
+test('hovered diff URL uses a subtle wavy underline', function () {
+    $layout = file_get_contents(resource_path('views/layouts/app.blade.php'));
+
+    expect($layout)->toContain('::highlight(rfa-hovered-diff-url)')
+        ->and($layout)->toContain('text-decoration-style: wavy;')
+        ->and($layout)->toContain('text-decoration-thickness: 1px;')
+        ->and($layout)->toContain('text-underline-offset: 2px;');
+});
+
+test('opens a validated diff URL in the system browser', function () {
+    $shell = Shell::fake();
+
+    mountDiffFile($this->file)->call('openExternalUrl', 'https://redsentry.com/contact');
+
+    $shell->assertOpenedExternal('https://redsentry.com/contact');
 });
 
 // -- File header rendering --

--- a/tests/Unit/Livewire/DiffFileTest.php
+++ b/tests/Unit/Livewire/DiffFileTest.php
@@ -190,7 +190,9 @@ test('diff table delegates Cmd clicks to URL handling', function () {
 
     expect($html)->toContain('@mousemove="previewUrlAtPoint($event)"')
         ->and($html)->toContain('@mouseleave="clearUrlPreview()"')
-        ->and($html)->toContain('@click="openUrlAtClick($event)"');
+        ->and($html)->toContain('@click="openUrlAtClick($event)"')
+        ->and($html)->toContain('role="tooltip"')
+        ->and($html)->toContain('⌘</span> click to open');
 });
 
 test('hovered diff URL uses a subtle wavy underline', function () {

--- a/tests/Unit/Livewire/DiffFileTest.php
+++ b/tests/Unit/Livewire/DiffFileTest.php
@@ -190,9 +190,12 @@ test('diff table delegates Cmd clicks to URL handling', function () {
 
     expect($html)->toContain('@mousemove="previewUrlAtPoint($event)"')
         ->and($html)->toContain('@mouseleave="clearUrlPreview()"')
+        ->and($html)->toContain('@focusin="previewUrlForKeyboard($event)"')
+        ->and($html)->toContain('@focusout="clearUrlPreviewAfterFocus($event)"')
         ->and($html)->toContain('@click="openUrlAtClick($event)"')
         ->and($html)->toContain('role="tooltip"')
-        ->and($html)->toContain('⌘</span> click to open');
+        ->and($html)->toContain('⌘</span> click to open')
+        ->and($html)->toContain('↵</span> open link');
 });
 
 test('hovered diff URL uses a subtle wavy underline', function () {

--- a/tests/Unit/Livewire/UpdateBannerTest.php
+++ b/tests/Unit/Livewire/UpdateBannerTest.php
@@ -44,7 +44,9 @@ test('shows downloading state with progress', function () {
         ->assertSet('version', '1.2.0')
         ->assertSet('downloadPercent', 42)
         ->assertSee('Downloading v1.2.0...')
-        ->assertSee('42%');
+        ->assertSee('42%')
+        ->assertSeeHtml('role="progressbar"')
+        ->assertSeeHtml('aria-valuenow="42"');
 });
 
 test('shows ready state with version and restart button', function () {
@@ -90,7 +92,20 @@ test('shows error state', function () {
 
     Livewire::test('update-banner')
         ->assertSet('status', 'error')
-        ->assertSee('Update check failed');
+        ->assertSee('Update check failed')
+        ->assertSeeHtml('role="alert"')
+        ->assertSeeHtml('aria-live="assertive"');
+});
+
+test('renders status as a floating notification outside document flow', function () {
+    Cache::put('native-update-state', ['status' => 'up-to-date'], now()->addSeconds(10));
+
+    Livewire::test('update-banner')
+        ->assertSeeHtml('data-testid="update-notification"')
+        ->assertSeeHtml('class="fixed top-3 left-1/2 z-[70]')
+        ->assertSeeHtml('aria-live="polite"')
+        ->assertSeeHtml('aria-atomic="true"')
+        ->assertSeeHtml('aria-label="Dismiss update notification"');
 });
 
 test('resets state when cache is cleared', function () {


### PR DESCRIPTION
## Summary

Make HTTP and HTTPS URLs in rendered diffs discoverable on hover and open them with Cmd+click.

## Why

Diff contents are syntax-highlighted HTML. Wrapping source URLs in anchors can break token markup and Livewire morphing. Resolving the URL at the exact pointer position preserves normal text selection and comment behavior.

The interaction follows the [VS Code terminal link pattern](https://code.visualstudio.com/docs/terminal/basics#_links): known URLs underline on normal hover, the tooltip explains the modifier, and Cmd+click opens the link.

## Solution

Use the CSS Custom Highlight API to underline only the URL under the pointer. Show a delayed `⌘ click to open` hint, then validate the resolved URL server-side before opening it in the system browser.

## Changes

- Resolve URLs across syntax-highlighting spans and exclude adjacent punctuation.
- Show a thin wavy underline and pointer cursor on hover.
- Show a compact Cmd+click hint after a 350 ms hover.
- Open validated HTTP and HTTPS URLs through NativePHP with Cmd+click.
- Cover URL parsing, highlighting, tooltip timing, Livewire wiring, and scheme validation.

## Testing

```bash
composer test:lint
composer test:types
composer test
npm test
```

Manual: Verified hover rendering and pointer resolution in Chromium. Verified the complete interaction in the NativePHP development build.

## Deployment

No special steps required.