### PR TITLE
Remove the redundant project registration warning

### DIFF
--- a/app/Actions/OpenProjectFromPathAction.php
+++ b/app/Actions/OpenProjectFromPathAction.php
@@ -8,7 +8,6 @@ use App\Exceptions\NotAGitRepositoryException;
 use App\Models\Project;
 use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\Log;
 use Throwable;
 
 final readonly class OpenProjectFromPathAction
@@ -37,21 +36,10 @@ final readonly class OpenProjectFromPathAction
 
             return null;
         } catch (Throwable $e) {
-            // Unexpected (e.g. a database error). Log it as a real failure rather
-            // than silently treating it as "not a git repository", and still avoid
-            // crashing the deep-link/menu handler. The Context fields surface the
-            // failure on the calling owner's canonical event so a swallowed error
-            // doesn't masquerade as a plain rejection there.
+            // The caller owns the canonical event, so preserve the failure in
+            // Context while keeping this action non-throwing.
             Context::add('rfa.reason', 'project_registration_failed');
             Context::add('rfa.error_class', $e::class);
-
-            // The owner already carries this hash as rfa.path_hash, so the
-            // correlation survives without a second copy of the path.
-            Log::warning('project.registration.failed', [
-                'reason' => 'project_registration_failed',
-                'path_hash' => hash('xxh128', $path),
-                'error_class' => $e::class,
-            ]);
 
             return null;
         }

--- a/reports/wide-events/2026-08-25.md
+++ b/reports/wide-events/2026-08-25.md
@@ -3,16 +3,16 @@
 ## Summary
 
 - Deterministic checks: pass
-- Findings: 0 critical, 0 warning, 1 info
+- Findings: 0 critical, 0 warning, 1 info (resolved)
 - Files reviewed: 15
 
 ## Deterministic Checks
 
 | Command | Result | Notes |
 |---|---|---|
-| `php artisan test --compact tests/Arch/LoggingConventionsTest.php` | pass | 9/9. C1-C7 and C9-C10 hold on `main` at `c17b6d7`. |
+| `php artisan test --compact tests/Arch/LoggingConventionsTest.php` | pass | 9/9. C1-C7 and C9-C10 hold after the resolution at `8e03b5e`. |
 | `php artisan test --compact tests/Feature/LogChannelPostureTest.php` | pass | 5/5. Resolved default channel and stack stay local (C8). |
-| Production facade inventory (command below) | pass | 143 hits across 15 production files. No hits in `config/` (only `config/logging.php` was in scope and does not call the facades). |
+| Production facade inventory (command below) | pass | 142 hits across 15 production files. No hits in `config/` (only `config/logging.php` was in scope and does not call the facades). |
 
 ```bash
 rg -n "Log::(debug|info|warning|error|critical)\(|Context::(flush|add)\(" app resources/views config -g'*.php'
@@ -20,13 +20,14 @@ rg -n "Log::(debug|info|warning|error|critical)\(|Context::(flush|add)\(" app re
 
 ## Findings
 
-### [INFO] `OpenProjectFromPathAction` warning duplicates fields already on both owner canonical events
+### [INFO] [RESOLVED] `OpenProjectFromPathAction` warning duplicates fields already on both owner canonical events
 
-- **File:** `app/Actions/OpenProjectFromPathAction.php:50`
+- **File:** `app/Actions/OpenProjectFromPathAction.php:38`
 - **Rule:** Agent Review Checklist A12, "Diagnostic detail uses safe fields ... and the chosen fields actually aid triage, not just satisfy the linter."
 - **Evidence:** The `Throwable` branch adds `rfa.reason = project_registration_failed`, `rfa.error_class = $e::class`, and returns null. It also emits `Log::warning('project.registration.failed', ['reason' => 'project_registration_failed', 'path_hash' => hash('xxh128', $path), 'error_class' => $e::class])`. Both current callers already carry those exact three values on their owner canonical events: `HandleDeepLink` writes `rfa.path_hash` (same `xxh128` hash) and `rfa.reason` / `rfa.error_class` into `deeplink.opened`, and `NativeAppServiceProvider::processInbox` writes `rfa.path_hash`, `rfa.reason`, `rfa.error_class` into `inbox.opened`.
 - **Impact:** Low. The warning gives triage no new field beyond what the owner already logs, so an operator sees the same failure twice per event. The previous audit surfaced this as a residual risk and left the warning in place as insurance against a future caller arriving without an owner.
 - **Suggested fix:** Optional. Either remove the `Log::warning` (rely on the owner's canonical event) or add a safe diagnostic field that neither owner event carries. Both callers cover the failure today, so removal is the cleaner path if `OpenProjectFromPathAction`'s callers remain owner-backed.
+- **Resolution:** Removed the redundant warning in `8e03b5e`. The action still records `rfa.reason` and `rfa.error_class` for the owner canonical event, and its unit test now asserts that the converted failure emits no child warning.
 
 ## Clean Areas
 

--- a/tests/Unit/Actions/OpenProjectFromPathActionTest.php
+++ b/tests/Unit/Actions/OpenProjectFromPathActionTest.php
@@ -47,17 +47,13 @@ test('returns null and swallows the exception when registration fails', function
     expect(Project::count())->toBe(0);
 });
 
-test('warns with a hashed path when registration fails unexpectedly', function () {
+test('records an owner error without a duplicate warning when registration fails unexpectedly', function () {
     Schema::drop('projects');
     Log::spy();
 
     expect(app(OpenProjectFromPathAction::class)->handle($this->repoPath))->toBeNull()
-        ->and(Context::get('rfa.reason'))->toBe('project_registration_failed');
+        ->and(Context::get('rfa.reason'))->toBe('project_registration_failed')
+        ->and(Context::get('rfa.error_class'))->not->toBeNull();
 
-    Log::shouldHaveReceived('warning')->once()->withArgs(
-        fn (string $event, array $payload): bool => $event === 'project.registration.failed'
-            && $payload['reason'] === 'project_registration_failed'
-            && $payload['path_hash'] === hash('xxh128', $this->repoPath)
-            && ! array_key_exists('path', $payload),
-    );
+    Log::shouldNotHaveReceived('warning');
 });


### PR DESCRIPTION
## Summary

- Remove the child `project.registration.failed` warning because both callers already record the same failure on their canonical event.
- Keep `rfa.reason` and `rfa.error_class` in Context for owner outcome mapping.
- Add regression coverage and mark the 2026-08-25 audit finding resolved.

## Tests

- `composer test` (2,073 tests, 5,619 assertions)
- `composer test:types`
- `php artisan test --compact tests/Arch/LoggingConventionsTest.php`
- `php artisan test --compact tests/Feature/LogChannelPostureTest.php`